### PR TITLE
Feat/extraction notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Full step-by-step: [Download manager – Setup (iOS & Android)](docs/download-ma
 | Model quantization | ✅ **Supported** | [Model setup](./docs/model-setup.md) | Automatic detection and preference for quantized (int8) models. |
 | Flexible model loading | ✅ **Supported** | [Model setup](./docs/model-setup.md) | Asset models, file system models, or auto-detection. |
 | TypeScript | ✅ **Supported** | — | Full type definitions included. |
-| Speaker Diarization | ❌ Not yet supported | [Diarization](./docs/diarization.md) | Scheduled for release 0.4.0 |
-| Speech Enhancement | ❌ Not yet supported | [Enhancement](./docs/enhancement.md) | Scheduled for release 0.5.0 |
+| Speech Enhancement | ❌ Not yet supported | [Enhancement](./docs/enhancement.md) | Scheduled for release 0.4.0 |
+| Speaker Diarization | ❌ Not yet supported | [Diarization](./docs/diarization.md) | Scheduled for release 0.5.0 |
 | Source Separation | ❌ Not yet supported | [Separation](./docs/separation.md) | Scheduled for release 0.6.0 |
 | VAD (Voice Activity Detection) | ❌ Not yet supported | [VAD](./docs/vad.md) | Scheduled for release 0.7.0 |
 

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxArchiveHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxArchiveHelper.kt
@@ -152,6 +152,19 @@ class SherpaOnnxArchiveHelper {
     }
   }
 
