### PR TITLE
Libarchive zstd support

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,7 +17,7 @@ runs:
 
     - name: Restore sherpa-onnx cache
       id: submodule-cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: |
           third_party/sherpa-onnx
@@ -38,7 +38,7 @@ runs:
 
     - name: Save sherpa-onnx cache
       if: steps.submodule-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: |
           third_party/sherpa-onnx
@@ -46,13 +46,13 @@ runs:
         key: ${{ steps.submodule-cache.outputs.cache-primary-key }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@v6
       with:
         node-version-file: .nvmrc
 
     - name: Restore dependencies
       id: yarn-cache
-      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache/restore@v5
       with:
         path: |
           **/node_modules
@@ -69,7 +69,7 @@ runs:
 
     - name: Cache dependencies
       if: steps.yarn-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache/save@v5
       with:
         path: |
           **/node_modules

--- a/.github/workflows/build-ffmpeg-android-release.yml
+++ b/.github/workflows/build-ffmpeg-android-release.yml
@@ -65,7 +65,7 @@ jobs:
           echo "opus=$(git -C third_party/opus rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Cache FFmpeg prebuilts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: ffmpeg-cache
         with:
           path: |

--- a/.github/workflows/build-libarchive-android-release.yml
+++ b/.github/workflows/build-libarchive-android-release.yml
@@ -54,6 +54,26 @@ jobs:
           add-to-path: true
           local-cache: true
 
+      # nttld/setup-ndk may set ndk-path to a parent dir; resolve to the root that contains the compiler.
+      - name: Resolve NDK root
+        id: ndk-root
+        run: |
+          BASE="${{ steps.setup-ndk.outputs.ndk-path }}"
+          CLANG="$BASE/toolchains/llvm/prebuilt/linux-x86_64/bin/clang"
+          if [ -f "$CLANG" ]; then
+            echo "ndk_root=$BASE" >> $GITHUB_OUTPUT
+          else
+            FOUND=$(find "$BASE" -maxdepth 6 -type f -path "*/toolchains/llvm/prebuilt/*/bin/clang" 2>/dev/null | head -1)
+            if [ -z "$FOUND" ]; then
+              echo "::error::NDK compiler not found under $BASE"
+              exit 1
+            fi
+            # FOUND = .../toolchains/llvm/prebuilt/HOST/bin/clang -> NDK root = ... (5 levels up from file)
+            NDK_ROOT=$(cd "$(dirname "$FOUND")/../../../../.." && pwd)
+            echo "ndk_root=$NDK_ROOT" >> $GITHUB_OUTPUT
+          fi
+          echo "Using NDK root: ${{ steps.ndk-root.outputs.ndk_root }}"
+
       - name: Get submodule versions
         id: submodules
         run: |
@@ -76,8 +96,8 @@ jobs:
           chmod +x build_zstd.sh
           ./build_zstd.sh
         env:
-          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
-          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_ROOT: ${{ steps.ndk-root.outputs.ndk_root }}
+          ANDROID_NDK_HOME: ${{ steps.ndk-root.outputs.ndk_root }}
 
       - name: Build libarchive
         if: steps.libarchive-cache.outputs.cache-hit != 'true'
@@ -86,8 +106,8 @@ jobs:
           chmod +x build_libarchive_android.sh
           ./build_libarchive_android.sh
         env:
-          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
-          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_ROOT: ${{ steps.ndk-root.outputs.ndk_root }}
+          ANDROID_NDK_HOME: ${{ steps.ndk-root.outputs.ndk_root }}
 
       - name: Package jniLibs layout
         run: |
@@ -151,7 +171,6 @@ jobs:
             libarchive-${{ steps.tag.outputs.maven_version }}.aar
           draft: false
           prerelease: false
-          skip_duplicate: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-libarchive-android-release.yml
+++ b/.github/workflows/build-libarchive-android-release.yml
@@ -54,17 +54,30 @@ jobs:
           add-to-path: true
           local-cache: true
 
-      - name: Get libarchive submodule version
+      - name: Get submodule versions
         id: submodules
         run: |
           echo "libarchive=$(git -C third_party/libarchive rev-parse HEAD 2>/dev/null || echo 'none')" >> "$GITHUB_OUTPUT"
+          echo "zstd=$(git -C third_party/zstd rev-parse HEAD 2>/dev/null || echo 'none')" >> "$GITHUB_OUTPUT"
 
       - name: Cache libarchive prebuilts
         uses: actions/cache@v4
         id: libarchive-cache
         with:
-          path: third_party/libarchive_prebuilt/android
-          key: libarchive-android-prebuilt-${{ steps.submodules.outputs.libarchive }}-${{ hashFiles('third_party/libarchive_prebuilt/build_libarchive_android.sh') }}
+          path: |
+            third_party/libarchive_prebuilt/android
+            third_party/zstd_prebuilt/android
+          key: libarchive-android-prebuilt-${{ steps.submodules.outputs.libarchive }}-${{ steps.submodules.outputs.zstd }}-${{ hashFiles('third_party/libarchive_prebuilt/build_libarchive_android.sh', 'third_party/zstd_prebuilt/build_zstd.sh') }}
+
+      - name: Build zstd
+        if: steps.libarchive-cache.outputs.cache-hit != 'true'
+        run: |
+          cd third_party/zstd_prebuilt
+          chmod +x build_zstd.sh
+          ./build_zstd.sh
+        env:
+          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
       - name: Build libarchive
         if: steps.libarchive-cache.outputs.cache-hit != 'true'
@@ -87,6 +100,10 @@ jobs:
             SRC="third_party/libarchive_prebuilt/android/$abi/lib"
             if [ -d "$SRC" ]; then
               cp "$SRC"/*.so "$LAYOUT/$abi/" 2>/dev/null || true
+            fi
+            ZSTD_SRC="third_party/zstd_prebuilt/android/$abi/lib"
+            if [ -d "$ZSTD_SRC" ]; then
+              cp "$ZSTD_SRC"/*.so "$LAYOUT/$abi/" 2>/dev/null || true
             fi
           done
           if [ -d "third_party/libarchive_prebuilt/android/include" ]; then

--- a/.github/workflows/build-libarchive-android-release.yml
+++ b/.github/workflows/build-libarchive-android-release.yml
@@ -54,6 +54,36 @@ jobs:
           add-to-path: true
           local-cache: true
 
+      # Resolve NDK root: ndk-path may point at a parent; we need the dir that contains both
+      # build/cmake/android.toolchain.cmake and toolchains/llvm/prebuilt/<host>/bin/clang.
+      - name: Resolve and validate NDK root
+        id: ndk
+        run: |
+          BASE="${{ steps.setup-ndk.outputs.ndk-path }}"
+          TOOLCHAIN_FILE="build/cmake/android.toolchain.cmake"
+          CLANG_REL="toolchains/llvm/prebuilt/linux-x86_64/bin/clang"
+          check_ndk_root() {
+            local r="$1"
+            [ -f "$r/$TOOLCHAIN_FILE" ] && [ -f "$r/$CLANG_REL" ]
+          }
+          if check_ndk_root "$BASE"; then
+            echo "ndk_root=$BASE" >> $GITHUB_OUTPUT
+            echo "NDK root: $BASE"
+            exit 0
+          fi
+          while IFS= read -r -d '' f; do
+            ROOT="$(cd "$(dirname "$f")/../.." && pwd)"
+            if check_ndk_root "$ROOT"; then
+              echo "ndk_root=$ROOT" >> $GITHUB_OUTPUT
+              echo "NDK root: $ROOT (resolved under ndk-path)"
+              exit 0
+            fi
+          done < <(find "$BASE" -maxdepth 5 -type f -path "*/build/cmake/android.toolchain.cmake" -print0 2>/dev/null)
+          echo "::error::NDK validation failed. Under $BASE no directory has both $TOOLCHAIN_FILE and $CLANG_REL"
+          echo "Contents of $BASE:"
+          ls -laR "$BASE" 2>/dev/null | head -80
+          exit 1
+
       - name: Get submodule versions
         id: submodules
         run: |
@@ -76,8 +106,8 @@ jobs:
           chmod +x build_zstd.sh
           ./build_zstd.sh
         env:
-          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
-          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_ROOT: ${{ steps.ndk.outputs.ndk_root }}
+          ANDROID_NDK_HOME: ${{ steps.ndk.outputs.ndk_root }}
 
       - name: Build libarchive
         if: steps.libarchive-cache.outputs.cache-hit != 'true'
@@ -86,8 +116,8 @@ jobs:
           chmod +x build_libarchive_android.sh
           ./build_libarchive_android.sh
         env:
-          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
-          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_ROOT: ${{ steps.ndk.outputs.ndk_root }}
+          ANDROID_NDK_HOME: ${{ steps.ndk.outputs.ndk_root }}
 
       - name: Package jniLibs layout
         run: |

--- a/.github/workflows/build-libarchive-android-release.yml
+++ b/.github/workflows/build-libarchive-android-release.yml
@@ -52,37 +52,7 @@ jobs:
         with:
           ndk-version: r29
           add-to-path: true
-          local-cache: false
-
-      # Resolve NDK root: ndk-path may point at a parent; we need the dir that contains both
-      # build/cmake/android.toolchain.cmake and toolchains/llvm/prebuilt/<host>/bin/clang.
-      - name: Resolve and validate NDK root
-        id: ndk
-        run: |
-          BASE="${{ steps.setup-ndk.outputs.ndk-path }}"
-          TOOLCHAIN_FILE="build/cmake/android.toolchain.cmake"
-          CLANG_REL="toolchains/llvm/prebuilt/linux-x86_64/bin/clang"
-          check_ndk_root() {
-            local r="$1"
-            [ -f "$r/$TOOLCHAIN_FILE" ] && [ -f "$r/$CLANG_REL" ]
-          }
-          if check_ndk_root "$BASE"; then
-            echo "ndk_root=$BASE" >> $GITHUB_OUTPUT
-            echo "NDK root: $BASE"
-            exit 0
-          fi
-          while IFS= read -r -d '' f; do
-            ROOT="$(cd "$(dirname "$f")/../.." && pwd)"
-            if check_ndk_root "$ROOT"; then
-              echo "ndk_root=$ROOT" >> $GITHUB_OUTPUT
-              echo "NDK root: $ROOT (resolved under ndk-path)"
-              exit 0
-            fi
-          done < <(find "$BASE" -maxdepth 5 -type f -path "*/build/cmake/android.toolchain.cmake" -print0 2>/dev/null)
-          echo "::error::NDK validation failed. Under $BASE no directory has both $TOOLCHAIN_FILE and $CLANG_REL"
-          echo "Contents of $BASE:"
-          ls -laR "$BASE" 2>/dev/null | head -80
-          exit 1
+          local-cache: false  # disable local cache to avoid linking errors: https://github.com/nttld/setup-ndk/issues/518#event-16541651206
 
       - name: Get submodule versions
         id: submodules
@@ -106,8 +76,8 @@ jobs:
           chmod +x build_zstd.sh
           ./build_zstd.sh
         env:
-          ANDROID_NDK_ROOT: ${{ steps.ndk.outputs.ndk_root }}
-          ANDROID_NDK_HOME: ${{ steps.ndk.outputs.ndk_root }}
+          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
       - name: Build libarchive
         if: steps.libarchive-cache.outputs.cache-hit != 'true'
@@ -116,8 +86,8 @@ jobs:
           chmod +x build_libarchive_android.sh
           ./build_libarchive_android.sh
         env:
-          ANDROID_NDK_ROOT: ${{ steps.ndk.outputs.ndk_root }}
-          ANDROID_NDK_HOME: ${{ steps.ndk.outputs.ndk_root }}
+          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
       - name: Package jniLibs layout
         run: |

--- a/.github/workflows/build-libarchive-android-release.yml
+++ b/.github/workflows/build-libarchive-android-release.yml
@@ -54,25 +54,6 @@ jobs:
           add-to-path: true
           local-cache: true
 
-      # Optional: resolve NDK root for libarchive (toolchain file). Zstd uses compilers from PATH (setup-ndk add-to-path).
-      - name: Resolve NDK root (for libarchive)
-        id: ndk-root
-        run: |
-          BASE="${{ steps.setup-ndk.outputs.ndk-path }}"
-          CLANG="$BASE/toolchains/llvm/prebuilt/linux-x86_64/bin/clang"
-          if [ -f "$CLANG" ]; then
-            echo "ndk_root=$BASE" >> $GITHUB_OUTPUT
-          else
-            FOUND=$(find "$BASE" -maxdepth 6 -type f -path "*/toolchains/llvm/prebuilt/*/bin/clang" 2>/dev/null | head -1)
-            if [ -n "$FOUND" ]; then
-              NDK_ROOT=$(cd "$(dirname "$FOUND")/../../../../.." && pwd)
-              echo "ndk_root=$NDK_ROOT" >> $GITHUB_OUTPUT
-            else
-              echo "ndk_root=$BASE" >> $GITHUB_OUTPUT
-            fi
-          fi
-          echo "Using NDK root: ${{ steps.ndk-root.outputs.ndk_root }}"
-
       - name: Get submodule versions
         id: submodules
         run: |
@@ -95,8 +76,8 @@ jobs:
           chmod +x build_zstd.sh
           ./build_zstd.sh
         env:
-          ANDROID_NDK_ROOT: ${{ steps.ndk-root.outputs.ndk_root }}
-          ANDROID_NDK_HOME: ${{ steps.ndk-root.outputs.ndk_root }}
+          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
       - name: Build libarchive
         if: steps.libarchive-cache.outputs.cache-hit != 'true'
@@ -105,8 +86,8 @@ jobs:
           chmod +x build_libarchive_android.sh
           ./build_libarchive_android.sh
         env:
-          ANDROID_NDK_ROOT: ${{ steps.ndk-root.outputs.ndk_root }}
-          ANDROID_NDK_HOME: ${{ steps.ndk-root.outputs.ndk_root }}
+          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
       - name: Package jniLibs layout
         run: |

--- a/.github/workflows/build-libarchive-android-release.yml
+++ b/.github/workflows/build-libarchive-android-release.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           ndk-version: r29
           add-to-path: true
-          local-cache: true
+          local-cache: false
 
       # Resolve NDK root: ndk-path may point at a parent; we need the dir that contains both
       # build/cmake/android.toolchain.cmake and toolchains/llvm/prebuilt/<host>/bin/clang.

--- a/.github/workflows/build-libarchive-android-release.yml
+++ b/.github/workflows/build-libarchive-android-release.yml
@@ -54,8 +54,8 @@ jobs:
           add-to-path: true
           local-cache: true
 
-      # nttld/setup-ndk may set ndk-path to a parent dir; resolve to the root that contains the compiler.
-      - name: Resolve NDK root
+      # Optional: resolve NDK root for libarchive (toolchain file). Zstd uses compilers from PATH (setup-ndk add-to-path).
+      - name: Resolve NDK root (for libarchive)
         id: ndk-root
         run: |
           BASE="${{ steps.setup-ndk.outputs.ndk-path }}"
@@ -64,13 +64,12 @@ jobs:
             echo "ndk_root=$BASE" >> $GITHUB_OUTPUT
           else
             FOUND=$(find "$BASE" -maxdepth 6 -type f -path "*/toolchains/llvm/prebuilt/*/bin/clang" 2>/dev/null | head -1)
-            if [ -z "$FOUND" ]; then
-              echo "::error::NDK compiler not found under $BASE"
-              exit 1
+            if [ -n "$FOUND" ]; then
+              NDK_ROOT=$(cd "$(dirname "$FOUND")/../../../../.." && pwd)
+              echo "ndk_root=$NDK_ROOT" >> $GITHUB_OUTPUT
+            else
+              echo "ndk_root=$BASE" >> $GITHUB_OUTPUT
             fi
-            # FOUND = .../toolchains/llvm/prebuilt/HOST/bin/clang -> NDK root = ... (5 levels up from file)
-            NDK_ROOT=$(cd "$(dirname "$FOUND")/../../../../.." && pwd)
-            echo "ndk_root=$NDK_ROOT" >> $GITHUB_OUTPUT
           fi
           echo "Using NDK root: ${{ steps.ndk-root.outputs.ndk_root }}"
 

--- a/.github/workflows/build-libarchive-android-release.yml
+++ b/.github/workflows/build-libarchive-android-release.yml
@@ -81,7 +81,7 @@ jobs:
           echo "zstd=$(git -C third_party/zstd rev-parse HEAD 2>/dev/null || echo 'none')" >> "$GITHUB_OUTPUT"
 
       - name: Cache libarchive prebuilts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: libarchive-cache
         with:
           path: |
@@ -134,7 +134,7 @@ jobs:
           find "$LAYOUT" -type f \( -name '*.so' -o -name '*.h' \) | head -50
 
       - name: Upload layout as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: libarchive-android-layout-${{ steps.tag.outputs.maven_version }}
           path: libarchive-android-layout/

--- a/.github/workflows/build-onnxruntime-android-release.yml
+++ b/.github/workflows/build-onnxruntime-android-release.yml
@@ -74,7 +74,7 @@ jobs:
           echo "Release tag: $RELEASE_TAG"
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -91,7 +91,7 @@ jobs:
           local-cache: true
 
       - name: Cache QNN SDK
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: qnn-cache
         with:
           path: qnn-sdk
@@ -128,7 +128,7 @@ jobs:
           echo "QNN SDK root: $QNN_ROOT"
 
       - name: Cache ONNX Runtime build output (AAR + all ABIs)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: ort-cache
         with:
           path: third_party/onnxruntime_prebuilt/android-arm64-qnn-nnapi-xnnpack
@@ -199,7 +199,6 @@ jobs:
             onnxruntime-android-qnn.zip
           draft: false
           prerelease: false
-          skip_duplicate: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-sherpa-onnx-android-release.yml
+++ b/.github/workflows/build-sherpa-onnx-android-release.yml
@@ -91,7 +91,7 @@ jobs:
           echo "sherpa=$(git -C third_party/sherpa-onnx rev-parse HEAD 2>/dev/null || echo 'none')" >> "$GITHUB_OUTPUT"
 
       - name: Cache QNN SDK
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: qnn-cache
         with:
           path: qnn-sdk
@@ -128,7 +128,7 @@ jobs:
           echo "QNN SDK root: $QNN_ROOT"
 
       - name: Cache sherpa-onnx prebuilts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: sherpa-cache
         with:
           path: third_party/sherpa-onnx-prebuilt/android
@@ -254,7 +254,6 @@ jobs:
             sherpa-onnx-${{ steps.tag.outputs.maven_version }}-java.aar
           draft: false
           prerelease: false
-          skip_duplicate: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/framework-ffmpeg-ios-framework.yml
+++ b/.github/workflows/framework-ffmpeg-ios-framework.yml
@@ -53,7 +53,7 @@ jobs:
           echo "opus=$(git -C third_party/opus rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Cache FFmpeg iOS prebuilts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: ffmpeg-cache
         with:
           path: |
@@ -110,7 +110,7 @@ jobs:
           cat third_party/ffmpeg_prebuilt/FFmpeg.xcframework/VERSION.txt
 
       - name: Upload XCFramework as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ffmpeg-xcframework-${{ steps.tag.outputs.version }}
           path: third_party/ffmpeg_prebuilt/FFmpeg.xcframework

--- a/.github/workflows/framework-libarchive-ios-framework.yml
+++ b/.github/workflows/framework-libarchive-ios-framework.yml
@@ -46,7 +46,31 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Using release tag: $RELEASE_TAG (version: $VERSION)"
 
+      - name: Get submodule versions
+        id: submodules
+        run: |
+          echo "libarchive=$(git -C third_party/libarchive rev-parse HEAD 2>/dev/null || echo 'none')" >> "$GITHUB_OUTPUT"
+          echo "zstd=$(git -C third_party/zstd rev-parse HEAD 2>/dev/null || echo 'none')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache libarchive + zstd prebuilts (iOS)
+        uses: actions/cache@v4
+        id: libarchive-ios-cache
+        with:
+          path: |
+            third_party/zstd_prebuilt/ios
+            third_party/libarchive_prebuilt/ios
+            third_party/libarchive_prebuilt/libarchive.xcframework
+          key: libarchive-ios-prebuilt-${{ steps.submodules.outputs.libarchive }}-${{ steps.submodules.outputs.zstd }}-${{ hashFiles('third_party/libarchive_prebuilt/build_libarchive_ios.sh', 'third_party/zstd_prebuilt/build_zstd_ios.sh') }}
+
+      - name: Build zstd (iOS)
+        if: steps.libarchive-ios-cache.outputs.cache-hit != 'true'
+        run: |
+          cd third_party/zstd_prebuilt
+          chmod +x build_zstd_ios.sh
+          ./build_zstd_ios.sh
+
       - name: Build libarchive iOS XCFramework
+        if: steps.libarchive-ios-cache.outputs.cache-hit != 'true'
         run: |
           chmod +x third_party/libarchive_prebuilt/build_libarchive_ios.sh
           third_party/libarchive_prebuilt/build_libarchive_ios.sh

--- a/.github/workflows/framework-libarchive-ios-framework.yml
+++ b/.github/workflows/framework-libarchive-ios-framework.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -53,7 +53,7 @@ jobs:
           echo "zstd=$(git -C third_party/zstd rev-parse HEAD 2>/dev/null || echo 'none')" >> "$GITHUB_OUTPUT"
 
       - name: Cache libarchive + zstd prebuilts (iOS)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: libarchive-ios-cache
         with:
           path: |
@@ -94,7 +94,6 @@ jobs:
           files: libarchive-ios.zip
           draft: false
           prerelease: false
-          skip_duplicate: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/framework-sherpa-onnx-ios-framework.yml
+++ b/.github/workflows/framework-sherpa-onnx-ios-framework.yml
@@ -47,8 +47,8 @@ jobs:
             VER="v${TAG#framework-v}"
           fi
           [ "${VER#v}" = "$VER" ] && VER="v$VER"
-          echo "SHERPA_ONNX_VERSION=$VER" >> $GITHUB_ENV
           echo "version=${VER#v}" >> $GITHUB_OUTPUT
+          echo "tag=$VER" >> $GITHUB_OUTPUT
           echo "Using sherpa-onnx version: $VER"
 
       - name: Use appropriate Xcode version
@@ -62,10 +62,10 @@ jobs:
 
       - name: Clone sherpa-onnx repository
         run: |
-          git clone --depth 1 --branch ${{ env.SHERPA_ONNX_VERSION }} https://github.com/k2-fsa/sherpa-onnx.git sherpa-onnx-source || \
+          git clone --depth 1 --branch ${{ steps.version.outputs.tag }} https://github.com/k2-fsa/sherpa-onnx.git sherpa-onnx-source || \
           git clone --depth 1 https://github.com/k2-fsa/sherpa-onnx.git sherpa-onnx-source
           cd sherpa-onnx-source
-          git checkout ${{ env.SHERPA_ONNX_VERSION }} || git checkout main
+          git checkout ${{ steps.version.outputs.tag }} || git checkout main
           git log -1 --oneline
 
       - name: Patch build-ios.sh to include C++ API library
@@ -319,7 +319,7 @@ jobs:
       - name: Create version info file
         run: |
           cat > ios/Frameworks/sherpa_onnx.xcframework/VERSION.txt << EOF
-          sherpa-onnx version: ${{ env.SHERPA_ONNX_VERSION }}
+          sherpa-onnx version: ${{ steps.version.outputs.tag }}
           Built on: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
           GitHub Actions Run: ${{ github.run_id }}
           Commit: ${{ github.sha }}
@@ -329,7 +329,7 @@ jobs:
       - name: Upload XCFramework as artifact
         uses: actions/upload-artifact@v7
         with:
-          name: sherpa-onnx-xcframework-${{ env.SHERPA_ONNX_VERSION }}
+          name: sherpa-onnx-xcframework-${{ steps.version.outputs.tag }}
           path: ios/Frameworks/sherpa_onnx.xcframework
           retention-days: 90
           compression-level: 6
@@ -344,7 +344,7 @@ jobs:
       - name: Upload framework archive as artifact
         uses: actions/upload-artifact@v7
         with:
-          name: sherpa-onnx-xcframework-zip-${{ env.SHERPA_ONNX_VERSION }}
+          name: sherpa-onnx-xcframework-zip-${{ steps.version.outputs.tag }}
           path: ios/Frameworks/sherpa_onnx.xcframework.zip
           retention-days: 90
 
@@ -376,7 +376,7 @@ jobs:
 
             ## Framework Details
 
-            - **Version:** ${{ env.SHERPA_ONNX_VERSION }}
+            - **Version:** ${{ steps.version.outputs.tag }}
             - **Architectures:** arm64 (device), arm64 + x86_64 (simulator)
             - **iOS Deployment Target:** 13.0+
             - **ONNX Runtime:** Included in this build
@@ -394,7 +394,7 @@ jobs:
         run: |
           echo "## sherpa-onnx XCFramework Build Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version:** ${{ env.SHERPA_ONNX_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** ${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Framework Location:** \`ios/Frameworks/sherpa_onnx.xcframework\`" >> $GITHUB_STEP_SUMMARY
           echo "- **GitHub Release:** [framework-v${{ steps.version.outputs.version }}](https://github.com/${{ github.repository }}/releases/tag/framework-v${{ steps.version.outputs.version }})" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/framework-sherpa-onnx-ios-framework.yml
+++ b/.github/workflows/framework-sherpa-onnx-ios-framework.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 1
@@ -327,7 +327,7 @@ jobs:
           cat ios/Frameworks/sherpa_onnx.xcframework/VERSION.txt
 
       - name: Upload XCFramework as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sherpa-onnx-xcframework-${{ env.SHERPA_ONNX_VERSION }}
           path: ios/Frameworks/sherpa_onnx.xcframework
@@ -342,7 +342,7 @@ jobs:
           ls -lh ios/Frameworks/sherpa_onnx.xcframework.zip
 
       - name: Upload framework archive as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sherpa-onnx-xcframework-zip-${{ env.SHERPA_ONNX_VERSION }}
           path: ios/Frameworks/sherpa_onnx.xcframework.zip

--- a/.github/workflows/sdk-android.yml
+++ b/.github/workflows/sdk-android.yml
@@ -36,7 +36,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Cache SherpaOnnx models
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: example/.model-cache
           key: ${{ runner.os }}-sherpa-models-${{ hashFiles('example/scripts/model-download-config.json', 'example/scripts/download-models.js') }}
@@ -70,7 +70,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -125,7 +125,7 @@ jobs:
           chmod +x gradlew.bat
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -248,7 +248,7 @@ jobs:
           fi
 
       - name: Upload Android APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-release-apk
           path: example/android/app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/sdk-ios.yml
+++ b/.github/workflows/sdk-ios.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Cache SherpaOnnx models
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: example/.model-cache
           key: ${{ runner.os }}-sherpa-models-${{ hashFiles('example/scripts/model-download-config.json', 'example/scripts/download-models.js') }}
@@ -208,7 +208,7 @@ jobs:
           fi
 
       - name: Upload iOS IPA artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-app-bundle
           path: example/ios/ipa/*.ipa

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract version from tag
         id: tag
@@ -79,7 +79,7 @@ jobs:
           echo "Tag: $TAG_NAME, Version: $VERSION"
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/sdk-sdk.yml
+++ b/.github/workflows/sdk-sdk.yml
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Cache SherpaOnnx models
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: example/.model-cache
           key: ${{ runner.os }}-sherpa-models-${{ hashFiles('example/scripts/model-download-config.json', 'example/scripts/download-models.js') }}
@@ -100,7 +100,7 @@ jobs:
           echo "artifact_path=artifacts/$TARFILE" >> $GITHUB_OUTPUT
 
       - name: Upload package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sdk-package
           path: ${{ steps.create_package_tarball.outputs.artifact_path }}

--- a/.github/workflows/test-sdk-integration.yml
+++ b/.github/workflows/test-sdk-integration.yml
@@ -34,12 +34,12 @@ jobs:
           submodules: recursive
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: react-native-sherpa-onnx/.nvmrc
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -143,13 +143,13 @@ jobs:
 
       - name: Upload Logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testproject-android-build-logs
           path: /tmp/testproject-build-android.log
 
       - name: Upload APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testproject-release-apk
           path: TestProject/android/app/build/outputs/apk/release/app-release.apk
@@ -172,7 +172,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: react-native-sherpa-onnx/.nvmrc
 
@@ -278,7 +278,7 @@ jobs:
 
       - name: Upload Logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testproject-ios-build-logs
           path: /tmp/testproject-build-ios.log

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,16 @@ third_party/shine_prebuilt/*
 !third_party/shine_prebuilt/build_shine.sh
 !third_party/shine_prebuilt/build_shine_ios.sh
 
+# ignore everything under zstd_prebuilt by default
+third_party/zstd_prebuilt/*
+!third_party/zstd_prebuilt/README.md
+!third_party/zstd_prebuilt/build_zstd.sh
+!third_party/zstd_prebuilt/build_zstd_ios.sh
+third_party/zstd_prebuilt/android/
+third_party/zstd_prebuilt/ios/
+third_party/zstd_prebuilt/build-*/
+third_party/zstd_prebuilt/build_ios/
+
 # ONNX Runtime prebuilt build artifacts (when building prebuilts locally)
 third_party/onnxruntime_prebuilt/*
 !third_party/onnxruntime_prebuilt/README.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "third_party/opus"]
 	path = third_party/opus
 	url = https://github.com/xiph/opus
+[submodule "third_party/zstd"]
+	path = third_party/zstd
+	url = https://github.com/facebook/zstd.git

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To build the sherpa-onnx iOS XCFramework yourself (e.g. custom version or patche
 | Text-to-Speech | ✅ **Supported** | Multiple model types (VITS, Matcha, Kokoro, etc.). See [Supported Model Types](#supported-model-types) and [TTS documentation](./docs/tts.md). |
 | Streaming Text-to-Speech | ✅ **Supported** | Incremental speech generation for low time-to-first-byte and playback while generating. See [Streaming TTS](./docs/tts-streaming.md). |
 | Execution providers (CPU, NNAPI, XNNPACK, Core ML, QNN) | ✅ **Supported** | See [Execution provider support](./docs/execution-providers.md). |
-| Play Asset Delivery (PAD) | ✅ **Supported** | Android only. See [Model Setup](./docs/model-setup.md). |
+| Play Asset Delivery (PAD) | ✅ **Supported** | Android only. See [Model Setup](./docs/model-setup.md) & [Extraction API](./docs/extraction.md). |
 | Automatic Model type detection | ✅ **Supported** | `detectSttModel()` and `detectTtsModel()` for a path. See [Model Setup: Model type detection](./docs/model-setup.md#model-detection). |
 | Model quantization | ✅ **Supported** | Automatic detection and preference for quantized (int8) models. |
 | Flexible model loading | ✅ **Supported** | Asset models, file system models, or auto-detection. |
@@ -166,6 +166,7 @@ For **streaming TTS** (incremental generation, low latency), use `createStreamin
 - [Source Separation](./docs/separation.md)
 - [Model Setup](./docs/model-setup.md) – Bundled assets, Play Asset Delivery (PAD), model discovery APIs, and troubleshooting
 - [Model Download Manager](./docs/download-manager.md)
+- [Extraction API](./docs/extraction.md)
 - [Disable FFMPEG](./docs/disable-ffmpeg.md)
 - [Disable LIBARCHIVE](./docs/disable-libarchive.md)
 

--- a/android/prebuilt-download.gradle
+++ b/android/prebuilt-download.gradle
@@ -14,7 +14,7 @@ def requiredFfmpegSoFiles = [
 def requiredSherpaOnnxSoFiles = [
   'libsherpa-onnx-jni.so', 'libsherpa-onnx-c-api.so', 'libsherpa-onnx-cxx-api.so', 'libonnxruntime.so'
 ]
-def requiredLibarchiveSoFiles = ['libarchive.so']
+def requiredLibarchiveSoFiles = ['libarchive.so', 'libzstd.so']
 def requiredOnnxruntimeJniSoFiles = ['libonnxruntime4j_jni.so']
 
 def jniLibsDir = file("${project.projectDir}/src/main/jniLibs")

--- a/android/prebuilt-versions.gradle
+++ b/android/prebuilt-versions.gradle
@@ -36,7 +36,7 @@ println "[react-native-sherpa-onnx] ffmpeg version (extracted/used): ${ffmpegVer
 def libarchiveVersion = System.getenv('LIBARCHIVE_VERSION')
 if (!libarchiveVersion) {
   def v = readVersionFromTagFile(new File(moduleRoot, 'third_party/libarchive_prebuilt/ANDROID_RELEASE_TAG'), 'libarchive-android-v')
-  libarchiveVersion = v ?: (project.hasProperty('libarchiveVersion') ? project.libarchiveVersion : '3.8.5')
+  libarchiveVersion = v ?: (project.hasProperty('libarchiveVersion') ? project.libarchiveVersion : '3.8.5-2')
 }
 project.ext.libarchiveVersion = libarchiveVersion
 println "[react-native-sherpa-onnx] libarchive version (extracted/used): ${libarchiveVersion}"

--- a/android/src/main/cpp/jni/archive/sherpa-onnx-archive-helper.cpp
+++ b/android/src/main/cpp/jni/archive/sherpa-onnx-archive-helper.cpp
@@ -101,6 +101,12 @@ static la_ssize_t ArchiveStreamReadCallback(struct archive* archive, void* clien
   archive_set_error(archive, EINVAL, "Stream read error");
   return -1;
 }
+
+// No-op close callback for stream mode: the stream lifetime is managed by the
+// caller (e.g. a JNI InputStream), so libarchive must not close it.
+static int ArchiveStreamCloseCallback(struct archive* /* archive */, void* /* client_data */) {
+  return ARCHIVE_OK;
+}
 #endif  // HAVE_LIBARCHIVE
 
 static std::string ToHex(const unsigned char* data, size_t size) {
@@ -501,7 +507,7 @@ bool ArchiveHelper::ExtractFromStream(
   stream_ctx.user_data = read_user_data;
   sha256_init(&stream_ctx.sha_ctx);
 
-  if (archive_read_open(archive, &stream_ctx, nullptr, ArchiveStreamReadCallback, ArchiveCloseCallback) != ARCHIVE_OK) {
+  if (archive_read_open(archive, &stream_ctx, nullptr, ArchiveStreamReadCallback, ArchiveStreamCloseCallback) != ARCHIVE_OK) {
     const char* err = archive_error_string(archive);
     if (out_error) *out_error = err ? std::string("Failed to open archive: ") + err : "Failed to open archive";
     archive_read_free(archive);
@@ -622,10 +628,9 @@ bool ArchiveHelper::ExtractFromStream(
             last_percent = percent;
             on_progress(compressed_bytes, total_bytes, static_cast<double>(percent));
           }
-        } else if (extracted_bytes - last_emit_bytes >= 1024 * 1024) {
-          last_emit_bytes = extracted_bytes;
-          long long compressed_bytes = archive_filter_bytes(archive, -1);
-          on_progress(compressed_bytes, 0, 0.0);
+        } else if (stream_ctx.bytes_read - last_emit_bytes >= 1024 * 1024) {
+          last_emit_bytes = stream_ctx.bytes_read;
+          on_progress(stream_ctx.bytes_read, 0, 0.0);
         }
       }
     }
@@ -664,8 +669,7 @@ bool ArchiveHelper::ExtractFromStream(
   }
 
   if (on_progress) {
-    long long compressed_bytes = stream_ctx.bytes_read;
-    on_progress(extracted_bytes, compressed_bytes, 100.0);
+    on_progress(stream_ctx.bytes_read, stream_ctx.bytes_read, 100.0);
   }
 
   return true;

--- a/android/src/main/cpp/jni/archive/sherpa-onnx-archive-helper.cpp
+++ b/android/src/main/cpp/jni/archive/sherpa-onnx-archive-helper.cpp
@@ -75,6 +75,32 @@ static void DrainRemainingAndClose(ArchiveReadContext* ctx) {
   fclose(ctx->file);
   ctx->file = nullptr;
 }
+
+struct StreamReadContext {
+  std::array<unsigned char, 64 * 1024> buffer{};
+  Sha256Context sha_ctx{};
+  long long bytes_read = 0;
+  ArchiveHelper::StreamReadCallback read_cb = nullptr;
+  void* user_data = nullptr;
+};
+
+static la_ssize_t ArchiveStreamReadCallback(struct archive* archive, void* client_data, const void** buff) {
+  auto* ctx = static_cast<StreamReadContext*>(client_data);
+  if (!ctx || !ctx->read_cb) {
+    archive_set_error(archive, EINVAL, "Invalid stream read context");
+    return -1;
+  }
+  std::ptrdiff_t n = ctx->read_cb(ctx->buffer.data(), ctx->buffer.size(), ctx->user_data);
+  if (n > 0) {
+    sha256_update(&ctx->sha_ctx, ctx->buffer.data(), static_cast<size_t>(n));
+    ctx->bytes_read += static_cast<long long>(n);
+    *buff = ctx->buffer.data();
+    return static_cast<la_ssize_t>(n);
+  }
+  if (n == 0) return 0;
+  archive_set_error(archive, EINVAL, "Stream read error");
+  return -1;
+}
 #endif  // HAVE_LIBARCHIVE
 
 static std::string ToHex(const unsigned char* data, size_t size) {
@@ -122,13 +148,15 @@ bool ArchiveHelper::ExtractTarBz2(
     return false;
   }
 
-  // Check target directory
+  // If target exists and is a directory, extract into it (merge). Otherwise require empty or force-remove.
   if (std::filesystem::exists(target_path)) {
-    if (force) {
+    if (std::filesystem::is_directory(target_path)) {
+      // Merge: extract into existing directory (e.g. multiple archives → same base path)
+    } else if (force) {
       std::error_code ec;
       std::filesystem::remove_all(target_path, ec);
       if (ec) {
-        if (out_error) *out_error = "Failed to remove target directory: " + ec.message();
+        if (out_error) *out_error = "Failed to remove target path: " + ec.message();
         return false;
       }
     } else {
@@ -137,7 +165,6 @@ bool ArchiveHelper::ExtractTarBz2(
     }
   }
 
-  // Create target directory
   std::error_code ec;
   std::filesystem::create_directories(target_path, ec);
   if (ec) {
@@ -355,6 +382,18 @@ bool ArchiveHelper::ExtractTarBz2(
       close_reader();
       return false;
     }
+
+    result = archive_write_finish_entry(disk);
+    if (result != ARCHIVE_OK && result != ARCHIVE_WARN) {
+      const char* err = archive_error_string(disk);
+      if (out_error) {
+        *out_error = err ? std::string("Failed to finish entry: ") + err : "Failed to finish entry";
+      }
+      archive_read_free(archive);
+      archive_write_free(disk);
+      close_reader();
+      return false;
+    }
   }
 
   archive_read_free(archive);
@@ -385,6 +424,252 @@ bool ArchiveHelper::ExtractTarZst(
     std::string* out_error,
     std::string* out_sha256) {
   return ExtractTarBz2(source_path, target_path, force, on_progress, out_error, out_sha256);
+}
+
+bool ArchiveHelper::ExtractFromStream(
+    StreamReadCallback read_cb,
+    void* read_user_data,
+    const std::string& target_path,
+    bool force,
+    std::function<void(long long, long long, double)> on_progress,
+    std::string* out_error,
+    std::string* out_sha256) {
+  cancel_requested_.store(false);
+
+#ifndef HAVE_LIBARCHIVE
+  (void)read_cb;
+  (void)read_user_data;
+  (void)target_path;
+  (void)force;
+  (void)on_progress;
+  (void)out_sha256;
+  if (out_error) *out_error = "libarchive not available. Build with libarchive or set sherpaOnnxDisableLibarchive=false in gradle.properties. See docs/disable-libarchive.md.";
+  return false;
+#else
+  if (!read_cb) {
+    if (out_error) *out_error = "Stream read callback is null";
+    return false;
+  }
+
+  if (std::filesystem::exists(target_path)) {
+    if (std::filesystem::is_directory(target_path)) {
+      // Merge: extract into existing directory (e.g. multiple archives → same base path)
+    } else if (force) {
+      std::error_code ec;
+      std::filesystem::remove_all(target_path, ec);
+      if (ec) {
+        if (out_error) *out_error = "Failed to remove target path: " + ec.message();
+        return false;
+      }
+    } else {
+      if (out_error) *out_error = "Target path already exists";
+      return false;
+    }
+  }
+
+  std::error_code ec;
+  std::filesystem::create_directories(target_path, ec);
+  if (ec) {
+    if (out_error) *out_error = "Failed to create target directory: " + ec.message();
+    return false;
+  }
+
+#ifndef NDEBUG
+  __android_log_print(ANDROID_LOG_INFO, "SherpaOnnx",
+                      "ExtractFromStream target_path=%s", target_path.c_str());
+#endif
+
+  std::string canonical_target = std::filesystem::canonical(target_path).string();
+  if (canonical_target.back() != '/') canonical_target += '/';
+
+  const long long total_bytes = 0;
+
+  struct archive* archive = archive_read_new();
+  if (!archive) {
+    if (out_error) *out_error = "Failed to create archive reader";
+    return false;
+  }
+
+  archive_read_support_format_tar(archive);
+  archive_read_support_filter_bzip2(archive);
+  archive_read_support_filter_gzip(archive);
+  archive_read_support_filter_xz(archive);
+  archive_read_support_filter_zstd(archive);
+
+  StreamReadContext stream_ctx;
+  stream_ctx.read_cb = read_cb;
+  stream_ctx.user_data = read_user_data;
+  sha256_init(&stream_ctx.sha_ctx);
+
+  if (archive_read_open(archive, &stream_ctx, nullptr, ArchiveStreamReadCallback, ArchiveCloseCallback) != ARCHIVE_OK) {
+    const char* err = archive_error_string(archive);
+    if (out_error) *out_error = err ? std::string("Failed to open archive: ") + err : "Failed to open archive";
+    archive_read_free(archive);
+    return false;
+  }
+
+  struct archive* disk = archive_write_disk_new();
+  if (!disk) {
+    if (out_error) *out_error = "Failed to create disk writer";
+    archive_read_free(archive);
+    return false;
+  }
+
+  archive_write_disk_set_options(disk,
+                                  ARCHIVE_EXTRACT_TIME |
+                                  ARCHIVE_EXTRACT_PERM |
+                                  ARCHIVE_EXTRACT_ACL |
+                                  ARCHIVE_EXTRACT_FFLAGS);
+  archive_write_disk_set_standard_lookup(disk);
+
+  struct archive_entry* entry = nullptr;
+  int result = ARCHIVE_OK;
+  long long extracted_bytes = 0;
+  int last_percent = -1;
+  long long last_emit_bytes = 0;
+  int entry_index = 0;
+
+  while ((result = archive_read_next_header(archive, &entry)) == ARCHIVE_OK) {
+    if (cancel_requested_.load()) {
+      if (out_error) *out_error = "Extraction cancelled";
+      archive_read_free(archive);
+      archive_write_free(disk);
+      return false;
+    }
+
+    const char* current_path = archive_entry_pathname(entry);
+    if (!current_path) {
+      archive_read_free(archive);
+      archive_write_free(disk);
+      if (out_error) *out_error = "Invalid entry path";
+      return false;
+    }
+
+    std::string entry_path(current_path);
+    std::string full_path = target_path;
+    if (full_path.back() != '/') full_path += '/';
+    full_path += entry_path;
+
+    std::string canonical_entry;
+    try {
+      std::filesystem::path p(full_path);
+      std::filesystem::path parent = p.parent_path();
+      if (std::filesystem::exists(parent)) {
+        canonical_entry = std::filesystem::canonical(parent).string();
+      } else {
+        while (!std::filesystem::exists(parent) && parent != parent.parent_path()) {
+          parent = parent.parent_path();
+        }
+        if (std::filesystem::exists(parent)) {
+          canonical_entry = std::filesystem::canonical(parent).string();
+        } else {
+          canonical_entry = canonical_target;
+        }
+      }
+      canonical_entry += '/';
+      canonical_entry += p.filename().string();
+    } catch (const std::exception&) {
+      canonical_entry = full_path;
+    }
+
+    if (canonical_entry.find(canonical_target) != 0) {
+      archive_read_free(archive);
+      archive_write_free(disk);
+      if (out_error) *out_error = "Blocked path traversal: " + entry_path;
+      return false;
+    }
+
+    archive_entry_set_pathname(entry, full_path.c_str());
+
+    result = archive_write_header(disk, entry);
+    if (result != ARCHIVE_OK) {
+      const char* err = archive_error_string(disk);
+      if (out_error) *out_error = err ? std::string("Failed to write entry: ") + err : "Failed to write entry";
+      archive_read_free(archive);
+      archive_write_free(disk);
+      return false;
+    }
+
+    const void* buff = nullptr;
+    size_t size = 0;
+    la_int64_t offset = 0;
+
+    while ((result = archive_read_data_block(archive, &buff, &size, &offset)) == ARCHIVE_OK) {
+      if (cancel_requested_.load()) {
+        if (out_error) *out_error = "Extraction cancelled";
+        archive_read_free(archive);
+        archive_write_free(disk);
+        return false;
+      }
+
+      result = archive_write_data_block(disk, buff, size, offset);
+      if (result != ARCHIVE_OK) {
+        const char* err = archive_error_string(disk);
+        if (out_error) *out_error = err ? std::string("Failed to write data: ") + err : "Failed to write data";
+        archive_read_free(archive);
+        archive_write_free(disk);
+        return false;
+      }
+
+      extracted_bytes += static_cast<long long>(size);
+
+      if (on_progress) {
+        if (total_bytes > 0) {
+          long long compressed_bytes = archive_filter_bytes(archive, -1);
+          int percent = static_cast<int>(total_bytes > 0 ? (compressed_bytes * 100) / total_bytes : 0);
+          percent = (percent > 100) ? 100 : ((percent < 0) ? 0 : percent);
+          if (percent != last_percent) {
+            last_percent = percent;
+            on_progress(compressed_bytes, total_bytes, static_cast<double>(percent));
+          }
+        } else if (extracted_bytes - last_emit_bytes >= 1024 * 1024) {
+          last_emit_bytes = extracted_bytes;
+          long long compressed_bytes = archive_filter_bytes(archive, -1);
+          on_progress(compressed_bytes, 0, 0.0);
+        }
+      }
+    }
+
+    if (result != ARCHIVE_EOF && result != ARCHIVE_OK) {
+      const char* err = archive_error_string(archive);
+      if (out_error) *out_error = err ? std::string("Failed to read data: ") + err : "Failed to read data";
+      archive_read_free(archive);
+      archive_write_free(disk);
+      return false;
+    }
+
+    result = archive_write_finish_entry(disk);
+    if (result != ARCHIVE_OK && result != ARCHIVE_WARN) {
+      const char* err = archive_error_string(disk);
+      if (out_error) *out_error = err ? std::string("Failed to finish entry: ") + err : "Failed to finish entry";
+      archive_read_free(archive);
+      archive_write_free(disk);
+      return false;
+    }
+    entry_index++;
+  }
+
+#ifndef NDEBUG
+  __android_log_print(ANDROID_LOG_INFO, "SherpaOnnx",
+                      "ExtractFromStream done entries=%d", entry_index);
+#endif
+
+  archive_read_free(archive);
+  archive_write_free(disk);
+
+  if (out_sha256) {
+    unsigned char digest[32];
+    sha256_final(&stream_ctx.sha_ctx, digest);
+    *out_sha256 = ToHex(digest, sizeof(digest));
+  }
+
+  if (on_progress) {
+    long long compressed_bytes = stream_ctx.bytes_read;
+    on_progress(extracted_bytes, compressed_bytes, 100.0);
+  }
+
+  return true;
+#endif
 }
 
 bool ArchiveHelper::ComputeFileSha256(

--- a/android/src/main/cpp/jni/archive/sherpa-onnx-archive-helper.cpp
+++ b/android/src/main/cpp/jni/archive/sherpa-onnx-archive-helper.cpp
@@ -167,11 +167,12 @@ bool ArchiveHelper::ExtractTarBz2(
     return false;
   }
 
-  // Configure archive to support tar and bzip2
+  // Configure archive to support tar and common compression (bzip2, gzip, xz, zstd)
   archive_read_support_format_tar(archive);
   archive_read_support_filter_bzip2(archive);
   archive_read_support_filter_gzip(archive);  // Also support gzip for compatibility
-  archive_read_support_filter_xz(archive);    // And xz
+  archive_read_support_filter_xz(archive);   // And xz
+  archive_read_support_filter_zstd(archive); // And zstd (.tar.zst)
 
   ArchiveReadContext read_ctx;
   read_ctx.file = fopen(source_path.c_str(), "rb");
@@ -374,6 +375,16 @@ bool ArchiveHelper::ExtractTarBz2(
 
   return true;
 #endif  // HAVE_LIBARCHIVE
+}
+
+bool ArchiveHelper::ExtractTarZst(
+    const std::string& source_path,
+    const std::string& target_path,
+    bool force,
+    std::function<void(long long, long long, double)> on_progress,
+    std::string* out_error,
+    std::string* out_sha256) {
+  return ExtractTarBz2(source_path, target_path, force, on_progress, out_error, out_sha256);
 }
 
 bool ArchiveHelper::ComputeFileSha256(

--- a/android/src/main/cpp/jni/archive/sherpa-onnx-archive-helper.h
+++ b/android/src/main/cpp/jni/archive/sherpa-onnx-archive-helper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <functional>
 #include <atomic>
@@ -10,6 +11,9 @@
  */
 class ArchiveHelper {
  public:
+  /** Callback to read bytes from a stream (e.g. Java InputStream via JNI). Returns bytes read, 0 on EOF, -1 on error. */
+  using StreamReadCallback = std::ptrdiff_t (*)(void* buf, size_t len, void* user_data);
+
   /**
    * Extract tar.bz2 (or .tar.zst, .tar.gz, .tar.xz) file to target directory.
    *
@@ -34,6 +38,19 @@ class ArchiveHelper {
    */
   static bool ExtractTarZst(
       const std::string& source_path,
+      const std::string& target_path,
+      bool force,
+      std::function<void(long long, long long, double)> on_progress = nullptr,
+      std::string* out_error = nullptr,
+      std::string* out_sha256 = nullptr);
+
+  /**
+   * Extract a tar archive (tar.zst or tar.bz2) from a stream via read_cb.
+   * Used for Android AssetManager streams; total_bytes can be 0 (progress then uses compressed bytes or periodic emit).
+   */
+  static bool ExtractFromStream(
+      StreamReadCallback read_cb,
+      void* read_user_data,
       const std::string& target_path,
       bool force,
       std::function<void(long long, long long, double)> on_progress = nullptr,

--- a/android/src/main/cpp/jni/archive/sherpa-onnx-archive-helper.h
+++ b/android/src/main/cpp/jni/archive/sherpa-onnx-archive-helper.h
@@ -11,13 +11,13 @@
 class ArchiveHelper {
  public:
   /**
-   * Extract tar.bz2 file to target directory
+   * Extract tar.bz2 (or .tar.zst, .tar.gz, .tar.xz) file to target directory.
    *
-   * @param sourcePath Path to the .tar.bz2 file
+   * @param sourcePath Path to the archive file
    * @param targetPath Destination directory path
    * @param force Whether to overwrite existing target directory
    * @param onProgress Callback for progress updates (bytesExtracted, totalBytes, percent)
-    * @param outSha256 Optional output SHA-256 hex of the archive file
+   * @param outSha256 Optional output SHA-256 hex of the archive file
    * @return true if extraction succeeded, false otherwise
    */
   static bool ExtractTarBz2(
@@ -28,7 +28,19 @@ class ArchiveHelper {
       std::string* out_error = nullptr,
       std::string* out_sha256 = nullptr);
 
-    /**
+  /**
+   * Extract .tar.zst (or other supported tar compression) file to target directory.
+   * Uses the same implementation as ExtractTarBz2 (libarchive supports zstd when built with ENABLE_ZSTD).
+   */
+  static bool ExtractTarZst(
+      const std::string& source_path,
+      const std::string& target_path,
+      bool force,
+      std::function<void(long long, long long, double)> on_progress = nullptr,
+      std::string* out_error = nullptr,
+      std::string* out_sha256 = nullptr);
+
+  /**
      * Compute SHA-256 of a file.
      *
      * @param file_path Path to the file

--- a/android/src/main/cpp/jni/archive/sherpa-onnx-archive-jni.cpp
+++ b/android/src/main/cpp/jni/archive/sherpa-onnx-archive-jni.cpp
@@ -250,6 +250,173 @@ Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeExtractTarZst(
   env->DeleteLocalRef(writeable_map_class);
 }
 
+namespace {
+struct InputStreamReadContext {
+  JNIEnv* env = nullptr;
+  jobject stream_global = nullptr;
+  jmethodID read_method = nullptr;
+  jbyteArray byte_array = nullptr;
+  const size_t buffer_size = 64 * 1024;
+};
+
+static std::ptrdiff_t JniStreamRead(void* buf, size_t len, void* user_data) {
+  auto* ctx = static_cast<InputStreamReadContext*>(user_data);
+  if (!ctx || !ctx->env || !ctx->stream_global || !ctx->read_method || !ctx->byte_array) {
+    return -1;
+  }
+  size_t to_read = (len < ctx->buffer_size) ? len : ctx->buffer_size;
+  jint n = ctx->env->CallIntMethod(ctx->stream_global, ctx->read_method, ctx->byte_array);
+  if (ctx->env->ExceptionCheck()) {
+    ctx->env->ExceptionClear();
+    return -1;
+  }
+  if (n <= 0) return 0;
+  ctx->env->GetByteArrayRegion(ctx->byte_array, 0, n, static_cast<jbyte*>(buf));
+  return static_cast<std::ptrdiff_t>(n);
+}
+}  // namespace
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeExtractTarZstFromStream(
+    JNIEnv* env,
+    jobject /* jthis */,
+    jobject j_input_stream,
+    jstring j_target_path,
+    jboolean j_force,
+    jobject j_progress_callback,
+    jobject j_promise) {
+  const char* target_path = env->GetStringUTFChars(j_target_path, nullptr);
+  std::string target_str(target_path);
+  env->ReleaseStringUTFChars(j_target_path, target_path);
+
+  jobject stream_global = env->NewGlobalRef(j_input_stream);
+  jclass stream_class = env->GetObjectClass(j_input_stream);
+  jmethodID read_method = env->GetMethodID(stream_class, "read", "([B)I");
+  env->DeleteLocalRef(stream_class);
+  if (!read_method) {
+    env->DeleteGlobalRef(stream_global);
+    jclass promise_class = env->GetObjectClass(j_promise);
+    jmethodID reject_method = env->GetMethodID(promise_class, "reject", "(Ljava/lang/String;Ljava/lang/String;)V");
+    env->CallVoidMethod(j_promise, reject_method,
+                        env->NewStringUTF("ARCHIVE_ERROR"),
+                        env->NewStringUTF("InputStream.read([B)I not found"));
+    env->DeleteLocalRef(promise_class);
+    return;
+  }
+
+  jbyteArray byte_array = env->NewByteArray(static_cast<jsize>(64 * 1024));
+  if (!byte_array) {
+    env->DeleteGlobalRef(stream_global);
+    return;
+  }
+
+  InputStreamReadContext read_ctx;
+  read_ctx.env = env;
+  read_ctx.stream_global = stream_global;
+  read_ctx.read_method = read_method;
+  read_ctx.byte_array = byte_array;
+
+  jmethodID on_progress_method = nullptr;
+  jobject j_progress_callback_global = nullptr;
+  if (j_progress_callback != nullptr) {
+    jclass callback_class = env->GetObjectClass(j_progress_callback);
+    on_progress_method = env->GetMethodID(callback_class, "invoke", "(JJD)V");
+    env->DeleteLocalRef(callback_class);
+    j_progress_callback_global = env->NewGlobalRef(j_progress_callback);
+  }
+
+  jclass promise_class = env->GetObjectClass(j_promise);
+  jmethodID resolve_method = env->GetMethodID(promise_class, "resolve", "(Ljava/lang/Object;)V");
+  jmethodID reject_method = env->GetMethodID(promise_class, "reject", "(Ljava/lang/String;Ljava/lang/String;)V");
+
+  jclass arguments_class = env->FindClass("com/facebook/react/bridge/Arguments");
+  jmethodID create_map_method = env->GetStaticMethodID(arguments_class, "createMap", "()Lcom/facebook/react/bridge/WritableMap;");
+  jobject result_map = env->CallStaticObjectMethod(arguments_class, create_map_method);
+
+  jclass writeable_map_class = env->FindClass("com/facebook/react/bridge/WritableMap");
+  jmethodID put_boolean_method = env->GetMethodID(writeable_map_class, "putBoolean", "(Ljava/lang/String;Z)V");
+  jmethodID put_string_method = env->GetMethodID(writeable_map_class, "putString", "(Ljava/lang/String;Ljava/lang/String;)V");
+
+  auto on_progress = [j_progress_callback_global, on_progress_method](
+      long long bytes_extracted, long long total_bytes, double percent) {
+    if (j_progress_callback_global != nullptr && on_progress_method != nullptr) {
+      JNIEnv* callback_env = nullptr;
+      bool should_detach = false;
+      if (g_vm->GetEnv(reinterpret_cast<void**>(&callback_env), JNI_VERSION_1_6) == JNI_EDETACHED) {
+        if (g_vm->AttachCurrentThread(&callback_env, nullptr) == JNI_OK) {
+          should_detach = true;
+        } else {
+          return;
+        }
+      }
+      if (callback_env != nullptr) {
+        callback_env->CallVoidMethod(j_progress_callback_global, on_progress_method,
+                            bytes_extracted, total_bytes, percent);
+        if (callback_env->ExceptionCheck()) {
+          callback_env->ExceptionClear();
+        }
+        if (should_detach) {
+          g_vm->DetachCurrentThread();
+        }
+      }
+    }
+  };
+
+  std::string error_msg;
+  std::string sha256;
+  bool success = ArchiveHelper::ExtractFromStream(
+      &JniStreamRead,
+      &read_ctx,
+      target_str,
+      j_force == JNI_TRUE,
+      on_progress,
+      &error_msg,
+      &sha256);
+
+  env->CallVoidMethod(result_map, put_boolean_method,
+                      env->NewStringUTF("success"), success ? JNI_TRUE : JNI_FALSE);
+
+  if (success) {
+    env->CallVoidMethod(result_map, put_string_method,
+                        env->NewStringUTF("path"), env->NewStringUTF(target_str.c_str()));
+    if (!sha256.empty()) {
+      env->CallVoidMethod(result_map, put_string_method,
+                          env->NewStringUTF("sha256"), env->NewStringUTF(sha256.c_str()));
+    }
+    env->CallVoidMethod(j_promise, resolve_method, result_map);
+  } else {
+    __android_log_print(ANDROID_LOG_WARN, "SherpaOnnxNative", "[ARCHIVE_ERROR] %s", error_msg.c_str());
+    env->CallVoidMethod(result_map, put_string_method,
+                        env->NewStringUTF("reason"), env->NewStringUTF(error_msg.c_str()));
+    env->CallVoidMethod(j_promise, reject_method,
+                        env->NewStringUTF("ARCHIVE_ERROR"),
+                        env->NewStringUTF(error_msg.c_str()));
+  }
+
+  env->DeleteGlobalRef(stream_global);
+  env->DeleteLocalRef(byte_array);
+  if (j_progress_callback_global != nullptr) {
+    env->DeleteGlobalRef(j_progress_callback_global);
+  }
+  env->DeleteLocalRef(result_map);
+  env->DeleteLocalRef(promise_class);
+  env->DeleteLocalRef(arguments_class);
+  env->DeleteLocalRef(writeable_map_class);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeExtractTarBz2FromStream(
+    JNIEnv* env,
+    jobject jthis,
+    jobject j_input_stream,
+    jstring j_target_path,
+    jboolean j_force,
+    jobject j_progress_callback,
+    jobject j_promise) {
+  Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeExtractTarZstFromStream(
+      env, jthis, j_input_stream, j_target_path, j_force, j_progress_callback, j_promise);
+}
+
 extern "C" JNIEXPORT void JNICALL
 Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeCancelExtract(JNIEnv* /* env */, jobject /* jthis */) {
   ArchiveHelper::Cancel();

--- a/android/src/main/cpp/jni/archive/sherpa-onnx-archive-jni.cpp
+++ b/android/src/main/cpp/jni/archive/sherpa-onnx-archive-jni.cpp
@@ -49,11 +49,9 @@ Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeExtractTarBz2(
     j_progress_callback_global = env->NewGlobalRef(j_progress_callback);
   }
 
-  // Get Promise.resolve and reject methods
+  // Get Promise.resolve method
   jclass promise_class = env->GetObjectClass(j_promise);
   jmethodID resolve_method = env->GetMethodID(promise_class, "resolve", "(Ljava/lang/Object;)V");
-  jmethodID reject_method = env->GetMethodID(promise_class, "reject", 
-                                              "(Ljava/lang/String;Ljava/lang/String;)V");
 
   // Get WritableMap from Arguments
   jclass arguments_class = env->FindClass("com/facebook/react/bridge/Arguments");
@@ -123,15 +121,12 @@ Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeExtractTarBz2(
       env->CallVoidMethod(result_map, put_string_method,
                           env->NewStringUTF("sha256"), env->NewStringUTF(sha256.c_str()));
     }
-    env->CallVoidMethod(j_promise, resolve_method, result_map);
   } else {
     __android_log_print(ANDROID_LOG_WARN, "SherpaOnnxNative", "[ARCHIVE_ERROR] %s", error_msg.c_str());
     env->CallVoidMethod(result_map, put_string_method,
                         env->NewStringUTF("reason"), env->NewStringUTF(error_msg.c_str()));
-    env->CallVoidMethod(j_promise, reject_method,
-                        env->NewStringUTF("ARCHIVE_ERROR"),
-                        env->NewStringUTF(error_msg.c_str()));
   }
+  env->CallVoidMethod(j_promise, resolve_method, result_map);
 
   // Clean up global reference
   if (j_progress_callback_global != nullptr) {
@@ -171,8 +166,6 @@ Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeExtractTarZst(
 
   jclass promise_class = env->GetObjectClass(j_promise);
   jmethodID resolve_method = env->GetMethodID(promise_class, "resolve", "(Ljava/lang/Object;)V");
-  jmethodID reject_method = env->GetMethodID(promise_class, "reject",
-                                              "(Ljava/lang/String;Ljava/lang/String;)V");
 
   jclass arguments_class = env->FindClass("com/facebook/react/bridge/Arguments");
   jmethodID create_map_method = env->GetStaticMethodID(
@@ -230,15 +223,12 @@ Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeExtractTarZst(
       env->CallVoidMethod(result_map, put_string_method,
                           env->NewStringUTF("sha256"), env->NewStringUTF(sha256.c_str()));
     }
-    env->CallVoidMethod(j_promise, resolve_method, result_map);
   } else {
     __android_log_print(ANDROID_LOG_WARN, "SherpaOnnxNative", "[ARCHIVE_ERROR] %s", error_msg.c_str());
     env->CallVoidMethod(result_map, put_string_method,
                         env->NewStringUTF("reason"), env->NewStringUTF(error_msg.c_str()));
-    env->CallVoidMethod(j_promise, reject_method,
-                        env->NewStringUTF("ARCHIVE_ERROR"),
-                        env->NewStringUTF(error_msg.c_str()));
   }
+  env->CallVoidMethod(j_promise, resolve_method, result_map);
 
   if (j_progress_callback_global != nullptr) {
     env->DeleteGlobalRef(j_progress_callback_global);
@@ -327,7 +317,6 @@ Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeExtractTarZstFromStream(
 
   jclass promise_class = env->GetObjectClass(j_promise);
   jmethodID resolve_method = env->GetMethodID(promise_class, "resolve", "(Ljava/lang/Object;)V");
-  jmethodID reject_method = env->GetMethodID(promise_class, "reject", "(Ljava/lang/String;Ljava/lang/String;)V");
 
   jclass arguments_class = env->FindClass("com/facebook/react/bridge/Arguments");
   jmethodID create_map_method = env->GetStaticMethodID(arguments_class, "createMap", "()Lcom/facebook/react/bridge/WritableMap;");
@@ -383,15 +372,12 @@ Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeExtractTarZstFromStream(
       env->CallVoidMethod(result_map, put_string_method,
                           env->NewStringUTF("sha256"), env->NewStringUTF(sha256.c_str()));
     }
-    env->CallVoidMethod(j_promise, resolve_method, result_map);
   } else {
     __android_log_print(ANDROID_LOG_WARN, "SherpaOnnxNative", "[ARCHIVE_ERROR] %s", error_msg.c_str());
     env->CallVoidMethod(result_map, put_string_method,
                         env->NewStringUTF("reason"), env->NewStringUTF(error_msg.c_str()));
-    env->CallVoidMethod(j_promise, reject_method,
-                        env->NewStringUTF("ARCHIVE_ERROR"),
-                        env->NewStringUTF(error_msg.c_str()));
   }
+  env->CallVoidMethod(j_promise, resolve_method, result_map);
 
   env->DeleteGlobalRef(stream_global);
   env->DeleteLocalRef(byte_array);

--- a/android/src/main/cpp/jni/archive/sherpa-onnx-archive-jni.cpp
+++ b/android/src/main/cpp/jni/archive/sherpa-onnx-archive-jni.cpp
@@ -145,6 +145,112 @@ Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeExtractTarBz2(
 }
 
 extern "C" JNIEXPORT void JNICALL
+Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeExtractTarZst(
+    JNIEnv* env,
+    jobject /* jthis */,
+    jstring j_source_path,
+    jstring j_target_path,
+    jboolean j_force,
+    jobject j_progress_callback,
+    jobject j_promise) {
+  const char* source_path = env->GetStringUTFChars(j_source_path, nullptr);
+  const char* target_path = env->GetStringUTFChars(j_target_path, nullptr);
+  std::string source_str(source_path);
+  std::string target_str(target_path);
+  env->ReleaseStringUTFChars(j_source_path, source_path);
+  env->ReleaseStringUTFChars(j_target_path, target_path);
+
+  jmethodID on_progress_method = nullptr;
+  jobject j_progress_callback_global = nullptr;
+  if (j_progress_callback != nullptr) {
+    jclass callback_class = env->GetObjectClass(j_progress_callback);
+    on_progress_method = env->GetMethodID(callback_class, "invoke", "(JJD)V");
+    env->DeleteLocalRef(callback_class);
+    j_progress_callback_global = env->NewGlobalRef(j_progress_callback);
+  }
+
+  jclass promise_class = env->GetObjectClass(j_promise);
+  jmethodID resolve_method = env->GetMethodID(promise_class, "resolve", "(Ljava/lang/Object;)V");
+  jmethodID reject_method = env->GetMethodID(promise_class, "reject",
+                                              "(Ljava/lang/String;Ljava/lang/String;)V");
+
+  jclass arguments_class = env->FindClass("com/facebook/react/bridge/Arguments");
+  jmethodID create_map_method = env->GetStaticMethodID(
+      arguments_class, "createMap", "()Lcom/facebook/react/bridge/WritableMap;");
+  jobject result_map = env->CallStaticObjectMethod(arguments_class, create_map_method);
+
+  jclass writeable_map_class = env->FindClass("com/facebook/react/bridge/WritableMap");
+  jmethodID put_boolean_method = env->GetMethodID(
+      writeable_map_class, "putBoolean", "(Ljava/lang/String;Z)V");
+  jmethodID put_string_method = env->GetMethodID(
+      writeable_map_class, "putString", "(Ljava/lang/String;Ljava/lang/String;)V");
+
+  auto on_progress = [j_progress_callback_global, on_progress_method](
+      long long bytes_extracted, long long total_bytes, double percent) {
+    if (j_progress_callback_global != nullptr && on_progress_method != nullptr) {
+      JNIEnv* callback_env = nullptr;
+      bool should_detach = false;
+      if (g_vm->GetEnv(reinterpret_cast<void**>(&callback_env), JNI_VERSION_1_6) == JNI_EDETACHED) {
+        if (g_vm->AttachCurrentThread(&callback_env, nullptr) == JNI_OK) {
+          should_detach = true;
+        } else {
+          return;
+        }
+      }
+      if (callback_env != nullptr) {
+        callback_env->CallVoidMethod(j_progress_callback_global, on_progress_method,
+                            bytes_extracted, total_bytes, percent);
+        if (callback_env->ExceptionCheck()) {
+          callback_env->ExceptionClear();
+        }
+        if (should_detach) {
+          g_vm->DetachCurrentThread();
+        }
+      }
+    }
+  };
+
+  std::string error_msg;
+  std::string sha256;
+  bool success = ArchiveHelper::ExtractTarZst(
+      source_str,
+      target_str,
+      j_force == JNI_TRUE,
+      on_progress,
+      &error_msg,
+      &sha256);
+
+  env->CallVoidMethod(result_map, put_boolean_method,
+                      env->NewStringUTF("success"), success ? JNI_TRUE : JNI_FALSE);
+
+  if (success) {
+    env->CallVoidMethod(result_map, put_string_method,
+                        env->NewStringUTF("path"), env->NewStringUTF(target_str.c_str()));
+    if (!sha256.empty()) {
+      env->CallVoidMethod(result_map, put_string_method,
+                          env->NewStringUTF("sha256"), env->NewStringUTF(sha256.c_str()));
+    }
+    env->CallVoidMethod(j_promise, resolve_method, result_map);
+  } else {
+    __android_log_print(ANDROID_LOG_WARN, "SherpaOnnxNative", "[ARCHIVE_ERROR] %s", error_msg.c_str());
+    env->CallVoidMethod(result_map, put_string_method,
+                        env->NewStringUTF("reason"), env->NewStringUTF(error_msg.c_str()));
+    env->CallVoidMethod(j_promise, reject_method,
+                        env->NewStringUTF("ARCHIVE_ERROR"),
+                        env->NewStringUTF(error_msg.c_str()));
+  }
+
+  if (j_progress_callback_global != nullptr) {
+    env->DeleteGlobalRef(j_progress_callback_global);
+  }
+
+  env->DeleteLocalRef(result_map);
+  env->DeleteLocalRef(promise_class);
+  env->DeleteLocalRef(arguments_class);
+  env->DeleteLocalRef(writeable_map_class);
+}
+
+extern "C" JNIEXPORT void JNICALL
 Java_com_sherpaonnx_SherpaOnnxArchiveHelper_nativeCancelExtract(JNIEnv* /* env */, jobject /* jthis */) {
   ArchiveHelper::Cancel();
 }

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxArchiveHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxArchiveHelper.kt
@@ -31,6 +31,11 @@ class SherpaOnnxArchiveHelper {
     nativeCancelExtract()
   }
 
+  fun cancelExtractTarZst() {
+    cancelRequested.set(true)
+    nativeCancelExtract()
+  }
+
   fun extractTarBz2(
     sourcePath: String,
     targetPath: String,
@@ -71,12 +76,55 @@ class SherpaOnnxArchiveHelper {
     }
   }
 
+  fun extractTarZst(
+    sourcePath: String,
+    targetPath: String,
+    force: Boolean,
+    promise: Promise,
+    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit
+  ) {
+    val promiseSettled = AtomicBoolean(false)
+    fun resolveOnce(success: Boolean, reason: String? = null) {
+      if (!promiseSettled.compareAndSet(false, true)) return
+      val result = Arguments.createMap()
+      result.putBoolean("success", success)
+      if (reason != null) result.putString("reason", reason)
+      promise.resolve(result)
+    }
+
+    try {
+      cancelRequested.set(false)
+      val progressCallback = object : Any() {
+        fun invoke(bytesExtracted: Long, totalBytes: Long, percent: Double) {
+          onProgress(bytesExtracted, totalBytes, percent)
+        }
+      }
+      extractExecutor.execute {
+        try {
+          nativeExtractTarZst(sourcePath, targetPath, force, progressCallback, promise)
+        } catch (e: Exception) {
+          resolveOnce(false, "Archive extraction error: ${e.message}")
+        }
+      }
+    } catch (e: Exception) {
+      resolveOnce(false, "Archive extraction error: ${e.message}")
+    }
+  }
+
   fun computeFileSha256(filePath: String, promise: Promise) {
     nativeComputeFileSha256(filePath, promise)
   }
 
   // Native JNI methods
   private external fun nativeExtractTarBz2(
+    sourcePath: String,
+    targetPath: String,
+    force: Boolean,
+    progressCallback: Any?,
+    promise: Promise
+  )
+
+  private external fun nativeExtractTarZst(
     sourcePath: String,
     targetPath: String,
     force: Boolean,

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxArchiveHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxArchiveHelper.kt
@@ -1,5 +1,7 @@
 package com.sherpaonnx
 
+import android.content.Context
+import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import java.util.concurrent.ExecutorService
@@ -111,6 +113,48 @@ class SherpaOnnxArchiveHelper {
     }
   }
 
+  fun extractTarZstFromAsset(
+    context: Context,
+    assetPath: String,
+    targetPath: String,
+    force: Boolean,
+    promise: Promise,
+    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit
+  ) {
+    if (BuildConfig.DEBUG) {
+      Log.i("SherpaOnnx", "extractTarZstFromAsset assetPath=$assetPath targetPath=$targetPath")
+    }
+    cancelRequested.set(false)
+    val progressCallback = object : Any() {
+      fun invoke(bytesExtracted: Long, totalBytes: Long, percent: Double) {
+        onProgress(bytesExtracted, totalBytes, percent)
+      }
+    }
+    extractExecutor.execute {
+      try {
+        context.assets.open(assetPath).use { stream ->
+          nativeExtractTarZstFromStream(stream, targetPath, force, progressCallback, promise)
+        }
+      } catch (e: Exception) {
+        val result = Arguments.createMap()
+        result.putBoolean("success", false)
+        result.putString("reason", e.message ?: "Failed to open asset")
+        promise.resolve(result)
+      }
+    }
+  }
+
+  fun extractTarBz2FromAsset(
+    context: Context,
+    assetPath: String,
+    targetPath: String,
+    force: Boolean,
+    promise: Promise,
+    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit
+  ) {
+    extractTarZstFromAsset(context, assetPath, targetPath, force, promise, onProgress)
+  }
+
   fun computeFileSha256(filePath: String, promise: Promise) {
     nativeComputeFileSha256(filePath, promise)
   }
@@ -126,6 +170,14 @@ class SherpaOnnxArchiveHelper {
 
   private external fun nativeExtractTarZst(
     sourcePath: String,
+    targetPath: String,
+    force: Boolean,
+    progressCallback: Any?,
+    promise: Promise
+  )
+
+  private external fun nativeExtractTarZstFromStream(
+    inputStream: java.io.InputStream,
     targetPath: String,
     force: Boolean,
     progressCallback: Any?,

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxAssetHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxAssetHelper.kt
@@ -82,10 +82,12 @@ internal class SherpaOnnxAssetHelper(
     try {
       val baseDir = File(path)
       if (!baseDir.exists()) {
-        throw IllegalArgumentException("Path does not exist: $path")
+        promise.resolve(Arguments.createArray())
+        return
       }
       if (!baseDir.isDirectory) {
-        throw IllegalArgumentException("Path is not a directory: $path")
+        promise.resolve(Arguments.createArray())
+        return
       }
 
       val folders = mutableListOf<String>()
@@ -134,11 +136,18 @@ internal class SherpaOnnxAssetHelper(
     try {
       Log.i(logTag, "getAssetPackPath: packName=$packName")
       val assetPackManager = AssetPackManagerFactory.getInstance(context)
-      val location: AssetPackLocation? = assetPackManager.getPackLocation(packName)
+      var location: AssetPackLocation? = assetPackManager.getPackLocation(packName)
       if (location == null) {
-        Log.i(logTag, "getAssetPackPath: location is null for pack '$packName'")
-        promise.resolve(null)
-        return
+        val allLocations = assetPackManager.getPackLocations()
+        location = allLocations?.get(packName)
+        if (allLocations != null) {
+          Log.i(logTag, "getAssetPackPath: getPackLocation was null, getPackLocations keys=${allLocations.keys}")
+        }
+        if (location == null) {
+          Log.i(logTag, "getAssetPackPath: location is null for pack '$packName'")
+          promise.resolve(null)
+          return
+        }
       }
       Log.i(logTag, "getAssetPackPath: storageMethod=${location.packStorageMethod()}, " +
         "assetsPath=${location.assetsPath()}, path=${location.path()}")
@@ -167,6 +176,42 @@ internal class SherpaOnnxAssetHelper(
     } catch (e: Exception) {
       Log.w(logTag, "getAssetPackPath failed: ${e.message}")
       promise.resolve(null)
+    }
+  }
+
+  /**
+   * Lists asset paths of .tar.zst and .tar.bz2 archives in a PAD pack when stored as APK_ASSETS.
+   * Returns empty array when pack is null or STORAGE_FILES (caller uses path + readDir in that case).
+   * APK_ASSETS: pack content is merged into the app asset root; canonical path is "models"
+   * (pack layout src/main/assets/models/). Same for Play Store and bundletool install-time delivery.
+   */
+  fun listBundledArchiveAssetPaths(packName: String, promise: Promise) {
+    try {
+      val assetPackManager = AssetPackManagerFactory.getInstance(context)
+      var location: AssetPackLocation? = assetPackManager.getPackLocation(packName)
+      if (location == null) {
+        location = assetPackManager.getPackLocations()?.get(packName)
+      }
+      if (location == null) {
+        promise.resolve(Arguments.createArray())
+        return
+      }
+      if (location.packStorageMethod() != AssetPackStorageMethod.STORAGE_FILES) {
+        val assetPrefix = "models"
+        val names = context.assets.list(assetPrefix) ?: emptyArray()
+        val archives = names.filter { it.endsWith(".tar.zst") || it.endsWith(".tar.bz2") }
+        val result = Arguments.createArray()
+        for (name in archives) {
+          result.pushString("$assetPrefix/$name")
+        }
+        Log.i(logTag, "listBundledArchiveAssetPaths: packName=$packName prefix=$assetPrefix count=${result.size()}")
+        promise.resolve(result)
+      } else {
+        promise.resolve(Arguments.createArray())
+      }
+    } catch (e: Exception) {
+      Log.w(logTag, "listBundledArchiveAssetPaths failed: ${e.message}")
+      promise.resolve(Arguments.createArray())
     }
   }
 

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -1019,6 +1019,44 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     assetHelper.getAssetPackPath(packName, promise)
   }
 
+  override fun listBundledArchiveAssetPaths(packName: String, promise: Promise) {
+    assetHelper.listBundledArchiveAssetPaths(packName, promise)
+  }
+
+  override fun extractTarZstFromAsset(
+    assetPath: String,
+    targetPath: String,
+    force: Boolean,
+    promise: Promise
+  ) {
+    archiveHelper.extractTarZstFromAsset(
+      reactApplicationContext,
+      assetPath,
+      targetPath,
+      force,
+      promise
+    ) { bytes, total, percent ->
+      emitExtractTarZstProgress(assetPath, bytes, total, percent)
+    }
+  }
+
+  override fun extractTarBz2FromAsset(
+    assetPath: String,
+    targetPath: String,
+    force: Boolean,
+    promise: Promise
+  ) {
+    archiveHelper.extractTarBz2FromAsset(
+      reactApplicationContext,
+      assetPath,
+      targetPath,
+      force,
+      promise
+    ) { bytes, total, percent ->
+      emitExtractProgress(assetPath, bytes, total, percent)
+    }
+  }
+
   companion object {
     const val NAME = "SherpaOnnx"
 

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -303,6 +303,17 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     promise.resolve(null)
   }
 
+  override fun extractTarZst(sourcePath: String, targetPath: String, force: Boolean, promise: Promise) {
+    archiveHelper.extractTarZst(sourcePath, targetPath, force, promise) { bytes, total, percent ->
+      emitExtractTarZstProgress(sourcePath, bytes, total, percent)
+    }
+  }
+
+  override fun cancelExtractTarZst(promise: Promise) {
+    archiveHelper.cancelExtractTarZst()
+    promise.resolve(null)
+  }
+
   override fun computeFileSha256(filePath: String, promise: Promise) {
     archiveHelper.computeFileSha256(filePath, promise)
   }
@@ -316,6 +327,17 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     payload.putDouble("totalBytes", totalBytes.toDouble())
     payload.putDouble("percent", percent)
     eventEmitter.emit("extractTarBz2Progress", payload)
+  }
+
+  private fun emitExtractTarZstProgress(sourcePath: String, bytes: Long, totalBytes: Long, percent: Double) {
+    val eventEmitter = reactApplicationContext
+      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+    val payload = Arguments.createMap()
+    payload.putString("sourcePath", sourcePath)
+    payload.putDouble("bytes", bytes.toDouble())
+    payload.putDouble("totalBytes", totalBytes.toDouble())
+    payload.putDouble("percent", percent)
+    eventEmitter.emit("extractTarZstProgress", payload)
   }
 
   /**

--- a/docs/disable-libarchive.md
+++ b/docs/disable-libarchive.md
@@ -1,9 +1,9 @@
 # Disabling libarchive (Android & iOS)
 
-By default, the `react-native-sherpa-onnx` SDK includes and links prebuilt libarchive binaries (`libarchive.xcframework` for iOS and `.so` libs for Android) to provide built-in archive extraction features (e.g. extracting `.tar.bz2` downloaded model bundles).
+By default, the `react-native-sherpa-onnx` SDK includes and links prebuilt libarchive binaries (`libarchive.xcframework` for iOS and `.so` libs for Android) to provide built-in archive extraction features (e.g. extracting `.tar.bz2` or `.tar.zst` downloaded model bundles).
 
 You can explicitly **disable libarchive** in this SDK if you want to:
-1. **Reduce App Size:** Omit libarchive binaries if you don't use the archive extraction helpers (`extractTarBz2`, `cancelExtractTarBz2`) and only use single-file `.onnx` models.
+1. **Reduce App Size:** Omit libarchive binaries if you don't use the archive extraction helpers (`extractTarBz2`, `cancelExtractTarBz2`, `extractTarZst`, `cancelExtractTarZst`) and only use single-file `.onnx` models.
 2. **Prevent Symbol Clashes:** Avoid duplicate native symbols if another native module or library in your app already ships its own libarchive. Having two copies of libarchive in the same process can cause runtime crashes or undefined behavior.
 
 ## How to disable libarchive
@@ -49,8 +49,10 @@ When libarchive is disabled, the following APIs **in this SDK** are built but re
 |-----|-------------|
 | **`extractTarBz2(sourcePath, targetPath, force, promise)`** | Extracts a `.tar.bz2` archive (e.g. a downloaded model bundle) to a target folder. Implemented in native code via libarchive; when disabled, the native implementation is not linked and the promise is rejected with an error message. |
 | **`cancelExtractTarBz2()`** | Cancels an ongoing `extractTarBz2` operation. When libarchive is disabled, there is no extraction implementation to cancel; calling this is a no-op. |
+| **`extractTarZst(sourcePath, targetPath, force, promise)`** | Extracts a `.tar.zst` or `.zst` archive. Implemented in native code via libarchive; when disabled, the native implementation is not linked and the promise is rejected with an error message. |
+| **`cancelExtractTarZst()`** | Cancels an ongoing `extractTarZst` operation. When libarchive is disabled, there is no extraction implementation to cancel; calling this is a no-op. |
 
-Both are exposed on the **`NativeSherpaOnnx`** spec (e.g. from `react-native-sherpa-onnx`). The progress event `extractTarBz2Progress` will not be emitted when extraction is disabled, because extraction never runs.
+All extraction helpers are exposed on the **`NativeSherpaOnnx`** spec (e.g. from `react-native-sherpa-onnx`). Progress events for extraction (for example `extractTarBz2Progress` and `extractTarZstProgress`) will not be emitted when extraction is disabled, because extraction never runs.
 
 ## Functions that still work without libarchive
 
@@ -62,23 +64,23 @@ All other features (STT, TTS, FFmpeg-based audio conversion, model detection, et
 
 ## Download Manager (`react-native-sherpa-onnx/download`)
 
-The [Model Download Manager](download-manager.md) uses native `extractTarBz2` for **archive models** (`.tar.bz2`). When libarchive is disabled, the following behavior applies:
+The [Model Download Manager](download-manager.md) uses native `extractTarBz2` / `extractTarZst` for **archive models** (`.tar.bz2`, `.tar.zst`). When libarchive is disabled, the following behavior applies:
 
 | API | Effect when libarchive is disabled |
 |-----|-------------------------------------|
-| **`downloadModelByCategory(category, id, options?)`** | For **archive models** (`.tar.bz2`): the file download completes, but the extraction step fails (native `extractTarBz2` is stubbed). The returned promise **rejects**; the model is not usable. For **single-file models** (`.onnx`): no extraction is used; download and usage work as normal. |
+| **`downloadModelByCategory(category, id, options?)`** | For **archive models** (`.tar.bz2`, `.tar.zst`): the file download completes, but the extraction step fails (native `extractTarBz2` / `extractTarZst` is stubbed). The returned promise **rejects**; the model is not usable. For **single-file models** (`.onnx`): no extraction is used; download and usage work as normal. |
 | **`getLocalModelPathByCategory(category, id)`** | Archive models are only considered “downloaded” after extraction and manifest write. When extraction never succeeds, they never appear; this returns `null` for archive models that were not previously extracted with libarchive enabled. Single-file models are unaffected. |
 | **`listDownloadedModelsByCategory(category)`** | Only lists models that have a complete manifest (download + extraction done). Archive models whose extraction failed will not appear. Single-file models work as usual. |
 | **`isModelDownloadedByCategory(category, id)`** | Returns `true` only when the model is fully downloaded and (for archives) extracted. Archive models fail extraction when libarchive is disabled, so they will not be reported as downloaded. |
 | **`subscribeDownloadProgress(listener)`** | Progress events for the **extracting** phase come from native extraction. When libarchive is disabled, extraction fails immediately after the download phase; the listener may see download progress, then the overall operation fails. |
 | **`refreshModelsByCategory`**, **`listModelsByCategory`**, **`getModelByIdByCategory`**, **`deleteModelByCategory`**, **`clearModelCacheByCategory`** | Do not depend on extraction; they work regardless of the libarchive flag. |
 
-**Summary:** With libarchive disabled, **archive models** (`.tar.bz2`) cannot be fully downloaded or used via the download manager; only **single-file models** (`.onnx`) can be downloaded and used through it. If you need archive-based models (e.g. from the official sherpa-onnx release list), do not disable libarchive, or provide extraction by other means and do not use `downloadModelByCategory` for those models.
+**Summary:** With libarchive disabled, **archive models** (`.tar.bz2`, `.tar.zst`) cannot be fully downloaded or used via the download manager; only **single-file models** (`.onnx`) can be downloaded and used through it. If you need archive-based models (e.g. from the official sherpa-onnx release list), do not disable libarchive, or provide extraction by other means and do not use `downloadModelByCategory` for those models.
 
 ## Risks and limitations of disabling libarchive
 
-1. **No built-in .tar.bz2 extraction**  
-   You must not call `extractTarBz2` when libarchive is disabled, or handle the rejection (e.g. show a message or use another extraction path). If your app relies on this to unpack model bundles, you need to extract archives by other means (e.g. a JS/native library that provides tar.bz2 extraction) or ship models in a non-archive format.
+1. **No built-in .tar.bz2/.tar.zst extraction**  
+   You must not call `extractTarBz2` or `extractTarZst` when libarchive is disabled, or handle the rejection (e.g. show a message or use another extraction path). If your app relies on this to unpack model bundles, you need to extract archives by other means (e.g. a JS/native library that provides tar.bz2/tar.zst extraction) or ship models in a non-archive format.
 
 2. **No runtime use of another libarchive**  
    Disabling libarchive here means this SDK’s native code is **compiled without** libarchive; the extraction helper is stubbed and always returns an error. The SDK does **not** call into another app-provided libarchive. You avoid shipping a duplicate `libarchive.so`; you do not get “shared” libarchive behavior.
@@ -98,5 +100,5 @@ The [Model Download Manager](download-manager.md) uses native `extractTarBz2` fo
 
 | Setting | Effect |
 |--------|--------|
-| **Android:** `sherpaOnnxDisableLibarchive=true`<br>**iOS:** `SHERPA_ONNX_DISABLE_LIBARCHIVE=1 pod install` | No libarchive linked or shipped (`libarchive.so` or `libarchive.xcframework`); build succeeds without libarchive prebuilts; `extractTarBz2` rejects with an error at runtime; `cancelExtractTarBz2` is a no-op; `computeFileSha256` still works. **Download Manager:** only single-file models (`.onnx`) can be downloaded and used; archive models (`.tar.bz2`) fail at extraction. Use when you have another libarchive in the app or do not need archive extraction. |
+| **Android:** `sherpaOnnxDisableLibarchive=true`<br>**iOS:** `SHERPA_ONNX_DISABLE_LIBARCHIVE=1 pod install` | No libarchive linked or shipped (`libarchive.so` or `libarchive.xcframework`); build succeeds without libarchive prebuilts; `extractTarBz2`/`extractTarZst` reject with an error at runtime; `cancelExtractTarBz2`/`cancelExtractTarZst` are no-ops; `computeFileSha256` still works. **Download Manager:** only single-file models (`.onnx`) can be downloaded and used; archive models (`.tar.bz2`, `.tar.zst`) fail at extraction. Use when you have another libarchive in the app or do not need archive extraction. |
 | **Default (Flag unset / false)** | libarchive is required; prebuilts, AAR, or XCFramework must provide libarchive; `extractTarBz2` and `cancelExtractTarBz2` work; Download Manager supports both archive and single-file models. Do not combine with another libarchive in the same process unless you accept the risk of clashes. |

--- a/docs/download-manager.md
+++ b/docs/download-manager.md
@@ -1,6 +1,6 @@
 # Model Download Manager
 
-Fetch, cache, and manage model assets from official sherpa-onnx GitHub Releases. Supports archive models (`.tar.bz2`) and single-file models (`.onnx`), with checksum verification and progress events.
+Fetch, cache, and manage model assets from official sherpa-onnx GitHub Releases. Supports archive models (`.tar.bz2`, `.tar.zst`) and single-file models (`.onnx`), with checksum verification and progress events.
 
 **Import path:** `react-native-sherpa-onnx/download`
 
@@ -220,6 +220,7 @@ Public helpers from `react-native-sherpa-onnx/download`. Most apps only need the
 | `parseChecksumFile(content)` | Parse a checksum.txt file |
 | `calculateFileChecksum(filePath)` | Calculate SHA-256 of a file |
 | `extractTarBz2(archivePath, destDir, options?)` | Extract a .tar.bz2 archive |
+| `extractTarZst(archivePath, destDir, options?)` | Extract a .tar.zst / .zst archive |
 
 ---
 

--- a/docs/extraction.md
+++ b/docs/extraction.md
@@ -1,0 +1,297 @@
+# Extraction API (Compressed Archives)
+
+The `react-native-sherpa-onnx/extraction` subpath provides a unified API to **list** and **extract** compressed model archives (`.tar.zst` and `.tar.bz2`). After extraction to a target directory (e.g. `DocumentDirectoryPath/models`), use `listModelsAtPath` and `autoModelPath` from the main package to discover and use the extracted models.
+
+---
+
+## Table of Contents
+
+- [When to use](#when-to-use)
+- [Normal assets vs. PAD assets](#normal-assets-vs-pad-assets)
+- [API Reference](#api-reference)
+  - [`getBundledArchives`](#getbundledarchivespackname)
+  - [`listBundledArchives`](#listbundledarchivesdirectorypath)
+  - [`extractArchive`](#extractarchivearchive-targetpath-options)
+  - [`Types`](#types)
+- [Function overview table](#function-overview-table)
+- [Path expectations table](#path-expectations-table)
+- [Examples](#examples)
+  - [PAD compressed archives (Android)](#1-pad-compressed-archives-android)
+  - [iOS main bundle archives](#2-ios-main-bundle-archives)
+  - [Non-PAD compressed archives (any platform)](#3-non-pad-compressed-archives-any-platform)
+- [Workflow: from archive to model init](#workflow-from-archive-to-model-init)
+- [See also](#see-also)
+
+---
+
+## When to use
+
+Use this API whenever your models are delivered as **compressed archives** (`.tar.zst` or `.tar.bz2`) that need to be extracted before the native sherpa-onnx engine can use them. Common scenarios:
+
+| Scenario | Function | Platform |
+| --- | --- | --- |
+| Android PAD pack with compressed archives | `getBundledArchives` | Android only |
+| iOS main-bundle archives | `listBundledArchives` | iOS (and Android) |
+| Archives downloaded to the filesystem | `listBundledArchives` | Both |
+| Extract any of the above | `extractArchive` | Both |
+
+If your models are already extracted (uncompressed folders) — for example plain PAD packs or bundled assets — you do **not** need this API. Use the path helpers from the [main package](model-setup.md) directly.
+
+---
+
+## Normal assets vs. PAD assets
+
+Understanding the distinction helps when reading the API, but **you never need to handle the difference yourself** — `extractArchive` does it automatically.
+
+| | Normal (filesystem) archive | PAD APK_ASSETS archive |
+| --- | --- | --- |
+| **Where it lives** | On the filesystem — iOS bundle, Documents dir, PAD `STORAGE_FILES`, or any directory | Embedded inside the APK (Android only) |
+| **How you list it** | `listBundledArchives(directoryPath)` | `getBundledArchives(packName)` (falls back to asset listing automatically) |
+| **`fromAsset`** | `undefined` / absent | `true` |
+| **`archivePath`** | Absolute filesystem path (e.g. `/data/.../whisper.tar.zst`) | Asset path (e.g. `models/whisper.tar.zst`) — pack content is merged at app asset root |
+| **`fileSize`** | Available (from `stat`) | Not available (0 or absent) |
+| **Extraction method** | Native reads from filesystem path | Native streams from Android `AssetManager` — no temp copy |
+| **Platform** | iOS + Android | Android only |
+
+### How `getBundledArchives` resolves the source automatically
+
+```
+getBundledArchives("sherpa_models")
+  │
+  ├─ getAssetPackPath returns a path?  →  STORAGE_FILES
+  │    └─ scanDirectoryForArchives(path)  →  BundledArchive[] (filesystem)
+  │
+  └─ getAssetPackPath returns null?    →  APK_ASSETS
+       └─ listBundledArchiveAssetPaths  →  BundledArchive[] (fromAsset: true, archivePath: "models/…")
+```
+
+For **APK_ASSETS**, the pack’s `src/main/assets/models/` content is merged into the app’s asset root, so the canonical path is **`models`** (same for Play Store and bundletool install-time delivery).
+
+---
+
+## API Reference
+
+Import from the extraction subpath:
+
+```typescript
+import {
+  getBundledArchives,
+  listBundledArchives,
+  extractArchive,
+  type BundledArchive,
+  type ExtractArchiveOptions,
+  type ExtractResult,
+  type ExtractProgressEvent,
+} from 'react-native-sherpa-onnx/extraction';
+```
+
+### getBundledArchives(packName)
+
+```ts
+function getBundledArchives(packName: string): Promise<BundledArchive[] | null>
+```
+
+**Android only.** Returns the list of `.tar.zst` and `.tar.bz2` archives in the given Play Asset Delivery pack.
+
+- When the pack is **STORAGE_FILES**, scans the pack directory on the filesystem.
+- When the pack is **APK_ASSETS**, lists archives at asset path `models` (pack content is merged at app asset root). Archives are returned with `fromAsset: true` and `archivePath` like `models/name.tar.zst`.
+- Returns `null` on **iOS** or when the pack is not available / empty.
+
+### listBundledArchives(directoryPath)
+
+```ts
+function listBundledArchives(directoryPath: string): Promise<BundledArchive[]>
+```
+
+Lists `.tar.zst` and `.tar.bz2` files in the given filesystem directory. **Cross-platform.** Use for:
+
+- iOS main-bundle archives (`MainBundlePath + '/models'`)
+- Archives downloaded to the documents directory
+- PAD STORAGE_FILES path (if you prefer calling `getAssetPackPath` yourself)
+- Any other folder
+
+Returns an empty array when the directory does not exist or contains no matching archives.
+
+### extractArchive(archive, targetPath, options?)
+
+```ts
+function extractArchive(
+  archive: BundledArchive,
+  targetPath: string,
+  options?: ExtractArchiveOptions
+): Promise<ExtractResult>
+```
+
+Extracts one archive into `targetPath`. Handles both source types transparently:
+
+- **Filesystem archives** → regular path-based extraction via native `extractTarZst` / `extractTarBz2`.
+- **APK asset archives** (`fromAsset: true`) → streams from the APK via `extractTarZstFromAsset` / `extractTarBz2FromAsset` (no temp copy).
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `force` | `boolean` | `true` | Overwrite existing files in `targetPath` |
+| `onProgress` | `(event) => void` | — | Callback with `{ bytes, totalBytes, percent }` |
+| `signal` | `AbortSignal` | — | Cancel extraction (throws `AbortError`) |
+
+### Types
+
+```ts
+type BundledArchive = {
+  modelId: string;       // derived from filename (e.g. "whisper-tiny" from "whisper-tiny.tar.zst")
+  archivePath: string;   // filesystem path or asset path (APK_ASSETS: "models/name.tar.zst")
+  format: 'tar.zst' | 'tar.bz2';
+  fileSize?: number;     // bytes (filesystem only)
+  fromAsset?: boolean;   // true for APK_ASSETS archives
+};
+
+type ExtractArchiveOptions = {
+  force?: boolean;
+  onProgress?: (event: ExtractProgressEvent) => void;
+  signal?: AbortSignal;
+};
+
+type ExtractResult = {
+  success: boolean;
+  path?: string;    // extracted directory
+  sha256?: string;  // source archive digest
+  reason?: string;  // error description
+};
+
+type ExtractProgressEvent = {
+  bytes: number;
+  totalBytes: number;
+  percent: number;       // 0–100
+};
+```
+
+---
+
+## Function overview table
+
+| Function | Input | Returns | Platform | Use case |
+| --- | --- | --- | --- | --- |
+| `getBundledArchives(packName)` | PAD pack name | `BundledArchive[] \| null` | Android | List archives in a PAD pack (STORAGE_FILES or APK_ASSETS) |
+| `listBundledArchives(dirPath)` | Absolute directory path | `BundledArchive[]` | iOS + Android | List archives in any filesystem directory |
+| `extractArchive(archive, target)` | `BundledArchive` + target dir | `ExtractResult` | iOS + Android | Extract a single archive (any source) |
+
+---
+
+## Path expectations table
+
+| Source | How to list | `archivePath` format | `fromAsset` | `fileSize` | Extraction path |
+| --- | --- | --- | --- | --- | --- |
+| **PAD STORAGE_FILES** | `getBundledArchives("pack")` | Absolute filesystem path | absent | ✅ | `extractTarZst` / `extractTarBz2` (path) |
+| **PAD APK_ASSETS** | `getBundledArchives("pack")` | `models/name.tar.zst` (app asset root) | `true` | ❌ | `extractTarZstFromAsset` / `extractTarBz2FromAsset` (stream) |
+| **iOS main bundle** | `listBundledArchives(MainBundlePath + '/models')` | Absolute filesystem path | absent | ✅ | `extractTarZst` / `extractTarBz2` (path) |
+| **Downloaded archive** | `listBundledArchives(DocumentDirectoryPath + '/downloads')` | Absolute filesystem path | absent | ✅ | `extractTarZst` / `extractTarBz2` (path) |
+| **Any other directory** | `listBundledArchives(path)` | Absolute filesystem path | absent | ✅ | `extractTarZst` / `extractTarBz2` (path) |
+
+> The consumer never needs to pick the extraction method — `extractArchive` reads `fromAsset` and `archivePath` to choose the correct native call automatically.
+
+---
+
+## Examples
+
+### 1. PAD compressed archives (Android)
+
+```typescript
+import { getBundledArchives, extractArchive } from 'react-native-sherpa-onnx/extraction';
+import { DocumentDirectoryPath } from '@dr.pogodin/react-native-fs';
+import { listModelsAtPath, autoModelPath } from 'react-native-sherpa-onnx';
+
+const targetDir = `${DocumentDirectoryPath}/models`;
+
+// List archives from PAD pack (STORAGE_FILES or APK_ASSETS — handled automatically)
+const archives = await getBundledArchives('sherpa_models');
+if (archives?.length) {
+  for (const archive of archives) {
+    await extractArchive(archive, targetDir, {
+      onProgress: (e) => console.log(archive.modelId, `${e.percent}%`),
+    });
+  }
+}
+
+// Discover extracted models
+const models = await listModelsAtPath(targetDir, true);
+// → [{ folder: 'whisper-tiny', hint: 'stt' }, ...]
+```
+
+### 2. iOS main bundle archives
+
+```typescript
+import { listBundledArchives, extractArchive } from 'react-native-sherpa-onnx/extraction';
+import { MainBundlePath, DocumentDirectoryPath } from '@dr.pogodin/react-native-fs';
+
+const bundleDir = `${MainBundlePath}/models`;
+const targetDir = `${DocumentDirectoryPath}/models`;
+
+const archives = await listBundledArchives(bundleDir);
+for (const archive of archives) {
+  await extractArchive(archive, targetDir, { force: false });
+}
+```
+
+### 3. Non-PAD compressed archives (any platform)
+
+If your app ships or downloads `.tar.zst` / `.tar.bz2` archives **outside** of Play Asset Delivery — for example archives bundled in the Android `assets/` folder, copied from the iOS bundle, or downloaded via the network — use `listBundledArchives` to discover them and `extractArchive` to extract.
+
+```typescript
+import { listBundledArchives, extractArchive } from 'react-native-sherpa-onnx/extraction';
+import { DocumentDirectoryPath } from '@dr.pogodin/react-native-fs';
+import { listModelsAtPath, fileModelPath } from 'react-native-sherpa-onnx';
+import { createSTT, detectSttModel } from 'react-native-sherpa-onnx/stt';
+
+// Suppose you downloaded model archives to a "downloads" folder
+const downloadsDir = `${DocumentDirectoryPath}/downloads`;
+const modelsDir = `${DocumentDirectoryPath}/models`;
+
+const archives = await listBundledArchives(downloadsDir);
+// → [{ modelId: 'whisper-tiny-en', archivePath: '/.../whisper-tiny-en.tar.zst', format: 'tar.zst', fileSize: 41230000 }]
+
+for (const archive of archives) {
+  const result = await extractArchive(archive, modelsDir, {
+    force: false, // skip if already extracted
+    onProgress: (e) => console.log(archive.modelId, `${e.percent}%`),
+  });
+  console.log('Extracted to:', result.path);
+}
+
+// Use the extracted models
+const models = await listModelsAtPath(modelsDir, true);
+const sttModel = models.find((m) => m.hint === 'stt');
+if (sttModel) {
+  const mp = fileModelPath(`${modelsDir}/${sttModel.folder}`);
+  const detection = await detectSttModel(mp);
+  if (detection.success) {
+    const stt = await createSTT({ modelPath: mp, modelType: 'auto' });
+    // ready to transcribe
+  }
+}
+```
+
+---
+
+## Workflow: from archive to model init
+
+```
+ ┌─────────────────────┐     ┌────────────────────┐     ┌─────────────────────┐
+ │  List archives       │     │  Extract            │     │  Use models          │
+ │                      │     │                     │     │                      │
+ │ getBundledArchives() │────▶│ extractArchive()    │────▶│ listModelsAtPath()   │
+ │ listBundledArchives()│     │   (handles PAD +    │     │ autoModelPath()      │
+ │                      │     │    filesystem)       │     │ createSTT / TTS()    │
+ └─────────────────────┘     └────────────────────┘     └─────────────────────┘
+```
+
+1. **List** — get `BundledArchive[]` descriptors for your archives
+2. **Extract** — extract each archive to a shared models directory
+3. **Use** — discover the resulting model folders and initialize engines
+
+---
+
+## See also
+
+- [Model setup](model-setup.md) — path helpers, `getAssetPackPath`, `listModelsAtPath`, `autoModelPath`
+- [Download manager](download-manager.md) — downloading models from the network
+- [STT](stt.md) — Speech-to-Text API
+- [TTS](tts.md) — Text-to-Speech API

--- a/docs/model-setup.md
+++ b/docs/model-setup.md
@@ -32,7 +32,7 @@ Discover, resolve, and validate model paths across bundled assets, Play Asset De
 | Path resolution | ✅ | `resolveModelPath()` — returns native-usable absolute path |
 | Asset listing | ✅ | `listAssetModels()` — scans `assets/models/` (Android) / bundle `models/` (iOS) |
 | Filesystem listing | ✅ | `listModelsAtPath()` — scans any directory |
-| PAD support | ✅ | `getAssetPackPath()` — Android only |
+| PAD support | ✅ | See [Extraction API](extraction.md) for more details - Android only |
 | STT model detection | ✅ | `detectSttModel()` — file-based type detection + required-file validation |
 | TTS model detection | ✅ | `detectTtsModel()` — file-based type detection |
 
@@ -227,6 +227,7 @@ function detectTtsModel(
 | --- | --- | --- | --- |
 | Bundled assets | `assetModelPath()` | `listAssetModels()` | Ship models with the app |
 | Play Asset Delivery | `fileModelPath()` | `getAssetPackPath()` + `listModelsAtPath()` | Large models on Android (on-demand packs) |
+| PAD compressed archives | — | `getBundledArchives()` + `extractArchive()` from `react-native-sherpa-onnx/extraction` | PAD packs with .tar.zst/.tar.bz2; extract to a dir then use `listModelsAtPath` + `autoModelPath` |
 | Downloaded models | `fileModelPath()` | `listModelsAtPath()` or Download Manager | User-selected models at runtime |
 | Fallback / auto | `autoModelPath()` | — | Try asset first, then file |
 
@@ -333,6 +334,7 @@ if (!detection.success) {
 
 ## See Also
 
+- [Extraction API](extraction.md) — `getBundledArchives`, `listBundledArchives`, `extractArchive` for PAD or bundle .tar.zst/.tar.bz2
 - [STT](stt.md) — Speech-to-Text API
 - [TTS](tts.md) — Text-to-Speech API
 - [Download Manager](download-manager.md) — Download models in-app

--- a/ios/SherpaOnnx.mm
+++ b/ios/SherpaOnnx.mm
@@ -38,7 +38,7 @@
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[ @"ttsStreamChunk", @"ttsStreamEnd", @"ttsStreamError", @"extractTarBz2Progress", @"pcmLiveStreamData", @"pcmLiveStreamError" ];
+    return @[ @"ttsStreamChunk", @"ttsStreamEnd", @"ttsStreamError", @"extractTarBz2Progress", @"extractTarZstProgress", @"pcmLiveStreamData", @"pcmLiveStreamError" ];
 }
 
 - (void)resolveModelPath:(JS::NativeSherpaOnnx::SpecResolveModelPathConfig &)config
@@ -159,6 +159,33 @@
                reject:(RCTPromiseRejectBlock)reject
 {
     [SherpaOnnxArchiveHelper cancelExtractTarBz2];
+    resolve(nil);
+}
+
+- (void)extractTarZst:(NSString *)sourcePath
+           targetPath:(NSString *)targetPath
+                force:(BOOL)force
+             resolve:(RCTPromiseResolveBlock)resolve
+             reject:(RCTPromiseRejectBlock)reject
+{
+    SherpaOnnxArchiveHelper *helper = [SherpaOnnxArchiveHelper new];
+    NSDictionary *result = [helper extractTarZst:sourcePath
+                                    targetPath:targetPath
+                                         force:force
+                                      progress:^(long long bytes, long long totalBytes, double percent) {
+        [self sendEventWithName:@"extractTarZstProgress"
+                           body:@{ @"sourcePath": sourcePath,
+                                   @"bytes": @(bytes),
+                                   @"totalBytes": @(totalBytes),
+                                   @"percent": @(percent) }];
+    }];
+    resolve(result);
+}
+
+- (void)cancelExtractTarZst:(RCTPromiseResolveBlock)resolve
+               reject:(RCTPromiseRejectBlock)reject
+{
+    [SherpaOnnxArchiveHelper cancelExtractTarZst];
     resolve(nil);
 }
 

--- a/ios/SherpaOnnx.mm
+++ b/ios/SherpaOnnx.mm
@@ -211,6 +211,32 @@
     resolve([NSNull null]);
 }
 
+- (void)listBundledArchiveAssetPaths:(NSString *)packName
+                             resolve:(RCTPromiseResolveBlock)resolve
+                              reject:(RCTPromiseRejectBlock)reject
+{
+    // PAD APK_ASSETS listing is Android-only.
+    resolve(@[]);
+}
+
+- (void)extractTarZstFromAsset:(NSString *)assetPath
+                   targetPath:(NSString *)targetPath
+                       force:(NSNumber *)force
+                     resolve:(RCTPromiseResolveBlock)resolve
+                      reject:(RCTPromiseRejectBlock)reject
+{
+    resolve(@{ @"success": @NO, @"reason": @"Not supported on iOS; use path-based extraction." });
+}
+
+- (void)extractTarBz2FromAsset:(NSString *)assetPath
+                   targetPath:(NSString *)targetPath
+                        force:(NSNumber *)force
+                      resolve:(RCTPromiseResolveBlock)resolve
+                       reject:(RCTPromiseRejectBlock)reject
+{
+    resolve(@{ @"success": @NO, @"reason": @"Not supported on iOS; use path-based extraction." });
+}
+
 - (void)convertAudioToFormat:(NSString *)inputPath
                  outputPath:(NSString *)outputPath
                      format:(NSString *)format

--- a/ios/archive/sherpa-onnx-archive-helper.h
+++ b/ios/archive/sherpa-onnx-archive-helper.h
@@ -11,10 +11,17 @@ typedef void (^SherpaOnnxArchiveProgressBlock)(long long bytes, long long totalB
                           force:(BOOL)force
                        progress:(nullable SherpaOnnxArchiveProgressBlock)progress;
 
+- (NSDictionary *)extractTarZst:(NSString *)sourcePath
+                     targetPath:(NSString *)targetPath
+                          force:(BOOL)force
+                       progress:(nullable SherpaOnnxArchiveProgressBlock)progress;
+
 - (nullable NSString *)computeFileSha256:(NSString *)filePath
                                    error:(NSError * _Nullable * _Nullable)error;
 
 + (void)cancelExtractTarBz2;
+
++ (void)cancelExtractTarZst;
 
 @end
 

--- a/ios/archive/sherpa-onnx-archive-helper.mm
+++ b/ios/archive/sherpa-onnx-archive-helper.mm
@@ -133,6 +133,15 @@ static NSString* ComputeFileSha256(NSString* filePath, NSError** error) {
 #endif
 }
 
++ (void)cancelExtractTarZst
+{
+#ifdef HAVE_LIBARCHIVE
+  g_cancelExtract.store(true);
+#else
+  // feature disabled
+#endif
+}
+
 - (NSDictionary *)extractTarBz2:(NSString *)sourcePath
          targetPath:(NSString *)targetPath
            force:(BOOL)force
@@ -174,6 +183,7 @@ static NSString* ComputeFileSha256(NSString* filePath, NSError** error) {
   struct archive *archive = archive_read_new();
   archive_read_support_format_tar(archive);
   archive_read_support_filter_bzip2(archive);
+  archive_read_support_filter_zstd(archive);
 
   ArchiveReadContext read_ctx;
   read_ctx.file = fopen([sourcePath UTF8String], "rb");
@@ -297,6 +307,14 @@ static NSString* ComputeFileSha256(NSString* filePath, NSError** error) {
 
   return @{ @"success": @YES, @"path": targetPath, @"sha256": sha256Hex ?: @"" };
 #endif
+}
+
+- (NSDictionary *)extractTarZst:(NSString *)sourcePath
+                     targetPath:(NSString *)targetPath
+                          force:(BOOL)force
+                       progress:(SherpaOnnxArchiveProgressBlock)progress
+{
+  return [self extractTarBz2:sourcePath targetPath:targetPath force:force progress:progress];
 }
 
 - (NSString *)computeFileSha256:(NSString *)filePath

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
       "types": "./lib/typescript/src/download/index.d.ts",
       "default": "./lib/module/download/index.js"
     },
+    "./extraction": {
+      "source": "./src/extraction/index.ts",
+      "types": "./lib/typescript/src/extraction/index.d.ts",
+      "default": "./lib/module/extraction/index.js"
+    },
     "./audio": {
       "source": "./src/audio/index.ts",
       "types": "./lib/typescript/src/audio/index.d.ts",

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -573,6 +573,42 @@ export interface Spec extends TurboModule {
   cancelExtractTarZst(): Promise<void>;
 
   /**
+   * List asset paths of .tar.zst and .tar.bz2 archives in a PAD pack when stored as APK_ASSETS.
+   * Android only; returns [] when pack is not available or not APK_ASSETS. Used by getBundledArchives.
+   */
+  listBundledArchiveAssetPaths(packName: string): Promise<string[]>;
+
+  /**
+   * Extract a .tar.zst archive from Android assets (AssetManager) to a target folder. Android only.
+   * Streams from asset; no copy of the archive to disk. Used when PAD pack is APK_ASSETS.
+   */
+  extractTarZstFromAsset(
+    assetPath: string,
+    targetPath: string,
+    force: boolean
+  ): Promise<{
+    success: boolean;
+    path?: string;
+    sha256?: string;
+    reason?: string;
+  }>;
+
+  /**
+   * Extract a .tar.bz2 archive from Android assets (AssetManager) to a target folder. Android only.
+   * Streams from asset; no copy of the archive to disk. Used when PAD pack is APK_ASSETS.
+   */
+  extractTarBz2FromAsset(
+    assetPath: string,
+    targetPath: string,
+    force: boolean
+  ): Promise<{
+    success: boolean;
+    path?: string;
+    sha256?: string;
+    reason?: string;
+  }>;
+
+  /**
    * Compute SHA-256 of a file and return the hex digest.
    */
   computeFileSha256(filePath: string): Promise<string>;

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -553,6 +553,26 @@ export interface Spec extends TurboModule {
   cancelExtractTarBz2(): Promise<void>;
 
   /**
+   * Extract a .tar.zst (or .zst) archive to a target folder.
+   * Returns { success, path } or { success, reason }.
+   */
+  extractTarZst(
+    sourcePath: string,
+    targetPath: string,
+    force: boolean
+  ): Promise<{
+    success: boolean;
+    path?: string;
+    sha256?: string;
+    reason?: string;
+  }>;
+
+  /**
+   * Cancel any in-progress tar.zst extraction.
+   */
+  cancelExtractTarZst(): Promise<void>;
+
+  /**
    * Compute SHA-256 of a file and return the hex digest.
    */
   computeFileSha256(filePath: string): Promise<string>;

--- a/src/download/extractTarZst.ts
+++ b/src/download/extractTarZst.ts
@@ -1,0 +1,77 @@
+import { DeviceEventEmitter } from 'react-native';
+import SherpaOnnx from '../NativeSherpaOnnx';
+
+export type ExtractProgressEvent = {
+  bytes: number;
+  totalBytes: number;
+  percent: number;
+};
+
+type ExtractResult = {
+  success: boolean;
+  path?: string;
+  sha256?: string;
+  reason?: string;
+};
+
+export async function extractTarZst(
+  sourcePath: string,
+  targetPath: string,
+  force = true,
+  onProgress?: (event: ExtractProgressEvent) => void,
+  signal?: AbortSignal
+): Promise<ExtractResult> {
+  let subscription: { remove: () => void } | null = null;
+  let removeAbortListener: (() => void) | null = null;
+
+  if (signal?.aborted) {
+    const abortError = new Error('Extraction aborted');
+    abortError.name = 'AbortError';
+    throw abortError;
+  }
+
+  if (onProgress) {
+    subscription = DeviceEventEmitter.addListener(
+      'extractTarZstProgress',
+      (event: ExtractProgressEvent & { sourcePath?: string }) => {
+        if (event.sourcePath != null && event.sourcePath !== sourcePath) {
+          return;
+        }
+        const safePercent = Math.max(0, Math.min(100, event.percent));
+        onProgress({ ...event, percent: safePercent });
+      }
+    );
+  }
+
+  if (signal) {
+    const onAbort = () => {
+      try {
+        SherpaOnnx.cancelExtractTarZst();
+      } catch {
+        // Ignore cancel errors to avoid crashing on abort.
+      }
+    };
+    signal.addEventListener('abort', onAbort);
+    removeAbortListener = () => signal.removeEventListener('abort', onAbort);
+  }
+
+  try {
+    const result = await SherpaOnnx.extractTarZst(
+      sourcePath,
+      targetPath,
+      force
+    );
+    if (!result.success) {
+      const message = result.reason || 'Extraction failed';
+      const error = new Error(message);
+      if (signal?.aborted || /cancel/i.test(message)) {
+        error.name = 'AbortError';
+      }
+      throw error;
+    }
+    return result;
+  } finally {
+    subscription?.remove();
+    removeAbortListener?.();
+  }
+}

--- a/src/download/index.ts
+++ b/src/download/index.ts
@@ -1,5 +1,7 @@
 export { extractTarBz2 } from './extractTarBz2';
 export type { ExtractProgressEvent } from './extractTarBz2';
+export { extractTarZst } from './extractTarZst';
+export type { ExtractProgressEvent as ExtractZstProgressEvent } from './extractTarZst';
 export {
   listModelsByCategory,
   refreshModelsByCategory,

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -1,0 +1,273 @@
+/**
+ * Extraction subpath: list and extract compressed model archives (.tar.zst / .tar.bz2).
+ *
+ * Three entry points:
+ *  - getBundledArchives(packName)    – Android PAD packs (STORAGE_FILES or APK_ASSETS)
+ *  - listBundledArchives(dirPath)    – any filesystem directory (cross-platform)
+ *  - extractArchive(archive, target) – unified extraction (auto-selects path or asset-stream)
+ *
+ * After extraction, use listModelsAtPath / autoModelPath from the main package.
+ */
+
+import { DeviceEventEmitter, Platform } from 'react-native';
+import { readDir, stat, exists } from '@dr.pogodin/react-native-fs';
+import SherpaOnnx from '../NativeSherpaOnnx';
+import { extractTarZst } from '../download/extractTarZst';
+import { extractTarBz2 } from '../download/extractTarBz2';
+import type {
+  BundledArchive,
+  ExtractArchiveOptions,
+  ExtractResult,
+  ExtractProgressEvent,
+} from './types';
+
+export type {
+  BundledArchive,
+  ExtractArchiveOptions,
+  ExtractResult,
+  ExtractProgressEvent,
+} from './types';
+
+// ── Constants & helpers ───────────────────────────────────────────
+
+const TAR_ZST = '.tar.zst';
+const TAR_BZ2 = '.tar.bz2';
+
+function formatFromFilename(name: string): 'tar.zst' | 'tar.bz2' | null {
+  if (name.endsWith(TAR_ZST)) return 'tar.zst';
+  if (name.endsWith(TAR_BZ2)) return 'tar.bz2';
+  return null;
+}
+
+function modelIdFromFilename(filename: string): string {
+  if (filename.endsWith(TAR_ZST)) return filename.slice(0, -TAR_ZST.length);
+  if (filename.endsWith(TAR_BZ2)) return filename.slice(0, -TAR_BZ2.length);
+  return filename;
+}
+
+/**
+ * Scan a filesystem directory for .tar.zst / .tar.bz2 entries.
+ * Shared by getBundledArchives (STORAGE_FILES) and listBundledArchives.
+ */
+async function scanDirectoryForArchives(
+  directoryPath: string
+): Promise<BundledArchive[]> {
+  const dirExists = await exists(directoryPath);
+  if (!dirExists) return [];
+
+  const entries = await readDir(directoryPath);
+  const archives: BundledArchive[] = [];
+
+  for (const entry of entries) {
+    const format = formatFromFilename(entry.name);
+    if (!format || !entry.isFile()) continue;
+
+    let fileSize = 0;
+    try {
+      const s = await stat(entry.path);
+      fileSize = s.size ?? 0;
+    } catch {
+      // stat may fail on some filesystems; fileSize stays 0
+    }
+
+    archives.push({
+      modelId: modelIdFromFilename(entry.name),
+      archivePath: entry.path,
+      format,
+      fileSize,
+    });
+  }
+
+  return archives;
+}
+
+// ── Public API ────────────────────────────────────────────────────
+
+/**
+ * List compressed archives delivered via a **Play Asset Delivery** pack.
+ *
+ * - **STORAGE_FILES** packs: scans the pack directory on the filesystem.
+ * - **APK_ASSETS** packs: queries the Android AssetManager for embedded archive paths.
+ *   Archives returned with `fromAsset: true` are extracted by streaming from the APK
+ *   (no temp copy needed).
+ * - **iOS / unavailable pack**: returns `null`.
+ *
+ * @param packName  Name of the PAD asset pack (e.g. `"sherpa_models"`)
+ */
+export async function getBundledArchives(
+  packName: string
+): Promise<BundledArchive[] | null> {
+  if (Platform.OS !== 'android') {
+    return null;
+  }
+
+  const packPath = await SherpaOnnx.getAssetPackPath(packName);
+
+  if (packPath != null && packPath.length > 0) {
+    const archives = await scanDirectoryForArchives(packPath);
+    return archives.length > 0 ? archives : null;
+  }
+
+  const assetPaths = await SherpaOnnx.listBundledArchiveAssetPaths(packName);
+  if (assetPaths.length === 0) return null;
+
+  return assetPaths.map((archivePath) => {
+    const filename = archivePath.split('/').pop() ?? archivePath;
+    const format = formatFromFilename(filename) ?? 'tar.zst';
+    return {
+      modelId: modelIdFromFilename(filename),
+      archivePath,
+      format,
+      fromAsset: true,
+    };
+  });
+}
+
+/**
+ * List `.tar.zst` and `.tar.bz2` archives in a filesystem directory.
+ *
+ * Works on **all platforms** — use for:
+ * - iOS main-bundle archives (`MainBundlePath + '/models'`)
+ * - Archives downloaded to the documents directory
+ * - Any other folder containing compressed model archives
+ *
+ * @param directoryPath  Absolute path to the directory to scan
+ */
+export async function listBundledArchives(
+  directoryPath: string
+): Promise<BundledArchive[]> {
+  return scanDirectoryForArchives(directoryPath);
+}
+
+/**
+ * Extract a single archive to the target directory.
+ *
+ * Handles both source types transparently:
+ * - **Filesystem archives** (from `listBundledArchives` or PAD STORAGE_FILES) —
+ *   uses the regular path-based extraction.
+ * - **APK asset archives** (`fromAsset: true`, from PAD APK_ASSETS) —
+ *   streams directly from the APK without copying the archive to disk first.
+ *
+ * @param archive    Descriptor returned by `getBundledArchives` or `listBundledArchives`
+ * @param targetPath Directory to extract into (e.g. `DocumentDirectoryPath + '/models'`)
+ * @param options    `force` (default `true`), `onProgress`, `signal` (AbortSignal)
+ */
+export async function extractArchive(
+  archive: BundledArchive,
+  targetPath: string,
+  options?: ExtractArchiveOptions
+): Promise<ExtractResult> {
+  const force = options?.force !== false;
+  const onProgress = options?.onProgress;
+  const signal = options?.signal;
+
+  if (signal?.aborted) {
+    const err = new Error('Extraction aborted');
+    err.name = 'AbortError';
+    throw err;
+  }
+
+  const useAssetStream =
+    Platform.OS === 'android' &&
+    (archive.fromAsset === true ||
+      archive.archivePath.startsWith('asset_packs/'));
+
+  if (useAssetStream) {
+    return extractFromAsset(archive, targetPath, force, onProgress, signal);
+  }
+
+  if (archive.format === 'tar.zst') {
+    return extractTarZst(
+      archive.archivePath,
+      targetPath,
+      force,
+      onProgress,
+      signal
+    );
+  }
+  return extractTarBz2(
+    archive.archivePath,
+    targetPath,
+    force,
+    onProgress,
+    signal
+  );
+}
+
+// ── Internal: asset-stream extraction (Android APK_ASSETS) ───────
+
+async function extractFromAsset(
+  archive: BundledArchive,
+  targetPath: string,
+  force: boolean,
+  onProgress?: (event: ExtractProgressEvent) => void,
+  signal?: AbortSignal
+): Promise<ExtractResult> {
+  const eventName =
+    archive.format === 'tar.zst'
+      ? 'extractTarZstProgress'
+      : 'extractTarBz2Progress';
+
+  let subscription: { remove: () => void } | null = null;
+  let removeAbortListener: (() => void) | null = null;
+
+  if (onProgress) {
+    subscription = DeviceEventEmitter.addListener(
+      eventName,
+      (event: ExtractProgressEvent & { sourcePath?: string }) => {
+        if (
+          event.sourcePath != null &&
+          event.sourcePath !== archive.archivePath
+        ) {
+          return;
+        }
+        const safePercent = Math.max(0, Math.min(100, event.percent));
+        onProgress({ ...event, percent: safePercent });
+      }
+    );
+  }
+
+  if (signal) {
+    const cancel =
+      archive.format === 'tar.zst'
+        ? SherpaOnnx.cancelExtractTarZst
+        : SherpaOnnx.cancelExtractTarBz2;
+    const onAbort = () => {
+      try {
+        cancel();
+      } catch {
+        // ignore
+      }
+    };
+    signal.addEventListener('abort', onAbort);
+    removeAbortListener = () => signal.removeEventListener('abort', onAbort);
+  }
+
+  try {
+    const result =
+      archive.format === 'tar.zst'
+        ? await SherpaOnnx.extractTarZstFromAsset(
+            archive.archivePath,
+            targetPath,
+            force
+          )
+        : await SherpaOnnx.extractTarBz2FromAsset(
+            archive.archivePath,
+            targetPath,
+            force
+          );
+
+    if (!result.success) {
+      const message = result.reason ?? 'Extraction failed';
+      const error = new Error(message);
+      if (signal?.aborted || /cancel/i.test(message)) {
+        error.name = 'AbortError';
+      }
+      throw error;
+    }
+    return result;
+  } finally {
+    subscription?.remove();
+    removeAbortListener?.();
+  }
+}

--- a/src/extraction/types.ts
+++ b/src/extraction/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Types for the extraction subpath.
+ *
+ * A BundledArchive describes a compressed model archive (.tar.zst or .tar.bz2)
+ * that can come from two distinct sources:
+ *
+ *  1. **Filesystem** — a regular file on disk (PAD STORAGE_FILES, iOS bundle,
+ *     downloaded archive, etc.). `fromAsset` is absent or `false`.
+ *  2. **Android APK asset** — embedded in the APK via PAD APK_ASSETS.
+ *     `fromAsset` is `true`; extraction streams directly from the APK.
+ *
+ * The consumer does not need to distinguish between the two:
+ * `extractArchive()` handles both transparently.
+ */
+
+/** Describes one compressed model archive. */
+export type BundledArchive = {
+  /** Identifier derived from the archive filename (filename minus the extension). */
+  modelId: string;
+  /**
+   * Path to the archive.
+   * - Filesystem archives: absolute path (e.g. `/data/.../models/whisper-tiny.tar.zst`).
+   * - APK assets: asset path (e.g. `asset_packs/sherpa_models/assets/whisper-tiny.tar.zst`).
+   */
+  archivePath: string;
+  /** Compression format. */
+  format: 'tar.zst' | 'tar.bz2';
+  /** File size in bytes (available for filesystem archives; 0 or absent for APK assets). */
+  fileSize?: number;
+  /** `true` when the archive lives inside the APK (APK_ASSETS). Absent for filesystem archives. */
+  fromAsset?: boolean;
+};
+
+/** Progress event emitted during extraction. */
+export type ExtractProgressEvent = {
+  /** Bytes extracted so far. */
+  bytes: number;
+  /** Total bytes of the archive (may be 0 when unknown). */
+  totalBytes: number;
+  /** Progress percentage 0–100. */
+  percent: number;
+};
+
+/** Result returned by `extractArchive`. */
+export type ExtractResult = {
+  success: boolean;
+  /** Absolute path to the extracted directory (on success). */
+  path?: string;
+  /** SHA-256 hex digest of the source archive (when available). */
+  sha256?: string;
+  /** Error description (on failure). */
+  reason?: string;
+};
+
+/** Options for `extractArchive`. */
+export type ExtractArchiveOptions = {
+  /** Overwrite existing files. Defaults to `true`. */
+  force?: boolean;
+  /** Callback for extraction progress. */
+  onProgress?: (event: ExtractProgressEvent) => void;
+  /** AbortSignal to cancel the extraction. */
+  signal?: AbortSignal;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,7 @@ export { copyFileToContentUri } from './tts';
 // - import { createSTT, createStreamingSTT, ... } from 'react-native-sherpa-onnx/stt'
 // - import { createTTS, ... } from 'react-native-sherpa-onnx/tts'
 // - import { ... } from 'react-native-sherpa-onnx/download'
+// - import { getBundledArchives, listBundledArchives, extractArchive } from 'react-native-sherpa-onnx/extraction'
 // - import { ... } from 'react-native-sherpa-onnx/vad' (planned)
 // - import { ... } from 'react-native-sherpa-onnx/diarization' (planned)
 // - import { ... } from 'react-native-sherpa-onnx/enhancement' (planned)

--- a/third_party/libarchive_prebuilt/ANDROID_RELEASE_TAG
+++ b/third_party/libarchive_prebuilt/ANDROID_RELEASE_TAG
@@ -1,1 +1,1 @@
-libarchive-android-v3.8.5-1
+libarchive-android-v3.8.5-2

--- a/third_party/libarchive_prebuilt/IOS_RELEASE_TAG
+++ b/third_party/libarchive_prebuilt/IOS_RELEASE_TAG
@@ -1,1 +1,1 @@
-libarchive-ios-v3.8.5-1
+libarchive-ios-v3.8.5-2

--- a/third_party/libarchive_prebuilt/build_libarchive_android.sh
+++ b/third_party/libarchive_prebuilt/build_libarchive_android.sh
@@ -33,6 +33,8 @@ if [ ! -d "$LIBARCHIVE_SRC" ] || [ ! -f "$LIBARCHIVE_SRC/CMakeLists.txt" ]; then
     exit 1
 fi
 
+ZSTD_PREBUILT="$REPO_ROOT/third_party/zstd_prebuilt/android"
+
 # Disable programs and tests; only build shared library. Disable optional deps not in NDK.
 CMAKE_OPTS=(
     -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE"
@@ -49,7 +51,7 @@ CMAKE_OPTS=(
     -DENABLE_LIBXML2=OFF
     -DENABLE_EXPAT=OFF
     -DENABLE_LZMA=OFF
-    -DENABLE_ZSTD=OFF
+    -DENABLE_ZSTD=ON
     -DENABLE_LIBB2=OFF
     -DENABLE_BZip2=OFF
     -DENABLE_LZ4=OFF
@@ -62,6 +64,13 @@ CMAKE_OPTS=(
 ABIS="arm64-v8a armeabi-v7a x86 x86_64"
 
 for ABI in $ABIS; do
+    ZSTD_PREFIX="$ZSTD_PREBUILT/$ABI"
+    if [ ! -f "$ZSTD_PREFIX/lib/libzstd.so" ] || [ ! -f "$ZSTD_PREFIX/include/zstd.h" ]; then
+        echo "Error: zstd prebuilt not found for $ABI at $ZSTD_PREFIX"
+        echo "Run: (cd third_party/zstd_prebuilt && ./build_zstd.sh)"
+        exit 1
+    fi
+
     echo "Building libarchive for $ABI..."
     BUILD_DIR="$WORK_DIR/build-$ABI"
     rm -rf "$BUILD_DIR"
@@ -75,6 +84,8 @@ for ABI in $ABIS; do
             opts+=("$o")
         fi
     done
+    opts+=(-DZSTD_INCLUDE_DIR="$ZSTD_PREFIX/include")
+    opts+=(-DZSTD_LIBRARY="$ZSTD_PREFIX/lib/libzstd.so")
     cmake "${opts[@]}" "$LIBARCHIVE_SRC"
     cmake --build . -j"$(nproc 2>/dev/null || echo 4)"
     cd "$SCRIPT_DIR"

--- a/third_party/libarchive_prebuilt/build_libarchive_ios.sh
+++ b/third_party/libarchive_prebuilt/build_libarchive_ios.sh
@@ -12,6 +12,8 @@ if [ ! -d "$LIBARCHIVE_SRC/libarchive" ]; then
     exit 1
 fi
 
+ZSTD_PREBUILT="$REPO_ROOT/third_party/zstd_prebuilt/ios"
+
 export IOS_MIN_VERSION="${IPHONEOS_DEPLOYMENT_TARGET:-12.0}"
 export SIM_MIN_VERSION="${IPHONESIMULATOR_DEPLOYMENT_TARGET:-$IOS_MIN_VERSION}"
 
@@ -26,13 +28,20 @@ build_slice() {
   local platform=$1
   local arch=$2
   local os_type=$3
-  
+
+  local zstd_prefix="$ZSTD_PREBUILT/$platform/$arch"
+  if [ ! -f "$zstd_prefix/lib/libzstd.a" ] || [ ! -f "$zstd_prefix/include/zstd.h" ]; then
+    echo "Error: zstd prebuilt not found at $zstd_prefix"
+    echo "Run: (cd third_party/zstd_prebuilt && ./build_zstd_ios.sh)"
+    exit 1
+  fi
+
   echo "===== Building libarchive ($platform $arch) ====="
-  
+
   local prefix="$OUTPUT_DIR/$platform/$arch"
   local tmp_build="$BUILD_DIR/$platform-$arch"
   mkdir -p "$prefix" "$tmp_build"
-  
+
   local cmake_args=(
     "-DCMAKE_INSTALL_PREFIX=$prefix"
     "-DCMAKE_BUILD_TYPE=Release"
@@ -52,7 +61,9 @@ build_slice() {
     "-DENABLE_EXPAT=OFF"
     "-DENABLE_LZMA=OFF"
     "-DENABLE_LZ4=OFF"
-    "-DENABLE_ZSTD=OFF"
+    "-DENABLE_ZSTD=ON"
+    "-DZSTD_INCLUDE_DIR=$zstd_prefix/include"
+    "-DZSTD_LIBRARY=$zstd_prefix/lib/libzstd.a"
     "-DENABLE_LZO=OFF"
     "-DENABLE_MBEDTLS=OFF"
     "-DENABLE_NETTLE=OFF"
@@ -61,7 +72,7 @@ build_slice() {
     "-DENABLE_MAC_OSX_APPLE_DOUBLE=OFF"
     "-DHAVE_LIBXML_XMLREADER_H=OFF"
   )
-  
+
   if [ "$platform" = "iphoneos" ]; then
     cmake_args+=("-DCMAKE_OSX_SYSROOT=iphoneos")
     cmake_args+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=$IOS_MIN_VERSION")
@@ -74,6 +85,13 @@ build_slice() {
   cmake "$LIBARCHIVE_SRC" "${cmake_args[@]}"
   make -j"$(sysctl -n hw.ncpu)"
   make install
+
+  # Merge libzstd.a into libarchive.a so the XCFramework is self-contained
+  local archive_lib="$prefix/lib/libarchive.a"
+  local merged="$prefix/lib/libarchive_merged.a"
+  libtool -static -o "$merged" "$archive_lib" "$zstd_prefix/lib/libzstd.a"
+  mv "$merged" "$archive_lib"
+  cd "$SCRIPT_DIR"
 }
 
 build_slice iphoneos arm64 iOS

--- a/third_party/zstd_prebuilt/README.md
+++ b/third_party/zstd_prebuilt/README.md
@@ -1,0 +1,8 @@
+# zstd prebuilt for libarchive
+
+Builds [zstd](https://github.com/facebook/zstd) for Android and iOS. Output is used by libarchive (with ENABLE_ZSTD=ON).
+
+- **Android:** `build_zstd.sh` → `android/<abi>/lib/libzstd.so` and `android/<abi>/include/`
+- **iOS:** `build_zstd_ios.sh` → `ios/<platform>/<arch>/lib/libzstd.a` and `include/`
+
+Prebuilt artifacts (android/, ios/, build-*) are not committed. Run the scripts after `git submodule update --init third_party/zstd`.

--- a/third_party/zstd_prebuilt/build_zstd.sh
+++ b/third_party/zstd_prebuilt/build_zstd.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Build zstd for Android (all ABIs) using NDK and CMake.
+# Requires: NDK (ANDROID_NDK_HOME or ANDROID_NDK_ROOT), zstd source in ../../third_party/zstd (submodule).
+# Output: android/<abi>/lib/libzstd.so and android/<abi>/include/
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ZSTD_SRC="$REPO_ROOT/third_party/zstd"
+WORK_DIR="$SCRIPT_DIR"
+OUTPUT_BASE="$WORK_DIR/android"
+ANDROID_API="${ANDROID_API:-21}"
+
+if [ -n "$ANDROID_NDK_HOME" ]; then
+    NDK="$ANDROID_NDK_HOME"
+elif [ -n "$ANDROID_NDK_ROOT" ]; then
+    NDK="$ANDROID_NDK_ROOT"
+else
+    echo "Error: Set ANDROID_NDK_HOME or ANDROID_NDK_ROOT to your Android NDK path."
+    exit 1
+fi
+
+TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake"
+if [ ! -f "$TOOLCHAIN_FILE" ]; then
+    echo "Error: Android CMake toolchain not found: $TOOLCHAIN_FILE"
+    exit 1
+fi
+
+if [ ! -d "$ZSTD_SRC" ] || [ ! -f "$ZSTD_SRC/build/cmake/CMakeLists.txt" ]; then
+    echo "Error: zstd source not found at $ZSTD_SRC"
+    echo "Run: git submodule update --init third_party/zstd"
+    exit 1
+fi
+
+# Build shared lib only; no programs, tests, or contrib.
+CMAKE_OPTS=(
+    -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE"
+    -DANDROID_ABI=ABI_PLACEHOLDER
+    -DANDROID_PLATFORM="android-${ANDROID_API}"
+    -DCMAKE_BUILD_TYPE=Release
+    -DZSTD_BUILD_PROGRAMS=OFF
+    -DZSTD_BUILD_TESTS=OFF
+    -DZSTD_BUILD_CONTRIB=OFF
+    -DZSTD_BUILD_SHARED=ON
+    -DZSTD_BUILD_STATIC=OFF
+    -DCMAKE_INSTALL_PREFIX=PREFIX_PLACEHOLDER
+)
+
+ABIS="arm64-v8a armeabi-v7a x86 x86_64"
+
+for ABI in $ABIS; do
+    echo "Building zstd for $ABI..."
+    BUILD_DIR="$WORK_DIR/build-$ABI"
+    rm -rf "$BUILD_DIR"
+    mkdir -p "$BUILD_DIR"
+    PREFIX="$OUTPUT_BASE/$ABI"
+    mkdir -p "$PREFIX"
+    cd "$BUILD_DIR"
+    opts=()
+    for o in "${CMAKE_OPTS[@]}"; do
+        if [ "$o" = "-DANDROID_ABI=ABI_PLACEHOLDER" ]; then
+            opts+=(-DANDROID_ABI="$ABI")
+        elif [ "$o" = "-DCMAKE_INSTALL_PREFIX=PREFIX_PLACEHOLDER" ]; then
+            opts+=(-DCMAKE_INSTALL_PREFIX="$PREFIX")
+        else
+            opts+=("$o")
+        fi
+    done
+    cmake "${opts[@]}" "$ZSTD_SRC/build/cmake"
+    cmake --build . -j"$(nproc 2>/dev/null || echo 4)"
+    cmake --install .
+    cd "$SCRIPT_DIR"
+done
+
+echo "Done. Output: $OUTPUT_BASE"
+echo "  libs: $OUTPUT_BASE/<abi>/lib/libzstd.so"
+echo "  include: $OUTPUT_BASE/<abi>/include/"

--- a/third_party/zstd_prebuilt/build_zstd.sh
+++ b/third_party/zstd_prebuilt/build_zstd.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
-# Build zstd for Android (all ABIs) using system CMake and NDK target compilers.
-# Same approach as opus_prebuilt/build_opus.sh and ffmpeg_prebuilt/build_ffmpeg.sh:
-# no Android CMake toolchain file; use NDK clang wrappers (e.g. aarch64-linux-android21-clang) from PATH or NDK.
-# Requires: NDK on PATH (e.g. via nttld/setup-ndk add-to-path) or ANDROID_NDK_HOME/ANDROID_NDK_ROOT.
+# Build zstd for Android (all ABIs) using NDK and CMake.
+# Same pattern as libarchive_prebuilt/build_libarchive_android.sh: only CMAKE_TOOLCHAIN_FILE + ANDROID_ABI/ANDROID_PLATFORM.
+# Requires: NDK (ANDROID_NDK_HOME or ANDROID_NDK_ROOT), zstd source in ../../third_party/zstd (submodule).
 # Output: android/<abi>/lib/libzstd.so and android/<abi>/include/
 
 set -e
@@ -14,53 +13,20 @@ WORK_DIR="$SCRIPT_DIR"
 OUTPUT_BASE="$WORK_DIR/android"
 ANDROID_API="${ANDROID_API:-21}"
 
-# Optional: allow NDK path for fallback compiler lookup (when not on PATH)
 if [ -n "$ANDROID_NDK_HOME" ]; then
     NDK="$ANDROID_NDK_HOME"
 elif [ -n "$ANDROID_NDK_ROOT" ]; then
     NDK="$ANDROID_NDK_ROOT"
 else
-    NDK=""
+    echo "Error: Set ANDROID_NDK_HOME or ANDROID_NDK_ROOT to your Android NDK path."
+    exit 1
 fi
 
-# Resolve compiler for the given ABI. Prefer PATH (setup-ndk add-to-path), then NDK/toolchains/llvm/prebuilt.
-resolve_compiler() {
-    local ABI=$1
-    local host="" compiler_name=""
-    case "$ABI" in
-        arm64-v8a)   host="aarch64-linux-android" ;;
-        armeabi-v7a) host="armv7a-linux-androideabi" ;;
-        x86)         host="i686-linux-android" ;;
-        x86_64)      host="x86_64-linux-android" ;;
-        *) echo "Unknown ABI: $ABI" >&2; return 1 ;;
-    esac
-    compiler_name="${host}${ANDROID_API}-clang"
-    # Prefer compiler from PATH (e.g. nttld/setup-ndk add-to-path)
-    if command -v "$compiler_name" >/dev/null 2>&1; then
-        echo "$(command -v "$compiler_name")"
-        return
-    fi
-    # Fallback: NDK toolchain layout (same as opus/ffmpeg)
-    if [ -n "$NDK" ]; then
-        case "$(uname -s)" in
-            Linux*)   HOST_TAG="linux-x86_64" ;;
-            Darwin*)
-                if [ "$(uname -m)" = "arm64" ] && [ -d "$NDK/toolchains/llvm/prebuilt/darwin-arm64" ]; then
-                    HOST_TAG="darwin-arm64"
-                else
-                    HOST_TAG="darwin-x86_64"
-                fi
-                ;;
-            *)        HOST_TAG="windows-x86_64" ;;
-        esac
-        local cc="$NDK/toolchains/llvm/prebuilt/$HOST_TAG/bin/$compiler_name"
-        if [ -f "$cc" ]; then
-            echo "$cc"
-            return
-        fi
-    fi
-    echo ""
-}
+TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake"
+if [ ! -f "$TOOLCHAIN_FILE" ]; then
+    echo "Error: Android CMake toolchain not found: $TOOLCHAIN_FILE"
+    exit 1
+fi
 
 if [ ! -d "$ZSTD_SRC" ] || [ ! -f "$ZSTD_SRC/build/cmake/CMakeLists.txt" ]; then
     echo "Error: zstd source not found at $ZSTD_SRC"
@@ -68,38 +34,41 @@ if [ ! -d "$ZSTD_SRC" ] || [ ! -f "$ZSTD_SRC/build/cmake/CMakeLists.txt" ]; then
     exit 1
 fi
 
+# Same CMake pattern as build_libarchive_android.sh: toolchain file only, no explicit compiler.
+CMAKE_OPTS=(
+    -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE"
+    -DANDROID_ABI=ABI_PLACEHOLDER
+    -DANDROID_PLATFORM="android-${ANDROID_API}"
+    -DCMAKE_BUILD_TYPE=Release
+    -DZSTD_BUILD_PROGRAMS=OFF
+    -DZSTD_BUILD_TESTS=OFF
+    -DZSTD_BUILD_CONTRIB=OFF
+    -DZSTD_BUILD_SHARED=ON
+    -DZSTD_BUILD_STATIC=OFF
+    -DCMAKE_INSTALL_PREFIX=PREFIX_PLACEHOLDER
+)
+
 ABIS="arm64-v8a armeabi-v7a x86 x86_64"
 
 for ABI in $ABIS; do
-    CC=$(resolve_compiler "$ABI")
-    if [ -z "$CC" ]; then
-        echo "Error: could not find NDK compiler for $ABI (set ANDROID_NDK_HOME or ensure NDK is on PATH, e.g. nttld/setup-ndk add-to-path: true)"
-        exit 1
-    fi
-    # NDK C++ compiler: same path with -clang++ (e.g. aarch64-linux-android21-clang++)
-    CXX="${CC%clang}clang++"
-    [ -f "$CXX" ] || CXX="$CC"
-
-    echo "Building zstd for $ABI (CC=$CC)..."
+    echo "Building zstd for $ABI..."
     BUILD_DIR="$WORK_DIR/build-$ABI"
     rm -rf "$BUILD_DIR"
     mkdir -p "$BUILD_DIR"
     PREFIX="$OUTPUT_BASE/$ABI"
     mkdir -p "$PREFIX"
     cd "$BUILD_DIR"
-
-    cmake "$ZSTD_SRC/build/cmake" \
-        -DCMAKE_SYSTEM_NAME=Linux \
-        -DCMAKE_C_COMPILER="$CC" \
-        -DCMAKE_CXX_COMPILER="$CXX" \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX="$PREFIX" \
-        -DZSTD_BUILD_PROGRAMS=OFF \
-        -DZSTD_BUILD_TESTS=OFF \
-        -DZSTD_BUILD_CONTRIB=OFF \
-        -DZSTD_BUILD_SHARED=ON \
-        -DZSTD_BUILD_STATIC=OFF
-
+    opts=()
+    for o in "${CMAKE_OPTS[@]}"; do
+        if [ "$o" = "-DANDROID_ABI=ABI_PLACEHOLDER" ]; then
+            opts+=(-DANDROID_ABI="$ABI")
+        elif [ "$o" = "-DCMAKE_INSTALL_PREFIX=PREFIX_PLACEHOLDER" ]; then
+            opts+=(-DCMAKE_INSTALL_PREFIX="$PREFIX")
+        else
+            opts+=("$o")
+        fi
+    done
+    cmake "${opts[@]}" "$ZSTD_SRC/build/cmake"
     cmake --build . -j"$(nproc 2>/dev/null || echo 4)"
     cmake --install .
     cd "$SCRIPT_DIR"

--- a/third_party/zstd_prebuilt/build_zstd.sh
+++ b/third_party/zstd_prebuilt/build_zstd.sh
@@ -21,6 +21,25 @@ else
     exit 1
 fi
 
+# Same host-tag detection as opus_prebuilt/build_opus.sh (so CI behaves the same)
+case "$(uname -s)" in
+    Linux*)   HOST_TAG="linux-x86_64" ;;
+    Darwin*)
+        if [ "$(uname -m)" = "arm64" ] && [ -d "$NDK/toolchains/llvm/prebuilt/darwin-arm64" ]; then
+            HOST_TAG="darwin-arm64"
+        else
+            HOST_TAG="darwin-x86_64"
+        fi
+        ;;
+    *)        HOST_TAG="windows-x86_64" ;;
+esac
+
+TOOLCHAIN="$NDK/toolchains/llvm/prebuilt/$HOST_TAG"
+if [ ! -d "$TOOLCHAIN" ]; then
+    echo "Error: toolchain not found: $TOOLCHAIN"
+    exit 1
+fi
+
 TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake"
 if [ ! -f "$TOOLCHAIN_FILE" ]; then
     echo "Error: Android CMake toolchain not found: $TOOLCHAIN_FILE"
@@ -34,8 +53,11 @@ if [ ! -d "$ZSTD_SRC" ] || [ ! -f "$ZSTD_SRC/build/cmake/CMakeLists.txt" ]; then
 fi
 
 # Build shared lib only; no programs, tests, or contrib.
+# Pass compiler from TOOLCHAIN (same layout as opus) so CMake uses an existing path.
 CMAKE_OPTS=(
     -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE"
+    -DCMAKE_C_COMPILER="$TOOLCHAIN/bin/clang"
+    -DCMAKE_CXX_COMPILER="$TOOLCHAIN/bin/clang++"
     -DANDROID_ABI=ABI_PLACEHOLDER
     -DANDROID_PLATFORM="android-${ANDROID_API}"
     -DCMAKE_BUILD_TYPE=Release

--- a/third_party/zstd_prebuilt/build_zstd.sh
+++ b/third_party/zstd_prebuilt/build_zstd.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Build zstd for Android (all ABIs) using NDK and CMake.
-# Requires: NDK (ANDROID_NDK_HOME or ANDROID_NDK_ROOT), zstd source in ../../third_party/zstd (submodule).
+# Build zstd for Android (all ABIs) using system CMake and NDK target compilers.
+# Same approach as opus_prebuilt/build_opus.sh and ffmpeg_prebuilt/build_ffmpeg.sh:
+# no Android CMake toolchain file; use NDK clang wrappers (e.g. aarch64-linux-android21-clang) from PATH or NDK.
+# Requires: NDK on PATH (e.g. via nttld/setup-ndk add-to-path) or ANDROID_NDK_HOME/ANDROID_NDK_ROOT.
 # Output: android/<abi>/lib/libzstd.so and android/<abi>/include/
 
 set -e
@@ -12,39 +14,53 @@ WORK_DIR="$SCRIPT_DIR"
 OUTPUT_BASE="$WORK_DIR/android"
 ANDROID_API="${ANDROID_API:-21}"
 
+# Optional: allow NDK path for fallback compiler lookup (when not on PATH)
 if [ -n "$ANDROID_NDK_HOME" ]; then
     NDK="$ANDROID_NDK_HOME"
 elif [ -n "$ANDROID_NDK_ROOT" ]; then
     NDK="$ANDROID_NDK_ROOT"
 else
-    echo "Error: Set ANDROID_NDK_HOME or ANDROID_NDK_ROOT to your Android NDK path."
-    exit 1
+    NDK=""
 fi
 
-# Same host-tag detection as opus_prebuilt/build_opus.sh (so CI behaves the same)
-case "$(uname -s)" in
-    Linux*)   HOST_TAG="linux-x86_64" ;;
-    Darwin*)
-        if [ "$(uname -m)" = "arm64" ] && [ -d "$NDK/toolchains/llvm/prebuilt/darwin-arm64" ]; then
-            HOST_TAG="darwin-arm64"
-        else
-            HOST_TAG="darwin-x86_64"
+# Resolve compiler for the given ABI. Prefer PATH (setup-ndk add-to-path), then NDK/toolchains/llvm/prebuilt.
+resolve_compiler() {
+    local ABI=$1
+    local host="" compiler_name=""
+    case "$ABI" in
+        arm64-v8a)   host="aarch64-linux-android" ;;
+        armeabi-v7a) host="armv7a-linux-androideabi" ;;
+        x86)         host="i686-linux-android" ;;
+        x86_64)      host="x86_64-linux-android" ;;
+        *) echo "Unknown ABI: $ABI" >&2; return 1 ;;
+    esac
+    compiler_name="${host}${ANDROID_API}-clang"
+    # Prefer compiler from PATH (e.g. nttld/setup-ndk add-to-path)
+    if command -v "$compiler_name" >/dev/null 2>&1; then
+        echo "$(command -v "$compiler_name")"
+        return
+    fi
+    # Fallback: NDK toolchain layout (same as opus/ffmpeg)
+    if [ -n "$NDK" ]; then
+        case "$(uname -s)" in
+            Linux*)   HOST_TAG="linux-x86_64" ;;
+            Darwin*)
+                if [ "$(uname -m)" = "arm64" ] && [ -d "$NDK/toolchains/llvm/prebuilt/darwin-arm64" ]; then
+                    HOST_TAG="darwin-arm64"
+                else
+                    HOST_TAG="darwin-x86_64"
+                fi
+                ;;
+            *)        HOST_TAG="windows-x86_64" ;;
+        esac
+        local cc="$NDK/toolchains/llvm/prebuilt/$HOST_TAG/bin/$compiler_name"
+        if [ -f "$cc" ]; then
+            echo "$cc"
+            return
         fi
-        ;;
-    *)        HOST_TAG="windows-x86_64" ;;
-esac
-
-TOOLCHAIN="$NDK/toolchains/llvm/prebuilt/$HOST_TAG"
-if [ ! -d "$TOOLCHAIN" ]; then
-    echo "Error: toolchain not found: $TOOLCHAIN"
-    exit 1
-fi
-
-TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake"
-if [ ! -f "$TOOLCHAIN_FILE" ]; then
-    echo "Error: Android CMake toolchain not found: $TOOLCHAIN_FILE"
-    exit 1
-fi
+    fi
+    echo ""
+}
 
 if [ ! -d "$ZSTD_SRC" ] || [ ! -f "$ZSTD_SRC/build/cmake/CMakeLists.txt" ]; then
     echo "Error: zstd source not found at $ZSTD_SRC"
@@ -52,44 +68,38 @@ if [ ! -d "$ZSTD_SRC" ] || [ ! -f "$ZSTD_SRC/build/cmake/CMakeLists.txt" ]; then
     exit 1
 fi
 
-# Build shared lib only; no programs, tests, or contrib.
-# Pass compiler from TOOLCHAIN (same layout as opus) so CMake uses an existing path.
-CMAKE_OPTS=(
-    -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE"
-    -DCMAKE_C_COMPILER="$TOOLCHAIN/bin/clang"
-    -DCMAKE_CXX_COMPILER="$TOOLCHAIN/bin/clang++"
-    -DANDROID_ABI=ABI_PLACEHOLDER
-    -DANDROID_PLATFORM="android-${ANDROID_API}"
-    -DCMAKE_BUILD_TYPE=Release
-    -DZSTD_BUILD_PROGRAMS=OFF
-    -DZSTD_BUILD_TESTS=OFF
-    -DZSTD_BUILD_CONTRIB=OFF
-    -DZSTD_BUILD_SHARED=ON
-    -DZSTD_BUILD_STATIC=OFF
-    -DCMAKE_INSTALL_PREFIX=PREFIX_PLACEHOLDER
-)
-
 ABIS="arm64-v8a armeabi-v7a x86 x86_64"
 
 for ABI in $ABIS; do
-    echo "Building zstd for $ABI..."
+    CC=$(resolve_compiler "$ABI")
+    if [ -z "$CC" ]; then
+        echo "Error: could not find NDK compiler for $ABI (set ANDROID_NDK_HOME or ensure NDK is on PATH, e.g. nttld/setup-ndk add-to-path: true)"
+        exit 1
+    fi
+    # NDK C++ compiler: same path with -clang++ (e.g. aarch64-linux-android21-clang++)
+    CXX="${CC%clang}clang++"
+    [ -f "$CXX" ] || CXX="$CC"
+
+    echo "Building zstd for $ABI (CC=$CC)..."
     BUILD_DIR="$WORK_DIR/build-$ABI"
     rm -rf "$BUILD_DIR"
     mkdir -p "$BUILD_DIR"
     PREFIX="$OUTPUT_BASE/$ABI"
     mkdir -p "$PREFIX"
     cd "$BUILD_DIR"
-    opts=()
-    for o in "${CMAKE_OPTS[@]}"; do
-        if [ "$o" = "-DANDROID_ABI=ABI_PLACEHOLDER" ]; then
-            opts+=(-DANDROID_ABI="$ABI")
-        elif [ "$o" = "-DCMAKE_INSTALL_PREFIX=PREFIX_PLACEHOLDER" ]; then
-            opts+=(-DCMAKE_INSTALL_PREFIX="$PREFIX")
-        else
-            opts+=("$o")
-        fi
-    done
-    cmake "${opts[@]}" "$ZSTD_SRC/build/cmake"
+
+    cmake "$ZSTD_SRC/build/cmake" \
+        -DCMAKE_SYSTEM_NAME=Linux \
+        -DCMAKE_C_COMPILER="$CC" \
+        -DCMAKE_CXX_COMPILER="$CXX" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+        -DZSTD_BUILD_PROGRAMS=OFF \
+        -DZSTD_BUILD_TESTS=OFF \
+        -DZSTD_BUILD_CONTRIB=OFF \
+        -DZSTD_BUILD_SHARED=ON \
+        -DZSTD_BUILD_STATIC=OFF
+
     cmake --build . -j"$(nproc 2>/dev/null || echo 4)"
     cmake --install .
     cd "$SCRIPT_DIR"

--- a/third_party/zstd_prebuilt/build_zstd_ios.sh
+++ b/third_party/zstd_prebuilt/build_zstd_ios.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Build zstd for iOS (static lib): iphoneos/arm64, iphonesimulator/arm64, iphonesimulator/x86_64, and universal simulator.
+# Requires: zstd source in ../../third_party/zstd (submodule).
+# Output: ios/<platform>/<arch>/lib/libzstd.a and include/; ios/iphonesimulator/universal/lib/libzstd.a
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ZSTD_SRC="$REPO_ROOT/third_party/zstd"
+
+if [ ! -d "$ZSTD_SRC" ] || [ ! -f "$ZSTD_SRC/build/cmake/CMakeLists.txt" ]; then
+    echo "Error: zstd source not found at $ZSTD_SRC"
+    echo "Run: git submodule update --init third_party/zstd"
+    exit 1
+fi
+
+export IOS_MIN_VERSION="${IPHONEOS_DEPLOYMENT_TARGET:-12.0}"
+export SIM_MIN_VERSION="${IPHONESIMULATOR_DEPLOYMENT_TARGET:-$IOS_MIN_VERSION}"
+
+BUILD_DIR="$SCRIPT_DIR/build_ios"
+OUTPUT_DIR="$SCRIPT_DIR/ios"
+
+rm -rf "$BUILD_DIR" "$OUTPUT_DIR"
+mkdir -p "$BUILD_DIR" "$OUTPUT_DIR"
+
+build_slice() {
+  local platform=$1
+  local arch=$2
+  local os_type=$3
+
+  echo "===== Building zstd ($platform $arch) ====="
+
+  local prefix="$OUTPUT_DIR/$platform/$arch"
+  local tmp_build="$BUILD_DIR/$platform-$arch"
+  mkdir -p "$prefix" "$tmp_build"
+
+  local cmake_args=(
+    "-DCMAKE_INSTALL_PREFIX=$prefix"
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_SYSTEM_NAME=$os_type"
+    "-DCMAKE_OSX_ARCHITECTURES=$arch"
+    "-DZSTD_BUILD_PROGRAMS=OFF"
+    "-DZSTD_BUILD_TESTS=OFF"
+    "-DZSTD_BUILD_CONTRIB=OFF"
+    "-DZSTD_BUILD_SHARED=OFF"
+    "-DZSTD_BUILD_STATIC=ON"
+  )
+
+  if [ "$platform" = "iphoneos" ]; then
+    cmake_args+=("-DCMAKE_OSX_SYSROOT=iphoneos")
+    cmake_args+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=$IOS_MIN_VERSION")
+  else
+    cmake_args+=("-DCMAKE_OSX_SYSROOT=iphonesimulator")
+    cmake_args+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=$SIM_MIN_VERSION")
+  fi
+
+  cd "$tmp_build"
+  cmake "$ZSTD_SRC/build/cmake" "${cmake_args[@]}"
+  make -j"$(sysctl -n hw.ncpu)"
+  make install
+  cd "$SCRIPT_DIR"
+}
+
+build_slice iphoneos arm64 iOS
+build_slice iphonesimulator arm64 iOS
+build_slice iphonesimulator x86_64 iOS
+
+echo "===== Creating universal simulator lib ====="
+
+SIM_LIB="$OUTPUT_DIR/iphonesimulator/universal/lib"
+mkdir -p "$SIM_LIB"
+
+lipo -create \
+  "$OUTPUT_DIR/iphonesimulator/arm64/lib/libzstd.a" \
+  "$OUTPUT_DIR/iphonesimulator/x86_64/lib/libzstd.a" \
+  -output "$SIM_LIB/libzstd.a"
+
+echo "Done. Output: $OUTPUT_DIR"
+echo "  ios/iphoneos/arm64/lib/libzstd.a"
+echo "  ios/iphonesimulator/arm64 lib/x86_64 lib/ and universal/lib/libzstd.a"


### PR DESCRIPTION
This pull request updates and improves several CI/CD GitHub Actions workflows, primarily to modernize dependencies, enhance caching strategies, and improve build reliability for Android and iOS frameworks. The main themes are upgrading action versions, improving cache handling for third-party dependencies, and refining the build process for libarchive and zstd.

**Action version upgrades and caching improvements:**

* Updated all uses of `actions/cache`, `actions/upload-artifact`, `actions/checkout`, `actions/setup-node`, and `actions/setup-java` to their latest major versions (mostly to `v5` or `v7`), ensuring better performance, security, and compatibility. (`.github/actions/setup/action.yml` [[1]](diffhunk://#diff-9fb8259afcb532c9556e2d41ae1ee97cf6de54b486cef93a7ef1bf39433fa530L20-R20) [[2]](diffhunk://#diff-9fb8259afcb532c9556e2d41ae1ee97cf6de54b486cef93a7ef1bf39433fa530L41-R55) [[3]](diffhunk://#diff-9fb8259afcb532c9556e2d41ae1ee97cf6de54b486cef93a7ef1bf39433fa530L72-R72); `.github/workflows/build-ffmpeg-android-release.yml` [[4]](diffhunk://#diff-ca8bcf5791a92fdaa0b161359a4bfc8d1fb321fbf85a45be127b72f564c4f59bL68-R68); `.github/workflows/build-libarchive-android-release.yml` [[5]](diffhunk://#diff-770680074d25dfa26bebeeeb6c0f720fa4a3170e3c794a30e9e13a971d9361f4L100-R117); `.github/workflows/build-onnxruntime-android-release.yml` [[6]](diffhunk://#diff-767843c1eae5ff2a410e2d9d24309ac9edc26d22f8a6835f0934597ed59ece7aL77-R77) [[7]](diffhunk://#diff-767843c1eae5ff2a410e2d9d24309ac9edc26d22f8a6835f0934597ed59ece7aL94-R94) [[8]](diffhunk://#diff-767843c1eae5ff2a410e2d9d24309ac9edc26d22f8a6835f0934597ed59ece7aL131-R131); `.github/workflows/build-sherpa-onnx-android-release.yml` [[9]](diffhunk://#diff-93716dc463627a83d758c9594d1bee51c5c5dfce43e8cc4cd23fd4e200610b38L94-R94) [[10]](diffhunk://#diff-93716dc463627a83d758c9594d1bee51c5c5dfce43e8cc4cd23fd4e200610b38L131-R131); `.github/workflows/framework-ffmpeg-ios-framework.yml` [[11]](diffhunk://#diff-c20e961ef33c8bdfb3cfd5f9b0d926ef955bbf3c7a46c698a16f4913ad0a07bcL56-R56) [[12]](diffhunk://#diff-c20e961ef33c8bdfb3cfd5f9b0d926ef955bbf3c7a46c698a16f4913ad0a07bcL113-R113); `.github/workflows/framework-libarchive-ios-framework.yml` [[13]](diffhunk://#diff-b27325576610d4beed9abe8c34ce65bffdb828554d18435cbdc82cb2face9991L27-R27) [[14]](diffhunk://#diff-b27325576610d4beed9abe8c34ce65bffdb828554d18435cbdc82cb2face9991R49-R73); `.github/workflows/framework-sherpa-onnx-ios-framework.yml` [[15]](diffhunk://#diff-4d99c98c0c302023bc2c9b0e176bbd80fbaca0fcf9cf8e653f30762a8d4cd060L25-R25) [[16]](diffhunk://#diff-4d99c98c0c302023bc2c9b0e176bbd80fbaca0fcf9cf8e653f30762a8d4cd060L322-R332) [[17]](diffhunk://#diff-4d99c98c0c302023bc2c9b0e176bbd80fbaca0fcf9cf8e653f30762a8d4cd060L345-R347); `.github/workflows/sdk-android.yml` [[18]](diffhunk://#diff-8ca549569b7ccd07623c645b8aab11a649a389764da2de4ca7bf2fa237421d39L39-R39) [[19]](diffhunk://#diff-8ca549569b7ccd07623c645b8aab11a649a389764da2de4ca7bf2fa237421d39L73-R73) [[20]](diffhunk://#diff-8ca549569b7ccd07623c645b8aab11a649a389764da2de4ca7bf2fa237421d39L128-R128) [[21]](diffhunk://#diff-8ca549569b7ccd07623c645b8aab11a649a389764da2de4ca7bf2fa237421d39L251-R251)

**Libarchive and zstd build and cache enhancements:**

* Added caching and build steps for the zstd library alongside libarchive for both Android and iOS, improving build efficiency and ensuring that both libraries are included in the prebuilt artifacts. The cache key now includes both submodule versions and build scripts. (`.github/workflows/build-libarchive-android-release.yml` [[1]](diffhunk://#diff-770680074d25dfa26bebeeeb6c0f720fa4a3170e3c794a30e9e13a971d9361f4L55-R80) [[2]](diffhunk://#diff-770680074d25dfa26bebeeeb6c0f720fa4a3170e3c794a30e9e13a971d9361f4R104-R107); `.github/workflows/framework-libarchive-ios-framework.yml` [[3]](diffhunk://#diff-b27325576610d4beed9abe8c34ce65bffdb828554d18435cbdc82cb2face9991R49-R73)
* Updated the artifact packaging steps to include zstd binaries and headers in the output alongside libarchive. (`.github/workflows/build-libarchive-android-release.yml` [.github/workflows/build-libarchive-android-release.ymlR104-R107](diffhunk://#diff-770680074d25dfa26bebeeeb6c0f720fa4a3170e3c794a30e9e13a971d9361f4R104-R107))

**Build process and artifact improvements:**

* Refined version and tag handling for the sherpa-onnx iOS framework, ensuring consistent and accurate versioning in both the build and artifact names, and improved cloning logic for the correct tag. (`.github/workflows/framework-sherpa-onnx-ios-framework.yml` [[1]](diffhunk://#diff-4d99c98c0c302023bc2c9b0e176bbd80fbaca0fcf9cf8e653f30762a8d4cd060L50-R51) [[2]](diffhunk://#diff-4d99c98c0c302023bc2c9b0e176bbd80fbaca0fcf9cf8e653f30762a8d4cd060L65-R68) [[3]](diffhunk://#diff-4d99c98c0c302023bc2c9b0e176bbd80fbaca0fcf9cf8e653f30762a8d4cd060L322-R332) [[4]](diffhunk://#diff-4d99c98c0c302023bc2c9b0e176bbd80fbaca0fcf9cf8e653f30762a8d4cd060L345-R347) [[5]](diffhunk://#diff-4d99c98c0c302023bc2c9b0e176bbd80fbaca0fcf9cf8e653f30762a8d4cd060L379-R379) [[6]](diffhunk://#diff-4d99c98c0c302023bc2c9b0e176bbd80fbaca0fcf9cf8e653f30762a8d4cd060L397-R397)
* Disabled local NDK caching in the libarchive Android workflow to avoid known linking errors, referencing a related upstream issue. (`.github/workflows/build-libarchive-android-release.yml` [.github/workflows/build-libarchive-android-release.ymlL55-R80](diffhunk://#diff-770680074d25dfa26bebeeeb6c0f720fa4a3170e3c794a30e9e13a971d9361f4L55-R80))

**Other workflow refinements:**

* Removed the `skip_duplicate` flag from GitHub release steps, likely to ensure all release artifacts are uploaded even if duplicates exist. (`.github/workflows/build-libarchive-android-release.yml` [[1]](diffhunk://#diff-770680074d25dfa26bebeeeb6c0f720fa4a3170e3c794a30e9e13a971d9361f4L137); `.github/workflows/build-onnxruntime-android-release.yml` [[2]](diffhunk://#diff-767843c1eae5ff2a410e2d9d24309ac9edc26d22f8a6835f0934597ed59ece7aL202); `.github/workflows/build-sherpa-onnx-android-release.yml` [[3]](diffhunk://#diff-93716dc463627a83d758c9594d1bee51c5c5dfce43e8cc4cd23fd4e200610b38L257); `.github/workflows/framework-libarchive-ios-framework.yml` [[4]](diffhunk://#diff-b27325576610d4beed9abe8c34ce65bffdb828554d18435cbdc82cb2face9991L73)

These changes collectively modernize the CI pipelines, improve build reproducibility, and ensure that third-party dependencies are handled more robustly.