### PR TITLE
Feat/update sherpa onnx 1.12.35

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Full step-by-step: [Download manager – Setup (iOS & Android)](docs/download-ma
 
 | Feature | Status | Docs | Notes |
 |---------|--------|------|-------|
-| Offline Speech-to-Text | ✅ **Supported** | [STT](./docs/stt.md) | No internet required; multiple model types (Zipformer, Paraformer, Whisper, etc.). See [Supported Model Types](#supported-model-types). |
+| Offline Speech-to-Text | ✅ **Supported** | [STT](./docs/stt.md) | No internet required; multiple model types (Zipformer, Paraformer, Whisper, Qwen3 ASR, Cohere Transcribe, etc.). See [Supported Model Types](#supported-model-types). |
 | Online (streaming) Speech-to-Text | ✅ **Supported** | [Streaming STT](./docs/stt-streaming.md) | Real-time recognition from microphone or stream; partial results, endpoint detection. Use streaming-capable models (e.g. transducer, paraformer). |
 | Live capture API | ✅ **Supported** | [PCM live stream](./docs/pcm-live-stream.md) | Native microphone capture with resampling for live transcription (use with streaming STT). |
 | Text-to-Speech | ✅ **Supported** | [TTS](./docs/tts.md) | Multiple model types (VITS, Matcha, Kokoro, etc.). See [Supported Model Types](#supported-model-types). |
@@ -159,6 +159,8 @@ Full step-by-step: [Download manager – Setup (iOS & Android)](docs/download-ma
 | **WeNet CTC**            | `'wenet_ctc'`     | CTC from WeNet; compact. Folder name should contain **wenet**. | [Download](https://k2-fsa.github.io/sherpa/onnx/pretrained_models/offline-ctc/wenet/index.html)  |
 | **SenseVoice**           | `'sense_voice'`   | Multilingual with emotion/punctuation. Folder name should contain **sense** or **sensevoice**. | [Download](https://k2-fsa.github.io/sherpa/onnx/pretrained_models/sense-voice/index.html)        |
 | **FunASR Nano**          | `'funasr_nano'`   | Lightweight LLM-based ASR. Folder name should contain **funasr** or **funasr-nano**. | [Download](https://k2-fsa.github.io/sherpa/onnx/pretrained_models/funasr-nano/index.html)        |
+| **Qwen3 ASR**            | `'qwen3_asr'`     | Encoder–decoder ASR (Qwen3-ASR ONNX: conv frontend, encoder, decoder, tokenizer). Folder name should contain **qwen3**. Optional `modelOptions.qwen3Asr` (e.g. comma-separated hotwords). | [Download](https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models) |
+| **Cohere Transcribe**    | `'cohere_transcribe'` | Cohere Transcribe ONNX (encoder, decoder, `tokens.txt`). Folder name should contain **cohere**. Optional `modelOptions.cohereTranscribe` (language, punctuation, ITN). | [Download](https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models) |
 | **Moonshine (v1)**        | `'moonshine'`     | Four-part streaming-capable ASR (preprocess, encode, uncached/cached decode). Folder name should contain **moonshine**. | [Download](https://k2-fsa.github.io/sherpa/onnx/moonshine/index.html) |
 | **Moonshine (v2)**        | `'moonshine_v2'`   | Two-part Moonshine (encoder + merged decoder); `.onnx` or `.ort`. Folder name should contain **moonshine** (v2 preferred if both layouts present). | [Download](https://k2-fsa.github.io/sherpa/onnx/moonshine/index.html) |
 | **Fire Red ASR**         | `'fire_red_asr'`  | Fire Red encoder–decoder ASR. Folder name should contain **fire_red** or **fire-red**. | [Download](https://k2-fsa.github.io/sherpa/onnx/FireRedAsr/index.html) |
@@ -234,7 +236,7 @@ We provide example applications to help you get started with `react-native-sherp
 
 The example app included in this repository demonstrates audio-to-text transcription, text-to-speech, and streaming features. It includes:
 
-- Multiple model type support (Zipformer, Paraformer, NeMo CTC, Whisper, WeNet CTC, SenseVoice, FunASR Nano, Moonshine, and more)
+- Multiple model type support (Zipformer, Paraformer, NeMo CTC, Whisper, WeNet CTC, SenseVoice, FunASR Nano, Qwen3 ASR, Cohere Transcribe, Moonshine, and more)
 - Model selection and configuration
 - **Offline** audio file transcription
 - **Online (streaming) STT** – live transcription from the microphone with partial results

--- a/android/src/main/assets/model_licenses/asr-models-license-status.csv
+++ b/android/src/main/assets/model_licenses/asr-models-license-status.csv
@@ -408,4 +408,4 @@ sherpa-onnx-rk3566-streaming-zipformer-small-bilingual-zh-en-2023-02-16.tar.bz2,
 sherpa-onnx-rk3566-streaming-zipformer-bilingual-zh-en-2023-02-20.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/csukuangfj/k2fsa-zipformer-bilingual-zh-en-t
 sherpa-onnx-rk3562-streaming-zipformer-small-bilingual-zh-en-2023-02-16.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/csukuangfj/k2fsa-zipformer-bilingual-zh-en-t
 sherpa-onnx-rk3562-streaming-zipformer-bilingual-zh-en-2023-02-20.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/csukuangfj/k2fsa-zipformer-bilingual-zh-en-t
-sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01.tar.bz2,exhausted,unknown,high,scan_exhausted,
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/CohereLabs/cohere-transcribe-03-2026

--- a/android/src/main/assets/model_licenses/asr-models-license-status.csv
+++ b/android/src/main/assets/model_licenses/asr-models-license-status.csv
@@ -408,3 +408,4 @@ sherpa-onnx-rk3566-streaming-zipformer-small-bilingual-zh-en-2023-02-16.tar.bz2,
 sherpa-onnx-rk3566-streaming-zipformer-bilingual-zh-en-2023-02-20.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/csukuangfj/k2fsa-zipformer-bilingual-zh-en-t
 sherpa-onnx-rk3562-streaming-zipformer-small-bilingual-zh-en-2023-02-16.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/csukuangfj/k2fsa-zipformer-bilingual-zh-en-t
 sherpa-onnx-rk3562-streaming-zipformer-bilingual-zh-en-2023-02-20.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/csukuangfj/k2fsa-zipformer-bilingual-zh-en-t
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01.tar.bz2,exhausted,unknown,high,scan_exhausted,

--- a/android/src/main/cpp/jni/model_detect/sherpa-onnx-model-detect-stt.cpp
+++ b/android/src/main/cpp/jni/model_detect/sherpa-onnx-model-detect-stt.cpp
@@ -62,6 +62,7 @@ static const char* KindToName(SttModelKind k) {
         case SttModelKind::kWhisper: return "whisper";
         case SttModelKind::kFunAsrNano: return "funasr_nano";
         case SttModelKind::kQwen3Asr: return "qwen3_asr";
+        case SttModelKind::kCohereTranscribe: return "cohere_transcribe";
         case SttModelKind::kFireRedAsr: return "fire_red_asr";
         case SttModelKind::kMoonshine: return "moonshine";
         case SttModelKind::kMoonshineV2: return "moonshine_v2";
@@ -90,6 +91,7 @@ SttModelKind ParseSttModelType(const std::string& modelType) {
     if (modelType == "whisper") return SttModelKind::kWhisper;
     if (modelType == "funasr_nano") return SttModelKind::kFunAsrNano;
     if (modelType == "qwen3_asr") return SttModelKind::kQwen3Asr;
+    if (modelType == "cohere_transcribe") return SttModelKind::kCohereTranscribe;
     if (modelType == "fire_red_asr") return SttModelKind::kFireRedAsr;
     if (modelType == "moonshine") return SttModelKind::kMoonshine;
     if (modelType == "moonshine_v2") return SttModelKind::kMoonshineV2;
@@ -130,6 +132,8 @@ static bool CapabilitySupportsKind(
             return cap.hasFunAsrNano;
         case SttModelKind::kQwen3Asr:
             return cap.hasQwen3Asr;
+        case SttModelKind::kCohereTranscribe:
+            return cap.hasCohereTranscribeLayout;
         case SttModelKind::kFireRedAsr:
             return cap.hasFireRedAsr;
         case SttModelKind::kMoonshine:
@@ -175,6 +179,8 @@ static std::vector<SttModelKind> GetKindsFromDirName(const std::string& modelDir
         add(SttModelKind::kMoonshineV2);
         add(SttModelKind::kMoonshine);
     }
+    if (lower.find("cohere") != std::string::npos)
+        add(SttModelKind::kCohereTranscribe);
     if (lower.find("whisper") != std::string::npos)
         add(SttModelKind::kWhisper);
     if (lower.find("paraformer") != std::string::npos)
@@ -323,6 +329,7 @@ static SttPathHints GetSttPathHints(const std::string& modelDir) {
     h.isLikelySenseVoice = lower.find("sense") != std::string::npos || lower.find("sensevoice") != std::string::npos;
     h.isLikelyFunAsrNano = lower.find("funasr") != std::string::npos || lower.find("funasr-nano") != std::string::npos;
     h.isLikelyQwen3Asr = lower.find("qwen3-asr") != std::string::npos || lower.find("qwen3_asr") != std::string::npos;
+    h.isLikelyCohere = lower.find("cohere") != std::string::npos;
     h.isLikelyZipformer = lower.find("zipformer") != std::string::npos;
     h.isLikelyMoonshine = lower.find("moonshine") != std::string::npos;
     h.isLikelyDolphin = lower.find("dolphin") != std::string::npos;
@@ -427,7 +434,11 @@ static SttCapabilities ComputeSttCapabilities(const SttCandidatePaths& paths, co
     bool hasWhisperDec = !paths.decoder.empty();
     bool hasQwen3Tok = !paths.qwen3TokenizerDir.empty();
     c.hasQwen3Asr = !paths.qwen3ConvFrontend.empty() && hasWhisperEnc && hasWhisperDec && hasQwen3Tok;
-    c.hasWhisper = hasWhisperEnc && hasWhisperDec && paths.joiner.empty() && !c.hasQwen3Asr;
+    c.hasCohereTranscribeLayout =
+        hasWhisperEnc && hasWhisperDec && paths.joiner.empty() && !paths.tokens.empty() && !c.hasQwen3Asr;
+    c.hasCohereTranscribe = c.hasCohereTranscribeLayout && hints.isLikelyCohere;
+    c.hasWhisper =
+        hasWhisperEnc && hasWhisperDec && paths.joiner.empty() && !c.hasQwen3Asr && !c.hasCohereTranscribe;
     bool hasFunAsrTok = !paths.funasrTokenizerDir.empty();
     c.hasFunAsrNano = !paths.funasrEncoderAdaptor.empty() && !paths.funasrLLM.empty() &&
                       !paths.funasrEmbedding.empty() && hasFunAsrTok;
@@ -469,6 +480,7 @@ static void CollectDetectedModels(
         out.push_back({"paraformer", modelDir});
     }
     if (cap.hasWhisper) out.push_back({"whisper", modelDir});
+    if (cap.hasCohereTranscribe) out.push_back({"cohere_transcribe", modelDir});
     if (cap.hasQwen3Asr) out.push_back({"qwen3_asr", modelDir});
     if (cap.hasFunAsrNano) out.push_back({"funasr_nano", modelDir});
     if (cap.hasMoonshine) out.push_back({"moonshine", modelDir});
@@ -533,6 +545,10 @@ static SttModelKind ResolveSttKind(
         }
         if (selected == SttModelKind::kQwen3Asr && !cap.hasQwen3Asr) {
             outError = "Qwen3-ASR model requested but conv_frontend/encoder/decoder/tokenizer not found in " + modelDir;
+            return SttModelKind::kUnknown;
+        }
+        if (selected == SttModelKind::kCohereTranscribe && !cap.hasCohereTranscribeLayout) {
+            outError = "Cohere Transcribe model requested but encoder/decoder/tokens.txt not found in " + modelDir;
             return SttModelKind::kUnknown;
         }
         if (selected == SttModelKind::kMoonshine && !cap.hasMoonshine) {
@@ -602,6 +618,7 @@ static SttModelKind ResolveSttKind(
     if (cap.hasCanary) return SttModelKind::kCanary;
     if (cap.hasFireRedAsr) return SttModelKind::kFireRedAsr;
     if (cap.hasQwen3Asr && hints.isLikelyQwen3Asr) return SttModelKind::kQwen3Asr;
+    if (cap.hasCohereTranscribe) return SttModelKind::kCohereTranscribe;
     if (cap.hasWhisper) return SttModelKind::kWhisper;
     if (cap.hasQwen3Asr) return SttModelKind::kQwen3Asr;
     if (cap.hasFunAsrNano) return SttModelKind::kFunAsrNano;
@@ -653,6 +670,10 @@ static void ApplyPathsForSttKind(SttModelKind kind, const SttCandidatePaths& can
             resultPaths.qwen3Encoder = candidate.encoder;
             resultPaths.qwen3Decoder = candidate.decoder;
             resultPaths.qwen3Tokenizer = candidate.qwen3TokenizerDir;
+            break;
+        case SttModelKind::kCohereTranscribe:
+            resultPaths.cohereEncoder = candidate.encoder;
+            resultPaths.cohereDecoder = candidate.decoder;
             break;
         case SttModelKind::kMoonshine:
             resultPaths.moonshinePreprocessor = candidate.moonshinePreprocessor;
@@ -747,13 +768,14 @@ SttDetectResult DetectSttModel(
             EmptyOrPath(candidate.encoder), EmptyOrPath(candidate.decoder));
         LOGI("DetectSttModel: funasr encoderAdaptor=%s llm=%s embedding=%s tokenizerDir=%s",
             EmptyOrPath(candidate.funasrEncoderAdaptor), EmptyOrPath(candidate.funasrLLM), EmptyOrPath(candidate.funasrEmbedding), EmptyOrPath(candidate.funasrTokenizerDir));
-        LOGI("DetectSttModel: hasTransducer=%d hasWhisper=%d hasMoonshine=%d hasMoonshineV2=%d hasParaformer=%d hasFunAsrNano=%d hasQwen3Asr=%d hasDolphin=%d hasFireRedAsr=%d hasFireRedCtc=%d hasCanary=%d hasOmnilingual=%d hasMedAsr=%d hasTeleSpeechCtc=%d hasToneCtc=%d",
+        LOGI("DetectSttModel: hasTransducer=%d hasWhisper=%d hasMoonshine=%d hasMoonshineV2=%d hasParaformer=%d hasFunAsrNano=%d hasQwen3Asr=%d hasCohereLayout=%d hasCohere=%d hasDolphin=%d hasFireRedAsr=%d hasFireRedCtc=%d hasCanary=%d hasOmnilingual=%d hasMedAsr=%d hasTeleSpeechCtc=%d hasToneCtc=%d",
             (int)cap.hasTransducer, (int)cap.hasWhisper, (int)cap.hasMoonshine, (int)cap.hasMoonshineV2,
-            (int)cap.hasParaformer, (int)cap.hasFunAsrNano, (int)cap.hasQwen3Asr, (int)cap.hasDolphin, (int)cap.hasFireRedAsr, (int)cap.hasFireRedCtc,
+            (int)cap.hasParaformer, (int)cap.hasFunAsrNano, (int)cap.hasQwen3Asr, (int)cap.hasCohereTranscribeLayout, (int)cap.hasCohereTranscribe,
+            (int)cap.hasDolphin, (int)cap.hasFireRedAsr, (int)cap.hasFireRedCtc,
             (int)cap.hasCanary, (int)cap.hasOmnilingual, (int)cap.hasMedAsr, (int)cap.hasTeleSpeechCtc, (int)cap.hasToneCtc);
-        LOGI("DetectSttModel: hints isLikelyNemo=%d isLikelyTdt=%d isLikelyWenetCtc=%d isLikelySenseVoice=%d isLikelyFunAsrNano=%d isLikelyQwen3Asr=%d isLikelyZipformer=%d isLikelyMoonshine=%d isLikelyDolphin=%d isLikelyFireRedAsr=%d isLikelyCanary=%d isLikelyOmnilingual=%d isLikelyMedAsr=%d isLikelyTeleSpeech=%d isLikelyToneCtc=%d isLikelyParaformer=%d isLikelyVad=%d isLikelyTdnn=%d",
+        LOGI("DetectSttModel: hints isLikelyNemo=%d isLikelyTdt=%d isLikelyWenetCtc=%d isLikelySenseVoice=%d isLikelyFunAsrNano=%d isLikelyQwen3Asr=%d isLikelyCohere=%d isLikelyZipformer=%d isLikelyMoonshine=%d isLikelyDolphin=%d isLikelyFireRedAsr=%d isLikelyCanary=%d isLikelyOmnilingual=%d isLikelyMedAsr=%d isLikelyTeleSpeech=%d isLikelyToneCtc=%d isLikelyParaformer=%d isLikelyVad=%d isLikelyTdnn=%d",
              (int)hints.isLikelyNemo, (int)hints.isLikelyTdt, (int)hints.isLikelyWenetCtc, (int)hints.isLikelySenseVoice,
-             (int)hints.isLikelyFunAsrNano, (int)hints.isLikelyQwen3Asr, (int)hints.isLikelyZipformer, (int)hints.isLikelyMoonshine, (int)hints.isLikelyDolphin,
+             (int)hints.isLikelyFunAsrNano, (int)hints.isLikelyQwen3Asr, (int)hints.isLikelyCohere, (int)hints.isLikelyZipformer, (int)hints.isLikelyMoonshine, (int)hints.isLikelyDolphin,
              (int)hints.isLikelyFireRedAsr, (int)hints.isLikelyCanary, (int)hints.isLikelyOmnilingual, (int)hints.isLikelyMedAsr,
              (int)hints.isLikelyTeleSpeech, (int)hints.isLikelyToneCtc, (int)hints.isLikelyParaformer, (int)hints.isLikelyVad, (int)hints.isLikelyTdnn);
     }
@@ -849,6 +871,10 @@ SttDetectResult DetectSttModel(
             LOGI("DetectSttModel: paths set qwen3_asr conv=%s encoder=%s decoder=%s tokenizer=%s",
                  EmptyOrPath(result.paths.qwen3ConvFrontend), EmptyOrPath(result.paths.qwen3Encoder),
                  EmptyOrPath(result.paths.qwen3Decoder), EmptyOrPath(result.paths.qwen3Tokenizer));
+            break;
+        case SttModelKind::kCohereTranscribe:
+            LOGI("DetectSttModel: paths set cohere_transcribe encoder=%s decoder=%s",
+                 EmptyOrPath(result.paths.cohereEncoder), EmptyOrPath(result.paths.cohereDecoder));
             break;
         default:
             break;

--- a/android/src/main/cpp/jni/model_detect/sherpa-onnx-model-detect.h
+++ b/android/src/main/cpp/jni/model_detect/sherpa-onnx-model-detect.h
@@ -21,6 +21,7 @@ enum class SttModelKind {
     kWhisper,
     kFunAsrNano,
     kQwen3Asr,
+    kCohereTranscribe,
     kFireRedAsr,
     kMoonshine,
     kMoonshineV2,
@@ -74,6 +75,9 @@ struct SttModelPaths {
     std::string qwen3Encoder;
     std::string qwen3Decoder;
     std::string qwen3Tokenizer;
+    /** Cohere Transcribe: encoder + decoder ONNX; tokens.txt in model_config.tokens. */
+    std::string cohereEncoder;
+    std::string cohereDecoder;
     // Moonshine
     std::string moonshinePreprocessor;
     std::string moonshineEncoder;
@@ -124,6 +128,8 @@ struct SttPathHints {
     bool isLikelySenseVoice = false;
     bool isLikelyFunAsrNano = false;
     bool isLikelyQwen3Asr = false;
+    /** Directory name contains cohere / cohere-transcribe (CohereLabs ASR). */
+    bool isLikelyCohere = false;
     bool isLikelyZipformer = false;
     bool isLikelyMoonshine = false;
     bool isLikelyDolphin = false;
@@ -149,6 +155,10 @@ struct SttCapabilities {
     bool hasParaformer = false;
     bool hasFunAsrNano = false;
     bool hasQwen3Asr = false;
+    /** Encoder+decoder+tokens, no joiner, not Qwen3 — structural match for Cohere (explicit type). */
+    bool hasCohereTranscribeLayout = false;
+    /** Auto: layout + directory name suggests Cohere (excludes from Whisper). */
+    bool hasCohereTranscribe = false;
     bool hasDolphin = false;
     bool hasFireRedAsr = false;
     /** True when dir name suggests Fire Red but only a single CTC/paraformer model (no encoder/decoder). Use zipformer_ctc. */

--- a/android/src/main/cpp/jni/model_detect/sherpa-onnx-stt-wrapper.cpp
+++ b/android/src/main/cpp/jni/model_detect/sherpa-onnx-stt-wrapper.cpp
@@ -24,6 +24,7 @@ const char* SttModelKindToString(SttModelKind k) {
     case SttModelKind::kWhisper: return "whisper";
     case SttModelKind::kFunAsrNano: return "funasr_nano";
     case SttModelKind::kQwen3Asr: return "qwen3_asr";
+    case SttModelKind::kCohereTranscribe: return "cohere_transcribe";
     case SttModelKind::kFireRedAsr: return "fire_red_asr";
     case SttModelKind::kMoonshine: return "moonshine";
     case SttModelKind::kMoonshineV2: return "moonshine_v2";
@@ -84,6 +85,8 @@ jobject SttDetectResultToJava(JNIEnv* env, const SttDetectResult& result) {
       PutString(env, pathsMap, mapPut, "qwen3Encoder", result.paths.qwen3Encoder);
       PutString(env, pathsMap, mapPut, "qwen3Decoder", result.paths.qwen3Decoder);
       PutString(env, pathsMap, mapPut, "qwen3Tokenizer", result.paths.qwen3Tokenizer);
+      PutString(env, pathsMap, mapPut, "cohereEncoder", result.paths.cohereEncoder);
+      PutString(env, pathsMap, mapPut, "cohereDecoder", result.paths.cohereDecoder);
       PutString(env, pathsMap, mapPut, "moonshinePreprocessor", result.paths.moonshinePreprocessor);
       PutString(env, pathsMap, mapPut, "moonshineEncoder", result.paths.moonshineEncoder);
       PutString(env, pathsMap, mapPut, "moonshineUncachedDecoder", result.paths.moonshineUncachedDecoder);

--- a/android/src/main/cpp/jni/model_detect/sherpa-onnx-validate-stt.cpp
+++ b/android/src/main/cpp/jni/model_detect/sherpa-onnx-validate-stt.cpp
@@ -59,6 +59,12 @@ static const SttFieldRequirement kQwen3AsrReqs[] = {
     {"qwen3Tokenizer",    &SttModelPaths::qwen3Tokenizer,    true},
 };
 
+static const SttFieldRequirement kCohereTranscribeReqs[] = {
+    {"cohereEncoder", &SttModelPaths::cohereEncoder, true},
+    {"cohereDecoder", &SttModelPaths::cohereDecoder, true},
+    {"tokens",        &SttModelPaths::tokens,        true},
+};
+
 static const SttFieldRequirement kMoonshineReqs[] = {
     {"moonshinePreprocessor",    &SttModelPaths::moonshinePreprocessor,    true},
     {"moonshineEncoder",         &SttModelPaths::moonshineEncoder,         true},
@@ -130,6 +136,9 @@ static const SttFieldRequirement* GetRequirements(SttModelKind kind, size_t& cou
         case SttModelKind::kQwen3Asr:
             count = std::size(kQwen3AsrReqs);
             return kQwen3AsrReqs;
+        case SttModelKind::kCohereTranscribe:
+            count = std::size(kCohereTranscribeReqs);
+            return kCohereTranscribeReqs;
         case SttModelKind::kMoonshine:
             count = std::size(kMoonshineReqs);
             return kMoonshineReqs;
@@ -172,6 +181,7 @@ static const char* SttKindToName(SttModelKind k) {
         case SttModelKind::kWhisper:       return "Whisper";
         case SttModelKind::kFunAsrNano:    return "FunASR Nano";
         case SttModelKind::kQwen3Asr:      return "Qwen3 ASR";
+        case SttModelKind::kCohereTranscribe: return "Cohere Transcribe";
         case SttModelKind::kFireRedAsr:    return "Fire Red ASR";
         case SttModelKind::kMoonshine:     return "Moonshine";
         case SttModelKind::kMoonshineV2:   return "Moonshine v2";

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxSttHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxSttHelper.kt
@@ -68,7 +68,8 @@ internal class SherpaOnnxSttHelper(
   /** Normalizes Qwen3-ASR hotwords to a comma-separated string for stream option "hotwords". */
   private fun normalizeQwen3HotwordsCsv(raw: String): String {
     if (raw.isEmpty()) return ""
-    val flat = raw.replace('\r', ' ').replace('\n', ',')
+    // Match iOS: treat \r and \n as phrase separators (then comma-split).
+    val flat = raw.replace('\r', '\n').replace('\n', ',')
     return flat.split(',')
       .map { it.trim() }
       .filter { it.isNotEmpty() }
@@ -344,9 +345,8 @@ internal class SherpaOnnxSttHelper(
         promise.reject("TRANSCRIBE_ERROR", "STT not initialized. Call initializeStt first.")
         return
       }
-      val pathToRead = if (filePath.startsWith("content://")) {
-        tempPath = resolveContentUriToFile(filePath, "stt_transcribe")
-        tempPath
+      val pathToRead: String = if (filePath.startsWith("content://")) {
+        resolveContentUriToFile(filePath, "stt_transcribe").also { tempPath = it }
       } else {
         filePath
       }
@@ -360,7 +360,7 @@ internal class SherpaOnnxSttHelper(
         return
       }
       val wave = WaveReader.readWave(pathToRead)
-      val samples = wave.samples
+      val samples = wave.samples ?: FloatArray(0)
       if (samples.isEmpty()) {
         promise.reject("TRANSCRIBE_ERROR", "Could not read audio samples (file=${f.length()} bytes). The file must be WAV format (use convertAudioToWav16k for MP3/FLAC).")
         return

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxSttHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxSttHelper.kt
@@ -350,7 +350,7 @@ internal class SherpaOnnxSttHelper(
       } else {
         filePath
       }
-      if (pathToRead == null || pathToRead.isBlank()) {
+      if (pathToRead.isBlank()) {
         promise.reject("TRANSCRIBE_ERROR", "Could not resolve audio file path")
         return
       }
@@ -361,7 +361,7 @@ internal class SherpaOnnxSttHelper(
       }
       val wave = WaveReader.readWave(pathToRead)
       val samples = wave.samples
-      if (samples == null || samples.isEmpty()) {
+      if (samples.isEmpty()) {
         promise.reject("TRANSCRIBE_ERROR", "Could not read audio samples (file=${f.length()} bytes). The file must be WAV format (use convertAudioToWav16k for MP3/FLAC).")
         return
       }

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxSttHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxSttHelper.kt
@@ -23,6 +23,7 @@ import com.k2fsa.sherpa.onnx.OfflineZipformerCtcModelConfig
 import com.k2fsa.sherpa.onnx.OfflineWenetCtcModelConfig
 import com.k2fsa.sherpa.onnx.OfflineFunAsrNanoModelConfig
 import com.k2fsa.sherpa.onnx.OfflineQwen3AsrModelConfig
+import com.k2fsa.sherpa.onnx.OfflineCohereTranscribeModelConfig
 import com.k2fsa.sherpa.onnx.OfflineMoonshineModelConfig
 import com.k2fsa.sherpa.onnx.OfflineDolphinModelConfig
 import com.k2fsa.sherpa.onnx.OfflineFireRedAsrModelConfig
@@ -48,7 +49,9 @@ internal class SherpaOnnxSttHelper(
   private data class SttEngineInstance(
     @Volatile var recognizer: OfflineRecognizer? = null,
     @Volatile var lastRecognizerConfig: OfflineRecognizerConfig? = null,
-    @Volatile var currentSttModelType: String? = null
+    @Volatile var currentSttModelType: String? = null,
+    /** Qwen3-ASR: comma-separated hotwords applied via OfflineStream.setOption (not hotwords_file). */
+    @Volatile var qwen3HotwordsForStream: String = ""
   )
 
   private val instances = ConcurrentHashMap<String, SttEngineInstance>()
@@ -61,6 +64,16 @@ internal class SherpaOnnxSttHelper(
   /** Hotwords are supported for transducer and NeMo transducer models (sherpa-onnx; NeMo: https://github.com/k2-fsa/sherpa-onnx/pull/3077). */
   private fun supportsHotwords(modelType: String): Boolean =
     modelType == "transducer" || modelType == "nemo_transducer"
+
+  /** Normalizes Qwen3-ASR hotwords to a comma-separated string for stream option "hotwords". */
+  private fun normalizeQwen3HotwordsCsv(raw: String): String {
+    if (raw.isEmpty()) return ""
+    val flat = raw.replace('\r', ' ').replace('\n', ',')
+    return flat.split(',')
+      .map { it.trim() }
+      .filter { it.isNotEmpty() }
+      .joinToString(",")
+  }
 
   /**
    * Resolves a single path to a file path. For content URIs (content://...) copies to app cache
@@ -282,6 +295,9 @@ internal class SherpaOnnxSttHelper(
       )
       inst.lastRecognizerConfig = config
       inst.currentSttModelType = modelTypeStr
+      inst.qwen3HotwordsForStream = if (modelTypeStr == "qwen3_asr") {
+        normalizeQwen3HotwordsCsv(modelOptions?.getMap("qwen3Asr")?.getString("hotwords")?.trim().orEmpty())
+      } else ""
       // Defer recognizer creation to the dedicated background thread so release() of the previous
       // recognizer can complete off the UI thread (avoids "destroyed mutex" / SIGSEGV when switching models).
       initHandler.post {
@@ -351,6 +367,10 @@ internal class SherpaOnnxSttHelper(
       }
       val stream: OfflineStream = rec.createStream()
       try {
+        if (inst.currentSttModelType == "qwen3_asr") {
+          val hw = inst.qwen3HotwordsForStream
+          if (hw.isNotEmpty()) stream.setOption("hotwords", hw)
+        }
         stream.acceptWaveform(samples, wave.sampleRate)
         rec.decode(stream)
         val result = rec.getResult(stream)
@@ -385,6 +405,10 @@ internal class SherpaOnnxSttHelper(
       val floatSamples = FloatArray(samples.size()) { i -> samples.getDouble(i).toFloat() }
       val stream: OfflineStream = rec.createStream()
       try {
+        if (inst.currentSttModelType == "qwen3_asr") {
+          val hw = inst.qwen3HotwordsForStream
+          if (hw.isNotEmpty()) stream.setOption("hotwords", hw)
+        }
         stream.acceptWaveform(floatSamples, sampleRate)
         rec.decode(stream)
         val result = rec.getResult(stream)
@@ -544,7 +568,12 @@ internal class SherpaOnnxSttHelper(
     }
     modelOptions.getMap("qwen3Asr")?.let { q ->
       val mnt = if (q.hasKey("maxNewTokens")) q.getInt("maxNewTokens") else null
-      parts.add("qwen3Asr:maxNewTokens=$mnt")
+      val hasHw = q.hasKey("hotwords") && q.getString("hotwords")?.isNotBlank() == true
+      parts.add("qwen3Asr:maxNewTokens=$mnt,hotwords=$hasHw")
+    }
+    modelOptions.getMap("cohereTranscribe")?.let { c ->
+      val lang = c.getString("language") ?: ""
+      parts.add("cohereTranscribe:lang=$lang")
     }
     return parts.joinToString(";").take(200)
   }
@@ -716,9 +745,24 @@ internal class SherpaOnnxSttHelper(
             maxNewTokens = if (q3?.hasKey("maxNewTokens") == true) q3.getInt("maxNewTokens") else 128,
             temperature = if (q3?.hasKey("temperature") == true) q3.getDouble("temperature").toFloat() else 1e-6f,
             topP = if (q3?.hasKey("topP") == true) q3.getDouble("topP").toFloat() else 0.8f,
-            seed = if (q3?.hasKey("seed") == true) q3.getInt("seed") else 42
+            seed = if (q3?.hasKey("seed") == true) q3.getInt("seed") else 42,
+            hotwords = ""
           ),
           tokens = ""
+        )
+      }
+      "cohere_transcribe" -> {
+        val ct = modelOptions?.getMap("cohereTranscribe")
+        OfflineModelConfig(
+          cohereTranscribe = OfflineCohereTranscribeModelConfig(
+            encoder = path(paths, "cohereEncoder"),
+            decoder = path(paths, "cohereDecoder"),
+            language = ct?.getString("language")?.trim()?.takeIf { it.isNotEmpty() } ?: "en",
+            usePunct = if (ct?.hasKey("usePunct") == true) ct.getBoolean("usePunct") else true,
+            useItn = if (ct?.hasKey("useItn") == true) ct.getBoolean("useItn") else true
+          ),
+          tokens = path(paths, "tokens"),
+          modelType = "cohere_transcribe"
         )
       }
       else -> {

--- a/docs/stt.md
+++ b/docs/stt.md
@@ -274,6 +274,7 @@ Several models accept a language hint. The SDK provides per-model lists of valid
 | Canary | `getCanaryLanguages()` | `modelOptions.canary.srcLang` / `tgtLang` |
 | FunASR Nano | `getFunasrNanoLanguages()` | `modelOptions.funasrNano.language` |
 | FunASR MLT Nano | `getFunasrMltNanoLanguages()` | `modelOptions.funasrNano.language` |
+| Cohere Transcribe (14-lang) | `getCohereTranscribeLanguages()` | `modelOptions.cohereTranscribe.language` |
 
 Each returns `{ id: string; name: string }[]`. Use `id` for the model option, `name` for display.
 

--- a/ios/Resources/model_licenses/asr-models-license-status.csv
+++ b/ios/Resources/model_licenses/asr-models-license-status.csv
@@ -408,4 +408,4 @@ sherpa-onnx-rk3566-streaming-zipformer-small-bilingual-zh-en-2023-02-16.tar.bz2,
 sherpa-onnx-rk3566-streaming-zipformer-bilingual-zh-en-2023-02-20.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/csukuangfj/k2fsa-zipformer-bilingual-zh-en-t
 sherpa-onnx-rk3562-streaming-zipformer-small-bilingual-zh-en-2023-02-16.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/csukuangfj/k2fsa-zipformer-bilingual-zh-en-t
 sherpa-onnx-rk3562-streaming-zipformer-bilingual-zh-en-2023-02-20.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/csukuangfj/k2fsa-zipformer-bilingual-zh-en-t
-sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01.tar.bz2,exhausted,unknown,high,scan_exhausted,
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/CohereLabs/cohere-transcribe-03-2026

--- a/ios/Resources/model_licenses/asr-models-license-status.csv
+++ b/ios/Resources/model_licenses/asr-models-license-status.csv
@@ -408,3 +408,4 @@ sherpa-onnx-rk3566-streaming-zipformer-small-bilingual-zh-en-2023-02-16.tar.bz2,
 sherpa-onnx-rk3566-streaming-zipformer-bilingual-zh-en-2023-02-20.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/csukuangfj/k2fsa-zipformer-bilingual-zh-en-t
 sherpa-onnx-rk3562-streaming-zipformer-small-bilingual-zh-en-2023-02-16.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/csukuangfj/k2fsa-zipformer-bilingual-zh-en-t
 sherpa-onnx-rk3562-streaming-zipformer-bilingual-zh-en-2023-02-20.tar.bz2,apache-2.0,yes,high,manual,https://huggingface.co/csukuangfj/k2fsa-zipformer-bilingual-zh-en-t
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01.tar.bz2,exhausted,unknown,high,scan_exhausted,

--- a/ios/SherpaOnnx+STT.mm
+++ b/ios/SherpaOnnx+STT.mm
@@ -37,6 +37,7 @@ static NSString *sttModelKindToNSString(sherpaonnx::SttModelKind kind) {
         case K::kWhisper: return @"whisper";
         case K::kFunAsrNano: return @"funasr_nano";
         case K::kQwen3Asr: return @"qwen3_asr";
+        case K::kCohereTranscribe: return @"cohere_transcribe";
         case K::kFireRedAsr: return @"fire_red_asr";
         case K::kMoonshine: return @"moonshine";
         case K::kMoonshineV2: return @"moonshine_v2";
@@ -166,11 +167,13 @@ static NSDictionary *sttResultToDict(const sherpaonnx::SttRecognitionResult& r) 
         sherpaonnx::SttCanaryOptions canaryOpts;
         sherpaonnx::SttFunAsrNanoOptions funasrNanoOpts;
         sherpaonnx::SttQwen3AsrOptions qwen3AsrOpts;
+        sherpaonnx::SttCohereTranscribeOptions cohereTranscribeOpts;
         const sherpaonnx::SttWhisperOptions *whisperOptsPtr = nullptr;
         const sherpaonnx::SttSenseVoiceOptions *senseVoiceOptsPtr = nullptr;
         const sherpaonnx::SttCanaryOptions *canaryOptsPtr = nullptr;
         const sherpaonnx::SttFunAsrNanoOptions *funasrNanoOptsPtr = nullptr;
         const sherpaonnx::SttQwen3AsrOptions *qwen3AsrOptsPtr = nullptr;
+        const sherpaonnx::SttCohereTranscribeOptions *cohereTranscribeOptsPtr = nullptr;
         if (modelOptions != nil && [modelOptions isKindOfClass:[NSDictionary class]]) {
             NSDictionary *w = modelOptions[@"whisper"];
             if ([w isKindOfClass:[NSDictionary class]]) {
@@ -218,14 +221,23 @@ static NSDictionary *sttResultToDict(const sherpaonnx::SttRecognitionResult& r) 
                 if (q3[@"temperature"] != nil) qwen3AsrOpts.temperature = [(NSNumber *)q3[@"temperature"] floatValue];
                 if (q3[@"topP"] != nil) qwen3AsrOpts.top_p = [(NSNumber *)q3[@"topP"] floatValue];
                 if (q3[@"seed"] != nil) qwen3AsrOpts.seed = [(NSNumber *)q3[@"seed"] intValue];
+                if (q3[@"hotwords"] != nil) qwen3AsrOpts.hotwords = std::string([(NSString *)q3[@"hotwords"] UTF8String]);
                 qwen3AsrOptsPtr = &qwen3AsrOpts;
+            }
+            NSDictionary *cohere = modelOptions[@"cohereTranscribe"];
+            if ([cohere isKindOfClass:[NSDictionary class]]) {
+                if (cohere[@"language"] != nil) cohereTranscribeOpts.language = std::string([(NSString *)cohere[@"language"] UTF8String]);
+                if (cohere[@"usePunct"] != nil) cohereTranscribeOpts.use_punct = [(NSNumber *)cohere[@"usePunct"] boolValue];
+                if (cohere[@"useItn"] != nil) cohereTranscribeOpts.use_itn = [(NSNumber *)cohere[@"useItn"] boolValue];
+                cohereTranscribeOptsPtr = &cohereTranscribeOpts;
             }
         }
 
         sherpaonnx::SttInitializeResult result = inst->wrapper->initialize(
             modelDirStr, preferInt8Opt, modelTypeOpt, debugVal, hotwordsFileOpt, hotwordsScoreOpt,
             numThreadsOpt, providerOpt, ruleFstsOpt, ruleFarsOpt, ditherOpt,
-            whisperOptsPtr, senseVoiceOptsPtr, canaryOptsPtr, funasrNanoOptsPtr, qwen3AsrOptsPtr);
+            whisperOptsPtr, senseVoiceOptsPtr, canaryOptsPtr, funasrNanoOptsPtr, qwen3AsrOptsPtr,
+            cohereTranscribeOptsPtr);
 
         if (result.success) {
             RCTLogInfo(@"Sherpa-onnx initialized successfully");

--- a/ios/model_detect/sherpa-onnx-model-detect-stt.mm
+++ b/ios/model_detect/sherpa-onnx-model-detect-stt.mm
@@ -59,6 +59,7 @@ static const char* KindToName(SttModelKind k) {
         case SttModelKind::kWhisper: return "whisper";
         case SttModelKind::kFunAsrNano: return "funasr_nano";
         case SttModelKind::kQwen3Asr: return "qwen3_asr";
+        case SttModelKind::kCohereTranscribe: return "cohere_transcribe";
         case SttModelKind::kFireRedAsr: return "fire_red_asr";
         case SttModelKind::kMoonshine: return "moonshine";
         case SttModelKind::kMoonshineV2: return "moonshine_v2";
@@ -87,6 +88,7 @@ SttModelKind ParseSttModelType(const std::string& modelType) {
     if (modelType == "whisper") return SttModelKind::kWhisper;
     if (modelType == "funasr_nano") return SttModelKind::kFunAsrNano;
     if (modelType == "qwen3_asr") return SttModelKind::kQwen3Asr;
+    if (modelType == "cohere_transcribe") return SttModelKind::kCohereTranscribe;
     if (modelType == "fire_red_asr") return SttModelKind::kFireRedAsr;
     if (modelType == "moonshine") return SttModelKind::kMoonshine;
     if (modelType == "moonshine_v2") return SttModelKind::kMoonshineV2;
@@ -127,6 +129,8 @@ static bool CapabilitySupportsKind(
             return cap.hasFunAsrNano;
         case SttModelKind::kQwen3Asr:
             return cap.hasQwen3Asr;
+        case SttModelKind::kCohereTranscribe:
+            return cap.hasCohereTranscribeLayout;
         case SttModelKind::kFireRedAsr:
             return cap.hasFireRedAsr;
         case SttModelKind::kMoonshine:
@@ -191,6 +195,8 @@ static std::vector<SttModelKind> GetKindsFromDirName(const std::string& modelDir
     }
     if (lower.find("qwen3-asr") != std::string::npos || lower.find("qwen3_asr") != std::string::npos)
         add(SttModelKind::kQwen3Asr);
+    if (lower.find("cohere") != std::string::npos)
+        add(SttModelKind::kCohereTranscribe);
     if (lower.find("funasr") != std::string::npos)
         add(SttModelKind::kFunAsrNano);
     if (lower.find("canary") != std::string::npos)
@@ -318,6 +324,7 @@ static SttPathHints GetSttPathHints(const std::string& modelDir) {
     h.isLikelySenseVoice = lower.find("sense") != std::string::npos || lower.find("sensevoice") != std::string::npos;
     h.isLikelyFunAsrNano = lower.find("funasr") != std::string::npos || lower.find("funasr-nano") != std::string::npos;
     h.isLikelyQwen3Asr = lower.find("qwen3-asr") != std::string::npos || lower.find("qwen3_asr") != std::string::npos;
+    h.isLikelyCohere = lower.find("cohere") != std::string::npos;
     h.isLikelyZipformer = lower.find("zipformer") != std::string::npos;
     h.isLikelyMoonshine = lower.find("moonshine") != std::string::npos;
     h.isLikelyDolphin = lower.find("dolphin") != std::string::npos;
@@ -361,7 +368,11 @@ static SttCapabilities ComputeSttCapabilities(const SttCandidatePaths& paths, co
     bool hasWhisperDec = !paths.decoder.empty();
     bool hasQwen3Tok = !paths.qwen3TokenizerDir.empty();
     c.hasQwen3Asr = !paths.qwen3ConvFrontend.empty() && hasWhisperEnc && hasWhisperDec && hasQwen3Tok;
-    c.hasWhisper = hasWhisperEnc && hasWhisperDec && paths.joiner.empty() && !c.hasQwen3Asr;
+    c.hasCohereTranscribeLayout =
+        hasWhisperEnc && hasWhisperDec && paths.joiner.empty() && !paths.tokens.empty() && !c.hasQwen3Asr;
+    c.hasCohereTranscribe = c.hasCohereTranscribeLayout && hints.isLikelyCohere;
+    c.hasWhisper =
+        hasWhisperEnc && hasWhisperDec && paths.joiner.empty() && !c.hasQwen3Asr && !c.hasCohereTranscribe;
     bool hasFunAsrTok = !paths.funasrTokenizerDir.empty();
     c.hasFunAsrNano = !paths.funasrEncoderAdaptor.empty() && !paths.funasrLLM.empty() &&
                       !paths.funasrEmbedding.empty() && hasFunAsrTok;
@@ -401,6 +412,7 @@ static void CollectDetectedModels(
         out.push_back({"paraformer", modelDir});
     }
     if (cap.hasWhisper) out.push_back({"whisper", modelDir});
+    if (cap.hasCohereTranscribe) out.push_back({"cohere_transcribe", modelDir});
     if (cap.hasQwen3Asr) out.push_back({"qwen3_asr", modelDir});
     if (cap.hasFunAsrNano) out.push_back({"funasr_nano", modelDir});
     if (cap.hasMoonshine) out.push_back({"moonshine", modelDir});
@@ -465,6 +477,10 @@ static SttModelKind ResolveSttKind(
         }
         if (selected == SttModelKind::kQwen3Asr && !cap.hasQwen3Asr) {
             outError = "Qwen3-ASR model requested but conv_frontend/encoder/decoder/tokenizer not found in " + modelDir;
+            return SttModelKind::kUnknown;
+        }
+        if (selected == SttModelKind::kCohereTranscribe && !cap.hasCohereTranscribeLayout) {
+            outError = "Cohere Transcribe model requested but encoder/decoder/tokens.txt not found in " + modelDir;
             return SttModelKind::kUnknown;
         }
         if (selected == SttModelKind::kMoonshine && !cap.hasMoonshine) {
@@ -534,6 +550,7 @@ static SttModelKind ResolveSttKind(
     if (cap.hasCanary) return SttModelKind::kCanary;
     if (cap.hasFireRedAsr) return SttModelKind::kFireRedAsr;
     if (cap.hasQwen3Asr && hints.isLikelyQwen3Asr) return SttModelKind::kQwen3Asr;
+    if (cap.hasCohereTranscribe) return SttModelKind::kCohereTranscribe;
     if (cap.hasWhisper) return SttModelKind::kWhisper;
     if (cap.hasQwen3Asr) return SttModelKind::kQwen3Asr;
     if (cap.hasFunAsrNano) return SttModelKind::kFunAsrNano;
@@ -586,6 +603,10 @@ static void ApplyPathsForSttKind(SttModelKind kind, const SttCandidatePaths& can
             resultPaths.qwen3Encoder = candidate.encoder;
             resultPaths.qwen3Decoder = candidate.decoder;
             resultPaths.qwen3Tokenizer = candidate.qwen3TokenizerDir;
+            break;
+        case SttModelKind::kCohereTranscribe:
+            resultPaths.cohereEncoder = candidate.encoder;
+            resultPaths.cohereDecoder = candidate.decoder;
             break;
         case SttModelKind::kMoonshine:
             resultPaths.moonshinePreprocessor = candidate.moonshinePreprocessor;
@@ -662,13 +683,14 @@ SttDetectResult DetectSttModel(
             EmptyOrPath(candidate.funasrEncoderAdaptor), EmptyOrPath(candidate.funasrLLM), EmptyOrPath(candidate.funasrEmbedding), EmptyOrPath(candidate.funasrTokenizerDir));
         LOGI("DetectSttModel: qwen3_asr conv=%s tokenizerDir=%s",
             EmptyOrPath(candidate.qwen3ConvFrontend), EmptyOrPath(candidate.qwen3TokenizerDir));
-        LOGI("DetectSttModel: hasTransducer=%d hasWhisper=%d hasMoonshine=%d hasMoonshineV2=%d hasParaformer=%d hasFunAsrNano=%d hasQwen3Asr=%d hasDolphin=%d hasFireRedAsr=%d hasFireRedCtc=%d hasCanary=%d hasOmnilingual=%d hasMedAsr=%d hasTeleSpeechCtc=%d hasToneCtc=%d",
+        LOGI("DetectSttModel: hasTransducer=%d hasWhisper=%d hasMoonshine=%d hasMoonshineV2=%d hasParaformer=%d hasFunAsrNano=%d hasQwen3Asr=%d hasCohereLayout=%d hasCohere=%d hasDolphin=%d hasFireRedAsr=%d hasFireRedCtc=%d hasCanary=%d hasOmnilingual=%d hasMedAsr=%d hasTeleSpeechCtc=%d hasToneCtc=%d",
             (int)cap.hasTransducer, (int)cap.hasWhisper, (int)cap.hasMoonshine, (int)cap.hasMoonshineV2,
-            (int)cap.hasParaformer, (int)cap.hasFunAsrNano, (int)cap.hasQwen3Asr, (int)cap.hasDolphin, (int)cap.hasFireRedAsr, (int)cap.hasFireRedCtc,
+            (int)cap.hasParaformer, (int)cap.hasFunAsrNano, (int)cap.hasQwen3Asr, (int)cap.hasCohereTranscribeLayout, (int)cap.hasCohereTranscribe,
+            (int)cap.hasDolphin, (int)cap.hasFireRedAsr, (int)cap.hasFireRedCtc,
             (int)cap.hasCanary, (int)cap.hasOmnilingual, (int)cap.hasMedAsr, (int)cap.hasTeleSpeechCtc, (int)cap.hasToneCtc);
-        LOGI("DetectSttModel: hints isLikelyNemo=%d isLikelyTdt=%d isLikelyWenetCtc=%d isLikelySenseVoice=%d isLikelyFunAsrNano=%d isLikelyQwen3Asr=%d isLikelyZipformer=%d isLikelyMoonshine=%d isLikelyDolphin=%d isLikelyFireRedAsr=%d isLikelyCanary=%d isLikelyOmnilingual=%d isLikelyMedAsr=%d isLikelyTeleSpeech=%d isLikelyToneCtc=%d isLikelyParaformer=%d isLikelyVad=%d isLikelyTdnn=%d",
+        LOGI("DetectSttModel: hints isLikelyNemo=%d isLikelyTdt=%d isLikelyWenetCtc=%d isLikelySenseVoice=%d isLikelyFunAsrNano=%d isLikelyQwen3Asr=%d isLikelyCohere=%d isLikelyZipformer=%d isLikelyMoonshine=%d isLikelyDolphin=%d isLikelyFireRedAsr=%d isLikelyCanary=%d isLikelyOmnilingual=%d isLikelyMedAsr=%d isLikelyTeleSpeech=%d isLikelyToneCtc=%d isLikelyParaformer=%d isLikelyVad=%d isLikelyTdnn=%d",
              (int)hints.isLikelyNemo, (int)hints.isLikelyTdt, (int)hints.isLikelyWenetCtc, (int)hints.isLikelySenseVoice,
-             (int)hints.isLikelyFunAsrNano, (int)hints.isLikelyQwen3Asr, (int)hints.isLikelyZipformer, (int)hints.isLikelyMoonshine, (int)hints.isLikelyDolphin,
+             (int)hints.isLikelyFunAsrNano, (int)hints.isLikelyQwen3Asr, (int)hints.isLikelyCohere, (int)hints.isLikelyZipformer, (int)hints.isLikelyMoonshine, (int)hints.isLikelyDolphin,
              (int)hints.isLikelyFireRedAsr, (int)hints.isLikelyCanary, (int)hints.isLikelyOmnilingual, (int)hints.isLikelyMedAsr,
              (int)hints.isLikelyTeleSpeech, (int)hints.isLikelyToneCtc, (int)hints.isLikelyParaformer, (int)hints.isLikelyVad, (int)hints.isLikelyTdnn);
     }
@@ -754,6 +776,10 @@ SttDetectResult DetectSttModel(
             LOGI("DetectSttModel: paths set qwen3_asr conv=%s encoder=%s decoder=%s tokenizer=%s",
                  EmptyOrPath(result.paths.qwen3ConvFrontend), EmptyOrPath(result.paths.qwen3Encoder),
                  EmptyOrPath(result.paths.qwen3Decoder), EmptyOrPath(result.paths.qwen3Tokenizer));
+            break;
+        case SttModelKind::kCohereTranscribe:
+            LOGI("DetectSttModel: paths set cohere_transcribe encoder=%s decoder=%s",
+                 EmptyOrPath(result.paths.cohereEncoder), EmptyOrPath(result.paths.cohereDecoder));
             break;
         default:
             break;

--- a/ios/model_detect/sherpa-onnx-model-detect.h
+++ b/ios/model_detect/sherpa-onnx-model-detect.h
@@ -21,6 +21,7 @@ enum class SttModelKind {
     kWhisper,
     kFunAsrNano,
     kQwen3Asr,
+    kCohereTranscribe,
     kFireRedAsr,
     kMoonshine,
     kMoonshineV2,
@@ -74,6 +75,9 @@ struct SttModelPaths {
     std::string qwen3Encoder;
     std::string qwen3Decoder;
     std::string qwen3Tokenizer;
+    /** Cohere Transcribe: encoder + decoder ONNX; tokens.txt in model_config.tokens. */
+    std::string cohereEncoder;
+    std::string cohereDecoder;
     std::string moonshinePreprocessor;
     std::string moonshineEncoder;
     std::string moonshineUncachedDecoder;
@@ -121,6 +125,7 @@ struct SttPathHints {
     bool isLikelySenseVoice = false;
     bool isLikelyFunAsrNano = false;
     bool isLikelyQwen3Asr = false;
+    bool isLikelyCohere = false;
     bool isLikelyZipformer = false;
     bool isLikelyMoonshine = false;
     bool isLikelyDolphin = false;
@@ -146,6 +151,8 @@ struct SttCapabilities {
     bool hasParaformer = false;
     bool hasFunAsrNano = false;
     bool hasQwen3Asr = false;
+    bool hasCohereTranscribeLayout = false;
+    bool hasCohereTranscribe = false;
     bool hasDolphin = false;
     bool hasFireRedAsr = false;
     /** True when dir name suggests Fire Red but only a single CTC/paraformer model (no encoder/decoder). Use zipformer_ctc. */

--- a/ios/model_detect/sherpa-onnx-validate-stt.mm
+++ b/ios/model_detect/sherpa-onnx-validate-stt.mm
@@ -59,6 +59,12 @@ static const SttFieldRequirement kQwen3AsrReqs[] = {
     {"qwen3Tokenizer",    &SttModelPaths::qwen3Tokenizer,    true},
 };
 
+static const SttFieldRequirement kCohereTranscribeReqs[] = {
+    {"cohereEncoder", &SttModelPaths::cohereEncoder, true},
+    {"cohereDecoder", &SttModelPaths::cohereDecoder, true},
+    {"tokens",        &SttModelPaths::tokens,        true},
+};
+
 static const SttFieldRequirement kMoonshineReqs[] = {
     {"moonshinePreprocessor",    &SttModelPaths::moonshinePreprocessor,    true},
     {"moonshineEncoder",         &SttModelPaths::moonshineEncoder,         true},
@@ -130,6 +136,9 @@ static const SttFieldRequirement* GetRequirements(SttModelKind kind, size_t& cou
         case SttModelKind::kQwen3Asr:
             count = std::size(kQwen3AsrReqs);
             return kQwen3AsrReqs;
+        case SttModelKind::kCohereTranscribe:
+            count = std::size(kCohereTranscribeReqs);
+            return kCohereTranscribeReqs;
         case SttModelKind::kMoonshine:
             count = std::size(kMoonshineReqs);
             return kMoonshineReqs;
@@ -172,6 +181,7 @@ static const char* SttKindToName(SttModelKind k) {
         case SttModelKind::kWhisper:       return "Whisper";
         case SttModelKind::kFunAsrNano:    return "FunASR Nano";
         case SttModelKind::kQwen3Asr:      return "Qwen3 ASR";
+        case SttModelKind::kCohereTranscribe: return "Cohere Transcribe";
         case SttModelKind::kFireRedAsr:    return "Fire Red ASR";
         case SttModelKind::kMoonshine:     return "Moonshine";
         case SttModelKind::kMoonshineV2:   return "Moonshine v2";

--- a/ios/stt/sherpa-onnx-stt-wrapper.h
+++ b/ios/stt/sherpa-onnx-stt-wrapper.h
@@ -92,6 +92,15 @@ struct SttQwen3AsrOptions {
     std::optional<float> temperature;
     std::optional<float> top_p;
     std::optional<int32_t> seed;
+    /** Comma-separated phrases; applied per stream via SetOption (not hotwords_file). Optional. */
+    std::optional<std::string> hotwords;
+};
+
+/** Model-specific options: Cohere Transcribe (OfflineCohereTranscribeModelConfig). */
+struct SttCohereTranscribeOptions {
+    std::optional<std::string> language;
+    std::optional<bool> use_punct;
+    std::optional<bool> use_itn;
 };
 
 /**
@@ -118,7 +127,8 @@ public:
         const SttSenseVoiceOptions* senseVoiceOpts = nullptr,
         const SttCanaryOptions* canaryOpts = nullptr,
         const SttFunAsrNanoOptions* funasrNanoOpts = nullptr,
-        const SttQwen3AsrOptions* qwen3AsrOpts = nullptr
+        const SttQwen3AsrOptions* qwen3AsrOpts = nullptr,
+        const SttCohereTranscribeOptions* cohereTranscribeOpts = nullptr
     );
 
     SttRecognitionResult transcribeFile(const std::string& filePath);

--- a/ios/stt/sherpa-onnx-stt-wrapper.mm
+++ b/ios/stt/sherpa-onnx-stt-wrapper.mm
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <cstdint>
 #include <limits>
+#include <vector>
 
 // iOS logging
 #ifdef __APPLE__
@@ -35,6 +36,37 @@ namespace fs = std::filesystem;
 #include "sherpa-onnx/c-api/cxx-api.h"
 
 namespace sherpaonnx {
+
+namespace {
+
+/** Qwen3-ASR reads hotwords from the stream option "hotwords" (comma-separated), not from hotwords_file. */
+static std::string NormalizeQwen3HotwordsCsv(const std::string& s) {
+    if (s.empty()) return "";
+    std::string flat;
+    flat.reserve(s.size());
+    for (unsigned char uc : s) {
+        char c = static_cast<char>(uc);
+        if (c == '\n' || c == '\r') flat += ',';
+        else flat += c;
+    }
+    std::vector<std::string> parts;
+    std::istringstream iss(flat);
+    std::string part;
+    while (std::getline(iss, part, ',')) {
+        size_t a = part.find_first_not_of(" \t");
+        if (a == std::string::npos) continue;
+        size_t b = part.find_last_not_of(" \t");
+        parts.push_back(part.substr(a, b - a + 1));
+    }
+    std::string out;
+    for (size_t i = 0; i < parts.size(); ++i) {
+        if (i) out += ',';
+        out += parts[i];
+    }
+    return out;
+}
+
+}  // namespace
 
 // Hotwords are supported for transducer and NeMo transducer (sherpa-onnx; NeMo: #3077).
 static bool SupportsHotwords(sherpaonnx::SttModelKind kind) {
@@ -112,6 +144,7 @@ public:
     sherpaonnx::SttModelKind currentModelKind = sherpaonnx::SttModelKind::kUnknown;
     std::optional<sherpa_onnx::cxx::OfflineRecognizer> recognizer;
     std::optional<sherpa_onnx::cxx::OfflineRecognizerConfig> lastConfig;
+    std::string qwen3_hotwords_csv;
 };
 
 SttWrapper::SttWrapper() : pImpl(std::make_unique<Impl>()) {
@@ -139,7 +172,8 @@ SttInitializeResult SttWrapper::initialize(
     const SttSenseVoiceOptions* senseVoiceOpts,
     const SttCanaryOptions* canaryOpts,
     const SttFunAsrNanoOptions* funasrNanoOpts,
-    const SttQwen3AsrOptions* qwen3AsrOpts
+    const SttQwen3AsrOptions* qwen3AsrOpts,
+    const SttCohereTranscribeOptions* cohereTranscribeOpts
 ) {
     SttInitializeResult result;
     result.success = false;
@@ -203,6 +237,13 @@ SttInitializeResult SttWrapper::initialize(
                 config.model_config.qwen3_asr.encoder = detect.paths.qwen3Encoder;
                 config.model_config.qwen3_asr.decoder = detect.paths.qwen3Decoder;
                 config.model_config.qwen3_asr.tokenizer = detect.paths.qwen3Tokenizer;
+                break;
+            case SttModelKind::kCohereTranscribe:
+                config.model_config.cohere_transcribe.encoder = detect.paths.cohereEncoder;
+                config.model_config.cohere_transcribe.decoder = detect.paths.cohereDecoder;
+                config.model_config.cohere_transcribe.language = "en";
+                config.model_config.cohere_transcribe.use_punct = true;
+                config.model_config.cohere_transcribe.use_itn = true;
                 break;
             case SttModelKind::kFireRedAsr:
                 config.model_config.fire_red_asr.encoder = detect.paths.fireRedEncoder;
@@ -317,6 +358,16 @@ SttInitializeResult SttWrapper::initialize(
                         config.model_config.qwen3_asr.seed = *qwen3AsrOpts->seed;
                 }
                 break;
+            case SttModelKind::kCohereTranscribe:
+                if (cohereTranscribeOpts) {
+                    if (cohereTranscribeOpts->language.has_value())
+                        config.model_config.cohere_transcribe.language = *cohereTranscribeOpts->language;
+                    if (cohereTranscribeOpts->use_punct.has_value())
+                        config.model_config.cohere_transcribe.use_punct = *cohereTranscribeOpts->use_punct;
+                    if (cohereTranscribeOpts->use_itn.has_value())
+                        config.model_config.cohere_transcribe.use_itn = *cohereTranscribeOpts->use_itn;
+                }
+                break;
             default:
                 break;
         }
@@ -358,6 +409,12 @@ SttInitializeResult SttWrapper::initialize(
 
         bool isWhisperModel = detect.selectedKind == SttModelKind::kWhisper &&
             !config.model_config.whisper.encoder.empty() && !config.model_config.whisper.decoder.empty();
+        pImpl->qwen3_hotwords_csv.clear();
+        if (detect.selectedKind == SttModelKind::kQwen3Asr && qwen3AsrOpts &&
+            qwen3AsrOpts->hotwords.has_value() && !qwen3AsrOpts->hotwords->empty()) {
+            pImpl->qwen3_hotwords_csv = NormalizeQwen3HotwordsCsv(*qwen3AsrOpts->hotwords);
+        }
+
         if (isWhisperModel) {
             LOGI("Initializing Whisper model with encoder: %s, decoder: %s", config.model_config.whisper.encoder.c_str(), config.model_config.whisper.decoder.c_str());
         } else if (detect.selectedKind == SttModelKind::kQwen3Asr) {
@@ -366,6 +423,11 @@ SttInitializeResult SttWrapper::initialize(
                  config.model_config.qwen3_asr.encoder.c_str(),
                  config.model_config.qwen3_asr.decoder.c_str(),
                  config.model_config.qwen3_asr.tokenizer.c_str());
+        } else if (detect.selectedKind == SttModelKind::kCohereTranscribe) {
+            LOGI("Initializing Cohere Transcribe: encoder=%s decoder=%s language=%s",
+                 config.model_config.cohere_transcribe.encoder.c_str(),
+                 config.model_config.cohere_transcribe.decoder.c_str(),
+                 config.model_config.cohere_transcribe.language.c_str());
         } else {
             LOGI("Initializing non-Whisper model");
         }
@@ -452,6 +514,8 @@ SttRecognitionResult SttWrapper::transcribeFile(const std::string& filePath) {
 
     try {
         auto stream = pImpl->recognizer.value().CreateStream();
+        if (pImpl->currentModelKind == SttModelKind::kQwen3Asr && !pImpl->qwen3_hotwords_csv.empty())
+            stream.SetOption("hotwords", pImpl->qwen3_hotwords_csv.c_str());
 
         // Ensure safe conversions: AcceptWaveform expects 32-bit ints
         if (wave.samples.size() > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
@@ -499,6 +563,8 @@ SttRecognitionResult SttWrapper::transcribeSamples(const std::vector<float>& sam
     }
     try {
         auto stream = pImpl->recognizer.value().CreateStream();
+        if (pImpl->currentModelKind == SttModelKind::kQwen3Asr && !pImpl->qwen3_hotwords_csv.empty())
+            stream.SetOption("hotwords", pImpl->qwen3_hotwords_csv.c_str());
         int32_t n = static_cast<int32_t>(samples.size());
         stream.AcceptWaveform(sampleRate, samples.data(), n);
         pImpl->recognizer.value().Decode(&stream);
@@ -552,6 +618,7 @@ void SttWrapper::release() {
     if (pImpl->initialized) {
         pImpl->recognizer.reset();
         pImpl->lastConfig.reset();
+        pImpl->qwen3_hotwords_csv.clear();
         pImpl->initialized = false;
         pImpl->modelDir.clear();
         pImpl->currentModelKind = sherpaonnx::SttModelKind::kUnknown;

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -21,7 +21,7 @@ export interface Spec extends TurboModule {
    * @param instanceId - Unique ID for this engine instance (from createSTT)
    * @param modelDir - Absolute path to model directory
    * @param preferInt8 - Optional: true = prefer int8 models, false = prefer regular models, undefined = try int8 first (default)
-   * @param modelType - Optional: explicit model type ('transducer', 'nemo_transducer', 'paraformer', 'nemo_ctc', 'wenet_ctc', 'sense_voice', 'zipformer_ctc', 'whisper', 'funasr_nano', 'qwen3_asr', 'fire_red_asr', 'moonshine', 'moonshine_v2', 'dolphin', 'canary', 'omnilingual', 'medasr', 'telespeech_ctc', 'auto'), undefined = auto (default)
+   * @param modelType - Optional: explicit model type ('transducer', 'nemo_transducer', 'paraformer', 'nemo_ctc', 'wenet_ctc', 'sense_voice', 'zipformer_ctc', 'whisper', 'funasr_nano', 'qwen3_asr', 'cohere_transcribe', 'fire_red_asr', 'moonshine', 'moonshine_v2', 'dolphin', 'canary', 'omnilingual', 'medasr', 'telespeech_ctc', 'auto'), undefined = auto (default)
    * @param debug - Optional: enable debug logging in native layer and sherpa-onnx (default: false)
    * @param hotwordsFile - Optional: path to hotwords file (OfflineRecognizerConfig)
    * @param hotwordsScore - Optional: hotwords score (default in Kotlin 1.5)
@@ -30,7 +30,7 @@ export interface Spec extends TurboModule {
    * @param ruleFsts - Optional: path(s) to rule FSTs for ITN (comma-separated)
    * @param ruleFars - Optional: path(s) to rule FARs for ITN (comma-separated)
    * @param dither - Optional: dither for feature extraction. **Android:** applied. **iOS:** ignored (native API does not expose it)
-   * @param modelOptions - Optional: model-specific options (whisper, senseVoice, canary, funasrNano, qwen3Asr). Only the block for the loaded model type is applied.
+   * @param modelOptions - Optional: model-specific options (whisper, senseVoice, canary, funasrNano, qwen3Asr, cohereTranscribe). Only the block for the loaded model type is applied.
    * @param modelingUnit - Optional: 'cjkchar' | 'bpe' | 'cjkchar+bpe' for hotwords tokenization (OfflineModelConfig.modelingUnit)
    * @param bpeVocab - Optional: path to BPE vocab file (OfflineModelConfig.bpeVocab), used when modelingUnit is bpe or cjkchar+bpe
    * @returns Object with success boolean, array of detected models (each with type and modelDir), and optional error when success is false.

--- a/src/stt/index.ts
+++ b/src/stt/index.ts
@@ -260,6 +260,7 @@ export type {
   STTModelType,
   SttModelOptions,
   SttQwen3AsrModelOptions,
+  SttCohereTranscribeModelOptions,
   SttRecognitionResult,
   SttRuntimeConfig,
   SttEngine,

--- a/src/stt/index.ts
+++ b/src/stt/index.ts
@@ -283,6 +283,6 @@ export {
   getFunasrMltNanoLanguages,
   FUNASR_MLT_NANO_LANGUAGES,
   getCohereTranscribeLanguages,
-  COHERE_TRANSCRIBE_14_LANG_LANGUAGES,
+  COHERE_TRANSCRIBE_LANGUAGES,
 } from './sttModelLanguages';
 export type { SttModelLanguage, WhisperLanguage } from './sttModelLanguages';

--- a/src/stt/index.ts
+++ b/src/stt/index.ts
@@ -282,5 +282,7 @@ export {
   FUNASR_NANO_LANGUAGES,
   getFunasrMltNanoLanguages,
   FUNASR_MLT_NANO_LANGUAGES,
+  getCohereTranscribeLanguages,
+  COHERE_TRANSCRIBE_14_LANG_LANGUAGES,
 } from './sttModelLanguages';
 export type { SttModelLanguage, WhisperLanguage } from './sttModelLanguages';

--- a/src/stt/sttModelLanguages.ts
+++ b/src/stt/sttModelLanguages.ts
@@ -239,32 +239,31 @@ export function getFunasrMltNanoLanguages(): readonly SttModelLanguage[] {
 // ========== Cohere Transcribe (14-language bundle) ==========
 // sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01.tar.bz2
 // European: EN, FR, DE, IT, ES, PT, EL, NL, PL
-// AIPAC: ZH (Mandarin), JA, KO, VI
+// APAC: ZH (Mandarin), JA, KO, VI
 // MENA: AR
 
 /** 14 languages for Cohere Transcribe ONNX (ISO-style ids for modelOptions.cohereTranscribe.language). */
-export const COHERE_TRANSCRIBE_14_LANG_LANGUAGES: readonly SttModelLanguage[] =
-  [
-    { id: 'en', name: 'english' },
-    { id: 'fr', name: 'french' },
-    { id: 'de', name: 'german' },
-    { id: 'it', name: 'italian' },
-    { id: 'es', name: 'spanish' },
-    { id: 'pt', name: 'portuguese' },
-    { id: 'el', name: 'greek' },
-    { id: 'nl', name: 'dutch' },
-    { id: 'pl', name: 'polish' },
-    { id: 'zh', name: 'chinese' },
-    { id: 'ja', name: 'japanese' },
-    { id: 'ko', name: 'korean' },
-    { id: 'vi', name: 'vietnamese' },
-    { id: 'ar', name: 'arabic' },
-  ] as const;
+export const COHERE_TRANSCRIBE_LANGUAGES: readonly SttModelLanguage[] = [
+  { id: 'en', name: 'english' },
+  { id: 'fr', name: 'french' },
+  { id: 'de', name: 'german' },
+  { id: 'it', name: 'italian' },
+  { id: 'es', name: 'spanish' },
+  { id: 'pt', name: 'portuguese' },
+  { id: 'el', name: 'greek' },
+  { id: 'nl', name: 'dutch' },
+  { id: 'pl', name: 'polish' },
+  { id: 'zh', name: 'chinese' },
+  { id: 'ja', name: 'japanese' },
+  { id: 'ko', name: 'korean' },
+  { id: 'vi', name: 'vietnamese' },
+  { id: 'ar', name: 'arabic' },
+] as const;
 
 /**
  * Returns languages for Cohere Transcribe 14-lang models.
  * Id is the value for modelOptions.cohereTranscribe.language (e.g. "en", "zh").
  */
 export function getCohereTranscribeLanguages(): readonly SttModelLanguage[] {
-  return COHERE_TRANSCRIBE_14_LANG_LANGUAGES;
+  return COHERE_TRANSCRIBE_LANGUAGES;
 }

--- a/src/stt/sttModelLanguages.ts
+++ b/src/stt/sttModelLanguages.ts
@@ -235,3 +235,36 @@ export function getFunasrNanoLanguages(): readonly SttModelLanguage[] {
 export function getFunasrMltNanoLanguages(): readonly SttModelLanguage[] {
   return FUNASR_MLT_NANO_LANGUAGES;
 }
+
+// ========== Cohere Transcribe (14-language bundle) ==========
+// sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01.tar.bz2
+// European: EN, FR, DE, IT, ES, PT, EL, NL, PL
+// AIPAC: ZH (Mandarin), JA, KO, VI
+// MENA: AR
+
+/** 14 languages for Cohere Transcribe ONNX (ISO-style ids for modelOptions.cohereTranscribe.language). */
+export const COHERE_TRANSCRIBE_14_LANG_LANGUAGES: readonly SttModelLanguage[] =
+  [
+    { id: 'en', name: 'english' },
+    { id: 'fr', name: 'french' },
+    { id: 'de', name: 'german' },
+    { id: 'it', name: 'italian' },
+    { id: 'es', name: 'spanish' },
+    { id: 'pt', name: 'portuguese' },
+    { id: 'el', name: 'greek' },
+    { id: 'nl', name: 'dutch' },
+    { id: 'pl', name: 'polish' },
+    { id: 'zh', name: 'chinese' },
+    { id: 'ja', name: 'japanese' },
+    { id: 'ko', name: 'korean' },
+    { id: 'vi', name: 'vietnamese' },
+    { id: 'ar', name: 'arabic' },
+  ] as const;
+
+/**
+ * Returns languages for Cohere Transcribe 14-lang models.
+ * Id is the value for modelOptions.cohereTranscribe.language (e.g. "en", "zh").
+ */
+export function getCohereTranscribeLanguages(): readonly SttModelLanguage[] {
+  return COHERE_TRANSCRIBE_14_LANG_LANGUAGES;
+}

--- a/src/stt/types.ts
+++ b/src/stt/types.ts
@@ -16,6 +16,7 @@ export type STTModelType =
   | 'whisper'
   | 'funasr_nano'
   | 'qwen3_asr'
+  | 'cohere_transcribe'
   | 'fire_red_asr'
   | 'moonshine'
   | 'dolphin'
@@ -52,6 +53,7 @@ export const STT_MODEL_TYPES: readonly STTModelType[] = [
   'whisper',
   'funasr_nano',
   'qwen3_asr',
+  'cohere_transcribe',
   'fire_red_asr',
   'moonshine',
   'dolphin',
@@ -131,6 +133,11 @@ export interface SttFunAsrNanoModelOptions {
 
 /** Options for Qwen3 ASR models. Applied only when modelType is 'qwen3_asr'. */
 export interface SttQwen3AsrModelOptions {
+  /**
+   * Optional comma-separated hotword phrases (UTF-8). Applied per decode via native stream option
+   * `"hotwords"` — not the same as transducer `hotwordsFile`. Omit when unused.
+   */
+  hotwords?: string;
   /** Max total sequence length. Default: 512. */
   maxTotalLen?: number;
   /** Max new tokens to generate. Default: 128. */
@@ -143,6 +150,16 @@ export interface SttQwen3AsrModelOptions {
   seed?: number;
 }
 
+/** Options for Cohere Transcribe models. Applied only when modelType is 'cohere_transcribe'. */
+export interface SttCohereTranscribeModelOptions {
+  /** Spoken language code (e.g. en, de, zh). Default: "en". */
+  language?: string;
+  /** Punctuation. Default: true. */
+  usePunct?: boolean;
+  /** Inverse text normalization. Default: true. */
+  useItn?: boolean;
+}
+
 /**
  * Model-specific STT options. Only the block for the actually loaded model type is applied;
  * others are ignored (e.g. whisper options have no effect when a paraformer model is loaded).
@@ -153,6 +170,7 @@ export interface SttModelOptions {
   canary?: SttCanaryModelOptions;
   funasrNano?: SttFunAsrNanoModelOptions;
   qwen3Asr?: SttQwen3AsrModelOptions;
+  cohereTranscribe?: SttCohereTranscribeModelOptions;
 }
 
 /**
@@ -183,6 +201,7 @@ export interface STTInitializeOptions {
    * - 'sense_voice': Force detection as SenseVoice model
    * - 'funasr_nano': Force detection as FunASR Nano model
    * - 'qwen3_asr': Force detection as Qwen3 ASR
+   * - 'cohere_transcribe': Cohere Transcribe (encoder/decoder + tokens.txt)
    * - 'fire_red_asr': FireRed ASR (encoder/decoder)
    * - 'moonshine': Moonshine (preprocess, encode, uncached_decode, cached_decode)
    * - 'dolphin': Dolphin (single model)

--- a/test/cpp/model_detect_test_utils.cpp
+++ b/test/cpp/model_detect_test_utils.cpp
@@ -129,6 +129,7 @@ SttModelKind SttKindFromString(const std::string& modelType) {
     if (t == "whisper") return SttModelKind::kWhisper;
     if (t == "funasr_nano") return SttModelKind::kFunAsrNano;
     if (t == "qwen3_asr") return SttModelKind::kQwen3Asr;
+    if (t == "cohere_transcribe") return SttModelKind::kCohereTranscribe;
     if (t == "fire_red_asr") return SttModelKind::kFireRedAsr;
     if (t == "moonshine") return SttModelKind::kMoonshine;
     if (t == "moonshine_v2") return SttModelKind::kMoonshineV2;
@@ -153,6 +154,7 @@ std::string SttKindToString(SttModelKind kind) {
         case SttModelKind::kWhisper: return "whisper";
         case SttModelKind::kFunAsrNano: return "funasr_nano";
         case SttModelKind::kQwen3Asr: return "qwen3_asr";
+        case SttModelKind::kCohereTranscribe: return "cohere_transcribe";
         case SttModelKind::kFireRedAsr: return "fire_red_asr";
         case SttModelKind::kMoonshine: return "moonshine";
         case SttModelKind::kMoonshineV2: return "moonshine_v2";

--- a/test/fixtures/asr-models-expected.csv
+++ b/test/fixtures/asr-models-expected.csv
@@ -408,3 +408,4 @@ sherpa-onnx-rk3566-streaming-zipformer-small-bilingual-zh-en-2023-02-16.tar.bz2,
 sherpa-onnx-rk3566-streaming-zipformer-bilingual-zh-en-2023-02-20.tar.bz2,unsupported
 sherpa-onnx-rk3562-streaming-zipformer-small-bilingual-zh-en-2023-02-16.tar.bz2,unsupported
 sherpa-onnx-rk3562-streaming-zipformer-bilingual-zh-en-2023-02-20.tar.bz2,unsupported
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01.tar.bz2,

--- a/test/fixtures/asr-models-expected.csv
+++ b/test/fixtures/asr-models-expected.csv
@@ -408,4 +408,4 @@ sherpa-onnx-rk3566-streaming-zipformer-small-bilingual-zh-en-2023-02-16.tar.bz2,
 sherpa-onnx-rk3566-streaming-zipformer-bilingual-zh-en-2023-02-20.tar.bz2,unsupported
 sherpa-onnx-rk3562-streaming-zipformer-small-bilingual-zh-en-2023-02-16.tar.bz2,unsupported
 sherpa-onnx-rk3562-streaming-zipformer-bilingual-zh-en-2023-02-20.tar.bz2,unsupported
-sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01.tar.bz2,
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01.tar.bz2,cohere_transcribe

--- a/test/fixtures/asr-models-structure.txt
+++ b/test/fixtures/asr-models-structure.txt
@@ -6866,3 +6866,20 @@ sherpa-onnx-rk3562-streaming-zipformer-bilingual-zh-en-2023-02-20/decoder.rknn
 sherpa-onnx-rk3562-streaming-zipformer-bilingual-zh-en-2023-02-20/encoder.rknn
 sherpa-onnx-rk3562-streaming-zipformer-bilingual-zh-en-2023-02-20/tokens.txt
 
+# Asset: sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01.tar.bz2
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/encoder.int8.onnx
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/test_wavs/
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/test_wavs/en.wav
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/test_wavs/ja.wav
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/test_wavs/de.wav
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/test_wavs/es.wav
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/test_wavs/ko.wav
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/test_wavs/vi.wav
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/test_wavs/zh.wav
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/test_wavs/ar.wav
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/test_wavs/fr.wav
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/decoder.int8.onnx
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/encoder.int8.onnx.data
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/tokens.txt
+sherpa-onnx-cohere-transcribe-14-lang-int8-2026-04-01/README.md

--- a/third_party/sherpa-onnx-prebuilt/ANDROID_RELEASE_TAG
+++ b/third_party/sherpa-onnx-prebuilt/ANDROID_RELEASE_TAG
@@ -1,1 +1,1 @@
-sherpa-onnx-android-v1.12.34-2
+sherpa-onnx-android-v1.12.35-1

--- a/third_party/sherpa-onnx-prebuilt/IOS_RELEASE_TAG
+++ b/third_party/sherpa-onnx-prebuilt/IOS_RELEASE_TAG
@@ -1,1 +1,1 @@
-sherpa-onnx-ios-v1.12.34-2
+sherpa-onnx-ios-v1.12.35-1


### PR DESCRIPTION
This pull request adds support for the Cohere Transcribe ASR model to the Android model detection and documentation. It updates the detection logic, capability reporting, and documentation to recognize and describe Cohere Transcribe models alongside existing ASR models.

**Sherpa-Onnx Features:**
By updating from `1.12.34` to `1.12.35`, the following featues had to be added to the sdk:
- Add hotwords support for Qwen3-ASR
- Added support for new modeltype: Cohere Transcribe (modelType: `cohere_transcribe`)

**Android model detection and capability logic:**

- Added `kCohereTranscribe` to the `SttModelKind` enum and extended model path structures to include Cohere Transcribe encoder and decoder paths. [[1]](diffhunk://#diff-2231c4064d52829008d4f68d2d9701343e4cec452e3f3d9e100f5a0f4f473ae1R24) [[2]](diffhunk://#diff-2231c4064d52829008d4f68d2d9701343e4cec452e3f3d9e100f5a0f4f473ae1R78-R80)
- Updated detection logic in `sherpa-onnx-model-detect-stt.cpp` to:
  - Recognize directory names containing "cohere" as likely Cohere Transcribe models. [[1]](diffhunk://#diff-1d1d95ba50d9e54d8eca2cf1a5a99e6f1bfa763a129df63828d36ff0abf6651bR182-R183) [[2]](diffhunk://#diff-1d1d95ba50d9e54d8eca2cf1a5a99e6f1bfa763a129df63828d36ff0abf6651bR332)
  - Identify Cohere Transcribe layout (encoder + decoder + tokens.txt, no joiner, not Qwen3) and set capability flags accordingly. [[1]](diffhunk://#diff-1d1d95ba50d9e54d8eca2cf1a5a99e6f1bfa763a129df63828d36ff0abf6651bL430-R441) [[2]](diffhunk://#diff-2231c4064d52829008d4f68d2d9701343e4cec452e3f3d9e100f5a0f4f473ae1R158-R161)
  - Prefer Cohere Transcribe over Whisper if both layouts are detected.
  - Ensure error reporting if expected Cohere files are missing.
  - Add Cohere Transcribe to the list of detected models and logging output. [[1]](diffhunk://#diff-1d1d95ba50d9e54d8eca2cf1a5a99e6f1bfa763a129df63828d36ff0abf6651bR483) [[2]](diffhunk://#diff-1d1d95ba50d9e54d8eca2cf1a5a99e6f1bfa763a129df63828d36ff0abf6651bL750-R778) [[3]](diffhunk://#diff-1d1d95ba50d9e54d8eca2cf1a5a99e6f1bfa763a129df63828d36ff0abf6651bR875-R878)
  - Map Cohere Transcribe paths to the result structure for downstream use. [[1]](diffhunk://#diff-1d1d95ba50d9e54d8eca2cf1a5a99e6f1bfa763a129df63828d36ff0abf6651bR674-R677) [[2]](diffhunk://#diff-83baf92603440631fd25a9274c87c3dc5a808a03c526cbd8966e766e5d509defR88-R89)
  - Update string conversion and parsing utilities for the new model kind. [[1]](diffhunk://#diff-1d1d95ba50d9e54d8eca2cf1a5a99e6f1bfa763a129df63828d36ff0abf6651bR65) [[2]](diffhunk://#diff-1d1d95ba50d9e54d8eca2cf1a5a99e6f1bfa763a129df63828d36ff0abf6651bR94) [[3]](diffhunk://#diff-83baf92603440631fd25a9274c87c3dc5a808a03c526cbd8966e766e5d509defR27)

**Documentation updates:**

- Added Cohere Transcribe and Qwen3 ASR to the list of supported offline speech-to-text model types and example app features in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-R119) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L237-R239)
- Added detailed table entries for Qwen3 ASR and Cohere Transcribe, including download links and configuration notes.
- Updated ASR model license status CSV to include Cohere Transcribe.

These changes ensure that Cohere Transcribe models are automatically detected, properly reported, and clearly documented for users and developers.