+  /**
+   * Which JNI stream entry to use for APK asset extraction.
+   *
+   * Both paths invoke libarchive’s `ExtractFromStream`, which **auto-detects** compression
+   * (`.tar.zst` vs `.tar.bz2`, etc.); `nativeExtractTarBz2FromStream` forwards to the same
+   * native implementation as zst. Keeping distinct JNI symbols preserves a clear API and avoids
+   * the impression that bz2 assets are mistakenly wired only to a “zst” method.
+   */
+  private enum class AssetTarStreamKind {
+    ZST,
+    BZ2,
+  }
+
   fun extractTarZstFromAsset(
     context: Context,
     assetPath: String,
@@ -161,8 +174,54 @@ class SherpaOnnxArchiveHelper {
     onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit,
     extractionNotification: SherpaOnnxExtractionNotificationHelper? = null,
   ) {
+    extractTarArchiveFromAsset(
+      context,
+      assetPath,
+      targetPath,
+      force,
+      promise,
+      onProgress,
+      extractionNotification,
+      AssetTarStreamKind.ZST,
+    )
+  }
+
+  fun extractTarBz2FromAsset(
+    context: Context,
+    assetPath: String,
+    targetPath: String,
+    force: Boolean,
+    promise: Promise,
+    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit,
+    extractionNotification: SherpaOnnxExtractionNotificationHelper? = null,
+  ) {
+    extractTarArchiveFromAsset(
+      context,
+      assetPath,
+      targetPath,
+      force,
+      promise,
+      onProgress,
+      extractionNotification,
+      AssetTarStreamKind.BZ2,
+    )
+  }
+
+  private fun extractTarArchiveFromAsset(
+    context: Context,
+    assetPath: String,
+    targetPath: String,
+    force: Boolean,
+    promise: Promise,
+    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit,
+    extractionNotification: SherpaOnnxExtractionNotificationHelper? = null,
+    kind: AssetTarStreamKind,
+  ) {
     if (BuildConfig.DEBUG) {
-      Log.i("SherpaOnnx", "extractTarZstFromAsset assetPath=$assetPath targetPath=$targetPath")
+      Log.i(
+        "SherpaOnnx",
+        "extractTar${if (kind == AssetTarStreamKind.ZST) "Zst" else "Bz2"}FromAsset assetPath=$assetPath targetPath=$targetPath",
+      )
     }
     extractExecutor.execute {
       val notif = extractionNotification
@@ -175,7 +234,12 @@ class SherpaOnnxArchiveHelper {
           }
         }
         context.assets.open(assetPath).use { stream ->
-          nativeExtractTarZstFromStream(stream, targetPath, force, progressCallback, promise)
+          when (kind) {
+            AssetTarStreamKind.ZST ->
+              nativeExtractTarZstFromStream(stream, targetPath, force, progressCallback, promise)
+            AssetTarStreamKind.BZ2 ->
+              nativeExtractTarBz2FromStream(stream, targetPath, force, progressCallback, promise)
+          }
         }
       } catch (e: Exception) {
         val result = Arguments.createMap()
@@ -186,26 +250,6 @@ class SherpaOnnxArchiveHelper {
         notif?.finish()
       }
     }
-  }
-
-  fun extractTarBz2FromAsset(
-    context: Context,
-    assetPath: String,
-    targetPath: String,
-    force: Boolean,
-    promise: Promise,
-    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit,
-    extractionNotification: SherpaOnnxExtractionNotificationHelper? = null,
-  ) {
-    extractTarZstFromAsset(
-      context,
-      assetPath,
-      targetPath,
-      force,
-      promise,
-      onProgress,
-      extractionNotification,
-    )
   }
 
   fun computeFileSha256(filePath: String, promise: Promise) {
@@ -230,6 +274,14 @@ class SherpaOnnxArchiveHelper {
   )
 
   private external fun nativeExtractTarZstFromStream(
+    inputStream: java.io.InputStream,
+    targetPath: String,
+    force: Boolean,
+    progressCallback: Any?,
+    promise: Promise
+  )
+
+  private external fun nativeExtractTarBz2FromStream(
     inputStream: java.io.InputStream,
     targetPath: String,
     force: Boolean,

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxArchiveHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxArchiveHelper.kt
@@ -54,7 +54,8 @@ class SherpaOnnxArchiveHelper {
     targetPath: String,
     force: Boolean,
     promise: Promise,
-    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit
+    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit,
+    extractionNotification: SherpaOnnxExtractionNotificationHelper? = null,
   ) {
     val promiseSettled = AtomicBoolean(false)
     fun resolveOnce(success: Boolean, reason: String? = null) {
@@ -70,26 +71,28 @@ class SherpaOnnxArchiveHelper {
       val cancelFlag = AtomicBoolean(false)
       cancelFlags[sourcePath] = cancelFlag
 
-      // Create a progress callback object that JNI can call
-      val progressCallback = object : Any() {
-        fun invoke(bytesExtracted: Long, totalBytes: Long, percent: Double) {
-          onProgress(bytesExtracted, totalBytes, percent)
-        }
-      }
-
       // Run extraction on a background thread so the React Native bridge thread is not blocked.
       // The thread pool allows multiple extractions in parallel.
       extractExecutor.execute {
+        val notif = extractionNotification
         try {
           // Check per-path cancel flag before starting the native extraction.
           if (cancelFlag.get()) {
             resolveOnce(false, "Cancelled")
             return@execute
           }
-          nativeExtractTarBz2(sourcePath, targetPath, force, progressCallback, promise)
+          notif?.start()
+          val wrappedCallback = object : Any() {
+            fun invoke(bytesExtracted: Long, totalBytes: Long, percent: Double) {
+              onProgress(bytesExtracted, totalBytes, percent)
+              notif?.updateProgress(percent)
+            }
+          }
+          nativeExtractTarBz2(sourcePath, targetPath, force, wrappedCallback, promise)
         } catch (e: Exception) {
           resolveOnce(false, "Archive extraction error: ${e.message}")
         } finally {
+          notif?.finish()
           cancelFlags.remove(sourcePath)
         }
       }
@@ -104,7 +107,8 @@ class SherpaOnnxArchiveHelper {
     targetPath: String,
     force: Boolean,
     promise: Promise,
-    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit
+    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit,
+    extractionNotification: SherpaOnnxExtractionNotificationHelper? = null,
   ) {
     val promiseSettled = AtomicBoolean(false)
     fun resolveOnce(success: Boolean, reason: String? = null) {
@@ -119,22 +123,26 @@ class SherpaOnnxArchiveHelper {
       val cancelFlag = AtomicBoolean(false)
       cancelFlags[sourcePath] = cancelFlag
 
-      val progressCallback = object : Any() {
-        fun invoke(bytesExtracted: Long, totalBytes: Long, percent: Double) {
-          onProgress(bytesExtracted, totalBytes, percent)
-        }
-      }
       extractExecutor.execute {
+        val notif = extractionNotification
         try {
           // Check per-path cancel flag before starting the native extraction.
           if (cancelFlag.get()) {
             resolveOnce(false, "Cancelled")
             return@execute
           }
-          nativeExtractTarZst(sourcePath, targetPath, force, progressCallback, promise)
+          notif?.start()
+          val wrappedCallback = object : Any() {
+            fun invoke(bytesExtracted: Long, totalBytes: Long, percent: Double) {
+              onProgress(bytesExtracted, totalBytes, percent)
+              notif?.updateProgress(percent)
+            }
+          }
+          nativeExtractTarZst(sourcePath, targetPath, force, wrappedCallback, promise)
         } catch (e: Exception) {
           resolveOnce(false, "Archive extraction error: ${e.message}")
         } finally {
+          notif?.finish()
           cancelFlags.remove(sourcePath)
         }
       }
@@ -150,18 +158,22 @@ class SherpaOnnxArchiveHelper {
     targetPath: String,
     force: Boolean,
     promise: Promise,
-    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit
+    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit,
+    extractionNotification: SherpaOnnxExtractionNotificationHelper? = null,
   ) {
     if (BuildConfig.DEBUG) {
       Log.i("SherpaOnnx", "extractTarZstFromAsset assetPath=$assetPath targetPath=$targetPath")
     }
-    val progressCallback = object : Any() {
-      fun invoke(bytesExtracted: Long, totalBytes: Long, percent: Double) {
-        onProgress(bytesExtracted, totalBytes, percent)
-      }
-    }
     extractExecutor.execute {
+      val notif = extractionNotification
       try {
+        notif?.start()
+        val progressCallback = object : Any() {
+          fun invoke(bytesExtracted: Long, totalBytes: Long, percent: Double) {
+            onProgress(bytesExtracted, totalBytes, percent)
+            notif?.updateProgress(percent)
+          }
+        }
         context.assets.open(assetPath).use { stream ->
           nativeExtractTarZstFromStream(stream, targetPath, force, progressCallback, promise)
         }
@@ -170,6 +182,8 @@ class SherpaOnnxArchiveHelper {
         result.putBoolean("success", false)
         result.putString("reason", e.message ?: "Failed to open asset")
         promise.resolve(result)
+      } finally {
+        notif?.finish()
       }
     }
   }
@@ -180,9 +194,18 @@ class SherpaOnnxArchiveHelper {
     targetPath: String,
     force: Boolean,
     promise: Promise,
-    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit
+    onProgress: (bytes: Long, totalBytes: Long, percent: Double) -> Unit,
+    extractionNotification: SherpaOnnxExtractionNotificationHelper? = null,
   ) {
-    extractTarZstFromAsset(context, assetPath, targetPath, force, promise, onProgress)
+    extractTarZstFromAsset(
+      context,
+      assetPath,
+      targetPath,
+      force,
+      promise,
+      onProgress,
+      extractionNotification,
+    )
   }
 
   fun computeFileSha256(filePath: String, promise: Promise) {

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxExtractionNotificationHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxExtractionNotificationHelper.kt
@@ -1,0 +1,102 @@
+package com.sherpaonnx
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+
+/**
+ * Android-only progress notification for archive extraction (mirrors background download visibility).
+ * Safe no-ops if posting fails (e.g. POST_NOTIFICATIONS denied).
+ */
+class SherpaOnnxExtractionNotificationHelper private constructor(
+  private val context: Context,
+  private val notificationId: Int,
+  private val title: String,
+  private val baseText: String,
+) {
+  private val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+  @Volatile private var lastBucket: Int = -1
+
+  companion object {
+    private const val TAG = "SherpaOnnxExtractNotif"
+    const val CHANNEL_ID = "sherpa_onnx_extraction"
+    private val nextNotificationId = java.util.concurrent.atomic.AtomicInteger(9_200_000)
+
+    private const val DEFAULT_TITLE = "Model extraction"
+    private const val DEFAULT_TEXT = "Extracting archive…"
+
+    fun maybeCreate(
+      context: Context,
+      showNotificationsEnabled: Boolean?,
+      titleOverride: String?,
+      textOverride: String?,
+    ): SherpaOnnxExtractionNotificationHelper? {
+      if (showNotificationsEnabled == false) return null
+      val title = titleOverride?.trim()?.takeIf { it.isNotEmpty() } ?: DEFAULT_TITLE
+      val text = textOverride?.trim()?.takeIf { it.isNotEmpty() } ?: DEFAULT_TEXT
+      val id = nextNotificationId.getAndIncrement()
+      return SherpaOnnxExtractionNotificationHelper(context.applicationContext, id, title, text)
+    }
+
+    fun ensureChannel(ctx: Context) {
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+      val nm = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+      val existing = nm.getNotificationChannel(CHANNEL_ID)
+      if (existing != null) return
+      val ch = NotificationChannel(
+        CHANNEL_ID,
+        "Model extraction",
+        NotificationManager.IMPORTANCE_LOW,
+      ).apply {
+        setShowBadge(false)
+      }
+      nm.createNotificationChannel(ch)
+    }
+  }
+
+  private fun buildProgress(percentInt: Int): NotificationCompat.Builder {
+    val p = percentInt.coerceIn(0, 100)
+    val line = "$baseText $p%"
+    return NotificationCompat.Builder(context, CHANNEL_ID)
+      .setSmallIcon(android.R.drawable.stat_sys_download)
+      .setContentTitle(title)
+      .setContentText(line)
+      .setStyle(NotificationCompat.BigTextStyle().bigText(line))
+      .setOnlyAlertOnce(true)
+      .setPriority(NotificationCompat.PRIORITY_LOW)
+      .setOngoing(true)
+      .setProgress(100, p, false)
+  }
+
+  fun start() {
+    try {
+      ensureChannel(context)
+      nm.notify(notificationId, buildProgress(0).build())
+    } catch (e: Exception) {
+      Log.w(TAG, "start: ${e.message}")
+    }
+  }
+
+  fun updateProgress(percent: Double) {
+    val p = percent.toInt().coerceIn(0, 100)
+    val bucket = p / 4
+    if (bucket == lastBucket && p != 0 && p != 100) return
+    lastBucket = bucket
+    try {
+      nm.notify(notificationId, buildProgress(p).build())
+    } catch (e: Exception) {
+      Log.w(TAG, "updateProgress: ${e.message}")
+    }
+  }
+
+  fun finish() {
+    try {
+      nm.cancel(notificationId)
+    } catch (e: Exception) {
+      Log.w(TAG, "finish: ${e.message}")
+    }
+  }
+}

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -293,10 +293,30 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     assetHelper.resolveModelPath(config, promise)
   }
 
-  override fun extractTarBz2(sourcePath: String, targetPath: String, force: Boolean, promise: Promise) {
-    archiveHelper.extractTarBz2(sourcePath, targetPath, force, promise) { bytes, total, percent ->
-      emitExtractProgress(sourcePath, bytes, total, percent)
-    }
+  override fun extractTarBz2(
+    sourcePath: String,
+    targetPath: String,
+    force: Boolean,
+    showNotificationsEnabled: Boolean?,
+    notificationTitle: String?,
+    notificationText: String?,
+    promise: Promise,
+  ) {
+    val notif = extractionNotificationOrNull(
+      showNotificationsEnabled,
+      notificationTitle,
+      notificationText,
+    )
+    archiveHelper.extractTarBz2(
+      sourcePath,
+      targetPath,
+      force,
+      promise,
+      { bytes, total, percent ->
+        emitExtractProgress(sourcePath, bytes, total, percent)
+      },
+      notif,
+    )
   }
 
   override fun cancelExtractTarBz2(promise: Promise) {
@@ -304,10 +324,30 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     promise.resolve(null)
   }
 
-  override fun extractTarZst(sourcePath: String, targetPath: String, force: Boolean, promise: Promise) {
-    archiveHelper.extractTarZst(sourcePath, targetPath, force, promise) { bytes, total, percent ->
-      emitExtractTarZstProgress(sourcePath, bytes, total, percent)
-    }
+  override fun extractTarZst(
+    sourcePath: String,
+    targetPath: String,
+    force: Boolean,
+    showNotificationsEnabled: Boolean?,
+    notificationTitle: String?,
+    notificationText: String?,
+    promise: Promise,
+  ) {
+    val notif = extractionNotificationOrNull(
+      showNotificationsEnabled,
+      notificationTitle,
+      notificationText,
+    )
+    archiveHelper.extractTarZst(
+      sourcePath,
+      targetPath,
+      force,
+      promise,
+      { bytes, total, percent ->
+        emitExtractTarZstProgress(sourcePath, bytes, total, percent)
+      },
+      notif,
+    )
   }
 
   override fun cancelExtractTarZst(promise: Promise) {
@@ -344,6 +384,20 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     payload.putDouble("totalBytes", totalBytes.toDouble())
     payload.putDouble("percent", percent)
     eventEmitter.emit("extractTarZstProgress", payload)
+  }
+
+  /** Null when extraction notifications are disabled (`showNotificationsEnabled == false`). */
+  private fun extractionNotificationOrNull(
+    showNotificationsEnabled: Boolean?,
+    notificationTitle: String?,
+    notificationText: String?,
+  ): SherpaOnnxExtractionNotificationHelper? {
+    return SherpaOnnxExtractionNotificationHelper.maybeCreate(
+      reactApplicationContext,
+      showNotificationsEnabled,
+      notificationTitle,
+      notificationText,
+    )
   }
 
   /**
@@ -1101,34 +1155,54 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     assetPath: String,
     targetPath: String,
     force: Boolean,
-    promise: Promise
+    showNotificationsEnabled: Boolean?,
+    notificationTitle: String?,
+    notificationText: String?,
+    promise: Promise,
   ) {
+    val notif = extractionNotificationOrNull(
+      showNotificationsEnabled,
+      notificationTitle,
+      notificationText,
+    )
     archiveHelper.extractTarZstFromAsset(
       reactApplicationContext,
       assetPath,
       targetPath,
       force,
-      promise
-    ) { bytes, total, percent ->
-      emitExtractTarZstProgress(assetPath, bytes, total, percent)
-    }
+      promise,
+      { bytes, total, percent ->
+        emitExtractTarZstProgress(assetPath, bytes, total, percent)
+      },
+      notif,
+    )
   }
 
   override fun extractTarBz2FromAsset(
     assetPath: String,
     targetPath: String,
     force: Boolean,
-    promise: Promise
+    showNotificationsEnabled: Boolean?,
+    notificationTitle: String?,
+    notificationText: String?,
+    promise: Promise,
   ) {
+    val notif = extractionNotificationOrNull(
+      showNotificationsEnabled,
+      notificationTitle,
+      notificationText,
+    )
     archiveHelper.extractTarBz2FromAsset(
       reactApplicationContext,
       assetPath,
       targetPath,
       force,
-      promise
-    ) { bytes, total, percent ->
-      emitExtractProgress(assetPath, bytes, total, percent)
-    }
+      promise,
+      { bytes, total, percent ->
+        emitExtractProgress(assetPath, bytes, total, percent)
+      },
+      notif,
+    )
   }
 
   override fun readAssetFileAsUtf8(assetPath: String, promise: Promise) {

--- a/docs/download-manager.md
+++ b/docs/download-manager.md
@@ -122,6 +122,10 @@ Posting a normal ongoing notification requires:
 
 Without this, the foreground download work may still run, but the **notification may not appear** in the shade—poor UX and difficult to record for Play policy.
 
+**Extraction progress notifications (Android)**
+
+After a download completes, **`runPostDownloadProcessing`** (used by `downloadModelByCategory`, `resumeDownload`, `extractModelByCategory`, etc.) runs native archive extraction. On **Android**, a separate **low-priority** ongoing notification (channel `sherpa_onnx_extraction`) shows unpack progress and is **cancelled when extraction finishes** (success or failure). This mirrors download visibility for long unpacks. **iOS** does not show a system extraction notification (same policy as NSURLSession download UX). Advanced apps can pass `showExtractionNotifications: false` (and optional title/text) via **`RunPostDownloadProcessingOptions`** when calling the post-download pipeline directly; the public **`extractArchive`** API also supports `showNotificationsEnabled` / `notificationTitle` / `notificationText` (see [extraction.md](extraction.md)).
+
 **Customizing downloader config (titles, grouping, headers, …)**
 
 Call **`configureModelDownloadBackgroundDownloader(options)`** from `react-native-sherpa-onnx/download` **once at app startup** (e.g. in `App.tsx`) **before** any model download. It forwards to the underlying `setConfig` and tells the SDK **not** to apply its built-in default notification settings on first download. The `options` shape is the same as `@kesha-antonov/react-native-background-downloader`’s `setConfig` (type **`BackgroundDownloaderSetConfigOptions`**).

--- a/docs/extraction.md
+++ b/docs/extraction.md
@@ -133,6 +133,9 @@ Extracts one archive into `targetPath`. Handles both source types transparently:
 | `force` | `boolean` | `true` | Overwrite existing files in `targetPath` |
 | `onProgress` | `(event) => void` | — | Callback with `{ bytes, totalBytes, percent }`. Correctly handles parallel extractions by filtering by source path. |
 | `signal` | `AbortSignal` | — | Cancel extraction (throws `AbortError`). Cancellation is **per-operation**, so cancelling one archive won't affect others. |
+| `showNotificationsEnabled` | `boolean` | `true` | **Android:** Native `NotificationManager` progress notification during extraction (updated on the native thread). Set `false` to disable (e.g. first-run prep with in-app UI only). **iOS:** Ignored; no extraction progress notification is shown. |
+| `notificationTitle` | `string` | generic | **Android:** Notification title. **iOS:** Ignored. |
+| `notificationText` | `string` | generic | **Android:** Base notification text; progress percent is appended. **iOS:** Ignored. |
 
 **Note on Parallelism:**
 - **Android:** Supports up to **2 concurrent extractions** via a fixed thread pool. Additional requests are queued.
@@ -154,6 +157,9 @@ type ExtractArchiveOptions = {
   force?: boolean;
   onProgress?: (event: ExtractProgressEvent) => void;
   signal?: AbortSignal;
+  showNotificationsEnabled?: boolean;
+  notificationTitle?: string;
+  notificationText?: string;
 };
 
 type ExtractResult = {

--- a/ios/SherpaOnnx.mm
+++ b/ios/SherpaOnnx.mm
@@ -138,9 +138,15 @@
 - (void)extractTarBz2:(NSString *)sourcePath
            targetPath:(NSString *)targetPath
                 force:(BOOL)force
-         resolve:(RCTPromiseResolveBlock)resolve
-         reject:(RCTPromiseRejectBlock)reject
+showNotificationsEnabled:(NSNumber *)showNotificationsEnabled
+    notificationTitle:(NSString *)notificationTitle
+     notificationText:(NSString *)notificationText
+              resolve:(RCTPromiseResolveBlock)resolve
+               reject:(RCTPromiseRejectBlock)reject
 {
+    (void)showNotificationsEnabled;
+    (void)notificationTitle;
+    (void)notificationText;
     SherpaOnnxArchiveHelper *helper = [SherpaOnnxArchiveHelper new];
     NSDictionary *result = [helper extractTarBz2:sourcePath
                                      targetPath:targetPath
@@ -165,9 +171,15 @@
 - (void)extractTarZst:(NSString *)sourcePath
            targetPath:(NSString *)targetPath
                 force:(BOOL)force
-             resolve:(RCTPromiseResolveBlock)resolve
-             reject:(RCTPromiseRejectBlock)reject
+showNotificationsEnabled:(NSNumber *)showNotificationsEnabled
+    notificationTitle:(NSString *)notificationTitle
+     notificationText:(NSString *)notificationText
+              resolve:(RCTPromiseResolveBlock)resolve
+               reject:(RCTPromiseRejectBlock)reject
 {
+    (void)showNotificationsEnabled;
+    (void)notificationTitle;
+    (void)notificationText;
     SherpaOnnxArchiveHelper *helper = [SherpaOnnxArchiveHelper new];
     NSDictionary *result = [helper extractTarZst:sourcePath
                                     targetPath:targetPath
@@ -229,19 +241,33 @@
 
 - (void)extractTarZstFromAsset:(NSString *)assetPath
                    targetPath:(NSString *)targetPath
-                       force:(NSNumber *)force
-                     resolve:(RCTPromiseResolveBlock)resolve
-                      reject:(RCTPromiseRejectBlock)reject
+                        force:(BOOL)force
+      showNotificationsEnabled:(NSNumber *)showNotificationsEnabled
+             notificationTitle:(NSString *)notificationTitle
+              notificationText:(NSString *)notificationText
+                       resolve:(RCTPromiseResolveBlock)resolve
+                        reject:(RCTPromiseRejectBlock)reject
 {
+    (void)force;
+    (void)showNotificationsEnabled;
+    (void)notificationTitle;
+    (void)notificationText;
     resolve(@{ @"success": @NO, @"reason": @"Not supported on iOS; use path-based extraction." });
 }
 
 - (void)extractTarBz2FromAsset:(NSString *)assetPath
                    targetPath:(NSString *)targetPath
-                        force:(NSNumber *)force
-                      resolve:(RCTPromiseResolveBlock)resolve
-                       reject:(RCTPromiseRejectBlock)reject
+                        force:(BOOL)force
+      showNotificationsEnabled:(NSNumber *)showNotificationsEnabled
+             notificationTitle:(NSString *)notificationTitle
+              notificationText:(NSString *)notificationText
+                       resolve:(RCTPromiseResolveBlock)resolve
+                        reject:(RCTPromiseRejectBlock)reject
 {
+    (void)force;
+    (void)showNotificationsEnabled;
+    (void)notificationTitle;
+    (void)notificationText;
     resolve(@{ @"success": @NO, @"reason": @"Not supported on iOS; use path-based extraction." });
 }
 

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -557,11 +557,18 @@ export interface Spec extends TurboModule {
   /**
    * Extract a .tar.bz2 archive to a target folder.
    * Returns { success, path } or { success, reason }.
+   *
+   * **Android:** When `showNotificationsEnabled` is true (default), a system notification shows
+   * extraction progress. Optional `notificationTitle` / `notificationText` customize the copy.
+   * **iOS:** Notification parameters are accepted but have no effect (no extraction progress notification).
    */
   extractTarBz2(
     sourcePath: string,
     targetPath: string,
-    force: boolean
+    force: boolean,
+    showNotificationsEnabled?: boolean,
+    notificationTitle?: string,
+    notificationText?: string
   ): Promise<{
     success: boolean;
     path?: string;
@@ -577,11 +584,16 @@ export interface Spec extends TurboModule {
   /**
    * Extract a .tar.zst (or .zst) archive to a target folder.
    * Returns { success, path } or { success, reason }.
+   *
+   * **Android:** Same notification behavior as `extractTarBz2`. **iOS:** No effect.
    */
   extractTarZst(
     sourcePath: string,
     targetPath: string,
-    force: boolean
+    force: boolean,
+    showNotificationsEnabled?: boolean,
+    notificationTitle?: string,
+    notificationText?: string
   ): Promise<{
     success: boolean;
     path?: string;
@@ -608,11 +620,15 @@ export interface Spec extends TurboModule {
   /**
    * Extract a .tar.zst archive from Android assets (AssetManager) to a target folder. Android only.
    * Streams from asset; no copy of the archive to disk. Used when PAD pack is APK_ASSETS.
+   * Notification options match `extractTarZst` (Android only).
    */
   extractTarZstFromAsset(
     assetPath: string,
     targetPath: string,
-    force: boolean
+    force: boolean,
+    showNotificationsEnabled?: boolean,
+    notificationTitle?: string,
+    notificationText?: string
   ): Promise<{
     success: boolean;
     path?: string;
@@ -623,11 +639,15 @@ export interface Spec extends TurboModule {
   /**
    * Extract a .tar.bz2 archive from Android assets (AssetManager) to a target folder. Android only.
    * Streams from asset; no copy of the archive to disk. Used when PAD pack is APK_ASSETS.
+   * Notification options match `extractTarBz2` (Android only).
    */
   extractTarBz2FromAsset(
     assetPath: string,
     targetPath: string,
-    force: boolean
+    force: boolean,
+    showNotificationsEnabled?: boolean,
+    notificationTitle?: string,
+    notificationText?: string
   ): Promise<{
     success: boolean;
     path?: string;

--- a/src/download/postDownloadProcessing.ts
+++ b/src/download/postDownloadProcessing.ts
@@ -43,6 +43,15 @@ export type RunPostDownloadProcessingOptions = {
   onChecksumIssue?: (issue: ChecksumIssue) => Promise<boolean>;
   deleteArchiveAfterExtract?: boolean;
   onProgress?: (progress: DownloadProgress) => void;
+  /**
+   * **Android:** Native extraction progress notification (default true), aligned with the download-manager flow.
+   * **iOS:** No effect.
+   */
+  showExtractionNotifications?: boolean;
+  /** **Android:** Optional notification title (default: SDK/native default title). */
+  extractionNotificationTitle?: string;
+  /** **Android:** Optional notification body prefix (progress percent is appended natively). */
+  extractionNotificationText?: string;
   /** Called to get current list of downloaded models for emitModelsListUpdated. */
   getDownloadedList: () => Promise<ModelMetaBase[]>;
 };
@@ -63,6 +72,9 @@ export async function runPostDownloadProcessing(
     deleteArchiveAfterExtract,
     onProgress,
     getDownloadedList,
+    showExtractionNotifications,
+    extractionNotificationTitle,
+    extractionNotificationText,
   } = options;
 
   registerActivePostProcess(category, id);
@@ -80,6 +92,9 @@ export async function runPostDownloadProcessing(
       deleteArchiveAfterExtract,
       onProgress,
       getDownloadedList,
+      showExtractionNotifications,
+      extractionNotificationTitle,
+      extractionNotificationText,
     });
   } finally {
     unregisterActivePostProcess(category, id);
@@ -102,6 +117,9 @@ async function runPostDownloadProcessingBody(
     deleteArchiveAfterExtract,
     onProgress,
     getDownloadedList,
+    showExtractionNotifications,
+    extractionNotificationTitle,
+    extractionNotificationText,
   } = options;
 
   const isAborted = () => Boolean(signal?.aborted);
@@ -164,7 +182,12 @@ async function runPostDownloadProcessingBody(
         onProgress?.(progress);
         emitDownloadProgress(category, id, progress);
       },
-      signal
+      signal,
+      {
+        showNotificationsEnabled: showExtractionNotifications !== false,
+        notificationTitle: extractionNotificationTitle,
+        notificationText: extractionNotificationText,
+      }
     );
   }
 

--- a/src/extraction/extractTarBz2.ts
+++ b/src/extraction/extractTarBz2.ts
@@ -1,6 +1,6 @@
 import { DeviceEventEmitter } from 'react-native';
 import SherpaOnnx from '../NativeSherpaOnnx';
-import type { ExtractArchiveOptions } from './types';
+import type { ExtractNotificationArgs } from './types';
 
 export type ExtractProgressEvent = {
   bytes: number;
@@ -14,11 +14,6 @@ type ExtractResult = {
   sha256?: string;
   reason?: string;
 };
-
-type ExtractNotificationArgs = Pick<
-  ExtractArchiveOptions,
-  'showNotificationsEnabled' | 'notificationTitle' | 'notificationText'
->;
 
 export async function extractTarBz2(
   sourcePath: string,

--- a/src/extraction/extractTarBz2.ts
+++ b/src/extraction/extractTarBz2.ts
@@ -1,5 +1,6 @@
 import { DeviceEventEmitter } from 'react-native';
 import SherpaOnnx from '../NativeSherpaOnnx';
+import type { ExtractArchiveOptions } from './types';
 
 export type ExtractProgressEvent = {
   bytes: number;
@@ -14,12 +15,18 @@ type ExtractResult = {
   reason?: string;
 };
 
+type ExtractNotificationArgs = Pick<
+  ExtractArchiveOptions,
+  'showNotificationsEnabled' | 'notificationTitle' | 'notificationText'
+>;
+
 export async function extractTarBz2(
   sourcePath: string,
   targetPath: string,
   force = true,
   onProgress?: (event: ExtractProgressEvent) => void,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  notification?: ExtractNotificationArgs
 ): Promise<ExtractResult> {
   let subscription: { remove: () => void } | null = null;
   let removeAbortListener: (() => void) | null = null;
@@ -62,7 +69,10 @@ export async function extractTarBz2(
     const result = await SherpaOnnx.extractTarBz2(
       sourcePath,
       targetPath,
-      force
+      force,
+      notification?.showNotificationsEnabled,
+      notification?.notificationTitle,
+      notification?.notificationText
     );
     if (!result.success) {
       const message = result.reason || 'Extraction failed';

--- a/src/extraction/extractTarZst.ts
+++ b/src/extraction/extractTarZst.ts
@@ -1,5 +1,6 @@
 import { DeviceEventEmitter } from 'react-native';
 import SherpaOnnx from '../NativeSherpaOnnx';
+import type { ExtractArchiveOptions } from './types';
 
 export type ExtractProgressEvent = {
   bytes: number;
@@ -14,12 +15,18 @@ type ExtractResult = {
   reason?: string;
 };
 
+type ExtractNotificationArgs = Pick<
+  ExtractArchiveOptions,
+  'showNotificationsEnabled' | 'notificationTitle' | 'notificationText'
+>;
+
 export async function extractTarZst(
   sourcePath: string,
   targetPath: string,
   force = true,
   onProgress?: (event: ExtractProgressEvent) => void,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  notification?: ExtractNotificationArgs
 ): Promise<ExtractResult> {
   let subscription: { remove: () => void } | null = null;
   let removeAbortListener: (() => void) | null = null;
@@ -61,7 +68,10 @@ export async function extractTarZst(
     const result = await SherpaOnnx.extractTarZst(
       sourcePath,
       targetPath,
-      force
+      force,
+      notification?.showNotificationsEnabled,
+      notification?.notificationTitle,
+      notification?.notificationText
     );
     if (!result.success) {
       const message = result.reason || 'Extraction failed';

--- a/src/extraction/extractTarZst.ts
+++ b/src/extraction/extractTarZst.ts
@@ -1,6 +1,6 @@
 import { DeviceEventEmitter } from 'react-native';
 import SherpaOnnx from '../NativeSherpaOnnx';
-import type { ExtractArchiveOptions } from './types';
+import type { ExtractNotificationArgs } from './types';
 
 export type ExtractProgressEvent = {
   bytes: number;
@@ -14,11 +14,6 @@ type ExtractResult = {
   sha256?: string;
   reason?: string;
 };
-
-type ExtractNotificationArgs = Pick<
-  ExtractArchiveOptions,
-  'showNotificationsEnabled' | 'notificationTitle' | 'notificationText'
->;
 
 export async function extractTarZst(
   sourcePath: string,

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -160,6 +160,11 @@ export async function extractArchive(
   const force = options?.force !== false;
   const onProgress = options?.onProgress;
   const signal = options?.signal;
+  const notification = {
+    showNotificationsEnabled: options?.showNotificationsEnabled,
+    notificationTitle: options?.notificationTitle,
+    notificationText: options?.notificationText,
+  };
 
   if (signal?.aborted) {
     const err = new Error('Extraction aborted');
@@ -173,7 +178,14 @@ export async function extractArchive(
       archive.archivePath.startsWith('asset_packs/'));
 
   if (useAssetStream) {
-    return extractFromAsset(archive, targetPath, force, onProgress, signal);
+    return extractFromAsset(
+      archive,
+      targetPath,
+      force,
+      onProgress,
+      signal,
+      notification
+    );
   }
 
   if (archive.format === 'tar.zst') {
@@ -182,7 +194,8 @@ export async function extractArchive(
       targetPath,
       force,
       onProgress,
-      signal
+      signal,
+      notification
     );
   }
   return extractTarBz2(
@@ -190,7 +203,8 @@ export async function extractArchive(
     targetPath,
     force,
     onProgress,
-    signal
+    signal,
+    notification
   );
 }
 
@@ -201,7 +215,12 @@ async function extractFromAsset(
   targetPath: string,
   force: boolean,
   onProgress?: (event: ExtractProgressEvent) => void,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  notification?: {
+    showNotificationsEnabled?: boolean;
+    notificationTitle?: string;
+    notificationText?: string;
+  }
 ): Promise<ExtractResult> {
   const eventName =
     archive.format === 'tar.zst'
@@ -245,12 +264,18 @@ async function extractFromAsset(
         ? await SherpaOnnx.extractTarZstFromAsset(
             archive.archivePath,
             targetPath,
-            force
+            force,
+            notification?.showNotificationsEnabled,
+            notification?.notificationTitle,
+            notification?.notificationText
           )
         : await SherpaOnnx.extractTarBz2FromAsset(
             archive.archivePath,
             targetPath,
-            force
+            force,
+            notification?.showNotificationsEnabled,
+            notification?.notificationTitle,
+            notification?.notificationText
           );
 
     if (!result.success) {

--- a/src/extraction/index.ts
+++ b/src/extraction/index.ts
@@ -17,6 +17,7 @@ import { extractTarBz2 } from './extractTarBz2';
 import type {
   BundledArchive,
   ExtractArchiveOptions,
+  ExtractNotificationArgs,
   ExtractResult,
   ExtractProgressEvent,
 } from './types';
@@ -24,6 +25,7 @@ import type {
 export type {
   BundledArchive,
   ExtractArchiveOptions,
+  ExtractNotificationArgs,
   ExtractResult,
   ExtractProgressEvent,
 } from './types';
@@ -216,11 +218,7 @@ async function extractFromAsset(
   force: boolean,
   onProgress?: (event: ExtractProgressEvent) => void,
   signal?: AbortSignal,
-  notification?: {
-    showNotificationsEnabled?: boolean;
-    notificationTitle?: string;
-    notificationText?: string;
-  }
+  notification?: ExtractNotificationArgs
 ): Promise<ExtractResult> {
   const eventName =
     archive.format === 'tar.zst'

--- a/src/extraction/types.ts
+++ b/src/extraction/types.ts
@@ -71,3 +71,9 @@ export type ExtractArchiveOptions = {
   /** **Android:** Notification body (progress text is appended). Default: generic. Ignored on iOS. */
   notificationText?: string;
 };
+
+/** Subset of `ExtractArchiveOptions` passed through to path- and asset-stream extractors. */
+export type ExtractNotificationArgs = Pick<
+  ExtractArchiveOptions,
+  'showNotificationsEnabled' | 'notificationTitle' | 'notificationText'
+>;

--- a/src/extraction/types.ts
+++ b/src/extraction/types.ts
@@ -60,4 +60,14 @@ export type ExtractArchiveOptions = {
   onProgress?: (event: ExtractProgressEvent) => void;
   /** AbortSignal to cancel the extraction. */
   signal?: AbortSignal;
+  /**
+   * **Android:** When true (default), the native layer posts a system notification with extraction
+   * progress. Set to false to disable (e.g. first-run bundled-model prep with in-app UI only).
+   * **iOS:** Accepted for API parity; no notification is shown.
+   */
+  showNotificationsEnabled?: boolean;
+  /** **Android:** Notification title. Default: generic “unpacking” title. Ignored on iOS. */
+  notificationTitle?: string;
+  /** **Android:** Notification body (progress text is appended). Default: generic. Ignored on iOS. */
+  notificationText?: string;
 };


### PR DESCRIPTION
This pull request adds support for showing native Android notifications during archive extraction, enhancing user feedback for long-running operations. It introduces a new notification helper class, updates the extraction APIs to accept notification-related options, and ensures that these notifications are started, updated, and finished appropriately throughout the extraction process. On iOS, the new options are accepted for API compatibility but are ignored, maintaining platform consistency.

**Android extraction notifications:**

* Added a new `SherpaOnnxExtractionNotificationHelper` class to manage Android system notifications for archive extraction progress, including creation, progress updates, and cleanup. Notifications are shown during extraction and cancelled when done, mirroring download notification behavior.
* Updated extraction methods in `SherpaOnnxArchiveHelper.kt` and `SherpaOnnxModule.kt` to accept notification options (`showNotificationsEnabled`, `notificationTitle`, `notificationText`), and to invoke the notification helper at appropriate stages of extraction (start, progress, finish). [[1]](diffhunk://#diff-e430833607e4a4cc0be0a9678a401db8e45631201aba67890dc8e2395cbec205L57-R58) [[2]](diffhunk://#diff-e430833607e4a4cc0be0a9678a401db8e45631201aba67890dc8e2395cbec205L73-R95) [[3]](diffhunk://#diff-e430833607e4a4cc0be0a9678a401db8e45631201aba67890dc8e2395cbec205L107-R111) [[4]](diffhunk://#diff-e430833607e4a4cc0be0a9678a401db8e45631201aba67890dc8e2395cbec205L122-R145) [[5]](diffhunk://#diff-e430833607e4a4cc0be0a9678a401db8e45631201aba67890dc8e2395cbec205L153-L164) [[6]](diffhunk://#diff-e430833607e4a4cc0be0a9678a401db8e45631201aba67890dc8e2395cbec205R185-R186) [[7]](diffhunk://#diff-e430833607e4a4cc0be0a9678a401db8e45631201aba67890dc8e2395cbec205L183-R208) [[8]](diffhunk://#diff-879656a663809608669376c509d884bda0e032ec094f58ce4e41a60afbbcf80dL296-R350) [[9]](diffhunk://#diff-879656a663809608669376c509d884bda0e032ec094f58ce4e41a60afbbcf80dR389-R402) [[10]](diffhunk://#diff-879656a663809608669376c509d884bda0e032ec094f58ce4e41a60afbbcf80dL1104-R1205)

**API and documentation updates:**

* Extended the public extraction API to accept notification-related options, and updated documentation to explain the new parameters and their behavior on Android and iOS. [[1]](diffhunk://#diff-45b39a922197d0dad56707d3924c76abc73f1e14a130f0c7f293008bd21904abR136-R138) [[2]](diffhunk://#diff-45b39a922197d0dad56707d3924c76abc73f1e14a130f0c7f293008bd21904abR160-R162) [[3]](diffhunk://#diff-eb28637175eff7f73e8f9b0d88fe701d631c059ae262d063ae8777053df8c44aR125-R128)
* On iOS, the new notification options are accepted but ignored, ensuring consistent API shape across platforms. [[1]](diffhunk://#diff-d13dacc2af1fc1eed39bdfd593a8c32afaec82fd31fdb9e4c6a39076232a7719R141-R149) [[2]](diffhunk://#diff-d13dacc2af1fc1eed39bdfd593a8c32afaec82fd31fdb9e4c6a39076232a7719R174-R182) [[3]](diffhunk://#diff-d13dacc2af1fc1eed39bdfd593a8c32afaec82fd31fdb9e4c6a39076232a7719L232-R270)