### PR TITLE
fix(gradle): pinned and unified gradle version to 8.13

### DIFF
--- a/.github/workflows/test-sdk-integration.yml
+++ b/.github/workflows/test-sdk-integration.yml
@@ -133,6 +133,7 @@ jobs:
           ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           chmod +x gradlew
+          ./gradlew wrapper --gradle-version 8.13
           ./gradlew assembleRelease --no-daemon --stacktrace 2>&1 | tee /tmp/testproject-build-android.log
           GRADLE_EXIT=${PIPESTATUS[0]}
           if [ "$GRADLE_EXIT" -ne 0 ]; then

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This pull request updates the Gradle version used in the project to ensure compatibility and stability in the build process. The main changes involve downgrading the Gradle wrapper version and updating the workflow to explicitly set this version before building.

Build system and workflow updates:

* Downgraded the Gradle wrapper from version 9.0.0 to 8.13 in `gradle-wrapper.properties` to address compatibility and stability concerns.
* Updated the CI workflow (`test-sdk-integration.yml`) to explicitly set the Gradle version to 8.13 before building the Android release, ensuring consistency during automated builds.