### PR TITLE
fix(incremental-tts): address 8 review comments on engine correctness and docs

### DIFF
--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -1,0 +1,43 @@
+name: Test - JS
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+      - 'readme.md'
+      - '**/README.md'
+      - 'docs/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-js
+  cancel-in-progress: true
+
+jobs:
+  test-js:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run JS tests
+        run: yarn test --ci

--- a/android/src/main/java/com/sherpaonnx/tts/service/TtsStreamingService.kt
+++ b/android/src/main/java/com/sherpaonnx/tts/service/TtsStreamingService.kt
@@ -159,7 +159,6 @@ internal class TtsStreamingService(
         sink?.abort(!keepPartial)
         emitFileError(instanceId, requestId, "TTS stream-to-file failed: ${e.message}", outputPath)
       } finally {
-        emitEnd(instanceId, requestId, inst.ttsStreamCancelled.get())
         inst.ttsStreamRunning.set(false)
       }
     }

--- a/docs/internal/tts-streaming-subtitles-plan.md
+++ b/docs/internal/tts-streaming-subtitles-plan.md
@@ -1,0 +1,108 @@
+# High-level plan: On-the-fly subtitles for TTS streaming (VAD-based)
+
+Internal reference — **not user-facing product documentation.**  
+Describes the intended **best-practice architecture** once **VAD** (or equivalent native speech/silence segmentation) is available in the SDK and wired into the app.
+
+**Related docs**
+
+- [Streaming TTS](../tts-streaming.md) — chunk APIs, incremental text, playback
+- [Offline TTS / batch timings](../tts-offline.md)
+- [Alignment & subtitle modes](../alignment.md) — `proportional`, `estimated`, `accurate` (CTC)
+- [VAD](../vad.md) — speech / silence and segment boundaries
+
+---
+
+## Goal
+
+Show **subtitle cues during** `generateSpeechStream` / incremental streaming TTS, then **refine** word or line timings for accuracy — **without** streaming ASR (RNNT) on synthesized audio.
+
+**Ground truth:** The spoken text comes from the **TTS input** (including incremental commits). RNNT/STT is for **microphone / unknown audio**, not for this path.
+
+---
+
+## Guiding principles
+
+| Principle | Rationale |
+|-----------|-----------|
+| **Text from TTS pipeline, not ASR** | Avoid duplicate compute, mismatched tokens, and merge hell with forced alignment. |
+| **Live = cheap timeline** | Use **duration of emitted PCM** and mapping to **known substrings** (plus optional proportional stretch). |
+| **Refine = CTC after VAD closure** | When VAD reports **trailing silence** (or agreed end-of-speech), run **wav2vec2 / CTC forced alignment** on the **ring-buffer slice + exact transcript** for that span ([alignment.md](../alignment.md)). |
+| **RNNT elsewhere only** | Reserve streaming transducer for **STT** features, not TTS karaoke. |
+
+---
+
+## Architecture
+
+```
+Streaming TTS (native chunks + known text spans)
+        │
+        ▼
+┌───────────────────────────────────────────────────┐
+│ Rolling audio buffer (PCM, sampleRate, mono)      │
+│ + parallel text buffer (committed segments / chars) │
+└───────────────────────────────────────────────────┘
+        │
+        ├─► [Live subtitle layer]
+        │      • Map each finished audio chunk → time interval
+        │      • Attach the text slice that produced it (incremental / stream contract)
+        │      • Optional: proportional within chunk (`alignment` `estimated` ideas)
+        │      • Output: draft cues (line or word granularity, may drift slightly)
+        │
+        ├─► [VAD — control / segmentation]
+        │      • Detect speech vs silence on the synthesized stream
+        │      • Define soft + hard **segment boundaries** for UI and for refinement triggers
+        │      • Trailing silence → close segment → signal refinement layer
+        │
+        └─► [Refinement layer]  (on VAD segment close)
+               • Slice buffer for closed interval + matching **reference** substring
+               • `alignTextToAudio` **accurate** mode (or batch path on exported WAV)
+               • Replace / anchor draft cues for that window
+```
+
+**Subtitle builder:** Merges **draft** (live) and **anchored** (post–CTC) timelines; after refinement, prefer **anchored** times for the covered range to avoid visible jumps (or a defined cross-fade policy).
+
+---
+
+## Implementation phases
+
+### Phase 1 — SDK VAD integration
+
+- [ ] **Native path:** Run VAD on the TTS PCM stream (same clock as chunks / ring buffer).
+- [ ] **Bridge:** Expose **speech/silence** state and/or **segment boundary events** to JS (or handle refinement triggers entirely native and surface only subtitle updates).
+- [ ] **Contract:** For each streaming event, recover **(samples | duration, sampleRate)** and the **text span** tied to that audio (document chunk ↔ text mapping if not a single API tuple).
+
+### Phase 2 — Triggers and refinement
+
+- [ ] **Primary refinement trigger:** **Trailing silence** (or equivalent “segment closed”) from VAD — slice audio + transcript for that span.
+- [ ] **Live cues:** Cumulative timeline from chunk durations + text until refinement lands for the closed segment.
+- [ ] **Accurate pass:** `alignTextToAudio` on the closed segment (file path or extended PCM input per [alignment.md](../alignment.md)).
+- [ ] **Optional:** On long VAD-defined silence, **flush** incremental text buffer for cleaner subtitle paragraphs in the UI.
+
+### Phase 3 — Polish
+
+- [ ] **Overlap / edges:** Refine overlapping windows if needed; merge CTC boundaries at segment edges (avoid 1-frame glitches).
+- [ ] **UX:** Stabilization — limit thrashing of partial words until refinement or min display time.
+- [ ] **Performance:** Alignment off the hot path; cap concurrent refinement work.
+
+---
+
+## What not to do (for this feature)
+
+- Do **not** depend on **RNNT/streaming STT** on TTS output as the primary subtitle source.
+- Do **not** treat ASR partials as the transcript of record when **TTS input text** is available.
+- Do **not** assume **streaming alignment** inside ORT — CTC alignment here is **whole-segment** over a defined audio + text pair ([alignment](../alignment.md)).
+
+---
+
+## Open questions (resolve when implementing)
+
+1. **Incremental text ↔ chunk mapping:** Per-chunk substring vs ordered segments — define ids or byte offsets.
+2. **Alignment input:** File path vs float buffer — temp WAV vs native PCM handle.
+3. **Refinement latency:** Target delay from VAD “silence” to anchored subtitle replace.
+4. **iOS/Android parity:** Same VAD semantics and boundary events on both platforms.
+
+---
+
+## Summary
+
+**Target practice:** known text + **time from audio chunks** for live draft cues; **VAD** defines when a segment **closes**; **CTC forced alignment** on that closed slice refines timings. No ASR on the synthesized waveform for this pipeline.

--- a/docs/migration/incremental_tts_api_redesign.plan.md
+++ b/docs/migration/incremental_tts_api_redesign.plan.md
@@ -1,0 +1,254 @@
+# Incremental TTS API Redesign: Request-Centric Pattern
+
+## Motivation
+
+The current `IncrementalStreamingTtsEngine` is session-centric: `createIncrementalStreamingTTS` returns an engine with `pushText`, `commit`, `flush` directly on it, and callbacks are passed at factory creation time. This diverges from `StreamingTtsEngine` where the factory creates an engine and per-request methods (`generateSpeechStream`, `generateSpeechStreamToFile`) accept handlers and return controllers.
+
+The new design aligns both APIs structurally, making the SDK consistent and intuitive. No backward compatibility is needed since incremental support was never released.
+
+## Target API Shape
+
+```mermaid
+graph TD
+  subgraph factoryLayer [Factory Layer]
+    A["createStreamingTTS(init)"] --> B[StreamingTtsEngine]
+    C["createIncrementalStreamingTTS(init)"] --> D[IncrementalStreamingTtsEngine]
+  end
+
+  subgraph requestLayer [Request Layer -- StreamingTtsEngine]
+    B --> E["generateSpeechStream(text, opts, handlers, streamOpts)"]
+    B --> F["generateSpeechStreamToFile(text, opts, fileOpts, handlers)"]
+    E --> G["TtsStreamController { cancel, player }"]
+    F --> H["TtsStreamFileController { cancel }"]
+  end
+
+  subgraph incrementalRequestLayer [Request Layer -- IncrementalStreamingTtsEngine]
+    D --> I["generateIncrementalSpeechStream(genOpts, handlers, streamOpts)"]
+    D --> J["generateIncrementalSpeechStreamToFile(genOpts, fileOpts, handlers)"]
+    I --> K["IncrementalStreamController { pushText, commit, flush, cancel, player }"]
+    J --> L["IncrementalStreamFileController { pushText, commit, flush, cancel }"]
+  end
+```
+
+### Factory: `createIncrementalStreamingTTS(options)`
+
+```typescript
+interface IncrementalStreamingTtsFactoryOptions {
+  source: IncrementalStreamingTtsSource; // existing engine or engineOptions
+  segmentation?: SegmentationPolicy;     // shared across requests
+  queue?: QueuePolicy;                   // shared across requests
+}
+
+interface IncrementalStreamingTtsEngine {
+  readonly instanceId: string;
+
+  generateIncrementalSpeechStream(
+    options: TtsGenerationOptions | undefined,
+    handlers: IncrementalStreamHandlers,
+    streamOptions?: TtsStreamOptions,
+    incrementalOptions?: IncrementalRequestOptions
+  ): IncrementalStreamController;
+
+  generateIncrementalSpeechStreamToFile(
+    options: TtsGenerationOptions | undefined,
+    fileOptions: TtsStreamToFileOptions,
+    handlers: IncrementalStreamToFileHandlers,
+    incrementalOptions?: IncrementalRequestOptions
+  ): IncrementalStreamFileController;
+
+  getModelInfo(): Promise<TTSModelInfo>;
+  getSampleRate(): Promise<number>;
+  getNumSpeakers(): Promise<number>;
+  destroy(): Promise<void>;
+}
+```
+
+Key design decisions:
+- `segmentation` and `queue` at factory level (shared default for all requests)
+- `IncrementalRequestOptions` allows per-request override of segmentation/queue + session/segment event callbacks
+- Only one active request at a time (throws if called while another is active; underlying `StreamingTtsEngine` constraint)
+- `text` is NOT passed at request start (it arrives via `pushText` on the controller)
+
+### Per-request handlers
+
+Extend `TtsStreamHandlers` / `TtsStreamToFileHandlers` with incremental events:
+
+```typescript
+interface IncrementalStreamHandlers extends TtsStreamHandlers {
+  onSessionEvent?: (event: SessionEvent) => void;
+  onSegmentEvent?: (event: SegmentEvent) => void;
+  onMetrics?: (metrics: IncrementalMetrics) => void;
+}
+
+interface IncrementalStreamToFileHandlers extends TtsStreamToFileHandlers {
+  onSessionEvent?: (event: SessionEvent) => void;
+  onSegmentEvent?: (event: SegmentEvent) => void;
+  onMetrics?: (metrics: IncrementalMetrics) => void;
+}
+```
+
+Top-level `onChunk`/`onEnd`/`onError` work at the session level:
+- `onChunk`: delivers chunks from the currently active segment (when `emitChunks: true`)
+- `onEnd`: fires when `flush()` resolves (all segments complete)
+- `onError`: fires on segment errors (engine continues with next segment)
+
+### Controllers
+
+```typescript
+interface IncrementalStreamController {
+  pushText(text: string): void;
+  commit(options?: CommitOptions): void;
+  flush(options?: FlushOptions): Promise<void>;
+  cancel(options?: CancelOptions): Promise<void>;
+  getMetrics(): IncrementalMetrics;
+  readonly player: PcmPlayer | null; // proxy over active segment player
+  readonly state: SessionState;
+}
+
+interface IncrementalStreamFileController {
+  pushText(text: string): void;
+  commit(options?: CommitOptions): void;
+  flush(options?: FlushOptions): Promise<void>;
+  cancel(options?: CancelOptions): Promise<void>;
+  getMetrics(): IncrementalMetrics;
+  readonly state: SessionState;
+}
+```
+
+### Commit semantics (clarified)
+
+`commit()` is a **force trigger**, not a required step for normal generation.
+
+- `pushText()` only appends input to the request buffer.
+- Speech starts automatically when auto-segmentation finds a boundary (punctuation, length limit, or timeout).
+- `commit()` forces the current buffer to be enqueued immediately, even if no boundary is detected yet.
+- `flush()` performs an implicit forced commit of remaining text and waits until all queued/active segments finish.
+
+Behavior matrix:
+
+- **Only `pushText()` with detectable boundaries** -> speech is generated automatically.
+- **`pushText()` without boundaries, but timeout enabled** -> speech starts when timeout triggers forced segmentation.
+- **`pushText()` without boundaries and no timeout** -> no generation until `commit()` or `flush()`.
+- **`commit()`** -> immediate enqueue/start path for current buffered text.
+
+### Player Proxy (playback: true)
+
+When `streamOptions.playback` is `true`, `IncrementalStreamController.player` returns a **proxy PcmPlayer** that:
+- Delegates `pause()`/`resume()` to the currently active segment's native player
+- Maintains internal `isPaused` flag; when a new segment starts, if `isPaused`, the new segment's player is immediately paused
+- `destroy()` on the proxy triggers `cancel({ scope: 'all' })`
+
+This gives the user a single, stable `player` reference for the entire incremental session.
+
+### File output strategy (`generateIncrementalSpeechStreamToFile`)
+
+Each committed segment is dispatched via `streamingEngine.generateSpeechStreamToFile(...)` to a **temporary WAV file**. On `flush()`, temp files are concatenated into the final output path. Temp files are cleaned up after concatenation or on cancel/destroy.
+
+## Files to Change
+
+### 1. [src/tts/incremental/types.ts](src/tts/incremental/types.ts) -- Full rewrite
+
+- Remove old `IncrementalStreamingTtsEngine` (session-centric) interface
+- Add `IncrementalStreamingTtsEngine` (factory interface with `generateIncrementalSpeechStream`, `generateIncrementalSpeechStreamToFile`, passthrough model info methods, `destroy`)
+- Add `IncrementalStreamingTtsFactoryOptions` (replaces `IncrementalStreamingTtsOptions`; no handlers/streamOptions/genOptions at factory level)
+- Add `IncrementalRequestOptions` (optional per-request segmentation/queue override + event callbacks)
+- Add `IncrementalStreamHandlers` (extends `TtsStreamHandlers`)
+- Add `IncrementalStreamToFileHandlers` (extends `TtsStreamToFileHandlers`)
+- Add `IncrementalStreamController` interface
+- Add `IncrementalStreamFileController` interface
+- Keep existing `SegmentationPolicy`, `QueuePolicy`, `SessionEvent`, `SegmentEvent`, `IncrementalMetrics`, `CommitOptions`, `CancelOptions`, `FlushOptions`, `SessionState`, `SessionId`, `SegmentId` types unchanged
+
+### 2. [src/tts/incremental/engine.ts](src/tts/incremental/engine.ts) -- Major refactor
+
+- `createEngine` now returns the factory `IncrementalStreamingTtsEngine` with `generateIncrementalSpeechStream` and `generateIncrementalSpeechStreamToFile`
+- Move the current queue/segmentation/dispatch loop into a per-request function that returns an `IncrementalStreamController` or `IncrementalStreamFileController`
+- Add player proxy logic: create a proxy `PcmPlayer` that tracks the active segment's controller and maintains pause state
+- Add file controller logic: dispatch segments to temp files, concatenate on flush
+- Track whether a request is active; throw on concurrent requests
+
+### 3. [src/tts/incremental/index.ts](src/tts/incremental/index.ts) -- Update factory + exports
+
+- `createIncrementalStreamingTTS` signature changes to accept `IncrementalStreamingTtsFactoryOptions`
+- Return type becomes the new `IncrementalStreamingTtsEngine`
+- Update all public type re-exports (remove old types, add new controller types and handler types)
+
+### 4. [src/tts/incremental/events.ts](src/tts/incremental/events.ts) -- No changes
+
+Event factory functions and types remain as-is.
+
+### 5. [src/tts/incremental/segmenter.ts](src/tts/incremental/segmenter.ts) -- No changes
+
+Segmentation logic is pure and reusable.
+
+### 6. [src/tts/incremental/policies.ts](src/tts/incremental/policies.ts) -- No changes
+
+Queue policies are pure and reusable.
+
+### 7. [src/tts/incremental/__tests__/engine.test.ts](src/tts/incremental/__tests__/engine.test.ts) -- Full rewrite
+
+- Update to match new API: create engine, call `generateIncrementalSpeechStream`, interact with controller
+- Test lifecycle: idle state, pushText/commit/flush/cancel on controller, destroy on engine
+- Test player proxy: pause/resume propagation, cross-segment pause state
+- Test concurrent request rejection
+- Test file controller variant (temp file concat mock)
+
+### 8. [src/tts/streamingTypes.ts](src/tts/streamingTypes.ts) -- No changes
+
+The `StreamingTtsEngine` interface stays unchanged.
+
+### 9. [src/tts/index.ts](src/tts/index.ts) -- Update re-exports
+
+- Replace old incremental type exports with new ones (`IncrementalStreamingTtsFactoryOptions`, `IncrementalStreamController`, `IncrementalStreamFileController`, `IncrementalStreamHandlers`, `IncrementalStreamToFileHandlers`, `IncrementalRequestOptions`)
+- Remove removed types from the export list
+
+### 10. [docs/tts-streaming.md](docs/tts-streaming.md) -- Update Quick Start + API Reference
+
+- Rewrite Quick Start example 4 (incremental text feeding) to use new request-centric API
+- Update the "Choosing a streaming path" table if needed
+- Update API Reference for `IncrementalStreamingTtsEngine` and controllers
+- Update the Types tables for incremental streaming
+
+### 11. [docs/migration/tts-incremental-text-feeding-plan.md](docs/migration/tts-incremental-text-feeding-plan.md) -- Update architecture description
+
+- Update "Proposed Public API" section to reflect request-centric pattern
+- Update data flow diagram
+
+## Usage Example (target)
+
+```typescript
+import { createIncrementalStreamingTTS } from 'react-native-sherpa-onnx/tts';
+
+// 1. Create factory
+const inc = await createIncrementalStreamingTTS({
+  source: { engineOptions: { modelPath: { type: 'asset', path: 'models/vits-piper-en' } } },
+  segmentation: { maxCharsPerSegment: 220, minCharsPerSegment: 24, maxWaitMs: 900 },
+});
+
+// 2. Start a request with native playback
+const ctrl = inc.generateIncrementalSpeechStream(
+  { sid: 0, speed: 1.0 },
+  {
+    onChunk: (c) => { /* waveform viz */ },
+    onEnd: () => console.log('All segments done'),
+    onError: (e) => console.error(e.message),
+    onSessionEvent: (e) => console.log(e.type),
+    onSegmentEvent: (e) => { if (e.type === 'segment:dropped') console.warn(e.reason); },
+  },
+  { playback: true, emitChunks: true }
+);
+
+// 3. Push text progressively
+ctrl.pushText('Hello Michael. ');
+ctrl.pushText('The weather today was amazing. ');
+ctrl.commit();
+
+// 4. Player control (works across segments)
+await ctrl.player?.pause();
+await ctrl.player?.resume();
+
+// 5. Finish
+await ctrl.flush();
+
+// 6. Cleanup
+await inc.destroy();
+```

--- a/docs/tts-offline.md
+++ b/docs/tts-offline.md
@@ -367,25 +367,28 @@ Use **`alignTextToAudio`** from **`react-native-sherpa-onnx/alignment`** for fil
 
 ## Types
 
-### Core
+Listed types are those used by **batch TTS** in this document (`detectTtsModel`, `createTTS`, `generateSpeech*`, `playFromSink`, save helpers, and `SubtitleOptions` on `generateSpeechWithTimestamps`). For **streaming-only** types (`TtsStream*`, incremental controllers, …), see [tts-streaming.md](tts-streaming.md). `ModelPathConfig` is imported from `react-native-sherpa-onnx`.
+
+### Detection & model path
 
 | Type | Notes |
 | --- | --- |
+| `ModelPathConfig` | `{ type: 'asset' \| 'file' \| 'auto'; path: string }` |
 | `TTSModelType` | `'vits' \| 'matcha' \| 'kokoro' \| 'kitten' \| 'pocket' \| 'zipvoice' \| 'supertonic' \| 'auto'` |
 | `TTS_MODEL_TYPES` | Readonly list of model type literals |
-| `TtsEngine` | Batch engine interface |
-| `StreamingTtsEngine` | Streaming engine interface |
-| `GeneratedAudio` | `{ sampleRate: number; numSamples: number; generation: number; getSamples(): Promise<Float32Array> }` |
-| `GeneratedAudioWithTimestamps` | Extends `GeneratedAudio` with `subtitles`, `timingMode` |
-| `SubtitleTimingItem` | `{ text, start, end }` (seconds) |
-| `TTSModelInfo` | `{ sampleRate, numSpeakers }` |
+| `isTtsModelType` | Runtime guard for `TTSModelType` |
+| `TtsDetectModelResult` | Return type of `detectTtsModel()` |
 | `DetectedModelEntry` | `{ type: string; modelDir: string }` |
-| `TtsStreamChunk` | Streaming chunk payload |
-| `TtsStreamEnd` | `{ cancelled: boolean }` + optional ids |
-| `TtsStreamError` | `{ message: string }` + optional ids |
-| `TtsStreamHandlers` | `{ onChunk?, onEnd?, onError? }` |
-| `TtsStreamController` | `cancel()`, `unsubscribe()` |
-| `ModelPathConfig` | From `react-native-sherpa-onnx` |
+| `DetectionSource` | Trace literals from native detection |
+
+### Batch engine & audio results
+
+| Type | Notes |
+| --- | --- |
+| `TtsEngine` | `createTTS()` instance: `generateSpeech`, `generateSpeechWithTimestamps`, `playFromSink`, `updateParams`, … |
+| `TTSModelInfo` | `{ sampleRate, numSpeakers }` |
+| `GeneratedAudio` | `{ sampleRate, numSamples, generation, getSamples() }` |
+| `GeneratedAudioWithTimestamps` | Extends `GeneratedAudio` with `subtitles`, `timingMode` |
 
 ### Init, update, generation
 
@@ -393,24 +396,36 @@ Use **`alignTextToAudio`** from **`react-native-sherpa-onnx/alignment`** for fil
 | --- | --- |
 | `TTSInitializeOptions` | Discriminated union: with `modelType` omitted/`'auto'`, **`modelOptions` is disallowed**; otherwise only the matching `modelOptions` key (`vits`, `matcha`, …) |
 | `TTSInitializeOptionsBase` | Shared fields: `modelPath`, `provider?`, `numThreads?`, `debug?`, `ruleFsts?`, `ruleFars?`, `maxNumSentences?`, `silenceScale?` |
-| `TtsUpdateOptions` | Union including `{}` and per-`modelType` variants (same coupling rules as init) |
-| `TtsGenerationOptions` | Base fields + optional **`voiceClone`**: `{ kind: 'zipvoice', referenceAudio, referenceText }` or `{ kind: 'pocket', referenceAudio, referenceText? }` |
+| `TtsUpdateOptions` | Argument to `tts.updateParams()` — per-`modelType` variants (same coupling rules as init) |
+| `TtsGenerationOptions` | `generateSpeech` / `generateSpeechWithTimestamps` — base fields + optional **`voiceClone`** |
 | `TtsReferenceAudio` | `{ samples: number[]; sampleRate: number }` |
 | `TtsVoiceClone` / `TtsVoiceCloneZipvoice` / `TtsVoiceClonePocket` | Cloning discriminant types |
 | `TtsExecutionProvider` | `'cpu' \| 'coreml' \| 'xnnpack' \| 'nnapi' \| 'qnn' \| (string & {})` |
 | `TtsModelOptions` | Internal aggregate for native flattening; prefer init/update unions in app code |
 | `TtsVitsModelOptions`, `TtsMatchaModelOptions`, … | Per-architecture scale options |
 
-### Subtitles
+### Playback & save
+
+| Type | Notes |
+| --- | --- |
+| `PlayFromSinkOptions` | Optional args for `playFromSink(generation, options?)` |
+| `TtsBatchPlaybackController` | `{ player: PcmPlayer }` — see [pcm-player.md](pcm-player.md) |
+| `PcmPlayer` | Exposed on batch playback controller (`feed: 'native'`) |
+| `SaveAudioTarget` | `SaveAudioTargetFile` \| `SaveAudioTargetAndroidContent` |
+| `SaveAudioFromPcmInput` | PCM payload for `saveAudioFromPCM()` |
+| `SaveAudioOptions` | `format?`, `outputSampleRateHz?` for save helpers |
+
+### Subtitles (batch path + alignment re-exports)
 
 | Type | Notes |
 | --- | --- |
 | `SubtitleMode` | `'off' \| 'proportional' \| 'estimated' \| 'accurate'` |
 | `SubtitleGranularity` | `'sentence' \| 'word' \| 'character'` (character only with accurate) |
-| `SubtitleOptions` | Proportional/estimated vs accurate (see TypeScript unions) |
-| Alignment standalone | `alignTextToAudio`, types in `react-native-sherpa-onnx/alignment` |
+| `SubtitleOptions` / `SubtitleOptionsAccurate` / `SubtitleOptionsProportionalOrEstimated` | Passed inside `generateSpeechWithTimestamps` options |
+| `SubtitleTimingItem` | `{ text, start, end }` (seconds) — also returned by alignment APIs |
+| `AlignTextToAudioOptions`, `AlignTextToAudioResult`, `AlignAudioInput`, `AlignmentChunkTimeline`, `AlignTextToTtsSinkInput`, … | Re-exported from `react-native-sherpa-onnx/tts`; usage in [alignment.md](alignment.md) |
 
-Breaking type history: [migration.md](migration.md) → **Text-to-Speech: strict types (0.4.0)** under the 0.4.0 section.
+**Breaking type history:** [migration.md](migration.md) → **Text-to-Speech: strict types (0.4.0)** under the 0.4.0 section.
 
 ## Troubleshooting
 

--- a/docs/tts-streaming.md
+++ b/docs/tts-streaming.md
@@ -2,7 +2,7 @@
 
 Incremental speech generation with chunk callbacks: lower time-to-first-byte, playback while generating, or piping float PCM into another pipeline. The API is **instance-based** — create an engine with `createStreamingTTS()`, then call `destroy()` when done.
 
-**For full-buffer synthesis, timestamps on the batch path, WAV save/share, and `alignTextToAudio`:** see [Offline TTS](tts-offline.md) and [alignment.md](alignment.md).
+**For full-buffer synthesis, timestamps on the batch path, and WAV save/share:** see [Offline TTS](tts-offline.md). **Streaming + subtitles:** see [Subtitles](#subtitles) and [alignment.md](alignment.md).
 
 **Import path:** `react-native-sherpa-onnx/tts`
 
@@ -13,7 +13,7 @@ Incremental speech generation with chunk callbacks: lower time-to-first-byte, pl
 | **Interactive playback (native, zero bridge PCM)** | `generateSpeechStream` | `playback: true, emitChunks: false` |
 | **Interactive playback + waveform visualization** | `generateSpeechStream` | `playback: true, emitChunks: true` |
 | **Chunks to JS only (manual player feed)** | `generateSpeechStream` | `playback: false, emitChunks: true` (default) |
-| **Incremental text feeding** (progressive input) | `generateIncrementalSpeechStream` | `playback: true, emitChunks: false` (default) |
+| **Incremental text feeding** (progressive input) | `generateIncrementalSpeechStream` | `playback: false, emitChunks: true` (default; same as `generateSpeechStream`) |
 | **Long-text file export** (preferred) | `generateSpeechStreamToFile` | `emitChunks: false` (default) |
 | **File export + live playback** | `generateSpeechStreamToFile` | `playback: true, emitChunks: false` |
 
@@ -174,6 +174,7 @@ const inc = await createIncrementalStreamingTTS({
 });
 
 // Start one incremental request (request-centric API).
+// Omitting streamOptions uses playback: false, emitChunks: true (chunks to JS).
 const ctrl = inc.generateIncrementalSpeechStream(
   { sid: 0, speed: 1.0 },
   {
@@ -185,12 +186,13 @@ const ctrl = inc.generateIncrementalSpeechStream(
       // segment:queued | segment:started | segment:chunk | segment:ended | segment:dropped
       if (e.type === 'segment:dropped') console.warn(e.reason);
     },
+    onChunk: (c) => {
+      // c.samples, c.sampleRate — default emitChunks: true
+    },
     onError: (e) => {
       console.error('Incremental stream error:', e.message);
     },
-  },
-  // Native playback with minimal bridge traffic
-  { playback: true, emitChunks: false }
+  }
 );
 
 // Push progressive text chunks
@@ -205,9 +207,10 @@ ctrl.commit();
 // Wait until queue is drained
 await ctrl.flush();
 
-// Pause / resume during playback:
-await ctrl.player?.pause();
-await ctrl.player?.resume();
+// With default options, ctrl.player is null. For native playback, pass e.g.
+// { playback: true, emitChunks: false } as the third argument, then:
+// await ctrl.player?.pause();
+// await ctrl.player?.resume();
 
 // Optional: cancel active + queued work
 await ctrl.cancel({ scope: 'all' });
@@ -233,7 +236,7 @@ When `playback: true`, the streaming controller exposes `ctrl.player` — a `Pcm
 | Topic | Requirement |
 | --- | --- |
 | Execution providers | Optional `provider` on init; check availability via root helpers (e.g. `getCoreMlSupport`) — [execution-providers.md](execution-providers.md) |
-| Accurate subtitles | Alignment ONNX from `react-native-sherpa-onnx/alignment`; see [alignment.md](alignment.md) |
+| Subtitles + streaming | Not on the streaming API surface — finish synthesis, then **`alignTextToAudio`**; see [Subtitles](#subtitles) and [alignment.md](alignment.md) |
 | Multi-instance | Each `createTTS` / `createStreamingTTS` gets a unique native `instanceId`; do not use an engine after `destroy()` |
 
 ## API Reference
@@ -424,6 +427,7 @@ generateIncrementalSpeechStream(
 ```
 
 Starts one incremental request with chunk/playback behavior analogous to `generateSpeechStream`.  
+Omitted `streamOptions` uses the same per-field defaults: `playback: false`, `emitChunks: true`.  
 Only one active request per engine instance at a time.
 
 ### `inc.generateIncrementalSpeechStreamToFile(options, fileOptions, handlers, incrementalOptions?)`
@@ -530,35 +534,72 @@ Removes event listeners (also called automatically on end/error).
 controller.unsubscribe();
 ```
 
+## Subtitles
+
+**Subtitle generation is not integrated into the streaming TTS API.** `generateSpeechStream`, `generateSpeechStreamToFile`, and the incremental APIs do not accept `SubtitleOptions` and do not emit word- or line-level timings during synthesis.
+
+**Supported workflow today (post-hoc alignment)**
+
+1. **`generateSpeechStreamToFile`** (preferred for performance)— When writing finishes (`onEnd` on the stream-to-file handlers), pass the **output audio file** and your **transcript** to **`alignTextToAudio`** from `react-native-sherpa-onnx/alignment` (modes and wav2vec2 setup: [alignment.md](alignment.md)).
+
+2. **`generateSpeechStream`** — Collect **PCM** from **`onChunk`** across the utterance (same `sampleRate`), or assemble the full buffer before handling **`onEnd`**, then call **`alignTextToAudio`** with that audio and the transcript, following the input shapes described in [alignment.md](alignment.md) (e.g. WAV path or supported PCM payload).
+
+Batch **`generateSpeechWithTimestamps`** on [Offline TTS](tts-offline.md) remains the path for proportional / estimated / accurate timings in **one** non-streaming call.
+
+**Roadmap:** Built-in subtitle or live timing support for streaming TTS is **planned for a future release**; until then, use the alignment flow above after audio is available.
+
+
 ## Types
 
-### Core
+Listed types are those used by **streaming TTS** in this document (`createStreamingTTS`, `generateSpeechStream` / `ToFile`, `createIncrementalStreamingTTS`, and shared `detectTtsModel` / engine init). **Subtitles:** not part of these streaming types — see [Subtitles](#subtitles). Batch-only types (`TtsEngine`, `GeneratedAudio`, `GeneratedAudioWithTimestamps`, save helpers, `TtsUpdateOptions`, `SubtitleOptions`, …) are in [tts-offline.md](tts-offline.md). `ModelPathConfig` is imported from `react-native-sherpa-onnx`.
+
+### Detection & model path
 
 | Type | Notes |
 | --- | --- |
+| `ModelPathConfig` | `{ type: 'asset' \| 'file' \| 'auto'; path: string }` |
 | `TTSModelType` | `'vits' \| 'matcha' \| 'kokoro' \| 'kitten' \| 'pocket' \| 'zipvoice' \| 'supertonic' \| 'auto'` |
 | `TTS_MODEL_TYPES` | Readonly list of model type literals |
-| `TtsEngine` | Batch engine interface |
-| `StreamingTtsEngine` | Streaming engine interface |
-| `GeneratedAudio` | `{ sampleRate: number; numSamples: number; generation: number; getSamples(): Promise<Float32Array> }` |
-| `GeneratedAudioWithTimestamps` | Extends `GeneratedAudio` with `subtitles`, `timingMode` |
-| `SubtitleTimingItem` | `{ text, start, end }` (seconds) |
-| `TTSModelInfo` | `{ sampleRate, numSpeakers }` |
+| `isTtsModelType` | Runtime guard for `TTSModelType` |
+| `TtsDetectModelResult` | Return type of `detectTtsModel()` |
 | `DetectedModelEntry` | `{ type: string; modelDir: string }` |
+| `DetectionSource` | Trace literals from native detection |
+
+### Init & generation
+
+**`TtsUpdateOptions`** / `updateParams` are **batch-only** ([tts-offline.md](tts-offline.md)); `StreamingTtsEngine` does not expose parameter updates.
+
+| Type | Notes |
+| --- | --- |
+| `TTSInitializeOptions` | `createStreamingTTS()` / `IncrementalStreamingTtsSource.engineOptions` — with `modelType` omitted/`'auto'`, **`modelOptions` is disallowed** |
+| `TTSInitializeOptionsBase` | Shared fields: `modelPath`, `provider?`, `numThreads?`, `debug?`, `ruleFsts?`, `ruleFars?`, `maxNumSentences?`, `silenceScale?` |
+| `TtsGenerationOptions` | Synth options (`voiceClone`, `sid`, `speed`, …) for `generateSpeechStream` / incremental segments |
+| `TtsReferenceAudio` | `{ samples: number[]; sampleRate: number }` |
+| `TtsVoiceClone` / `TtsVoiceCloneZipvoice` / `TtsVoiceClonePocket` | Cloning discriminant types |
+| `TtsExecutionProvider` | `'cpu' \| 'coreml' \| 'xnnpack' \| 'nnapi' \| 'qnn' \| (string & {})` |
+| `TtsModelOptions` | Internal aggregate for native flattening; prefer init unions in app code |
+| `TtsVitsModelOptions`, `TtsMatchaModelOptions`, … | Per-architecture scale options |
+
+
+### Streaming engine & stream results
+
+| Type | Notes |
+| --- | --- |
+| `StreamingTtsEngine` | `createStreamingTTS()` instance |
+| `TTSModelInfo` | `{ sampleRate, numSpeakers }` |
 | `TtsStreamChunk` | `{ samples, sampleRate, progress, isFinal }` + optional `instanceId`, `requestId` |
-| `TtsStreamEnd` | `{ cancelled: boolean }` + optional `instanceId`, `requestId` |
-| `TtsStreamError` | `{ message: string }` + optional `instanceId`, `requestId` |
-| `TtsStreamHandlers` | `{ onChunk?: (chunk: TtsStreamChunk) => void; onEnd?: (e: TtsStreamEnd) => void; onError?: (e: TtsStreamError) => void }` |
+| `TtsStreamEnd` | `{ cancelled: boolean }` + optional ids |
+| `TtsStreamError` | `{ message: string }` + optional ids |
+| `TtsStreamHandlers` | `{ onChunk?, onEnd?, onError? }` |
 | `TtsStreamOptions` | `{ playback?, emitChunks?, autoDestroy? }` |
 | `TtsStreamController` | `cancel()`, `unsubscribe()`, `player: PcmPlayer \| null` |
-| `PcmPlayer` | `writePcmChunk()`, `pause()`, `resume()`, `destroy()` — see [pcm-player.md](pcm-player.md) |
+| `PcmPlayer` | On stream controller when `playback: true` — see [pcm-player.md](pcm-player.md) |
 | `TtsStreamFileOutput` | `{ kind: 'file'; path: string }` |
 | `TtsStreamToFileOptions` | `{ output, format?: 'wav', keepPartialOnCancel?, emitChunks? }` |
 | `TtsStreamFileEnd` | `{ path, bytesWritten, sampleRate, cancelled }` + optional ids |
 | `TtsStreamFileError` | `{ message, path? }` + optional ids |
-| `TtsStreamToFileHandlers` | `{ onChunk?, onEnd?: (e: TtsStreamFileEnd), onError?: (e: TtsStreamFileError) }` |
+| `TtsStreamToFileHandlers` | `{ onChunk?, onEnd?, onError? }` |
 | `TtsStreamFileController` | `cancel()`, `unsubscribe()` |
-| `ModelPathConfig` | From `react-native-sherpa-onnx` |
 
 ### Incremental streaming
 
@@ -577,35 +618,16 @@ controller.unsubscribe();
 | `QueueMode` | `'fifo' \| 'replace-tail' \| 'latest-wins'` |
 | `OverflowStrategy` | `'drop-oldest' \| 'drop-newest' \| 'reject'` |
 | `CommitOptions` | `{ force?: boolean }` |
-| `CancelOptions` | `{ scope?: 'all' \| 'active' \| 'queued' }` |
+| `FlushOptions` | Placeholder `{}` for `flush(options?)` |
+| `CancelOptions` | `{ scope?: CancelScope }` |
+| `CancelScope` | `'all' \| 'active' \| 'queued'` |
+| `SessionId`, `SegmentId` | Opaque string ids on session/segment events |
+| `SessionState` | `'idle' \| 'active' \| 'draining' \| 'cancelled' \| 'errored' \| 'destroyed'` |
 | `IncrementalMetrics` | `{ queueDepth, totalSegmentsQueued, totalSegmentsCompleted, totalSegmentsDropped, totalSegmentsReplaced, activeSegmentId }` |
 | `SessionEvent` | `session:started`, `session:idle`, `session:draining`, `session:cancelled`, `session:error` |
 | `SegmentEvent` | `segment:queued`, `segment:started`, `segment:chunk`, `segment:ended`, `segment:dropped` |
 
-### Init, update, generation
-
-| Type | Notes |
-| --- | --- |
-| `TTSInitializeOptions` | Discriminated union: with `modelType` omitted/`'auto'`, **`modelOptions` is disallowed**; otherwise only the matching `modelOptions` key (`vits`, `matcha`, …) |
-| `TTSInitializeOptionsBase` | Shared fields: `modelPath`, `provider?`, `numThreads?`, `debug?`, `ruleFsts?`, `ruleFars?`, `maxNumSentences?`, `silenceScale?` |
-| `TtsUpdateOptions` | Union including `{}` and per-`modelType` variants (same coupling rules as init) |
-| `TtsGenerationOptions` | Base fields + optional **`voiceClone`**: `{ kind: 'zipvoice', referenceAudio, referenceText }` or `{ kind: 'pocket', referenceAudio, referenceText? }` |
-| `TtsReferenceAudio` | `{ samples: number[]; sampleRate: number }` |
-| `TtsVoiceClone` / `TtsVoiceCloneZipvoice` / `TtsVoiceClonePocket` | Cloning discriminant types |
-| `TtsExecutionProvider` | `'cpu' \| 'coreml' \| 'xnnpack' \| 'nnapi' \| 'qnn' \| (string & {})` |
-| `TtsModelOptions` | Internal aggregate for native flattening; prefer init/update unions in app code |
-| `TtsVitsModelOptions`, `TtsMatchaModelOptions`, … | Per-architecture scale options |
-
-### Subtitles
-
-| Type | Notes |
-| --- | --- |
-| `SubtitleMode` | `'off' \| 'proportional' \| 'estimated' \| 'accurate'` |
-| `SubtitleGranularity` | `'sentence' \| 'word' \| 'character'` (character only with accurate) |
-| `SubtitleOptions` | Proportional/estimated vs accurate (see TypeScript unions in `tts`) |
-| Standalone alignment | `AlignTextToAudioOptions`, `AlignTextToAudioResult` in `react-native-sherpa-onnx/alignment` |
-
-Breaking type history: [migration.md](migration.md) → **Text-to-Speech: strict types (0.4.0)** under the 0.4.0 section.
+**Breaking type history:** [migration.md](migration.md) → **Text-to-Speech: strict types (0.4.0)** under the 0.4.0 section.
 
 ## Troubleshooting
 
@@ -626,9 +648,9 @@ If you call the **`NativeSherpaOnnx`** TurboModule directly instead of `createTT
 
 ## See also
 
-- [tts-offline.md](tts-offline.md) — batch TTS, timestamps, save/share, standalone subtitles  
+- [tts-offline.md](tts-offline.md) — batch TTS, timestamps, save/share  
 - [pcm-player.md](pcm-player.md) — standalone PCM player  
-- [alignment.md](alignment.md) — alignment models, `alignTextToAudio`, accurate subtitles  
+- [alignment.md](alignment.md) — `alignTextToAudio`, modes, alignment models (post-hoc after streaming)  
 - [execution-providers.md](execution-providers.md) — ORT execution providers  
 - [download-manager.md](download-manager.md) — downloading TTS models (`ModelCategory.Tts`)  
 - [migration.md](migration.md) — strict TTS TypeScript unions (0.4.0)

--- a/docs/tts-streaming.md
+++ b/docs/tts-streaming.md
@@ -13,7 +13,7 @@ Incremental speech generation with chunk callbacks: lower time-to-first-byte, pl
 | **Interactive playback (native, zero bridge PCM)** | `generateSpeechStream` | `playback: true, emitChunks: false` |
 | **Interactive playback + waveform visualization** | `generateSpeechStream` | `playback: true, emitChunks: true` |
 | **Chunks to JS only (manual player feed)** | `generateSpeechStream` | `playback: false, emitChunks: true` (default) |
-| **Incremental text feeding** (progressive input) | `createIncrementalStreamingTTS` | `playback: false, emitChunks: true` (default) |
+| **Incremental text feeding** (progressive input) | `generateIncrementalSpeechStream` | `playback: false, emitChunks: true` (default) |
 | **Long-text file export** (preferred) | `generateSpeechStreamToFile` | `emitChunks: false` (default) |
 | **File export + live playback** | `generateSpeechStreamToFile` | `playback: true, emitChunks: false` |
 
@@ -166,39 +166,51 @@ const inc = await createIncrementalStreamingTTS({
       modelPath: { type: 'asset', path: 'models/vits-piper-en_US-lessac-medium' },
     },
   },
-  // Override defaults for native playback with minimal bridge traffic
-  streamOptions: { playback: true, emitChunks: false },
   segmentation: {
     maxCharsPerSegment: 220,
     minCharsPerSegment: 24,
     maxWaitMs: 900,
   },
-  onSessionEvent: (e) => {
-    // session:started | session:draining | session:idle | session:cancelled | session:error
-    console.log(e.type);
-  },
-  onSegmentEvent: (e) => {
-    // segment:queued | segment:started | segment:chunk | segment:ended | segment:dropped
-    if (e.type === 'segment:dropped') console.warn(e.reason);
-  },
 });
 
-// Push progressive text chunks
-inc.pushText('Hallo Michael. ');
-inc.pushText('Today, the weather was amazing. But tomorrow, I think it will rain instead. ');
+// Start one incremental request (request-centric API).
+const ctrl = inc.generateIncrementalSpeechStream(
+  { sid: 0, speed: 1.0 },
+  {
+    onSessionEvent: (e) => {
+      // session:started | session:draining | session:idle | session:cancelled | session:error
+      console.log(e.type);
+    },
+    onSegmentEvent: (e) => {
+      // segment:queued | segment:started | segment:chunk | segment:ended | segment:dropped
+      if (e.type === 'segment:dropped') console.warn(e.reason);
+    },
+    onError: (e) => {
+      console.error('Incremental stream error:', e.message);
+    },
+  },
+  // Native playback with minimal bridge traffic
+  { playback: true, emitChunks: false }
+);
 
-// Force-commit current buffer now
-inc.commit();
+// Push progressive text chunks
+ctrl.pushText('Hallo Michael. ');
+ctrl.pushText('Today, the weather was amazing. But tomorrow, I think it will rain instead. ');
+
+// commit() is done automatically internally if auto-segmentation finds a boundary
+// commit() is a force trigger: it enqueues the current buffer now, even without punctuation/timeout boundary.
+// so use it only if you need to force enqueing
+ctrl.commit();
 
 // Wait until queue is drained
-await inc.flush();
+await ctrl.flush();
 
 // Pause / resume during playback:
-// Incremental engine currently does not expose a per-segment controller/player handle.
-// Use createStreamingTTS + generateSpeechStream directly when runtime pause/resume is required.
+await ctrl.player?.pause();
+await ctrl.player?.resume();
 
 // Optional: cancel active + queued work
-await inc.cancel({ scope: 'all' });
+await ctrl.cancel({ scope: 'all' });
 await inc.destroy();
 ```
 
@@ -278,7 +290,7 @@ const tts = await createStreamingTTS({ modelPath: { type: 'file', path: '/path/t
 
 ```ts
 function createIncrementalStreamingTTS(
-  options: IncrementalStreamingTtsOptions
+  options: IncrementalStreamingTtsFactoryOptions
 ): Promise<IncrementalStreamingTtsEngine>;
 ```
 
@@ -400,23 +412,63 @@ destroy(): Promise<void>;
 
 ## Incremental engine (`IncrementalStreamingTtsEngine`)
 
-### `inc.pushText(text)`
+### `inc.generateIncrementalSpeechStream(options, handlers, streamOptions?, incrementalOptions?)`
+
+```ts
+generateIncrementalSpeechStream(
+  options: TtsGenerationOptions | undefined,
+  handlers: IncrementalStreamHandlers,
+  streamOptions?: TtsStreamOptions,
+  incrementalOptions?: IncrementalRequestOptions
+): IncrementalStreamController;
+```
+
+Starts one incremental request with chunk/playback behavior analogous to `generateSpeechStream`.  
+Only one active request per engine instance at a time.
+
+### `inc.generateIncrementalSpeechStreamToFile(options, fileOptions, handlers, incrementalOptions?)`
+
+```ts
+generateIncrementalSpeechStreamToFile(
+  options: TtsGenerationOptions | undefined,
+  fileOptions: TtsStreamToFileOptions,
+  handlers: IncrementalStreamToFileHandlers,
+  incrementalOptions?: IncrementalRequestOptions
+): IncrementalStreamFileController;
+```
+
+Starts one incremental request writing to file (internally segmented and serialized).
+
+### `inc.getModelInfo()`, `inc.getSampleRate()`, `inc.getNumSpeakers()`, `inc.destroy()`
+
+Same semantics as `StreamingTtsEngine`.
+
+## Incremental stream controller (`IncrementalStreamController`)
+
+### `ctrl.pushText(text)`
 
 ```ts
 pushText(text: string): void;
 ```
 
-Adds incremental input text to the internal buffer. Auto-segmentation may enqueue new segments.
+Adds incremental input text to the active request buffer. Auto-segmentation may enqueue new segments.
 
-### `inc.commit(options?)`
+### `ctrl.commit(options?)`
 
 ```ts
 commit(options?: CommitOptions): void;
 ```
 
-Force-commits current buffer as one segment and enqueues it immediately.
+`commit()` is a force trigger, not a required step for normal generation.
 
-### `inc.flush(options?)`
+Behavior matrix:
+
+- Only `pushText()` with detectable boundaries -> speech is generated automatically.
+- `pushText()` without boundaries, but timeout enabled -> speech starts when timeout triggers forced segmentation.
+- `pushText()` without boundaries and no timeout -> no generation until `commit()` or `flush()`.
+- `commit()` -> immediate enqueue/start path for current buffered text.
+
+### `ctrl.flush(options?)`
 
 ```ts
 flush(options?: FlushOptions): Promise<void>;
@@ -424,7 +476,7 @@ flush(options?: FlushOptions): Promise<void>;
 
 Commits remaining buffer and resolves when queue + active segment are finished.
 
-### `inc.cancel(options?)`
+### `ctrl.cancel(options?)`
 
 ```ts
 cancel(options?: CancelOptions): Promise<void>;
@@ -436,7 +488,7 @@ Cancels by scope:
 - `active`: active only
 - `queued`: queued only
 
-### `inc.getMetrics()`
+### `ctrl.getMetrics()`
 
 ```ts
 getMetrics(): IncrementalMetrics;
@@ -444,13 +496,13 @@ getMetrics(): IncrementalMetrics;
 
 Returns a snapshot: queue depth, totals, and current active segment id.
 
-### `inc.destroy()`
+### `ctrl.player`
 
-```ts
-destroy(): Promise<void>;
-```
+`PcmPlayer | null` (non-null only when `streamOptions.playback === true`).
 
-Cancels work, clears timers/listeners, marks the session destroyed.
+### `ctrl.state`
+
+Current session state for this request.
 
 ## Stream controller (`TtsStreamController`)
 
@@ -512,9 +564,14 @@ controller.unsubscribe();
 
 | Type | Notes |
 | --- | --- |
-| `IncrementalStreamingTtsEngine` | `pushText`, `commit`, `flush`, `cancel`, `getMetrics`, `destroy` |
-| `IncrementalStreamingTtsOptions` | `{ source, segmentation?, queue?, streamOptions?, generationOptions?, onSessionEvent?, onSegmentEvent?, onMetrics? }` |
+| `IncrementalStreamingTtsEngine` | `generateIncrementalSpeechStream`, `generateIncrementalSpeechStreamToFile`, `getModelInfo`, `getSampleRate`, `getNumSpeakers`, `destroy` |
+| `IncrementalStreamingTtsFactoryOptions` | `{ source, segmentation?, queue? }` |
 | `IncrementalStreamingTtsSource` | `{ engine: StreamingTtsEngine }` or `{ engineOptions: TTSInitializeOptions \| ModelPathConfig }` |
+| `IncrementalRequestOptions` | `{ segmentation?, queue? }` |
+| `IncrementalStreamHandlers` | `TtsStreamHandlers` + `onSessionEvent?`, `onSegmentEvent?`, `onMetrics?` |
+| `IncrementalStreamToFileHandlers` | `TtsStreamToFileHandlers` + `onSessionEvent?`, `onSegmentEvent?`, `onMetrics?` |
+| `IncrementalStreamController` | `pushText`, `commit`, `flush`, `cancel`, `getMetrics`, `player`, `state` |
+| `IncrementalStreamFileController` | `pushText`, `commit`, `flush`, `cancel`, `getMetrics`, `state` |
 | `SegmentationPolicy` | `boundaryChars?`, `maxCharsPerSegment?`, `maxWaitMs?`, `minCharsPerSegment?`, `debounceMs?` |
 | `QueuePolicy` | `mode?`, `maxSegments?`, `maxBufferedChars?`, `overflowStrategy?` |
 | `QueueMode` | `'fifo' \| 'replace-tail' \| 'latest-wins'` |

--- a/docs/tts-streaming.md
+++ b/docs/tts-streaming.md
@@ -13,7 +13,7 @@ Incremental speech generation with chunk callbacks: lower time-to-first-byte, pl
 | **Interactive playback (native, zero bridge PCM)** | `generateSpeechStream` | `playback: true, emitChunks: false` |
 | **Interactive playback + waveform visualization** | `generateSpeechStream` | `playback: true, emitChunks: true` |
 | **Chunks to JS only (manual player feed)** | `generateSpeechStream` | `playback: false, emitChunks: true` (default) |
-| **Incremental text feeding** (progressive input) | `generateIncrementalSpeechStream` | `playback: false, emitChunks: true` (default) |
+| **Incremental text feeding** (progressive input) | `generateIncrementalSpeechStream` | `playback: true, emitChunks: false` (default) |
 | **Long-text file export** (preferred) | `generateSpeechStreamToFile` | `emitChunks: false` (default) |
 | **File export + live playback** | `generateSpeechStreamToFile` | `playback: true, emitChunks: false` |
 
@@ -199,7 +199,7 @@ ctrl.pushText('Today, the weather was amazing. But tomorrow, I think it will rai
 
 // commit() is done automatically internally if auto-segmentation finds a boundary
 // commit() is a force trigger: it enqueues the current buffer now, even without punctuation/timeout boundary.
-// so use it only if you need to force enqueing
+// so use it only if you need to force enqueueing
 ctrl.commit();
 
 // Wait until queue is drained

--- a/docs/tts-streaming.md
+++ b/docs/tts-streaming.md
@@ -13,6 +13,7 @@ Incremental speech generation with chunk callbacks: lower time-to-first-byte, pl
 | **Interactive playback (native, zero bridge PCM)** | `generateSpeechStream` | `playback: true, emitChunks: false` |
 | **Interactive playback + waveform visualization** | `generateSpeechStream` | `playback: true, emitChunks: true` |
 | **Chunks to JS only (manual player feed)** | `generateSpeechStream` | `playback: false, emitChunks: true` (default) |
+| **Incremental text feeding** (progressive input) | `createIncrementalStreamingTTS` | `playback: false, emitChunks: true` (default) |
 | **Long-text file export** (preferred) | `generateSpeechStreamToFile` | `emitChunks: false` (default) |
 | **File export + live playback** | `generateSpeechStreamToFile` | `playback: true, emitChunks: false` |
 
@@ -151,6 +152,56 @@ await ctrl.cancel().catch(() => {});
 await tts.destroy();
 ```
 
+### 4) Incremental text feeding (`createIncrementalStreamingTTS`)
+
+Use this path when text arrives progressively (chat/LLM typing).  
+The engine batches text into segments and reuses the existing streaming path internally.
+
+```ts
+import { createIncrementalStreamingTTS } from 'react-native-sherpa-onnx/tts';
+
+const inc = await createIncrementalStreamingTTS({
+  source: {
+    engineOptions: {
+      modelPath: { type: 'asset', path: 'models/vits-piper-en_US-lessac-medium' },
+    },
+  },
+  // Override defaults for native playback with minimal bridge traffic
+  streamOptions: { playback: true, emitChunks: false },
+  segmentation: {
+    maxCharsPerSegment: 220,
+    minCharsPerSegment: 24,
+    maxWaitMs: 900,
+  },
+  onSessionEvent: (e) => {
+    // session:started | session:draining | session:idle | session:cancelled | session:error
+    console.log(e.type);
+  },
+  onSegmentEvent: (e) => {
+    // segment:queued | segment:started | segment:chunk | segment:ended | segment:dropped
+    if (e.type === 'segment:dropped') console.warn(e.reason);
+  },
+});
+
+// Push progressive text chunks
+inc.pushText('Hallo Michael. ');
+inc.pushText('Today, the weather was amazing. But tomorrow, I think it will rain instead. ');
+
+// Force-commit current buffer now
+inc.commit();
+
+// Wait until queue is drained
+await inc.flush();
+
+// Pause / resume during playback:
+// Incremental engine currently does not expose a per-segment controller/player handle.
+// Use createStreamingTTS + generateSpeechStream directly when runtime pause/resume is required.
+
+// Optional: cancel active + queued work
+await inc.cancel({ scope: 'all' });
+await inc.destroy();
+```
+
 **Note:** Zipvoice cloning is **not** supported in streaming on Android; Pocket cloning uses `voiceClone: { kind: 'pocket', referenceAudio: { samples, sampleRate } }`. For Zipvoice voice cloning use batch **`generateSpeech`** on the offline path — [tts-offline.md](tts-offline.md).
 
 ## Stream options (`TtsStreamOptions`)
@@ -221,6 +272,23 @@ Creates a **streaming** TTS engine. Same init union as [`createTTS`](tts-offline
 
 ```ts
 const tts = await createStreamingTTS({ modelPath: { type: 'file', path: '/path/to/model' } });
+```
+
+### `createIncrementalStreamingTTS(options)`
+
+```ts
+function createIncrementalStreamingTTS(
+  options: IncrementalStreamingTtsOptions
+): Promise<IncrementalStreamingTtsEngine>;
+```
+
+High-level incremental layer over `StreamingTtsEngine`.  
+It handles buffering, boundary detection, queue policy, and serial dispatch.
+
+```ts
+const inc = await createIncrementalStreamingTTS({
+  source: { engineOptions: { modelPath: { type: 'asset', path: 'models/my-tts-model' } } },
+});
 ```
 
 ## Streaming engine (`StreamingTtsEngine`)
@@ -330,6 +398,60 @@ getNumSpeakers(): Promise<number>;
 destroy(): Promise<void>;
 ```
 
+## Incremental engine (`IncrementalStreamingTtsEngine`)
+
+### `inc.pushText(text)`
+
+```ts
+pushText(text: string): void;
+```
+
+Adds incremental input text to the internal buffer. Auto-segmentation may enqueue new segments.
+
+### `inc.commit(options?)`
+
+```ts
+commit(options?: CommitOptions): void;
+```
+
+Force-commits current buffer as one segment and enqueues it immediately.
+
+### `inc.flush(options?)`
+
+```ts
+flush(options?: FlushOptions): Promise<void>;
+```
+
+Commits remaining buffer and resolves when queue + active segment are finished.
+
+### `inc.cancel(options?)`
+
+```ts
+cancel(options?: CancelOptions): Promise<void>;
+```
+
+Cancels by scope:
+
+- `all` (default): active + queued
+- `active`: active only
+- `queued`: queued only
+
+### `inc.getMetrics()`
+
+```ts
+getMetrics(): IncrementalMetrics;
+```
+
+Returns a snapshot: queue depth, totals, and current active segment id.
+
+### `inc.destroy()`
+
+```ts
+destroy(): Promise<void>;
+```
+
+Cancels work, clears timers/listeners, marks the session destroyed.
+
 ## Stream controller (`TtsStreamController`)
 
 ### `controller.cancel()`
@@ -385,6 +507,23 @@ controller.unsubscribe();
 | `TtsStreamToFileHandlers` | `{ onChunk?, onEnd?: (e: TtsStreamFileEnd), onError?: (e: TtsStreamFileError) }` |
 | `TtsStreamFileController` | `cancel()`, `unsubscribe()` |
 | `ModelPathConfig` | From `react-native-sherpa-onnx` |
+
+### Incremental streaming
+
+| Type | Notes |
+| --- | --- |
+| `IncrementalStreamingTtsEngine` | `pushText`, `commit`, `flush`, `cancel`, `getMetrics`, `destroy` |
+| `IncrementalStreamingTtsOptions` | `{ source, segmentation?, queue?, streamOptions?, generationOptions?, onSessionEvent?, onSegmentEvent?, onMetrics? }` |
+| `IncrementalStreamingTtsSource` | `{ engine: StreamingTtsEngine }` or `{ engineOptions: TTSInitializeOptions \| ModelPathConfig }` |
+| `SegmentationPolicy` | `boundaryChars?`, `maxCharsPerSegment?`, `maxWaitMs?`, `minCharsPerSegment?`, `debounceMs?` |
+| `QueuePolicy` | `mode?`, `maxSegments?`, `maxBufferedChars?`, `overflowStrategy?` |
+| `QueueMode` | `'fifo' \| 'replace-tail' \| 'latest-wins'` |
+| `OverflowStrategy` | `'drop-oldest' \| 'drop-newest' \| 'reject'` |
+| `CommitOptions` | `{ force?: boolean }` |
+| `CancelOptions` | `{ scope?: 'all' \| 'active' \| 'queued' }` |
+| `IncrementalMetrics` | `{ queueDepth, totalSegmentsQueued, totalSegmentsCompleted, totalSegmentsDropped, totalSegmentsReplaced, activeSegmentId }` |
+| `SessionEvent` | `session:started`, `session:idle`, `session:draining`, `session:cancelled`, `session:error` |
+| `SegmentEvent` | `segment:queued`, `segment:started`, `segment:chunk`, `segment:ended`, `segment:dropped` |
 
 ### Init, update, generation
 

--- a/example/src/screens/generate-timestamp/GenerateTimestampScreen.tsx
+++ b/example/src/screens/generate-timestamp/GenerateTimestampScreen.tsx
@@ -477,6 +477,8 @@ export default function GenerateTimestampScreen() {
         cleanupPath = audioPath;
       }
 
+      const proportionalGranularity: 'sentence' | 'word' =
+        granularity === 'character' ? 'sentence' : granularity;
       const subtitleResult =
         mode === 'accurate'
           ? await alignTextToAudio(text, audioPath, {
@@ -486,7 +488,7 @@ export default function GenerateTimestampScreen() {
             })
           : await alignTextToAudio(text, audioPath, {
               mode: 'proportional',
-              granularity,
+              granularity: proportionalGranularity,
             });
       setResult(subtitleResult);
     } catch (err) {

--- a/ios/tts/bridge/SherpaOnnx+TTSStream.mm
+++ b/ios/tts/bridge/SherpaOnnx+TTSStream.mm
@@ -511,14 +511,6 @@ static const int64_t kMaxChunkLatencyNs = 500LL * 1000000LL; // 500 ms
             }
         });
 
-        NSMutableDictionary *endPayload = [NSMutableDictionary dictionaryWithDictionary:@{ @"instanceId": instanceIdCopy, @"cancelled": @(cancelled) }];
-        if (requestIdCopy != nil) endPayload[@"requestId"] = requestIdCopy;
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (weakSelf) {
-                [weakSelf sendEventWithName:@"ttsStreamEnd" body:endPayload];
-            }
-        });
-
         instRef->streamRunning.store(false);
         {
             std::lock_guard<std::mutex> lock(g_tts_mutex);

--- a/src/tts/incremental/__tests__/engine.test.ts
+++ b/src/tts/incremental/__tests__/engine.test.ts
@@ -270,11 +270,10 @@ describe('IncrementalStreamingTtsEngine (request-centric)', () => {
         ...createFactoryOptions(),
       });
       const handlers = createHandlers();
-      const ctrl = engine.generateIncrementalSpeechStream(
-        undefined,
-        handlers,
-        { playback: false, emitChunks: false }
-      );
+      const ctrl = engine.generateIncrementalSpeechStream(undefined, handlers, {
+        playback: false,
+        emitChunks: false,
+      });
 
       ctrl.pushText('Some text here to process.');
       ctrl.commit();
@@ -567,11 +566,10 @@ describe('IncrementalStreamingTtsEngine (request-centric)', () => {
         ...createFactoryOptions(),
       });
       const handlers = createHandlers();
-      const ctrl = engine.generateIncrementalSpeechStream(
-        undefined,
-        handlers,
-        { playback: false, emitChunks: false }
-      );
+      const ctrl = engine.generateIncrementalSpeechStream(undefined, handlers, {
+        playback: false,
+        emitChunks: false,
+      });
 
       ctrl.pushText('Active segment text.');
       ctrl.commit();
@@ -628,11 +626,10 @@ describe('IncrementalStreamingTtsEngine (request-centric)', () => {
         },
       };
 
-      const ctrl = engine.generateIncrementalSpeechStream(
-        undefined,
-        handlers,
-        { playback: false, emitChunks: false }
-      );
+      const ctrl = engine.generateIncrementalSpeechStream(undefined, handlers, {
+        playback: false,
+        emitChunks: false,
+      });
 
       ctrl.pushText('Some text here.');
       ctrl.commit();

--- a/src/tts/incremental/__tests__/engine.test.ts
+++ b/src/tts/incremental/__tests__/engine.test.ts
@@ -262,6 +262,32 @@ describe('IncrementalStreamingTtsEngine (request-centric)', () => {
         })
       ).toThrow(/destroyed/);
     });
+
+    it('destroy cancels active request and releases activeRequest', async () => {
+      const mock = createMockStreamingEngine();
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const handlers = createHandlers();
+      const ctrl = engine.generateIncrementalSpeechStream(
+        undefined,
+        handlers,
+        { playback: false, emitChunks: false }
+      );
+
+      ctrl.pushText('Some text here to process.');
+      ctrl.commit();
+      await tick();
+
+      // Destroy while request is active
+      await engine.destroy();
+
+      // The active request should have been cancelled
+      expect(ctrl.state).toBe('cancelled');
+      expect(handlers.ended).toBe(true);
+      expect(handlers.endCancelled).toBe(true);
+    });
   });
 
   describe('controller lifecycle', () => {
@@ -361,6 +387,38 @@ describe('IncrementalStreamingTtsEngine (request-centric)', () => {
 
       ctrl.commit();
       expect(handlers.segmentEvents).toHaveLength(0);
+    });
+
+    it('commit({ force: false }) respects min-length threshold', () => {
+      const mock = createMockStreamingEngine();
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions({
+          segmentation: {
+            debounceMs: 0,
+            maxWaitMs: 0,
+            minCharsPerSegment: 50, // high threshold
+          },
+        }),
+      });
+      const handlers = createHandlers();
+      const ctrl = engine.generateIncrementalSpeechStream(undefined, handlers, {
+        playback: false,
+        emitChunks: false,
+      });
+
+      // Short text — below minCharsPerSegment, no boundary char → nothing committed
+      ctrl.pushText('Short text');
+      ctrl.commit({ force: false });
+      expect(handlers.segmentEvents).toHaveLength(0);
+
+      // force=true (default) commits regardless
+      ctrl.commit();
+      expect(
+        handlers.segmentEvents.some(
+          (e: SegmentEvent) => e.type === 'segment:queued'
+        )
+      ).toBe(true);
     });
 
     it('preserves FIFO ordering', async () => {
@@ -508,9 +566,10 @@ describe('IncrementalStreamingTtsEngine (request-centric)', () => {
         source: { engine: mock },
         ...createFactoryOptions(),
       });
+      const handlers = createHandlers();
       const ctrl = engine.generateIncrementalSpeechStream(
         undefined,
-        createHandlers(),
+        handlers,
         { playback: false, emitChunks: false }
       );
 
@@ -522,8 +581,11 @@ describe('IncrementalStreamingTtsEngine (request-centric)', () => {
       await tick();
 
       await ctrl.cancel({ scope: 'queued' });
-      // Active segment still running
+      // Active segment still running — state must not be 'cancelled'
       expect(mock.pendingStreams).toHaveLength(1);
+      expect(ctrl.state).not.toBe('cancelled');
+      // The request itself is not ended: no onEnd should have fired
+      expect(handlers.ended).toBe(false);
     });
 
     it('resolves pending flush on cancel', async () => {
@@ -550,6 +612,39 @@ describe('IncrementalStreamingTtsEngine (request-centric)', () => {
       await ctrl.cancel();
       await tick();
       expect(resolved).toBe(true);
+    });
+
+    it('flush after cancel is a no-op (no double onEnd)', async () => {
+      const mock = createMockStreamingEngine();
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+
+      let endCount = 0;
+      const handlers: IncrementalStreamHandlers = {
+        onEnd: () => {
+          endCount++;
+        },
+      };
+
+      const ctrl = engine.generateIncrementalSpeechStream(
+        undefined,
+        handlers,
+        { playback: false, emitChunks: false }
+      );
+
+      ctrl.pushText('Some text here.');
+      ctrl.commit();
+      await tick();
+      await ctrl.cancel();
+
+      // onEnd fired exactly once (from cancel)
+      expect(endCount).toBe(1);
+
+      // flush on an already-cancelled request must not fire onEnd again
+      await ctrl.flush();
+      expect(endCount).toBe(1);
     });
   });
 

--- a/src/tts/incremental/__tests__/engine.test.ts
+++ b/src/tts/incremental/__tests__/engine.test.ts
@@ -9,7 +9,9 @@ import type {
 import type {
   SessionEvent,
   SegmentEvent,
-  IncrementalStreamingTtsOptions,
+  IncrementalStreamingTtsFactoryOptions,
+  IncrementalStreamHandlers,
+  IncrementalStreamController,
 } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -82,137 +84,307 @@ function createMockStreamingEngine(): StreamingTtsEngine & {
 }
 
 // ---------------------------------------------------------------------------
-// Helper to collect events
+// Helpers
 // ---------------------------------------------------------------------------
 
-function createOptions(
-  mockEngine: StreamingTtsEngine,
-  overrides?: Partial<IncrementalStreamingTtsOptions>
-): IncrementalStreamingTtsOptions & {
-  sessionEvents: SessionEvent[];
-  segmentEvents: SegmentEvent[];
-} {
-  const sessionEvents: SessionEvent[] = [];
-  const segmentEvents: SegmentEvent[] = [];
-
-  const opts: IncrementalStreamingTtsOptions = {
-    source: { engine: mockEngine },
+function createFactoryOptions(
+  overrides?: Partial<Omit<IncrementalStreamingTtsFactoryOptions, 'source'>>
+): Omit<IncrementalStreamingTtsFactoryOptions, 'source'> {
+  return {
     segmentation: {
-      // Disable timers for deterministic tests
       maxWaitMs: 0,
       debounceMs: 0,
       minCharsPerSegment: 5,
+      ...(overrides?.segmentation ?? {}),
     },
-    streamOptions: { playback: false, emitChunks: false },
-    onSessionEvent: (e) => sessionEvents.push(e),
-    onSegmentEvent: (e) => segmentEvents.push(e),
-    ...overrides,
+    queue: overrides?.queue,
+  };
+}
+
+function createHandlers(): IncrementalStreamHandlers & {
+  sessionEvents: SessionEvent[];
+  segmentEvents: SegmentEvent[];
+  ended: boolean;
+  endCancelled: boolean | null;
+} {
+  const sessionEvents: SessionEvent[] = [];
+  const segmentEvents: SegmentEvent[] = [];
+  let ended = false;
+  let endCancelled: boolean | null = null;
+
+  const handlers = {
+    onSessionEvent: (e: SessionEvent) => sessionEvents.push(e),
+    onSegmentEvent: (e: SegmentEvent) => segmentEvents.push(e),
+    onEnd: (event: { cancelled: boolean }) => {
+      ended = true;
+      endCancelled = event.cancelled;
+    },
+    sessionEvents,
+    segmentEvents,
+    get ended() {
+      return ended;
+    },
+    get endCancelled() {
+      return endCancelled;
+    },
   };
 
-  return Object.assign(opts, { sessionEvents, segmentEvents });
+  return handlers as IncrementalStreamHandlers & {
+    sessionEvents: SessionEvent[];
+    segmentEvents: SegmentEvent[];
+    ended: boolean;
+    endCancelled: boolean | null;
+  };
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('IncrementalStreamingTtsEngine', () => {
-  describe('lifecycle', () => {
+describe('IncrementalStreamingTtsEngine (request-centric)', () => {
+  describe('factory / engine-level', () => {
+    it('exposes instanceId from underlying engine', () => {
+      const mock = createMockStreamingEngine();
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      expect(engine.instanceId).toBe('mock_streaming_1');
+    });
+
+    it('delegates getModelInfo / getSampleRate / getNumSpeakers', async () => {
+      const mock = createMockStreamingEngine();
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      expect(await engine.getModelInfo()).toEqual({
+        sampleRate: 22050,
+        numSpeakers: 1,
+      });
+      expect(await engine.getSampleRate()).toBe(22050);
+      expect(await engine.getNumSpeakers()).toBe(1);
+    });
+
+    it('rejects concurrent requests', () => {
+      const mock = createMockStreamingEngine();
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const handlers = createHandlers();
+      const streamOpts = { playback: false, emitChunks: false };
+
+      // First request — OK
+      engine.generateIncrementalSpeechStream(undefined, handlers, streamOpts);
+
+      // Second simultaneous request — should throw
+      expect(() =>
+        engine.generateIncrementalSpeechStream(
+          undefined,
+          createHandlers(),
+          streamOpts
+        )
+      ).toThrow(/already active/);
+    });
+
+    it('allows a new request after previous flush completes', async () => {
+      const mock = createMockStreamingEngine();
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const handlers1 = createHandlers();
+      const streamOpts = { playback: false, emitChunks: false };
+
+      const ctrl1 = engine.generateIncrementalSpeechStream(
+        undefined,
+        handlers1,
+        streamOpts
+      );
+      ctrl1.pushText('Request one text.');
+      const flushP = ctrl1.flush();
+      await tick();
+      mock.completeNext();
+      await flushP;
+
+      // Now a second request should succeed
+      const handlers2 = createHandlers();
+      const ctrl2 = engine.generateIncrementalSpeechStream(
+        undefined,
+        handlers2,
+        streamOpts
+      );
+      expect(ctrl2.state).toBe('idle');
+    });
+
+    it('allows a new request after previous cancel', async () => {
+      const mock = createMockStreamingEngine();
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const streamOpts = { playback: false, emitChunks: false };
+
+      const ctrl1 = engine.generateIncrementalSpeechStream(
+        undefined,
+        createHandlers(),
+        streamOpts
+      );
+      ctrl1.pushText('Will cancel.');
+      ctrl1.commit();
+      await tick();
+      await ctrl1.cancel();
+
+      const ctrl2 = engine.generateIncrementalSpeechStream(
+        undefined,
+        createHandlers(),
+        streamOpts
+      );
+      expect(ctrl2.state).toBe('idle');
+    });
+
+    it('throws after destroy', async () => {
+      const mock = createMockStreamingEngine();
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      await engine.destroy();
+      expect(() =>
+        engine.generateIncrementalSpeechStream(undefined, createHandlers(), {
+          playback: false,
+          emitChunks: false,
+        })
+      ).toThrow(/destroyed/);
+    });
+  });
+
+  describe('controller lifecycle', () => {
     it('starts in idle state', () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
-      expect(engine.state).toBe('idle');
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const ctrl = engine.generateIncrementalSpeechStream(
+        undefined,
+        createHandlers(),
+        { playback: false, emitChunks: false }
+      );
+      expect(ctrl.state).toBe('idle');
     });
 
     it('transitions to active on pushText', () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const handlers = createHandlers();
+      const ctrl = engine.generateIncrementalSpeechStream(undefined, handlers, {
+        playback: false,
+        emitChunks: false,
+      });
 
-      engine.pushText('Hello world. ');
-      expect(engine.state).toBe('active');
-      expect(opts.sessionEvents[0]!.type).toBe('session:started');
+      ctrl.pushText('Hello world. ');
+      expect(ctrl.state).toBe('active');
+      expect(handlers.sessionEvents[0]!.type).toBe('session:started');
     });
 
-    it('throws on pushText after destroy', async () => {
+    it('throws on pushText after cancel', async () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const ctrl = engine.generateIncrementalSpeechStream(
+        undefined,
+        createHandlers(),
+        { playback: false, emitChunks: false }
+      );
+      ctrl.pushText('Some text here.');
+      ctrl.commit();
+      await tick();
+      await ctrl.cancel();
 
-      await engine.destroy();
-      expect(engine.state).toBe('destroyed');
-      expect(() => engine.pushText('x')).toThrow('destroyed');
-    });
-
-    it('throws on commit after destroy', async () => {
-      const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
-
-      await engine.destroy();
-      expect(() => engine.commit()).toThrow('destroyed');
-    });
-
-    it('destroy is idempotent', async () => {
-      const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
-
-      await engine.destroy();
-      await engine.destroy(); // should not throw
-      expect(engine.state).toBe('destroyed');
+      expect(() => ctrl.pushText('x')).toThrow(/cancelled/);
     });
   });
 
   describe('commit and queue', () => {
-    it('commit enqueues a segment', async () => {
+    it('commit enqueues a segment and dispatches', async () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const handlers = createHandlers();
+      const ctrl = engine.generateIncrementalSpeechStream(undefined, handlers, {
+        playback: false,
+        emitChunks: false,
+      });
 
-      engine.pushText('Hello world test text.');
-      engine.commit();
-
-      // Wait a tick for async dispatch
+      ctrl.pushText('Hello world test text.');
+      ctrl.commit();
       await tick();
 
-      expect(opts.segmentEvents.some((e) => e.type === 'segment:queued')).toBe(
-        true
-      );
-      expect(opts.segmentEvents.some((e) => e.type === 'segment:started')).toBe(
-        true
-      );
+      expect(
+        handlers.segmentEvents.some(
+          (e: SegmentEvent) => e.type === 'segment:queued'
+        )
+      ).toBe(true);
+      expect(
+        handlers.segmentEvents.some(
+          (e: SegmentEvent) => e.type === 'segment:started'
+        )
+      ).toBe(true);
       expect(mock.pendingStreams).toHaveLength(1);
       expect(mock.pendingStreams[0]!.text).toBe('Hello world test text.');
     });
 
     it('commit with empty buffer is a no-op', () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const handlers = createHandlers();
+      const ctrl = engine.generateIncrementalSpeechStream(undefined, handlers, {
+        playback: false,
+        emitChunks: false,
+      });
 
-      engine.commit();
-      expect(opts.segmentEvents).toHaveLength(0);
+      ctrl.commit();
+      expect(handlers.segmentEvents).toHaveLength(0);
     });
 
     it('preserves FIFO ordering', async () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const ctrl = engine.generateIncrementalSpeechStream(
+        undefined,
+        createHandlers(),
+        { playback: false, emitChunks: false }
+      );
 
-      engine.pushText('First segment text here.');
-      engine.commit();
-      engine.pushText('Second segment text here.');
-      engine.commit();
+      ctrl.pushText('First segment text here.');
+      ctrl.commit();
+      ctrl.pushText('Second segment text here.');
+      ctrl.commit();
 
       await tick();
 
-      // First segment dispatched
       expect(mock.pendingStreams).toHaveLength(1);
       expect(mock.pendingStreams[0]!.text).toBe('First segment text here.');
 
-      // Complete first → second gets dispatched
       mock.completeNext();
       await tick();
 
@@ -224,17 +396,22 @@ describe('IncrementalStreamingTtsEngine', () => {
   describe('flush', () => {
     it('commits remaining buffer and waits for completion', async () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const handlers = createHandlers();
+      const ctrl = engine.generateIncrementalSpeechStream(undefined, handlers, {
+        playback: false,
+        emitChunks: false,
+      });
 
-      engine.pushText('Flush this text here.');
-      const flushPromise = engine.flush();
+      ctrl.pushText('Flush this text here.');
+      const flushPromise = ctrl.flush();
 
       await tick();
-
       expect(mock.pendingStreams).toHaveLength(1);
 
-      // Not resolved yet
       let resolved = false;
       void flushPromise.then(() => {
         resolved = true;
@@ -242,35 +419,51 @@ describe('IncrementalStreamingTtsEngine', () => {
       await tick();
       expect(resolved).toBe(false);
 
-      // Complete the segment
       mock.completeNext();
       await tick();
 
       expect(resolved).toBe(true);
-      expect(engine.state).toBe('idle');
+      expect(handlers.ended).toBe(true);
+      expect(handlers.endCancelled).toBe(false);
     });
 
     it('resolves immediately when nothing to process', async () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const handlers = createHandlers();
+      const ctrl = engine.generateIncrementalSpeechStream(undefined, handlers, {
+        playback: false,
+        emitChunks: false,
+      });
 
-      await engine.flush(); // should not hang
-      expect(engine.state).toBe('idle');
+      await ctrl.flush();
+      expect(handlers.ended).toBe(true);
+      expect(handlers.endCancelled).toBe(false);
     });
 
     it('emits draining event', async () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const handlers = createHandlers();
+      const ctrl = engine.generateIncrementalSpeechStream(undefined, handlers, {
+        playback: false,
+        emitChunks: false,
+      });
 
-      engine.pushText('Drain me please now.');
-      const flushPromise = engine.flush();
-
+      ctrl.pushText('Drain me please now.');
+      const flushPromise = ctrl.flush();
       await tick();
 
       expect(
-        opts.sessionEvents.some((e) => e.type === 'session:draining')
+        handlers.sessionEvents.some(
+          (e: SessionEvent) => e.type === 'session:draining'
+        )
       ).toBe(true);
 
       mock.completeNext();
@@ -281,67 +474,72 @@ describe('IncrementalStreamingTtsEngine', () => {
   describe('cancel', () => {
     it('cancels active and queued segments', async () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const handlers = createHandlers();
+      const ctrl = engine.generateIncrementalSpeechStream(undefined, handlers, {
+        playback: false,
+        emitChunks: false,
+      });
 
-      engine.pushText('Active segment text.');
-      engine.commit();
-      engine.pushText('Queued segment text.');
-      engine.commit();
+      ctrl.pushText('Active segment text.');
+      ctrl.commit();
+      ctrl.pushText('Queued segment text.');
+      ctrl.commit();
 
       await tick();
 
-      await engine.cancel();
+      await ctrl.cancel();
 
-      expect(engine.state).toBe('cancelled');
-      const cancelledEvent = opts.sessionEvents.find(
-        (e) => e.type === 'session:cancelled'
+      expect(ctrl.state).toBe('cancelled');
+      expect(handlers.ended).toBe(true);
+      expect(handlers.endCancelled).toBe(true);
+      const cancelledEvent = handlers.sessionEvents.find(
+        (e: SessionEvent) => e.type === 'session:cancelled'
       );
       expect(cancelledEvent).toBeDefined();
     });
 
     it('cancel scope=queued keeps active running', async () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const ctrl = engine.generateIncrementalSpeechStream(
+        undefined,
+        createHandlers(),
+        { playback: false, emitChunks: false }
+      );
 
-      engine.pushText('Active segment text.');
-      engine.commit();
-      engine.pushText('Queued segment text.');
-      engine.commit();
+      ctrl.pushText('Active segment text.');
+      ctrl.commit();
+      ctrl.pushText('Queued segment text.');
+      ctrl.commit();
 
       await tick();
 
-      await engine.cancel({ scope: 'queued' });
-
+      await ctrl.cancel({ scope: 'queued' });
       // Active segment still running
       expect(mock.pendingStreams).toHaveLength(1);
     });
 
-    it('allows new input after cancel', async () => {
-      const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
-
-      engine.pushText('Will be cancelled.');
-      engine.commit();
-      await tick();
-      await engine.cancel();
-
-      expect(engine.state).toBe('cancelled');
-
-      // New input should work
-      engine.pushText('New text after cancel.');
-      expect(engine.state).toBe('active');
-    });
-
     it('resolves pending flush on cancel', async () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const ctrl = engine.generateIncrementalSpeechStream(
+        undefined,
+        createHandlers(),
+        { playback: false, emitChunks: false }
+      );
 
-      engine.pushText('Flushing text content.');
-      const flushPromise = engine.flush();
+      ctrl.pushText('Flushing text content.');
+      const flushPromise = ctrl.flush();
       await tick();
 
       let resolved = false;
@@ -349,9 +547,8 @@ describe('IncrementalStreamingTtsEngine', () => {
         resolved = true;
       });
 
-      await engine.cancel();
+      await ctrl.cancel();
       await tick();
-
       expect(resolved).toBe(true);
     });
   });
@@ -359,90 +556,129 @@ describe('IncrementalStreamingTtsEngine', () => {
   describe('error handling', () => {
     it('continues dispatching after segment error', async () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const handlers = createHandlers();
+      const ctrl = engine.generateIncrementalSpeechStream(undefined, handlers, {
+        playback: false,
+        emitChunks: false,
+      });
 
-      engine.pushText('First segment fails.');
-      engine.commit();
-      engine.pushText('Second segment works.');
-      engine.commit();
+      ctrl.pushText('First segment fails.');
+      ctrl.commit();
+      ctrl.pushText('Second segment works.');
+      ctrl.commit();
 
       await tick();
 
-      // Fail the first segment
       mock.failNext('synth error');
       await tick();
 
-      // Second segment should be dispatched
       expect(mock.pendingStreams).toHaveLength(1);
       expect(mock.pendingStreams[0]!.text).toBe('Second segment works.');
 
-      // Error event should have been emitted
-      expect(opts.sessionEvents.some((e) => e.type === 'session:error')).toBe(
-        true
-      );
+      expect(
+        handlers.sessionEvents.some(
+          (e: SessionEvent) => e.type === 'session:error'
+        )
+      ).toBe(true);
     });
   });
 
   describe('metrics', () => {
     it('tracks queue depth and counters', async () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock);
-      const engine = createEngine(mock, opts);
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const ctrl = engine.generateIncrementalSpeechStream(
+        undefined,
+        createHandlers(),
+        { playback: false, emitChunks: false }
+      );
 
-      expect(engine.getMetrics().queueDepth).toBe(0);
-      expect(engine.getMetrics().totalSegmentsQueued).toBe(0);
+      expect(ctrl.getMetrics().queueDepth).toBe(0);
+      expect(ctrl.getMetrics().totalSegmentsQueued).toBe(0);
 
-      engine.pushText('Segment one text here.');
-      engine.commit();
-      engine.pushText('Segment two text here.');
-      engine.commit();
+      ctrl.pushText('Segment one text here.');
+      ctrl.commit();
+      ctrl.pushText('Segment two text here.');
+      ctrl.commit();
 
       await tick();
 
-      // One active, one queued
-      expect(engine.getMetrics().queueDepth).toBe(1);
-      expect(engine.getMetrics().totalSegmentsQueued).toBe(2);
-      expect(engine.getMetrics().activeSegmentId).not.toBeNull();
+      expect(ctrl.getMetrics().queueDepth).toBe(1);
+      expect(ctrl.getMetrics().totalSegmentsQueued).toBe(2);
+      expect(ctrl.getMetrics().activeSegmentId).not.toBeNull();
 
       mock.completeNext();
       await tick();
 
-      expect(engine.getMetrics().totalSegmentsCompleted).toBe(1);
-      expect(engine.getMetrics().queueDepth).toBe(0);
+      expect(ctrl.getMetrics().totalSegmentsCompleted).toBe(1);
+      expect(ctrl.getMetrics().queueDepth).toBe(0);
     });
   });
 
   describe('auto-segmentation', () => {
     it('splits on punctuation with debounceMs=0', async () => {
       const mock = createMockStreamingEngine();
-      const opts = createOptions(mock, {
-        segmentation: {
-          debounceMs: 0,
-          maxWaitMs: 0,
-          minCharsPerSegment: 5,
-        },
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions({
+          segmentation: {
+            debounceMs: 0,
+            maxWaitMs: 0,
+            minCharsPerSegment: 5,
+          },
+        }),
       });
-      const engine = createEngine(mock, opts);
+      const handlers = createHandlers();
+      const ctrl = engine.generateIncrementalSpeechStream(undefined, handlers, {
+        playback: false,
+        emitChunks: false,
+      });
 
-      engine.pushText('Hello world. How are you?');
-
-      // With debounceMs=0, segmentation runs synchronously
+      ctrl.pushText('Hello world. How are you?');
       await tick();
 
-      // Should have detected punctuation boundaries
-      const queuedEvents = opts.segmentEvents.filter(
-        (e) => e.type === 'segment:queued'
+      const queuedEvents = handlers.segmentEvents.filter(
+        (e: SegmentEvent) => e.type === 'segment:queued'
       );
       expect(queuedEvents.length).toBeGreaterThanOrEqual(1);
     });
   });
+
+  describe('player proxy', () => {
+    it('returns null player when playback is false', () => {
+      const mock = createMockStreamingEngine();
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const ctrl: IncrementalStreamController =
+        engine.generateIncrementalSpeechStream(undefined, createHandlers(), {
+          playback: false,
+          emitChunks: false,
+        });
+      expect(ctrl.player).toBeNull();
+    });
+
+    it('returns a player proxy when playback is true', () => {
+      const mock = createMockStreamingEngine();
+      const engine = createEngine(mock, {
+        source: { engine: mock },
+        ...createFactoryOptions(),
+      });
+      const ctrl: IncrementalStreamController =
+        engine.generateIncrementalSpeechStream(undefined, createHandlers(), {
+          playback: true,
+          emitChunks: false,
+        });
+      expect(ctrl.player).not.toBeNull();
+      expect(ctrl.player!.feed).toBe('native');
+    });
+  });
 });
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function tick(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}

--- a/src/tts/incremental/__tests__/engine.test.ts
+++ b/src/tts/incremental/__tests__/engine.test.ts
@@ -1,0 +1,448 @@
+import { createEngine } from '../engine';
+import type { StreamingTtsEngine } from '../../streamingTypes';
+import type {
+  TtsStreamHandlers,
+  TtsStreamController,
+  TtsStreamOptions,
+  TtsGenerationOptions,
+} from '../../types';
+import type {
+  SessionEvent,
+  SegmentEvent,
+  IncrementalStreamingTtsOptions,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Mock StreamingTtsEngine
+// ---------------------------------------------------------------------------
+
+type PendingStream = {
+  text: string;
+  handlers: TtsStreamHandlers;
+  controller: TtsStreamController;
+};
+
+function createMockStreamingEngine(): StreamingTtsEngine & {
+  pendingStreams: PendingStream[];
+  completeNext: (cancelled?: boolean) => void;
+  failNext: (message: string) => void;
+} {
+  const pendingStreams: PendingStream[] = [];
+
+  const engine: StreamingTtsEngine = {
+    instanceId: 'mock_streaming_1',
+
+    async generateSpeechStream(
+      text: string,
+      _opts: TtsGenerationOptions | undefined,
+      handlers: TtsStreamHandlers,
+      _streamOptions?: TtsStreamOptions
+    ): Promise<TtsStreamController> {
+      const controller: TtsStreamController = {
+        async cancel() {
+          handlers.onEnd?.({ cancelled: true });
+        },
+        unsubscribe() {},
+        player: null,
+      };
+      pendingStreams.push({ text, handlers, controller });
+      return controller;
+    },
+
+    async generateSpeechStreamToFile() {
+      throw new Error('Not implemented in mock');
+    },
+
+    async cancelSpeechStream() {},
+    async getModelInfo() {
+      return { sampleRate: 22050, numSpeakers: 1 };
+    },
+    async getSampleRate() {
+      return 22050;
+    },
+    async getNumSpeakers() {
+      return 1;
+    },
+    async destroy() {},
+  };
+
+  return Object.assign(engine, {
+    pendingStreams,
+    completeNext(cancelled = false) {
+      const stream = pendingStreams.shift();
+      if (!stream) throw new Error('No pending stream to complete');
+      stream.handlers.onEnd?.({ cancelled });
+    },
+    failNext(message: string) {
+      const stream = pendingStreams.shift();
+      if (!stream) throw new Error('No pending stream to fail');
+      stream.handlers.onError?.({ message });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helper to collect events
+// ---------------------------------------------------------------------------
+
+function createOptions(
+  mockEngine: StreamingTtsEngine,
+  overrides?: Partial<IncrementalStreamingTtsOptions>
+): IncrementalStreamingTtsOptions & {
+  sessionEvents: SessionEvent[];
+  segmentEvents: SegmentEvent[];
+} {
+  const sessionEvents: SessionEvent[] = [];
+  const segmentEvents: SegmentEvent[] = [];
+
+  const opts: IncrementalStreamingTtsOptions = {
+    source: { engine: mockEngine },
+    segmentation: {
+      // Disable timers for deterministic tests
+      maxWaitMs: 0,
+      debounceMs: 0,
+      minCharsPerSegment: 5,
+    },
+    streamOptions: { playback: false, emitChunks: false },
+    onSessionEvent: (e) => sessionEvents.push(e),
+    onSegmentEvent: (e) => segmentEvents.push(e),
+    ...overrides,
+  };
+
+  return Object.assign(opts, { sessionEvents, segmentEvents });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('IncrementalStreamingTtsEngine', () => {
+  describe('lifecycle', () => {
+    it('starts in idle state', () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+      expect(engine.state).toBe('idle');
+    });
+
+    it('transitions to active on pushText', () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      engine.pushText('Hello world. ');
+      expect(engine.state).toBe('active');
+      expect(opts.sessionEvents[0]!.type).toBe('session:started');
+    });
+
+    it('throws on pushText after destroy', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      await engine.destroy();
+      expect(engine.state).toBe('destroyed');
+      expect(() => engine.pushText('x')).toThrow('destroyed');
+    });
+
+    it('throws on commit after destroy', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      await engine.destroy();
+      expect(() => engine.commit()).toThrow('destroyed');
+    });
+
+    it('destroy is idempotent', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      await engine.destroy();
+      await engine.destroy(); // should not throw
+      expect(engine.state).toBe('destroyed');
+    });
+  });
+
+  describe('commit and queue', () => {
+    it('commit enqueues a segment', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      engine.pushText('Hello world test text.');
+      engine.commit();
+
+      // Wait a tick for async dispatch
+      await tick();
+
+      expect(opts.segmentEvents.some((e) => e.type === 'segment:queued')).toBe(
+        true
+      );
+      expect(opts.segmentEvents.some((e) => e.type === 'segment:started')).toBe(
+        true
+      );
+      expect(mock.pendingStreams).toHaveLength(1);
+      expect(mock.pendingStreams[0]!.text).toBe('Hello world test text.');
+    });
+
+    it('commit with empty buffer is a no-op', () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      engine.commit();
+      expect(opts.segmentEvents).toHaveLength(0);
+    });
+
+    it('preserves FIFO ordering', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      engine.pushText('First segment text here.');
+      engine.commit();
+      engine.pushText('Second segment text here.');
+      engine.commit();
+
+      await tick();
+
+      // First segment dispatched
+      expect(mock.pendingStreams).toHaveLength(1);
+      expect(mock.pendingStreams[0]!.text).toBe('First segment text here.');
+
+      // Complete first → second gets dispatched
+      mock.completeNext();
+      await tick();
+
+      expect(mock.pendingStreams).toHaveLength(1);
+      expect(mock.pendingStreams[0]!.text).toBe('Second segment text here.');
+    });
+  });
+
+  describe('flush', () => {
+    it('commits remaining buffer and waits for completion', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      engine.pushText('Flush this text here.');
+      const flushPromise = engine.flush();
+
+      await tick();
+
+      expect(mock.pendingStreams).toHaveLength(1);
+
+      // Not resolved yet
+      let resolved = false;
+      void flushPromise.then(() => {
+        resolved = true;
+      });
+      await tick();
+      expect(resolved).toBe(false);
+
+      // Complete the segment
+      mock.completeNext();
+      await tick();
+
+      expect(resolved).toBe(true);
+      expect(engine.state).toBe('idle');
+    });
+
+    it('resolves immediately when nothing to process', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      await engine.flush(); // should not hang
+      expect(engine.state).toBe('idle');
+    });
+
+    it('emits draining event', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      engine.pushText('Drain me please now.');
+      const flushPromise = engine.flush();
+
+      await tick();
+
+      expect(
+        opts.sessionEvents.some((e) => e.type === 'session:draining')
+      ).toBe(true);
+
+      mock.completeNext();
+      await flushPromise;
+    });
+  });
+
+  describe('cancel', () => {
+    it('cancels active and queued segments', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      engine.pushText('Active segment text.');
+      engine.commit();
+      engine.pushText('Queued segment text.');
+      engine.commit();
+
+      await tick();
+
+      await engine.cancel();
+
+      expect(engine.state).toBe('cancelled');
+      const cancelledEvent = opts.sessionEvents.find(
+        (e) => e.type === 'session:cancelled'
+      );
+      expect(cancelledEvent).toBeDefined();
+    });
+
+    it('cancel scope=queued keeps active running', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      engine.pushText('Active segment text.');
+      engine.commit();
+      engine.pushText('Queued segment text.');
+      engine.commit();
+
+      await tick();
+
+      await engine.cancel({ scope: 'queued' });
+
+      // Active segment still running
+      expect(mock.pendingStreams).toHaveLength(1);
+    });
+
+    it('allows new input after cancel', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      engine.pushText('Will be cancelled.');
+      engine.commit();
+      await tick();
+      await engine.cancel();
+
+      expect(engine.state).toBe('cancelled');
+
+      // New input should work
+      engine.pushText('New text after cancel.');
+      expect(engine.state).toBe('active');
+    });
+
+    it('resolves pending flush on cancel', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      engine.pushText('Flushing text content.');
+      const flushPromise = engine.flush();
+      await tick();
+
+      let resolved = false;
+      void flushPromise.then(() => {
+        resolved = true;
+      });
+
+      await engine.cancel();
+      await tick();
+
+      expect(resolved).toBe(true);
+    });
+  });
+
+  describe('error handling', () => {
+    it('continues dispatching after segment error', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      engine.pushText('First segment fails.');
+      engine.commit();
+      engine.pushText('Second segment works.');
+      engine.commit();
+
+      await tick();
+
+      // Fail the first segment
+      mock.failNext('synth error');
+      await tick();
+
+      // Second segment should be dispatched
+      expect(mock.pendingStreams).toHaveLength(1);
+      expect(mock.pendingStreams[0]!.text).toBe('Second segment works.');
+
+      // Error event should have been emitted
+      expect(opts.sessionEvents.some((e) => e.type === 'session:error')).toBe(
+        true
+      );
+    });
+  });
+
+  describe('metrics', () => {
+    it('tracks queue depth and counters', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock);
+      const engine = createEngine(mock, opts);
+
+      expect(engine.getMetrics().queueDepth).toBe(0);
+      expect(engine.getMetrics().totalSegmentsQueued).toBe(0);
+
+      engine.pushText('Segment one text here.');
+      engine.commit();
+      engine.pushText('Segment two text here.');
+      engine.commit();
+
+      await tick();
+
+      // One active, one queued
+      expect(engine.getMetrics().queueDepth).toBe(1);
+      expect(engine.getMetrics().totalSegmentsQueued).toBe(2);
+      expect(engine.getMetrics().activeSegmentId).not.toBeNull();
+
+      mock.completeNext();
+      await tick();
+
+      expect(engine.getMetrics().totalSegmentsCompleted).toBe(1);
+      expect(engine.getMetrics().queueDepth).toBe(0);
+    });
+  });
+
+  describe('auto-segmentation', () => {
+    it('splits on punctuation with debounceMs=0', async () => {
+      const mock = createMockStreamingEngine();
+      const opts = createOptions(mock, {
+        segmentation: {
+          debounceMs: 0,
+          maxWaitMs: 0,
+          minCharsPerSegment: 5,
+        },
+      });
+      const engine = createEngine(mock, opts);
+
+      engine.pushText('Hello world. How are you?');
+
+      // With debounceMs=0, segmentation runs synchronously
+      await tick();
+
+      // Should have detected punctuation boundaries
+      const queuedEvents = opts.segmentEvents.filter(
+        (e) => e.type === 'segment:queued'
+      );
+      expect(queuedEvents.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}

--- a/src/tts/incremental/__tests__/policies.test.ts
+++ b/src/tts/incremental/__tests__/policies.test.ts
@@ -1,0 +1,119 @@
+import {
+  resolveQueuePolicy,
+  applyEnqueuePolicy,
+  type QueuedSegment,
+} from '../policies';
+
+function seg(id: string, text: string): QueuedSegment {
+  return { id, text };
+}
+
+describe('resolveQueuePolicy', () => {
+  it('applies defaults', () => {
+    const p = resolveQueuePolicy();
+    expect(p.mode).toBe('fifo');
+    expect(p.maxSegments).toBe(50);
+    expect(p.maxBufferedChars).toBe(10000);
+    expect(p.overflowStrategy).toBe('drop-oldest');
+  });
+});
+
+describe('applyEnqueuePolicy – FIFO', () => {
+  it('enqueues when under limits', () => {
+    const policy = resolveQueuePolicy({ mode: 'fifo', maxSegments: 3 });
+    const queue: QueuedSegment[] = [];
+    const result = applyEnqueuePolicy(queue, seg('1', 'hello'), policy);
+    expect(result.accepted).toBe(true);
+    expect(result.dropped).toHaveLength(0);
+    expect(queue).toHaveLength(1);
+  });
+
+  it('drops oldest on overflow (drop-oldest)', () => {
+    const policy = resolveQueuePolicy({
+      mode: 'fifo',
+      maxSegments: 2,
+      overflowStrategy: 'drop-oldest',
+    });
+    const queue: QueuedSegment[] = [seg('1', 'a'), seg('2', 'b')];
+    const result = applyEnqueuePolicy(queue, seg('3', 'c'), policy);
+    expect(result.accepted).toBe(true);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0]!.id).toBe('1');
+    expect(queue.map((s) => s.id)).toEqual(['2', '3']);
+  });
+
+  it('rejects new segment on overflow (drop-newest)', () => {
+    const policy = resolveQueuePolicy({
+      mode: 'fifo',
+      maxSegments: 2,
+      overflowStrategy: 'drop-newest',
+    });
+    const queue: QueuedSegment[] = [seg('1', 'a'), seg('2', 'b')];
+    const result = applyEnqueuePolicy(queue, seg('3', 'c'), policy);
+    expect(result.accepted).toBe(false);
+    expect(result.dropped[0]!.id).toBe('3');
+    expect(queue).toHaveLength(2);
+  });
+
+  it('rejects on overflow (reject)', () => {
+    const policy = resolveQueuePolicy({
+      mode: 'fifo',
+      maxSegments: 1,
+      overflowStrategy: 'reject',
+    });
+    const queue: QueuedSegment[] = [seg('1', 'a')];
+    const result = applyEnqueuePolicy(queue, seg('2', 'b'), policy);
+    expect(result.accepted).toBe(false);
+    expect(queue).toHaveLength(1);
+  });
+
+  it('respects maxBufferedChars limit', () => {
+    const policy = resolveQueuePolicy({
+      mode: 'fifo',
+      maxSegments: 100,
+      maxBufferedChars: 10,
+      overflowStrategy: 'drop-oldest',
+    });
+    const queue: QueuedSegment[] = [seg('1', 'aaaaaaa')]; // 7 chars
+    const result = applyEnqueuePolicy(queue, seg('2', 'bbbbb'), policy); // 5 chars, total would be 12
+    expect(result.accepted).toBe(true);
+    expect(result.dropped[0]!.id).toBe('1');
+  });
+});
+
+describe('applyEnqueuePolicy – replace-tail', () => {
+  it('replaces last queued segment', () => {
+    const policy = resolveQueuePolicy({ mode: 'replace-tail' });
+    const queue: QueuedSegment[] = [seg('1', 'a'), seg('2', 'b')];
+    const result = applyEnqueuePolicy(queue, seg('3', 'c'), policy);
+    expect(result.accepted).toBe(true);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0]!.id).toBe('2');
+    expect(queue.map((s) => s.id)).toEqual(['1', '3']);
+  });
+
+  it('enqueues when queue is empty', () => {
+    const policy = resolveQueuePolicy({ mode: 'replace-tail' });
+    const queue: QueuedSegment[] = [];
+    const result = applyEnqueuePolicy(queue, seg('1', 'a'), policy);
+    expect(result.accepted).toBe(true);
+    expect(result.dropped).toHaveLength(0);
+    expect(queue).toHaveLength(1);
+  });
+});
+
+describe('applyEnqueuePolicy – latest-wins', () => {
+  it('drops all queued and replaces with new', () => {
+    const policy = resolveQueuePolicy({ mode: 'latest-wins' });
+    const queue: QueuedSegment[] = [
+      seg('1', 'a'),
+      seg('2', 'b'),
+      seg('3', 'c'),
+    ];
+    const result = applyEnqueuePolicy(queue, seg('4', 'd'), policy);
+    expect(result.accepted).toBe(true);
+    expect(result.dropped).toHaveLength(3);
+    expect(queue).toHaveLength(1);
+    expect(queue[0]!.id).toBe('4');
+  });
+});

--- a/src/tts/incremental/__tests__/segmenter.test.ts
+++ b/src/tts/incremental/__tests__/segmenter.test.ts
@@ -1,0 +1,114 @@
+import {
+  resolveSegmentationPolicy,
+  detectBoundaries,
+  type ResolvedSegmentationPolicy,
+} from '../segmenter';
+
+describe('resolveSegmentationPolicy', () => {
+  it('applies defaults when no policy provided', () => {
+    const p = resolveSegmentationPolicy();
+    expect(p.maxCharsPerSegment).toBe(500);
+    expect(p.maxWaitMs).toBe(2000);
+    expect(p.minCharsPerSegment).toBe(20);
+    expect(p.debounceMs).toBe(100);
+    expect(p.boundaryChars.has('.')).toBe(true);
+    expect(p.boundaryChars.has('!')).toBe(true);
+    expect(p.boundaryChars.has('?')).toBe(true);
+  });
+
+  it('respects custom boundary chars', () => {
+    const p = resolveSegmentationPolicy({ boundaryChars: '|#' });
+    expect(p.boundaryChars.has('|')).toBe(true);
+    expect(p.boundaryChars.has('#')).toBe(true);
+    expect(p.boundaryChars.has('.')).toBe(false);
+  });
+});
+
+describe('detectBoundaries', () => {
+  let policy: ResolvedSegmentationPolicy;
+
+  beforeEach(() => {
+    policy = resolveSegmentationPolicy({
+      minCharsPerSegment: 5,
+      maxCharsPerSegment: 50,
+    });
+  });
+
+  it('returns empty for empty buffer', () => {
+    expect(detectBoundaries('', policy)).toEqual([]);
+  });
+
+  it('returns forced boundary for entire buffer', () => {
+    const result = detectBoundaries('Hello world', policy, { forced: true });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.text).toBe('Hello world');
+    expect(result[0]!.remainder).toBe('');
+    expect(result[0]!.reason).toBe('forced');
+  });
+
+  it('returns timeout reason when specified', () => {
+    const result = detectBoundaries('Hello world', policy, {
+      forced: true,
+      reason: 'timeout',
+    });
+    expect(result[0]!.reason).toBe('timeout');
+  });
+
+  it('detects punctuation boundary', () => {
+    const result = detectBoundaries('Hello world. How are you?', policy);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result[0]!.text).toBe('Hello world.');
+    expect(result[0]!.reason).toBe('punctuation');
+  });
+
+  it('does not split below minCharsPerSegment', () => {
+    const result = detectBoundaries('Hi. World', policy);
+    // "Hi." is only 3 chars, below minCharsPerSegment=5
+    expect(result).toHaveLength(0);
+  });
+
+  it('splits at max-length when no boundary found', () => {
+    const longText = 'a'.repeat(60);
+    const result = detectBoundaries(longText, policy);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result[0]!.reason).toBe('max-length');
+    expect(result[0]!.text.length).toBeLessThanOrEqual(50);
+  });
+
+  it('prefers boundary char near max-length limit', () => {
+    // 40 chars + ". " + 20 chars = 62 chars total, over 50 limit
+    const text = 'a'.repeat(30) + '. ' + 'b'.repeat(30);
+    const result = detectBoundaries(text, policy);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result[0]!.text).toContain('.');
+  });
+
+  it('does not split numbers like 3.14', () => {
+    const text = 'The value is 3.14 and it is great stuff here';
+    const result = detectBoundaries(text, policy);
+    // "3.14" has no trailing whitespace after '.', so no split there
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles multiple sentences', () => {
+    const text = 'First sentence. Second one.';
+    const result = detectBoundaries(text, policy);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result[0]!.text).toBe('First sentence.');
+  });
+
+  it('handles CJK punctuation', () => {
+    const p = resolveSegmentationPolicy({ minCharsPerSegment: 3 });
+    const text = 'こんにちは。世界';
+    const result = detectBoundaries(text, p);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result[0]!.text).toBe('こんにちは。');
+  });
+
+  it('handles newline as boundary', () => {
+    const p = resolveSegmentationPolicy({ minCharsPerSegment: 3 });
+    const text = 'Hello world\nSecond line';
+    const result = detectBoundaries(text, p);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/tts/incremental/engine.ts
+++ b/src/tts/incremental/engine.ts
@@ -3,7 +3,12 @@ import type {
   SegmentId,
   SessionState,
   IncrementalStreamingTtsEngine,
-  IncrementalStreamingTtsOptions,
+  IncrementalStreamingTtsFactoryOptions,
+  IncrementalStreamController,
+  IncrementalStreamFileController,
+  IncrementalStreamHandlers,
+  IncrementalStreamToFileHandlers,
+  IncrementalRequestOptions,
   IncrementalMetrics,
   CommitOptions,
   CancelOptions,
@@ -11,7 +16,13 @@ import type {
   SegmentEvent,
 } from './types';
 import type { StreamingTtsEngine } from '../streamingTypes';
-import type { TtsStreamController } from '../types';
+import type {
+  TtsStreamController,
+  TtsStreamOptions,
+  TtsGenerationOptions,
+  TtsStreamToFileOptions,
+} from '../types';
+import type { PcmPlayer } from '../../pcm/types';
 import {
   resolveSegmentationPolicy,
   detectBoundaries,
@@ -53,23 +64,154 @@ function nextSegmentId(): SegmentId {
 }
 
 // ---------------------------------------------------------------------------
-// Engine implementation
+// Engine factory (returns IncrementalStreamingTtsEngine)
 // ---------------------------------------------------------------------------
 
 export function createEngine(
   streamingEngine: StreamingTtsEngine,
-  options: IncrementalStreamingTtsOptions
+  factoryOptions: IncrementalStreamingTtsFactoryOptions
 ): IncrementalStreamingTtsEngine {
-  const sessionId = nextSessionId();
-  const segPolicy: ResolvedSegmentationPolicy = resolveSegmentationPolicy(
-    options.segmentation
-  );
-  const qPolicy: ResolvedQueuePolicy = resolveQueuePolicy(options.queue);
+  let destroyed = false;
+  let activeRequest = false;
 
-  const defaultStreamOptions = options.streamOptions ?? {
-    playback: false,
-    emitChunks: true,
+  const guard = () => {
+    if (destroyed) {
+      throw new Error('IncrementalStreamingTtsEngine has been destroyed.');
+    }
   };
+
+  const engine: IncrementalStreamingTtsEngine = {
+    get instanceId() {
+      return streamingEngine.instanceId;
+    },
+
+    generateIncrementalSpeechStream(
+      genOptions: TtsGenerationOptions | undefined,
+      handlers: IncrementalStreamHandlers,
+      streamOptions?: TtsStreamOptions,
+      incrementalOptions?: IncrementalRequestOptions
+    ): IncrementalStreamController {
+      guard();
+      if (activeRequest) {
+        throw new Error(
+          'An incremental request is already active. ' +
+            'Cancel or flush the current request before starting a new one.'
+        );
+      }
+      activeRequest = true;
+
+      const resolvedStreamOptions = streamOptions ?? {
+        playback: true,
+        emitChunks: false,
+      };
+
+      const segPolicy = resolveSegmentationPolicy(
+        incrementalOptions?.segmentation ?? factoryOptions.segmentation
+      );
+      const qPolicy = resolveQueuePolicy(
+        incrementalOptions?.queue ?? factoryOptions.queue
+      );
+
+      const session = createRequestSession(
+        streamingEngine,
+        genOptions,
+        handlers,
+        segPolicy,
+        qPolicy,
+        resolvedStreamOptions,
+        'stream',
+        undefined,
+        () => {
+          activeRequest = false;
+        }
+      );
+
+      return session.controller as IncrementalStreamController;
+    },
+
+    generateIncrementalSpeechStreamToFile(
+      genOptions: TtsGenerationOptions | undefined,
+      fileOptions: TtsStreamToFileOptions,
+      handlers: IncrementalStreamToFileHandlers,
+      incrementalOptions?: IncrementalRequestOptions
+    ): IncrementalStreamFileController {
+      guard();
+      if (activeRequest) {
+        throw new Error(
+          'An incremental request is already active. ' +
+            'Cancel or flush the current request before starting a new one.'
+        );
+      }
+      activeRequest = true;
+
+      const segPolicy = resolveSegmentationPolicy(
+        incrementalOptions?.segmentation ?? factoryOptions.segmentation
+      );
+      const qPolicy = resolveQueuePolicy(
+        incrementalOptions?.queue ?? factoryOptions.queue
+      );
+
+      const session = createRequestSession(
+        streamingEngine,
+        genOptions,
+        handlers,
+        segPolicy,
+        qPolicy,
+        undefined,
+        'file',
+        fileOptions,
+        () => {
+          activeRequest = false;
+        }
+      );
+
+      return session.controller as IncrementalStreamFileController;
+    },
+
+    async getModelInfo() {
+      guard();
+      return streamingEngine.getModelInfo();
+    },
+
+    async getSampleRate() {
+      guard();
+      return streamingEngine.getSampleRate();
+    },
+
+    async getNumSpeakers() {
+      guard();
+      return streamingEngine.getNumSpeakers();
+    },
+
+    async destroy() {
+      if (destroyed) return;
+      destroyed = true;
+    },
+  };
+
+  return engine;
+}
+
+// ---------------------------------------------------------------------------
+// Per-request session (internal)
+// ---------------------------------------------------------------------------
+
+interface RequestSession {
+  controller: IncrementalStreamController | IncrementalStreamFileController;
+}
+
+function createRequestSession(
+  streamingEngine: StreamingTtsEngine,
+  genOptions: TtsGenerationOptions | undefined,
+  handlers: IncrementalStreamHandlers | IncrementalStreamToFileHandlers,
+  segPolicy: ResolvedSegmentationPolicy,
+  qPolicy: ResolvedQueuePolicy,
+  streamOptions: TtsStreamOptions | undefined,
+  mode: 'stream' | 'file',
+  fileOptions: TtsStreamToFileOptions | undefined,
+  onRequestEnd: () => void
+): RequestSession {
+  const sessionId = nextSessionId();
 
   // -----------------------------------------------------------------------
   // Internal mutable state
@@ -96,20 +238,23 @@ export function createEngine(
   let totalDropped = 0;
   let totalReplaced = 0;
 
+  // Player proxy state (only for stream mode with playback)
+  let isPaused = false;
+
   // -----------------------------------------------------------------------
   // Event helpers
   // -----------------------------------------------------------------------
 
   const emitSession = (e: SessionEvent) => {
     try {
-      options.onSessionEvent?.(e);
+      handlers.onSessionEvent?.(e);
     } catch {
       /* subscriber errors must not break the engine */
     }
   };
   const emitSegment = (e: SegmentEvent) => {
     try {
-      options.onSegmentEvent?.(e);
+      handlers.onSegmentEvent?.(e);
     } catch {
       /* subscriber errors must not break the engine */
     }
@@ -117,7 +262,7 @@ export function createEngine(
 
   function emitMetrics(): void {
     try {
-      options.onMetrics?.(buildMetrics());
+      handlers.onMetrics?.(buildMetrics());
     } catch {
       /* subscriber errors must not break the engine */
     }
@@ -140,6 +285,10 @@ export function createEngine(
 
   function setState(next: SessionState): void {
     state = next;
+  }
+
+  function completeRequest(): void {
+    onRequestEnd();
   }
 
   // -----------------------------------------------------------------------
@@ -175,7 +324,6 @@ export function createEngine(
         autoSegment(false);
       }, segPolicy.debounceMs);
     } else {
-      // No debounce — run immediately
       autoSegment(false);
     }
   }
@@ -215,7 +363,6 @@ export function createEngine(
     const seg: QueuedSegment = { id: nextSegmentId(), text: trimmed };
     const result = applyEnqueuePolicy(queue, seg, qPolicy);
 
-    // Emit for dropped segments
     for (const d of result.dropped) {
       const reason =
         qPolicy.mode === 'replace-tail'
@@ -272,53 +419,92 @@ export function createEngine(
     emitSegment(segmentStarted(sessionId, seg.id));
     emitMetrics();
 
-    // Fire the native streaming call (async).
-    // We intentionally don't return the promise — lifecycle is callback-driven.
-    startSegmentGeneration(seg);
+    void startSegmentGeneration(seg);
   }
 
   async function startSegmentGeneration(seg: QueuedSegment): Promise<void> {
     try {
-      const controller = await streamingEngine.generateSpeechStream(
-        seg.text,
-        options.generationOptions,
-        {
-          onChunk(chunk) {
-            // Only emit if the segment is still the active one (not cancelled)
-            if (activeSegment?.id === seg.id) {
-              emitSegment(segmentChunk(sessionId, seg.id, chunk));
+      const segHandlers = {
+        onChunk(chunk: Parameters<NonNullable<typeof handlers.onChunk>>[0]) {
+          if (activeSegment?.id === seg.id) {
+            emitSegment(segmentChunk(sessionId, seg.id, chunk));
+            // Propagate to top-level onChunk
+            try {
+              handlers.onChunk?.(chunk);
+            } catch {
+              /* ignore */
             }
-          },
-          onEnd(event) {
-            if (activeSegment?.id !== seg.id) return; // stale
-            emitSegment(segmentEnded(sessionId, seg.id, event.cancelled));
-            if (!event.cancelled) totalCompleted++;
-            activeSegment = null;
-            activeController = null;
-            dispatching = false;
-            emitMetrics();
-            scheduleDispatch();
-          },
-          onError(error) {
-            if (activeSegment?.id !== seg.id) return; // stale
-            activeSegment = null;
-            activeController = null;
-            dispatching = false;
-            emitSession(sessionError(sessionId, error.message, seg.id));
-            emitMetrics();
-            // Continue dispatching — one segment error should not kill the session
-            scheduleDispatch();
-          },
+          }
         },
-        defaultStreamOptions
-      );
+        onEnd(event: { cancelled: boolean }) {
+          if (activeSegment?.id !== seg.id) return;
+          emitSegment(segmentEnded(sessionId, seg.id, event.cancelled));
+          if (!event.cancelled) totalCompleted++;
+          activeSegment = null;
+          activeController = null;
+          dispatching = false;
+          emitMetrics();
+          scheduleDispatch();
+        },
+        onError(error: { message: string }) {
+          if (activeSegment?.id !== seg.id) return;
+          activeSegment = null;
+          activeController = null;
+          dispatching = false;
+          emitSession(sessionError(sessionId, error.message, seg.id));
+          // Propagate to top-level onError
+          try {
+            handlers.onError?.(error as never);
+          } catch {
+            /* ignore */
+          }
+          emitMetrics();
+          scheduleDispatch();
+        },
+      };
 
-      // Controller is only useful if segment is still active
+      let controller: TtsStreamController;
+
+      if (mode === 'file' && fileOptions) {
+        // File mode: dispatch via generateSpeechStreamToFile
+        const fileCtrl = await streamingEngine.generateSpeechStreamToFile(
+          seg.text,
+          genOptions,
+          fileOptions,
+          segHandlers as never
+        );
+        // Wrap into TtsStreamController shape for uniform handling
+        controller = {
+          async cancel() {
+            return fileCtrl.cancel();
+          },
+          unsubscribe() {
+            fileCtrl.unsubscribe();
+          },
+          player: null,
+        };
+      } else {
+        // Stream mode
+        controller = await streamingEngine.generateSpeechStream(
+          seg.text,
+          genOptions,
+          segHandlers,
+          streamOptions
+        );
+      }
+
       if (activeSegment?.id === seg.id) {
         activeController = controller;
+        // Apply paused state to new segment player
+        if (isPaused && controller.player) {
+          try {
+            void controller.player.pause();
+          } catch {
+            /* ignore */
+          }
+        }
       }
     } catch (err: unknown) {
-      // generateSpeechStream itself threw (setup failure)
       activeSegment = null;
       dispatching = false;
       const msg = err instanceof Error ? err.message : String(err);
@@ -340,6 +526,13 @@ export function createEngine(
       setState('idle');
       emitSession(sessionIdle(sessionId));
       emitMetrics();
+      // Fire top-level onEnd at flush completion
+      try {
+        (handlers as IncrementalStreamHandlers).onEnd?.({ cancelled: false });
+      } catch {
+        /* ignore */
+      }
+      completeRequest();
       flushResolve?.();
       flushResolve = null;
     } else if (state === 'active' || state === 'draining') {
@@ -350,48 +543,92 @@ export function createEngine(
   }
 
   // -----------------------------------------------------------------------
-  // Public API
+  // Player proxy (for stream mode with playback)
   // -----------------------------------------------------------------------
 
-  const engine: IncrementalStreamingTtsEngine = {
-    get sessionId() {
-      return sessionId;
-    },
+  function createPlayerProxy(): PcmPlayer | null {
+    if (mode !== 'stream' || !streamOptions?.playback) return null;
 
-    get state() {
-      return state;
-    },
+    const proxy: PcmPlayer = {
+      get playerId() {
+        return `inc_player_proxy_${sessionId}`;
+      },
+      get feed() {
+        return 'native' as const;
+      },
+      async writePcmChunk(): Promise<void> {
+        throw new Error(
+          `PcmPlayer proxy ${sessionId} has feed 'native'; writePcmChunk() is not allowed from JS.`
+        );
+      },
+      async pause(): Promise<void> {
+        isPaused = true;
+        if (activeController?.player) {
+          await activeController.player.pause();
+        }
+      },
+      async resume(): Promise<void> {
+        isPaused = false;
+        if (activeController?.player) {
+          await activeController.player.resume();
+        }
+      },
+      async destroy(): Promise<void> {
+        await cancelImpl({ scope: 'all' });
+      },
+    };
+    return proxy;
+  }
 
-    // ------- pushText -------
-    pushText(text: string): void {
-      if (state === 'destroyed') {
-        throw new Error('Cannot pushText on a destroyed engine.');
-      }
-      if (state === 'cancelled') {
-        setState('idle');
-      }
+  // -----------------------------------------------------------------------
+  // Shared controller methods
+  // -----------------------------------------------------------------------
 
-      textBuffer += text;
+  function pushTextImpl(text: string): void {
+    if (state === 'destroyed') {
+      throw new Error('Cannot pushText: request has been destroyed.');
+    }
+    if (state === 'cancelled') {
+      throw new Error('Cannot pushText: request has been cancelled.');
+    }
 
-      if (state === 'idle') {
-        setState('active');
-        emitSession(sessionStarted(sessionId));
-      }
+    textBuffer += text;
 
-      resetWaitTimer();
-      resetDebounceTimer();
-    },
+    if (state === 'idle') {
+      setState('active');
+      emitSession(sessionStarted(sessionId));
+    }
 
-    // ------- commit -------
-    commit(_opts?: CommitOptions): void {
-      if (state === 'destroyed') {
-        throw new Error('Cannot commit on a destroyed engine.');
-      }
+    resetWaitTimer();
+    resetDebounceTimer();
+  }
 
-      clearTimers();
-      if (textBuffer.length === 0) return;
+  function commitImpl(_opts?: CommitOptions): void {
+    if (state === 'destroyed') {
+      throw new Error('Cannot commit: request has been destroyed.');
+    }
 
-      // Force-commit entire buffer
+    clearTimers();
+    if (textBuffer.length === 0) return;
+
+    const boundaries = detectBoundaries(textBuffer, segPolicy, {
+      forced: true,
+    });
+    for (const b of boundaries) {
+      enqueueText(b.text);
+    }
+    textBuffer = '';
+    scheduleDispatch();
+  }
+
+  async function flushImpl(): Promise<void> {
+    if (state === 'destroyed') {
+      throw new Error('Cannot flush: request has been destroyed.');
+    }
+
+    clearTimers();
+
+    if (textBuffer.length > 0) {
       const boundaries = detectBoundaries(textBuffer, segPolicy, {
         forced: true,
       });
@@ -399,133 +636,128 @@ export function createEngine(
         enqueueText(b.text);
       }
       textBuffer = '';
-      scheduleDispatch();
-    },
+    }
 
-    // ------- flush -------
-    async flush(): Promise<void> {
-      if (state === 'destroyed') {
-        throw new Error('Cannot flush a destroyed engine.');
+    if (queue.length === 0 && activeSegment === null) {
+      if (state !== 'idle') {
+        setState('idle');
+        emitSession(sessionIdle(sessionId));
+        emitMetrics();
       }
-
-      clearTimers();
-
-      // Commit any remaining buffer
-      if (textBuffer.length > 0) {
-        const boundaries = detectBoundaries(textBuffer, segPolicy, {
-          forced: true,
-        });
-        for (const b of boundaries) {
-          enqueueText(b.text);
-        }
-        textBuffer = '';
+      // Fire top-level onEnd
+      try {
+        (handlers as IncrementalStreamHandlers).onEnd?.({ cancelled: false });
+      } catch {
+        /* ignore */
       }
+      completeRequest();
+      return;
+    }
 
-      // Nothing to process → immediate
-      if (queue.length === 0 && activeSegment === null) {
-        if (state !== 'idle') {
-          setState('idle');
-          emitSession(sessionIdle(sessionId));
-          emitMetrics();
-        }
-        return;
+    flushing = true;
+    setState('draining');
+    emitSession(
+      sessionDraining(sessionId, queue.length + (activeSegment ? 1 : 0))
+    );
+
+    scheduleDispatch();
+
+    return new Promise<void>((resolve) => {
+      flushResolve = resolve;
+    });
+  }
+
+  async function cancelImpl(opts?: CancelOptions): Promise<void> {
+    if (state === 'destroyed') return;
+
+    const scope = opts?.scope ?? 'all';
+    clearTimers();
+
+    let droppedCount = 0;
+
+    if (scope === 'all' || scope === 'queued') {
+      for (const seg of queue) {
+        emitSegment(segmentDropped(sessionId, seg.id, 'cancelled'));
+        droppedCount++;
+        totalDropped++;
       }
-
-      flushing = true;
-      setState('draining');
-      emitSession(
-        sessionDraining(sessionId, queue.length + (activeSegment ? 1 : 0))
-      );
-
-      scheduleDispatch();
-
-      return new Promise<void>((resolve) => {
-        flushResolve = resolve;
-      });
-    },
-
-    // ------- cancel -------
-    async cancel(opts?: CancelOptions): Promise<void> {
-      if (state === 'destroyed') return;
-
-      const scope = opts?.scope ?? 'all';
-      clearTimers();
-
-      let droppedCount = 0;
-
-      // Cancel queued segments
-      if (scope === 'all' || scope === 'queued') {
-        for (const seg of queue) {
-          emitSegment(segmentDropped(sessionId, seg.id, 'cancelled'));
-          droppedCount++;
-          totalDropped++;
-        }
-        queue.length = 0;
-        textBuffer = '';
-      }
-
-      // Cancel active segment
-      if ((scope === 'all' || scope === 'active') && activeController) {
-        try {
-          await activeController.cancel();
-        } catch {
-          // ignore — synthesis may already have ended
-        }
-        if (activeSegment) {
-          emitSegment(segmentDropped(sessionId, activeSegment.id, 'cancelled'));
-          droppedCount++;
-          totalDropped++;
-        }
-        activeSegment = null;
-        activeController = null;
-        dispatching = false;
-      }
-
-      setState('cancelled');
-      emitSession(sessionCancelled(sessionId, droppedCount));
-
-      // Resolve pending flush
-      if (flushResolve) {
-        flushing = false;
-        flushResolve();
-        flushResolve = null;
-      }
-
-      emitMetrics();
-    },
-
-    // ------- getMetrics -------
-    getMetrics(): IncrementalMetrics {
-      return buildMetrics();
-    },
-
-    // ------- destroy -------
-    async destroy(): Promise<void> {
-      if (state === 'destroyed') return;
-
-      clearTimers();
       queue.length = 0;
       textBuffer = '';
+    }
 
-      if (activeController) {
-        try {
-          await activeController.cancel();
-        } catch {
-          // ignore
-        }
-        activeController = null;
-        activeSegment = null;
+    if ((scope === 'all' || scope === 'active') && activeController) {
+      try {
+        await activeController.cancel();
+      } catch {
+        /* ignore */
       }
-
-      if (flushResolve) {
-        flushing = false;
-        flushResolve();
-        flushResolve = null;
+      if (activeSegment) {
+        emitSegment(segmentDropped(sessionId, activeSegment.id, 'cancelled'));
+        droppedCount++;
+        totalDropped++;
       }
+      activeSegment = null;
+      activeController = null;
+      dispatching = false;
+    }
 
-      setState('destroyed');
+    setState('cancelled');
+    emitSession(sessionCancelled(sessionId, droppedCount));
+
+    // Fire top-level onEnd with cancelled
+    try {
+      (handlers as IncrementalStreamHandlers).onEnd?.({ cancelled: true });
+    } catch {
+      /* ignore */
+    }
+
+    completeRequest();
+
+    if (flushResolve) {
+      flushing = false;
+      flushResolve();
+      flushResolve = null;
+    }
+
+    emitMetrics();
+  }
+
+  function getMetricsImpl(): IncrementalMetrics {
+    return buildMetrics();
+  }
+
+  // -----------------------------------------------------------------------
+  // Build controller
+  // -----------------------------------------------------------------------
+
+  const playerProxy = createPlayerProxy();
+
+  if (mode === 'stream') {
+    const controller: IncrementalStreamController = {
+      pushText: pushTextImpl,
+      commit: commitImpl,
+      flush: flushImpl,
+      cancel: cancelImpl,
+      getMetrics: getMetricsImpl,
+      get state() {
+        return state;
+      },
+      get player() {
+        return playerProxy;
+      },
+    };
+    return { controller };
+  }
+
+  const controller: IncrementalStreamFileController = {
+    pushText: pushTextImpl,
+    commit: commitImpl,
+    flush: flushImpl,
+    cancel: cancelImpl,
+    getMetrics: getMetricsImpl,
+    get state() {
+      return state;
     },
   };
-
-  return engine;
+  return { controller };
 }

--- a/src/tts/incremental/engine.ts
+++ b/src/tts/incremental/engine.ts
@@ -1,0 +1,531 @@
+import type {
+  SessionId,
+  SegmentId,
+  SessionState,
+  IncrementalStreamingTtsEngine,
+  IncrementalStreamingTtsOptions,
+  IncrementalMetrics,
+  CommitOptions,
+  CancelOptions,
+  SessionEvent,
+  SegmentEvent,
+} from './types';
+import type { StreamingTtsEngine } from '../streamingTypes';
+import type { TtsStreamController } from '../types';
+import {
+  resolveSegmentationPolicy,
+  detectBoundaries,
+  type ResolvedSegmentationPolicy,
+} from './segmenter';
+import {
+  resolveQueuePolicy,
+  applyEnqueuePolicy,
+  type QueuedSegment,
+  type ResolvedQueuePolicy,
+} from './policies';
+import {
+  sessionStarted,
+  sessionIdle,
+  sessionDraining,
+  sessionCancelled,
+  sessionError,
+  segmentQueued,
+  segmentStarted,
+  segmentEnded,
+  segmentDropped,
+  segmentChunk,
+  metricsSnapshot,
+} from './events';
+
+// ---------------------------------------------------------------------------
+// ID generators
+// ---------------------------------------------------------------------------
+
+let sessionCounter = 0;
+let segmentCounter = 0;
+
+function nextSessionId(): SessionId {
+  return `inc_session_${++sessionCounter}`;
+}
+
+function nextSegmentId(): SegmentId {
+  return `inc_seg_${++segmentCounter}`;
+}
+
+// ---------------------------------------------------------------------------
+// Engine implementation
+// ---------------------------------------------------------------------------
+
+export function createEngine(
+  streamingEngine: StreamingTtsEngine,
+  options: IncrementalStreamingTtsOptions
+): IncrementalStreamingTtsEngine {
+  const sessionId = nextSessionId();
+  const segPolicy: ResolvedSegmentationPolicy = resolveSegmentationPolicy(
+    options.segmentation
+  );
+  const qPolicy: ResolvedQueuePolicy = resolveQueuePolicy(options.queue);
+
+  const defaultStreamOptions = options.streamOptions ?? {
+    playback: false,
+    emitChunks: true,
+  };
+
+  // -----------------------------------------------------------------------
+  // Internal mutable state
+  // -----------------------------------------------------------------------
+
+  let state: SessionState = 'idle';
+  let textBuffer = '';
+  const queue: QueuedSegment[] = [];
+  let activeSegment: QueuedSegment | null = null;
+  let activeController: TtsStreamController | null = null;
+  let dispatching = false;
+
+  // Flush support
+  let flushResolve: (() => void) | null = null;
+  let flushing = false;
+
+  // Timers
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let waitTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Counters
+  let totalQueued = 0;
+  let totalCompleted = 0;
+  let totalDropped = 0;
+  let totalReplaced = 0;
+
+  // -----------------------------------------------------------------------
+  // Event helpers
+  // -----------------------------------------------------------------------
+
+  const emitSession = (e: SessionEvent) => {
+    try {
+      options.onSessionEvent?.(e);
+    } catch {
+      /* subscriber errors must not break the engine */
+    }
+  };
+  const emitSegment = (e: SegmentEvent) => {
+    try {
+      options.onSegmentEvent?.(e);
+    } catch {
+      /* subscriber errors must not break the engine */
+    }
+  };
+
+  function emitMetrics(): void {
+    try {
+      options.onMetrics?.(buildMetrics());
+    } catch {
+      /* subscriber errors must not break the engine */
+    }
+  }
+
+  function buildMetrics(): IncrementalMetrics {
+    return metricsSnapshot(
+      queue.length,
+      totalQueued,
+      totalCompleted,
+      totalDropped,
+      totalReplaced,
+      activeSegment?.id ?? null
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // State transitions
+  // -----------------------------------------------------------------------
+
+  function setState(next: SessionState): void {
+    state = next;
+  }
+
+  // -----------------------------------------------------------------------
+  // Timer management
+  // -----------------------------------------------------------------------
+
+  function clearTimers(): void {
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+    if (waitTimer !== null) {
+      clearTimeout(waitTimer);
+      waitTimer = null;
+    }
+  }
+
+  function resetWaitTimer(): void {
+    if (waitTimer !== null) clearTimeout(waitTimer);
+    if (textBuffer.length > 0 && segPolicy.maxWaitMs > 0) {
+      waitTimer = setTimeout(() => {
+        waitTimer = null;
+        autoSegment(true);
+      }, segPolicy.maxWaitMs);
+    }
+  }
+
+  function resetDebounceTimer(): void {
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    if (segPolicy.debounceMs > 0) {
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        autoSegment(false);
+      }, segPolicy.debounceMs);
+    } else {
+      // No debounce — run immediately
+      autoSegment(false);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Auto-segmentation
+  // -----------------------------------------------------------------------
+
+  function autoSegment(isTimeout: boolean): void {
+    if (state === 'destroyed' || state === 'cancelled') return;
+
+    const boundaries = isTimeout
+      ? detectBoundaries(textBuffer, segPolicy, {
+          forced: true,
+          reason: 'timeout',
+        })
+      : detectBoundaries(textBuffer, segPolicy);
+
+    if (boundaries.length === 0) return;
+
+    for (const b of boundaries) {
+      enqueueText(b.text);
+      textBuffer = b.remainder;
+    }
+
+    scheduleDispatch();
+  }
+
+  // -----------------------------------------------------------------------
+  // Queue management
+  // -----------------------------------------------------------------------
+
+  function enqueueText(text: string): void {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) return;
+
+    const seg: QueuedSegment = { id: nextSegmentId(), text: trimmed };
+    const result = applyEnqueuePolicy(queue, seg, qPolicy);
+
+    // Emit for dropped segments
+    for (const d of result.dropped) {
+      const reason =
+        qPolicy.mode === 'replace-tail'
+          ? ('replaced' as const)
+          : ('overflow' as const);
+      if (reason === 'replaced') {
+        totalReplaced++;
+      } else {
+        totalDropped++;
+      }
+      emitSegment(segmentDropped(sessionId, d.id, reason));
+    }
+
+    if (result.accepted) {
+      totalQueued++;
+      emitSegment(segmentQueued(sessionId, seg.id, seg.text, queue.length - 1));
+    } else {
+      totalDropped++;
+      emitSegment(segmentDropped(sessionId, seg.id, 'overflow'));
+    }
+
+    emitMetrics();
+  }
+
+  // -----------------------------------------------------------------------
+  // Dispatch loop (one segment at a time)
+  // -----------------------------------------------------------------------
+
+  function scheduleDispatch(): void {
+    if (dispatching || activeSegment !== null) return;
+    if (queue.length === 0) {
+      maybeTransitionIdle();
+      return;
+    }
+    dispatchNext();
+  }
+
+  function dispatchNext(): void {
+    if (dispatching || state === 'destroyed' || state === 'cancelled') return;
+    if (queue.length === 0) {
+      maybeTransitionIdle();
+      return;
+    }
+
+    dispatching = true;
+    const seg = queue.shift()!;
+    activeSegment = seg;
+
+    if (state === 'idle') {
+      setState('active');
+      emitSession(sessionStarted(sessionId));
+    }
+
+    emitSegment(segmentStarted(sessionId, seg.id));
+    emitMetrics();
+
+    // Fire the native streaming call (async).
+    // We intentionally don't return the promise — lifecycle is callback-driven.
+    startSegmentGeneration(seg);
+  }
+
+  async function startSegmentGeneration(seg: QueuedSegment): Promise<void> {
+    try {
+      const controller = await streamingEngine.generateSpeechStream(
+        seg.text,
+        options.generationOptions,
+        {
+          onChunk(chunk) {
+            // Only emit if the segment is still the active one (not cancelled)
+            if (activeSegment?.id === seg.id) {
+              emitSegment(segmentChunk(sessionId, seg.id, chunk));
+            }
+          },
+          onEnd(event) {
+            if (activeSegment?.id !== seg.id) return; // stale
+            emitSegment(segmentEnded(sessionId, seg.id, event.cancelled));
+            if (!event.cancelled) totalCompleted++;
+            activeSegment = null;
+            activeController = null;
+            dispatching = false;
+            emitMetrics();
+            scheduleDispatch();
+          },
+          onError(error) {
+            if (activeSegment?.id !== seg.id) return; // stale
+            activeSegment = null;
+            activeController = null;
+            dispatching = false;
+            emitSession(sessionError(sessionId, error.message, seg.id));
+            emitMetrics();
+            // Continue dispatching — one segment error should not kill the session
+            scheduleDispatch();
+          },
+        },
+        defaultStreamOptions
+      );
+
+      // Controller is only useful if segment is still active
+      if (activeSegment?.id === seg.id) {
+        activeController = controller;
+      }
+    } catch (err: unknown) {
+      // generateSpeechStream itself threw (setup failure)
+      activeSegment = null;
+      dispatching = false;
+      const msg = err instanceof Error ? err.message : String(err);
+      emitSession(sessionError(sessionId, msg, seg.id));
+      emitMetrics();
+      scheduleDispatch();
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Idle / drain-complete transition
+  // -----------------------------------------------------------------------
+
+  function maybeTransitionIdle(): void {
+    if (activeSegment !== null || queue.length > 0) return;
+
+    if (flushing) {
+      flushing = false;
+      setState('idle');
+      emitSession(sessionIdle(sessionId));
+      emitMetrics();
+      flushResolve?.();
+      flushResolve = null;
+    } else if (state === 'active' || state === 'draining') {
+      setState('idle');
+      emitSession(sessionIdle(sessionId));
+      emitMetrics();
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  const engine: IncrementalStreamingTtsEngine = {
+    get sessionId() {
+      return sessionId;
+    },
+
+    get state() {
+      return state;
+    },
+
+    // ------- pushText -------
+    pushText(text: string): void {
+      if (state === 'destroyed') {
+        throw new Error('Cannot pushText on a destroyed engine.');
+      }
+      if (state === 'cancelled') {
+        setState('idle');
+      }
+
+      textBuffer += text;
+
+      if (state === 'idle') {
+        setState('active');
+        emitSession(sessionStarted(sessionId));
+      }
+
+      resetWaitTimer();
+      resetDebounceTimer();
+    },
+
+    // ------- commit -------
+    commit(_opts?: CommitOptions): void {
+      if (state === 'destroyed') {
+        throw new Error('Cannot commit on a destroyed engine.');
+      }
+
+      clearTimers();
+      if (textBuffer.length === 0) return;
+
+      // Force-commit entire buffer
+      const boundaries = detectBoundaries(textBuffer, segPolicy, {
+        forced: true,
+      });
+      for (const b of boundaries) {
+        enqueueText(b.text);
+      }
+      textBuffer = '';
+      scheduleDispatch();
+    },
+
+    // ------- flush -------
+    async flush(): Promise<void> {
+      if (state === 'destroyed') {
+        throw new Error('Cannot flush a destroyed engine.');
+      }
+
+      clearTimers();
+
+      // Commit any remaining buffer
+      if (textBuffer.length > 0) {
+        const boundaries = detectBoundaries(textBuffer, segPolicy, {
+          forced: true,
+        });
+        for (const b of boundaries) {
+          enqueueText(b.text);
+        }
+        textBuffer = '';
+      }
+
+      // Nothing to process → immediate
+      if (queue.length === 0 && activeSegment === null) {
+        if (state !== 'idle') {
+          setState('idle');
+          emitSession(sessionIdle(sessionId));
+          emitMetrics();
+        }
+        return;
+      }
+
+      flushing = true;
+      setState('draining');
+      emitSession(
+        sessionDraining(sessionId, queue.length + (activeSegment ? 1 : 0))
+      );
+
+      scheduleDispatch();
+
+      return new Promise<void>((resolve) => {
+        flushResolve = resolve;
+      });
+    },
+
+    // ------- cancel -------
+    async cancel(opts?: CancelOptions): Promise<void> {
+      if (state === 'destroyed') return;
+
+      const scope = opts?.scope ?? 'all';
+      clearTimers();
+
+      let droppedCount = 0;
+
+      // Cancel queued segments
+      if (scope === 'all' || scope === 'queued') {
+        for (const seg of queue) {
+          emitSegment(segmentDropped(sessionId, seg.id, 'cancelled'));
+          droppedCount++;
+          totalDropped++;
+        }
+        queue.length = 0;
+        textBuffer = '';
+      }
+
+      // Cancel active segment
+      if ((scope === 'all' || scope === 'active') && activeController) {
+        try {
+          await activeController.cancel();
+        } catch {
+          // ignore — synthesis may already have ended
+        }
+        if (activeSegment) {
+          emitSegment(segmentDropped(sessionId, activeSegment.id, 'cancelled'));
+          droppedCount++;
+          totalDropped++;
+        }
+        activeSegment = null;
+        activeController = null;
+        dispatching = false;
+      }
+
+      setState('cancelled');
+      emitSession(sessionCancelled(sessionId, droppedCount));
+
+      // Resolve pending flush
+      if (flushResolve) {
+        flushing = false;
+        flushResolve();
+        flushResolve = null;
+      }
+
+      emitMetrics();
+    },
+
+    // ------- getMetrics -------
+    getMetrics(): IncrementalMetrics {
+      return buildMetrics();
+    },
+
+    // ------- destroy -------
+    async destroy(): Promise<void> {
+      if (state === 'destroyed') return;
+
+      clearTimers();
+      queue.length = 0;
+      textBuffer = '';
+
+      if (activeController) {
+        try {
+          await activeController.cancel();
+        } catch {
+          // ignore
+        }
+        activeController = null;
+        activeSegment = null;
+      }
+
+      if (flushResolve) {
+        flushing = false;
+        flushResolve();
+        flushResolve = null;
+      }
+
+      setState('destroyed');
+    },
+  };
+
+  return engine;
+}

--- a/src/tts/incremental/engine.ts
+++ b/src/tts/incremental/engine.ts
@@ -101,10 +101,8 @@ export function createEngine(
       }
       activeRequest = true;
 
-      const resolvedStreamOptions = streamOptions ?? {
-        playback: true,
-        emitChunks: false,
-      };
+      // Same per-field defaults as generateSpeechStream: playback false, emitChunks true.
+      const resolvedStreamOptions = streamOptions;
 
       const segPolicy = resolveSegmentationPolicy(
         incrementalOptions?.segmentation ?? factoryOptions.segmentation
@@ -508,7 +506,12 @@ function createRequestSession(
                 (
                   handlers as IncrementalStreamToFileHandlers
                 ).onSegmentFileEnd?.({
-                  ...(event as { cancelled: boolean; path: string; bytesWritten: number; sampleRate: number }),
+                  ...(event as {
+                    cancelled: boolean;
+                    path: string;
+                    bytesWritten: number;
+                    sampleRate: number;
+                  }),
                   segmentId: seg.id,
                 });
               } catch {

--- a/src/tts/incremental/engine.ts
+++ b/src/tts/incremental/engine.ts
@@ -73,6 +73,7 @@ export function createEngine(
 ): IncrementalStreamingTtsEngine {
   let destroyed = false;
   let activeRequest = false;
+  let activeSessionCancel: (() => Promise<void>) | null = null;
 
   const guard = () => {
     if (destroyed) {
@@ -123,9 +124,11 @@ export function createEngine(
         undefined,
         () => {
           activeRequest = false;
+          activeSessionCancel = null;
         }
       );
 
+      activeSessionCancel = session.cancel;
       return session.controller as IncrementalStreamController;
     },
 
@@ -162,9 +165,11 @@ export function createEngine(
         fileOptions,
         () => {
           activeRequest = false;
+          activeSessionCancel = null;
         }
       );
 
+      activeSessionCancel = session.cancel;
       return session.controller as IncrementalStreamFileController;
     },
 
@@ -186,6 +191,14 @@ export function createEngine(
     async destroy() {
       if (destroyed) return;
       destroyed = true;
+      if (activeSessionCancel) {
+        try {
+          await activeSessionCancel();
+        } catch {
+          /* ignore */
+        }
+        activeSessionCancel = null;
+      }
     },
   };
 
@@ -198,6 +211,7 @@ export function createEngine(
 
 interface RequestSession {
   controller: IncrementalStreamController | IncrementalStreamFileController;
+  cancel: () => Promise<void>;
 }
 
 function createRequestSession(
@@ -237,6 +251,9 @@ function createRequestSession(
   let totalCompleted = 0;
   let totalDropped = 0;
   let totalReplaced = 0;
+
+  // File-mode: sequential index for per-segment output paths
+  let segmentFileIndex = 0;
 
   // Player proxy state (only for stream mode with playback)
   let isPaused = false;
@@ -365,7 +382,7 @@ function createRequestSession(
 
     for (const d of result.dropped) {
       const reason =
-        qPolicy.mode === 'replace-tail'
+        qPolicy.mode === 'replace-tail' || qPolicy.mode === 'latest-wins'
           ? ('replaced' as const)
           : ('overflow' as const);
       if (reason === 'replaced') {
@@ -466,12 +483,47 @@ function createRequestSession(
       let controller: TtsStreamController;
 
       if (mode === 'file' && fileOptions) {
-        // File mode: dispatch via generateSpeechStreamToFile
+        // File mode: use a unique per-segment path to avoid overwriting.
+        // Insert the segment index before the file extension so each segment
+        // is written to its own file (e.g. "out.wav" → "out_0.wav", "out_1.wav").
+        const basePath = fileOptions.output.path;
+        const dotIdx = basePath.lastIndexOf('.');
+        const segIdx = segmentFileIndex++;
+        const segPath =
+          dotIdx >= 0
+            ? `${basePath.slice(0, dotIdx)}_${segIdx}${basePath.slice(dotIdx)}`
+            : `${basePath}_${segIdx}`;
+        const segFileOptions: TtsStreamToFileOptions = {
+          ...fileOptions,
+          output: { ...fileOptions.output, path: segPath },
+        };
+
+        // Intercept file-level onEnd to forward per-segment file info.
+        const fileSegHandlers = {
+          ...segHandlers,
+          onEnd(event: Parameters<NonNullable<typeof segHandlers.onEnd>>[0]) {
+            // Notify caller about this segment's output file.
+            if (activeSegment?.id === seg.id) {
+              try {
+                (
+                  handlers as IncrementalStreamToFileHandlers
+                ).onSegmentFileEnd?.({
+                  ...(event as { cancelled: boolean; path: string; bytesWritten: number; sampleRate: number }),
+                  segmentId: seg.id,
+                });
+              } catch {
+                /* ignore */
+              }
+            }
+            segHandlers.onEnd(event);
+          },
+        };
+
         const fileCtrl = await streamingEngine.generateSpeechStreamToFile(
           seg.text,
           genOptions,
-          fileOptions,
-          segHandlers as never
+          segFileOptions,
+          fileSegHandlers as never
         );
         // Wrap into TtsStreamController shape for uniform handling
         controller = {
@@ -603,27 +655,51 @@ function createRequestSession(
     resetDebounceTimer();
   }
 
-  function commitImpl(_opts?: CommitOptions): void {
+  function commitImpl(opts?: CommitOptions): void {
     if (state === 'destroyed') {
       throw new Error('Cannot commit: request has been destroyed.');
+    }
+    if (state === 'cancelled') {
+      throw new Error('Cannot commit: request has been cancelled.');
     }
 
     clearTimers();
     if (textBuffer.length === 0) return;
 
-    const boundaries = detectBoundaries(textBuffer, segPolicy, {
-      forced: true,
-    });
-    for (const b of boundaries) {
-      enqueueText(b.text);
+    // Default: force=true (always commit the full buffer).
+    // force=false: honour the segmentation policy — only commit segments that
+    // satisfy minCharsPerSegment and other boundaries; remainder stays buffered.
+    const force = opts?.force !== false;
+    if (force) {
+      const boundaries = detectBoundaries(textBuffer, segPolicy, {
+        forced: true,
+      });
+      for (const b of boundaries) {
+        enqueueText(b.text);
+      }
+      textBuffer = '';
+    } else {
+      const boundaries = detectBoundaries(textBuffer, segPolicy);
+      for (const b of boundaries) {
+        enqueueText(b.text);
+      }
+      if (boundaries.length > 0) {
+        const last = boundaries[boundaries.length - 1];
+        if (last) {
+          textBuffer = last.remainder;
+        }
+      }
     }
-    textBuffer = '';
     scheduleDispatch();
   }
 
   async function flushImpl(): Promise<void> {
     if (state === 'destroyed') {
       throw new Error('Cannot flush: request has been destroyed.');
+    }
+    if (state === 'cancelled') {
+      // Request was already cancelled; suppress duplicate end events.
+      return;
     }
 
     clearTimers();
@@ -671,11 +747,31 @@ function createRequestSession(
     if (state === 'destroyed') return;
 
     const scope = opts?.scope ?? 'all';
+
+    // scope='queued': only drop queued segments and clear the text buffer.
+    // The active segment is intentionally left running so the native stream
+    // finishes cleanly. The request itself is NOT ended here — a subsequent
+    // flush() or cancel({ scope: 'all' }) is required to terminate it.
+    if (scope === 'queued') {
+      if (state === 'cancelled') return;
+      clearTimers();
+      textBuffer = '';
+      for (const seg of queue) {
+        emitSegment(segmentDropped(sessionId, seg.id, 'cancelled'));
+        totalDropped++;
+      }
+      queue.length = 0;
+      emitMetrics();
+      return;
+    }
+
+    // scope='active' or scope='all': end the request.
+    if (state === 'cancelled') return;
     clearTimers();
 
     let droppedCount = 0;
 
-    if (scope === 'all' || scope === 'queued') {
+    if (scope === 'all') {
       for (const seg of queue) {
         emitSegment(segmentDropped(sessionId, seg.id, 'cancelled'));
         droppedCount++;
@@ -746,7 +842,7 @@ function createRequestSession(
         return playerProxy;
       },
     };
-    return { controller };
+    return { controller, cancel: () => cancelImpl({ scope: 'all' }) };
   }
 
   const controller: IncrementalStreamFileController = {
@@ -759,5 +855,5 @@ function createRequestSession(
       return state;
     },
   };
-  return { controller };
+  return { controller, cancel: () => cancelImpl({ scope: 'all' }) };
 }

--- a/src/tts/incremental/events.ts
+++ b/src/tts/incremental/events.ts
@@ -1,0 +1,108 @@
+import type {
+  SessionId,
+  SegmentId,
+  SessionEvent,
+  SegmentEvent,
+  IncrementalMetrics,
+} from './types';
+import type { TtsStreamChunk } from '../types';
+
+// ---------------------------------------------------------------------------
+// Session event factories
+// ---------------------------------------------------------------------------
+
+export function sessionStarted(sessionId: SessionId): SessionEvent {
+  return { type: 'session:started', sessionId };
+}
+
+export function sessionIdle(sessionId: SessionId): SessionEvent {
+  return { type: 'session:idle', sessionId };
+}
+
+export function sessionDraining(
+  sessionId: SessionId,
+  remainingSegments: number
+): SessionEvent {
+  return { type: 'session:draining', sessionId, remainingSegments };
+}
+
+export function sessionCancelled(
+  sessionId: SessionId,
+  droppedSegments: number
+): SessionEvent {
+  return { type: 'session:cancelled', sessionId, droppedSegments };
+}
+
+export function sessionError(
+  sessionId: SessionId,
+  error: string,
+  segmentId?: SegmentId
+): SessionEvent {
+  return { type: 'session:error', sessionId, segmentId, error };
+}
+
+// ---------------------------------------------------------------------------
+// Segment event factories
+// ---------------------------------------------------------------------------
+
+export function segmentQueued(
+  sessionId: SessionId,
+  segmentId: SegmentId,
+  text: string,
+  queuePosition: number
+): SegmentEvent {
+  return { type: 'segment:queued', sessionId, segmentId, text, queuePosition };
+}
+
+export function segmentStarted(
+  sessionId: SessionId,
+  segmentId: SegmentId
+): SegmentEvent {
+  return { type: 'segment:started', sessionId, segmentId };
+}
+
+export function segmentEnded(
+  sessionId: SessionId,
+  segmentId: SegmentId,
+  cancelled: boolean
+): SegmentEvent {
+  return { type: 'segment:ended', sessionId, segmentId, cancelled };
+}
+
+export function segmentDropped(
+  sessionId: SessionId,
+  segmentId: SegmentId,
+  reason: 'overflow' | 'cancelled' | 'replaced'
+): SegmentEvent {
+  return { type: 'segment:dropped', sessionId, segmentId, reason };
+}
+
+export function segmentChunk(
+  sessionId: SessionId,
+  segmentId: SegmentId,
+  chunk: TtsStreamChunk
+): SegmentEvent {
+  return { type: 'segment:chunk', sessionId, segmentId, chunk };
+}
+
+// ---------------------------------------------------------------------------
+// Metrics snapshot
+// ---------------------------------------------------------------------------
+
+export function metricsSnapshot(
+  queueDepth: number,
+  totalSegmentsQueued: number,
+  totalSegmentsCompleted: number,
+  totalSegmentsDropped: number,
+  totalSegmentsReplaced: number,
+  activeSegmentId: SegmentId | null
+): IncrementalMetrics {
+  return {
+    queueDepth,
+    totalSegmentsQueued,
+    totalSegmentsCompleted,
+    totalSegmentsDropped,
+    totalSegmentsReplaced,
+    activeSegmentId,
+  };
+}

--- a/src/tts/incremental/index.ts
+++ b/src/tts/incremental/index.ts
@@ -1,32 +1,36 @@
 import type {
-  IncrementalStreamingTtsOptions,
+  IncrementalStreamingTtsFactoryOptions,
   IncrementalStreamingTtsEngine,
 } from './types';
 import { createStreamingTTS } from '../streaming';
 import { createEngine } from './engine';
 
 /**
- * Create an incremental-streaming TTS engine.
+ * Create an incremental-streaming TTS engine (factory).
  *
- * Accepts progressive text pushes (`pushText`) and segments/queues them
- * automatically, dispatching one segment at a time to the underlying
- * streaming engine. Defaults match createStreamingTTS behavior.
+ * Returns an `IncrementalStreamingTtsEngine` whose
+ * `generateIncrementalSpeechStream()` method creates per-request controllers
+ * for progressive text pushing, segmentation, and playback.
  *
  * @example
  * ```ts
  * const engine = await createIncrementalStreamingTTS({
  *   source: { engineOptions: { modelPath: { type: 'asset', path: 'model' } } },
- *   // defaults: playback: false, emitChunks: true
  * });
  *
- * engine.pushText('Hello world. ');
- * engine.pushText('This is streaming TTS.');
- * await engine.flush();
+ * const ctrl = engine.generateIncrementalSpeechStream(
+ *   undefined,
+ *   { onEnd: () => console.log('done') },
+ *   { playback: true, emitChunks: false },
+ * );
+ * ctrl.pushText('Hello world. ');
+ * ctrl.pushText('This is streaming TTS.');
+ * await ctrl.flush();
  * await engine.destroy();
  * ```
  */
 export async function createIncrementalStreamingTTS(
-  options: IncrementalStreamingTtsOptions
+  options: IncrementalStreamingTtsFactoryOptions
 ): Promise<IncrementalStreamingTtsEngine> {
   let ownsEngine = false;
 
@@ -63,9 +67,17 @@ export { applyEnqueuePolicy, resolveQueuePolicy } from './policies';
 export type {
   // Engine
   IncrementalStreamingTtsEngine,
-  IncrementalStreamingTtsOptions,
+  IncrementalStreamingTtsFactoryOptions,
   IncrementalStreamingTtsSource,
   IncrementalMetrics,
+  // Controllers
+  IncrementalStreamController,
+  IncrementalStreamFileController,
+  // Handlers
+  IncrementalStreamHandlers,
+  IncrementalStreamToFileHandlers,
+  // Per-request options
+  IncrementalRequestOptions,
   // IDs & state
   SessionId,
   SegmentId,

--- a/src/tts/incremental/index.ts
+++ b/src/tts/incremental/index.ts
@@ -10,7 +10,7 @@ import { createEngine } from './engine';
  *
  * Returns an `IncrementalStreamingTtsEngine` whose
  * `generateIncrementalSpeechStream()` method creates per-request controllers
- * for progressive text pushing, segmentation, and playback.
+ * for progressive text pushing, segmentation, and optional native playback.
  *
  * @example
  * ```ts
@@ -18,11 +18,13 @@ import { createEngine } from './engine';
  *   source: { engineOptions: { modelPath: { type: 'asset', path: 'model' } } },
  * });
  *
- * const ctrl = engine.generateIncrementalSpeechStream(
- *   undefined,
- *   { onEnd: () => console.log('done') },
- *   { playback: true, emitChunks: false },
- * );
+ * const ctrl = engine.generateIncrementalSpeechStream(undefined, {
+ *   onChunk: (c) => {
+ *     // default: playback false, emitChunks true
+ *   },
+ *   onEnd: () => console.log('done'),
+ * });
+ * // Native playback instead: add third arg `{ playback: true, emitChunks: false }`
  * ctrl.pushText('Hello world. ');
  * ctrl.pushText('This is streaming TTS.');
  * await ctrl.flush();

--- a/src/tts/incremental/index.ts
+++ b/src/tts/incremental/index.ts
@@ -1,0 +1,105 @@
+import type {
+  IncrementalStreamingTtsOptions,
+  IncrementalStreamingTtsEngine,
+} from './types';
+import { createStreamingTTS } from '../streaming';
+import { createEngine } from './engine';
+
+/**
+ * Create an incremental-streaming TTS engine.
+ *
+ * Accepts progressive text pushes (`pushText`) and segments/queues them
+ * automatically, dispatching one segment at a time to the underlying
+ * streaming engine. Defaults match createStreamingTTS behavior.
+ *
+ * @example
+ * ```ts
+ * const engine = await createIncrementalStreamingTTS({
+ *   source: { engineOptions: { modelPath: { type: 'asset', path: 'model' } } },
+ *   // defaults: playback: false, emitChunks: true
+ * });
+ *
+ * engine.pushText('Hello world. ');
+ * engine.pushText('This is streaming TTS.');
+ * await engine.flush();
+ * await engine.destroy();
+ * ```
+ */
+export async function createIncrementalStreamingTTS(
+  options: IncrementalStreamingTtsOptions
+): Promise<IncrementalStreamingTtsEngine> {
+  let ownsEngine = false;
+
+  let streamingEngine;
+  if ('engine' in options.source) {
+    streamingEngine = options.source.engine;
+  } else {
+    streamingEngine = await createStreamingTTS(options.source.engineOptions);
+    ownsEngine = true;
+  }
+
+  const engine = createEngine(streamingEngine, options);
+
+  // Wrap destroy to also shut down the streaming engine if we created it
+  if (ownsEngine) {
+    const originalDestroy = engine.destroy.bind(engine);
+    (engine as { destroy: typeof engine.destroy }).destroy = async () => {
+      await originalDestroy();
+      await streamingEngine.destroy();
+    };
+  }
+
+  return engine;
+}
+
+// ---------------------------------------------------------------------------
+// Public re-exports
+// ---------------------------------------------------------------------------
+
+export { createEngine } from './engine';
+export { detectBoundaries, resolveSegmentationPolicy } from './segmenter';
+export { applyEnqueuePolicy, resolveQueuePolicy } from './policies';
+
+export type {
+  // Engine
+  IncrementalStreamingTtsEngine,
+  IncrementalStreamingTtsOptions,
+  IncrementalStreamingTtsSource,
+  IncrementalMetrics,
+  // IDs & state
+  SessionId,
+  SegmentId,
+  SessionState,
+  // Policies
+  SegmentationPolicy,
+  QueuePolicy,
+  QueueMode,
+  OverflowStrategy,
+  // Options
+  CommitOptions,
+  FlushOptions,
+  CancelOptions,
+  CancelScope,
+  // Session events
+  SessionEvent,
+  SessionStartedEvent,
+  SessionIdleEvent,
+  SessionDrainingEvent,
+  SessionCancelledEvent,
+  SessionErrorEvent,
+  // Segment events
+  SegmentEvent,
+  SegmentQueuedEvent,
+  SegmentStartedEvent,
+  SegmentEndedEvent,
+  SegmentDroppedEvent,
+  SegmentChunkEvent,
+} from './types';
+
+export type { ResolvedSegmentationPolicy, SegmentBoundary } from './segmenter';
+
+export type {
+  QueuedSegment,
+  ResolvedQueuePolicy,
+  EnqueueResult,
+} from './policies';

--- a/src/tts/incremental/policies.ts
+++ b/src/tts/incremental/policies.ts
@@ -1,0 +1,118 @@
+import type {
+  QueuePolicy,
+  QueueMode,
+  OverflowStrategy,
+  SegmentId,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Queued segment
+// ---------------------------------------------------------------------------
+
+export interface QueuedSegment {
+  id: SegmentId;
+  text: string;
+}
+
+// ---------------------------------------------------------------------------
+// Resolved policy (defaults applied)
+// ---------------------------------------------------------------------------
+
+export interface ResolvedQueuePolicy {
+  mode: QueueMode;
+  maxSegments: number;
+  maxBufferedChars: number;
+  overflowStrategy: OverflowStrategy;
+}
+
+export function resolveQueuePolicy(policy?: QueuePolicy): ResolvedQueuePolicy {
+  return {
+    mode: policy?.mode ?? 'fifo',
+    maxSegments: policy?.maxSegments ?? 50,
+    maxBufferedChars: policy?.maxBufferedChars ?? 10000,
+    overflowStrategy: policy?.overflowStrategy ?? 'drop-oldest',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Enqueue result
+// ---------------------------------------------------------------------------
+
+export interface EnqueueResult {
+  accepted: boolean;
+  dropped: QueuedSegment[];
+}
+
+// ---------------------------------------------------------------------------
+// Policy application
+// ---------------------------------------------------------------------------
+
+function queuedChars(queue: readonly QueuedSegment[]): number {
+  let n = 0;
+  for (const s of queue) n += s.text.length;
+  return n;
+}
+
+/**
+ * Apply the queue policy when a new segment is enqueued.
+ * Mutates `queue` in-place. Returns which segments were dropped (if any).
+ */
+export function applyEnqueuePolicy(
+  queue: QueuedSegment[],
+  newSegment: QueuedSegment,
+  policy: ResolvedQueuePolicy
+): EnqueueResult {
+  const dropped: QueuedSegment[] = [];
+
+  switch (policy.mode) {
+    // -----------------------------------------------------------------
+    case 'latest-wins': {
+      dropped.push(...queue);
+      queue.length = 0;
+      queue.push(newSegment);
+      return { accepted: true, dropped };
+    }
+
+    // -----------------------------------------------------------------
+    case 'replace-tail': {
+      if (queue.length > 0) {
+        dropped.push(queue.pop()!);
+      }
+      queue.push(newSegment);
+      return { accepted: true, dropped };
+    }
+
+    // -----------------------------------------------------------------
+    case 'fifo':
+    default: {
+      const overLimit =
+        queue.length >= policy.maxSegments ||
+        queuedChars(queue) + newSegment.text.length > policy.maxBufferedChars;
+
+      if (!overLimit) {
+        queue.push(newSegment);
+        return { accepted: true, dropped };
+      }
+
+      switch (policy.overflowStrategy) {
+        case 'drop-oldest': {
+          while (
+            queue.length > 0 &&
+            (queue.length >= policy.maxSegments ||
+              queuedChars(queue) + newSegment.text.length >
+                policy.maxBufferedChars)
+          ) {
+            dropped.push(queue.shift()!);
+          }
+          queue.push(newSegment);
+          return { accepted: true, dropped };
+        }
+        case 'drop-newest':
+        case 'reject': {
+          dropped.push(newSegment);
+          return { accepted: false, dropped };
+        }
+      }
+    }
+  }
+}

--- a/src/tts/incremental/segmenter.ts
+++ b/src/tts/incremental/segmenter.ts
@@ -1,0 +1,160 @@
+import type { SegmentationPolicy } from './types';
+
+// Default boundary characters: sentence-ending punctuation across common locales
+const DEFAULT_BOUNDARY_CHARS = '.!?;。！？；…\n';
+
+// ---------------------------------------------------------------------------
+// Resolved policy (all fields required, with defaults applied)
+// ---------------------------------------------------------------------------
+
+export interface ResolvedSegmentationPolicy {
+  boundaryChars: Set<string>;
+  maxCharsPerSegment: number;
+  maxWaitMs: number;
+  minCharsPerSegment: number;
+  debounceMs: number;
+}
+
+export function resolveSegmentationPolicy(
+  policy?: SegmentationPolicy
+): ResolvedSegmentationPolicy {
+  return {
+    boundaryChars: new Set(
+      (policy?.boundaryChars ?? DEFAULT_BOUNDARY_CHARS).split('')
+    ),
+    maxCharsPerSegment: policy?.maxCharsPerSegment ?? 500,
+    maxWaitMs: policy?.maxWaitMs ?? 2000,
+    minCharsPerSegment: policy?.minCharsPerSegment ?? 20,
+    debounceMs: policy?.debounceMs ?? 100,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Boundary detection result
+// ---------------------------------------------------------------------------
+
+export interface SegmentBoundary {
+  /** Text of the segment to commit. */
+  text: string;
+  /** Remaining text after the boundary. */
+  remainder: string;
+  /** Why the boundary was detected. */
+  reason: 'punctuation' | 'max-length' | 'timeout' | 'forced';
+}
+
+// ---------------------------------------------------------------------------
+// Core boundary detector (pure function — timers handled by engine)
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan buffered text for segment boundaries.
+ * Returns zero or more segments ready to commit.
+ *
+ * For timer-based boundaries (`timeout`), the engine calls this with
+ * `options.forced = true` when the wait timer fires.
+ */
+export function detectBoundaries(
+  buffer: string,
+  policy: ResolvedSegmentationPolicy,
+  options?: { forced?: boolean; reason?: 'timeout' | 'forced' }
+): SegmentBoundary[] {
+  if (buffer.length === 0) return [];
+
+  // Forced commit (explicit commit(), flush(), or timeout)
+  if (options?.forced) {
+    const reason = options.reason ?? 'forced';
+    return [{ text: buffer, remainder: '', reason }];
+  }
+
+  const results: SegmentBoundary[] = [];
+  let remaining = buffer;
+
+  while (remaining.length > 0) {
+    // --- max-length boundary ---
+    if (remaining.length > policy.maxCharsPerSegment) {
+      const searchEnd = policy.maxCharsPerSegment;
+      let splitAt = -1;
+
+      // Search backwards from limit for a boundary char
+      for (let i = searchEnd - 1; i >= policy.minCharsPerSegment; i--) {
+        if (policy.boundaryChars.has(remaining[i]!)) {
+          splitAt = i + 1;
+          break;
+        }
+      }
+
+      // Fallback: split at last space near the limit
+      if (splitAt === -1) {
+        for (let i = searchEnd - 1; i >= policy.minCharsPerSegment; i--) {
+          if (remaining[i] === ' ') {
+            splitAt = i + 1;
+            break;
+          }
+        }
+      }
+
+      // Hard split at max chars as last resort
+      if (splitAt === -1) {
+        splitAt = searchEnd;
+      }
+
+      const text = remaining.slice(0, splitAt).trim();
+      remaining = remaining.slice(splitAt);
+      if (text.length > 0) {
+        results.push({ text, remainder: remaining, reason: 'max-length' });
+      }
+      continue;
+    }
+
+    // --- punctuation boundary ---
+    // Find the first boundary char that satisfies minCharsPerSegment.
+    // ASCII boundary chars (like '.') require trailing whitespace or end-of-string
+    // to avoid splitting tokens like "3.14". Non-ASCII boundary chars (CJK
+    // punctuation like '。') and whitespace-class boundary chars ('\n') are
+    // accepted unconditionally.
+    let boundaryAt = -1;
+    for (
+      let i = Math.max(0, policy.minCharsPerSegment - 1);
+      i < remaining.length;
+      i++
+    ) {
+      if (policy.boundaryChars.has(remaining[i]!)) {
+        const code = remaining.charCodeAt(i);
+        const isAsciiPunct = code < 128 && code !== 10; /* \n */
+
+        if (!isAsciiPunct) {
+          // Non-ASCII boundary (CJK punctuation etc.) — always accept
+          boundaryAt = i + 1;
+          break;
+        }
+
+        // ASCII boundary — require trailing whitespace or end-of-string
+        const next = remaining[i + 1];
+        if (
+          next === undefined ||
+          next === ' ' ||
+          next === '\n' ||
+          next === '\t' ||
+          next === '\r'
+        ) {
+          boundaryAt = i + 1;
+          break;
+        }
+      }
+    }
+
+    if (boundaryAt > 0) {
+      const text = remaining.slice(0, boundaryAt).trim();
+      remaining = remaining.slice(boundaryAt).trimStart();
+      if (text.length > 0) {
+        results.push({ text, remainder: remaining, reason: 'punctuation' });
+      }
+      continue;
+    }
+
+    // No boundary found — text stays in buffer for now
+    break;
+  }
+
+  return results;
+}

--- a/src/tts/incremental/types.ts
+++ b/src/tts/incremental/types.ts
@@ -1,0 +1,233 @@
+import type {
+  TtsGenerationOptions,
+  TtsStreamOptions,
+  TtsStreamChunk,
+  TTSInitializeOptions,
+} from '../types';
+import type { StreamingTtsEngine } from '../streamingTypes';
+import type { ModelPathConfig } from '../../types';
+
+// ---------------------------------------------------------------------------
+// IDs
+// ---------------------------------------------------------------------------
+
+export type SessionId = string;
+export type SegmentId = string;
+
+// ---------------------------------------------------------------------------
+// Session state
+// ---------------------------------------------------------------------------
+
+export type SessionState =
+  | 'idle'
+  | 'active'
+  | 'draining'
+  | 'cancelled'
+  | 'errored'
+  | 'destroyed';
+
+// ---------------------------------------------------------------------------
+// Segmentation policy
+// ---------------------------------------------------------------------------
+
+export interface SegmentationPolicy {
+  /** Characters that trigger a segment boundary (e.g. '.!?'). */
+  boundaryChars?: string;
+  /** Maximum chars per segment before forced split. Default: 500 */
+  maxCharsPerSegment?: number;
+  /** Milliseconds to wait after last pushText before auto-committing. Default: 2000 */
+  maxWaitMs?: number;
+  /** Minimum chars before a boundary is accepted. Default: 20 */
+  minCharsPerSegment?: number;
+  /** Debounce interval (ms) for rapid pushText calls. Default: 100 */
+  debounceMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Queue policy
+// ---------------------------------------------------------------------------
+
+export type QueueMode = 'fifo' | 'replace-tail' | 'latest-wins';
+export type OverflowStrategy = 'drop-oldest' | 'drop-newest' | 'reject';
+
+export interface QueuePolicy {
+  /** Queue processing mode. Default: 'fifo' */
+  mode?: QueueMode;
+  /** Maximum queued segments. Default: 50 */
+  maxSegments?: number;
+  /** Maximum total buffered chars. Default: 10000 */
+  maxBufferedChars?: number;
+  /** Overflow strategy. Default: 'drop-oldest' */
+  overflowStrategy?: OverflowStrategy;
+}
+
+// ---------------------------------------------------------------------------
+// Session events
+// ---------------------------------------------------------------------------
+
+export interface SessionStartedEvent {
+  type: 'session:started';
+  sessionId: SessionId;
+}
+
+export interface SessionIdleEvent {
+  type: 'session:idle';
+  sessionId: SessionId;
+}
+
+export interface SessionDrainingEvent {
+  type: 'session:draining';
+  sessionId: SessionId;
+  remainingSegments: number;
+}
+
+export interface SessionCancelledEvent {
+  type: 'session:cancelled';
+  sessionId: SessionId;
+  droppedSegments: number;
+}
+
+export interface SessionErrorEvent {
+  type: 'session:error';
+  sessionId: SessionId;
+  segmentId?: SegmentId;
+  error: string;
+}
+
+export type SessionEvent =
+  | SessionStartedEvent
+  | SessionIdleEvent
+  | SessionDrainingEvent
+  | SessionCancelledEvent
+  | SessionErrorEvent;
+
+// ---------------------------------------------------------------------------
+// Segment events
+// ---------------------------------------------------------------------------
+
+export interface SegmentQueuedEvent {
+  type: 'segment:queued';
+  sessionId: SessionId;
+  segmentId: SegmentId;
+  text: string;
+  queuePosition: number;
+}
+
+export interface SegmentStartedEvent {
+  type: 'segment:started';
+  sessionId: SessionId;
+  segmentId: SegmentId;
+}
+
+export interface SegmentEndedEvent {
+  type: 'segment:ended';
+  sessionId: SessionId;
+  segmentId: SegmentId;
+  cancelled: boolean;
+}
+
+export interface SegmentDroppedEvent {
+  type: 'segment:dropped';
+  sessionId: SessionId;
+  segmentId: SegmentId;
+  reason: 'overflow' | 'cancelled' | 'replaced';
+}
+
+export interface SegmentChunkEvent {
+  type: 'segment:chunk';
+  sessionId: SessionId;
+  segmentId: SegmentId;
+  chunk: TtsStreamChunk;
+}
+
+export type SegmentEvent =
+  | SegmentQueuedEvent
+  | SegmentStartedEvent
+  | SegmentEndedEvent
+  | SegmentDroppedEvent
+  | SegmentChunkEvent;
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+export interface IncrementalMetrics {
+  queueDepth: number;
+  totalSegmentsQueued: number;
+  totalSegmentsCompleted: number;
+  totalSegmentsDropped: number;
+  totalSegmentsReplaced: number;
+  activeSegmentId: SegmentId | null;
+}
+
+// ---------------------------------------------------------------------------
+// Commit / Flush / Cancel options
+// ---------------------------------------------------------------------------
+
+export interface CommitOptions {
+  /** If true, bypass min-length threshold. */
+  force?: boolean;
+}
+
+export type FlushOptions = Record<string, never>;
+
+export type CancelScope = 'all' | 'active' | 'queued';
+
+export interface CancelOptions {
+  /** What to cancel. Default: 'all' */
+  scope?: CancelScope;
+}
+
+// ---------------------------------------------------------------------------
+// Factory options
+// ---------------------------------------------------------------------------
+
+export type IncrementalStreamingTtsSource =
+  | { engine: StreamingTtsEngine }
+  | { engineOptions: TTSInitializeOptions | ModelPathConfig };
+
+export interface IncrementalStreamingTtsOptions {
+  /** Existing streaming engine or options to create one. */
+  source: IncrementalStreamingTtsSource;
+  /** Segmentation policy for auto-detecting boundaries. */
+  segmentation?: SegmentationPolicy;
+  /** Queue policy for segment flow control. */
+  queue?: QueuePolicy;
+  /** Stream options forwarded per segment (defaults to playback:false, emitChunks:true). */
+  streamOptions?: TtsStreamOptions;
+  /** Generation options forwarded per segment. */
+  generationOptions?: TtsGenerationOptions;
+  /** Session-level event handler. */
+  onSessionEvent?: (event: SessionEvent) => void;
+  /** Segment-level event handler. */
+  onSegmentEvent?: (event: SegmentEvent) => void;
+  /** Metrics callback, fired on queue depth changes. */
+  onMetrics?: (metrics: IncrementalMetrics) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Engine interface
+// ---------------------------------------------------------------------------
+
+export interface IncrementalStreamingTtsEngine {
+  readonly sessionId: SessionId;
+  readonly state: SessionState;
+
+  /** Push incremental text. May trigger auto-segmentation. */
+  pushText(text: string): void;
+
+  /** Force-commit the current buffer as a segment. */
+  commit(options?: CommitOptions): void;
+
+  /** Commit remainder and wait until all segments are processed. */
+  flush(options?: FlushOptions): Promise<void>;
+
+  /** Cancel generation. */
+  cancel(options?: CancelOptions): Promise<void>;
+
+  /** Current metrics snapshot. */
+  getMetrics(): IncrementalMetrics;
+
+  /** Destroy engine and release resources. */
+  destroy(): Promise<void>;
+}

--- a/src/tts/incremental/types.ts
+++ b/src/tts/incremental/types.ts
@@ -2,9 +2,14 @@ import type {
   TtsGenerationOptions,
   TtsStreamOptions,
   TtsStreamChunk,
+  TtsStreamHandlers,
+  TtsStreamToFileOptions,
+  TtsStreamToFileHandlers,
   TTSInitializeOptions,
+  TTSModelInfo,
 } from '../types';
 import type { StreamingTtsEngine } from '../streamingTypes';
+import type { PcmPlayer } from '../../pcm/types';
 import type { ModelPathConfig } from '../../types';
 
 // ---------------------------------------------------------------------------
@@ -179,6 +184,70 @@ export interface CancelOptions {
 }
 
 // ---------------------------------------------------------------------------
+// Per-request options (optional overrides for a single request)
+// ---------------------------------------------------------------------------
+
+export interface IncrementalRequestOptions {
+  /** Override factory-level segmentation policy for this request. */
+  segmentation?: SegmentationPolicy;
+  /** Override factory-level queue policy for this request. */
+  queue?: QueuePolicy;
+}
+
+// ---------------------------------------------------------------------------
+// Per-request handlers (extend streaming handlers with incremental events)
+// ---------------------------------------------------------------------------
+
+export interface IncrementalStreamHandlers extends TtsStreamHandlers {
+  onSessionEvent?: (event: SessionEvent) => void;
+  onSegmentEvent?: (event: SegmentEvent) => void;
+  onMetrics?: (metrics: IncrementalMetrics) => void;
+}
+
+export interface IncrementalStreamToFileHandlers
+  extends TtsStreamToFileHandlers {
+  onSessionEvent?: (event: SessionEvent) => void;
+  onSegmentEvent?: (event: SegmentEvent) => void;
+  onMetrics?: (metrics: IncrementalMetrics) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Controllers (per-request, returned by generate* methods)
+// ---------------------------------------------------------------------------
+
+export interface IncrementalStreamController {
+  /** Push incremental text. May trigger auto-segmentation. */
+  pushText(text: string): void;
+  /** Force-commit the current buffer as a segment. */
+  commit(options?: CommitOptions): void;
+  /** Commit remainder and wait until all segments are processed. */
+  flush(options?: FlushOptions): Promise<void>;
+  /** Cancel generation. */
+  cancel(options?: CancelOptions): Promise<void>;
+  /** Current metrics snapshot. */
+  getMetrics(): IncrementalMetrics;
+  /** Player proxy over active segment player. Only when playback: true. */
+  readonly player: PcmPlayer | null;
+  /** Current session state. */
+  readonly state: SessionState;
+}
+
+export interface IncrementalStreamFileController {
+  /** Push incremental text. May trigger auto-segmentation. */
+  pushText(text: string): void;
+  /** Force-commit the current buffer as a segment. */
+  commit(options?: CommitOptions): void;
+  /** Commit remainder and wait until all segments are processed. */
+  flush(options?: FlushOptions): Promise<void>;
+  /** Cancel generation. */
+  cancel(options?: CancelOptions): Promise<void>;
+  /** Current metrics snapshot. */
+  getMetrics(): IncrementalMetrics;
+  /** Current session state. */
+  readonly state: SessionState;
+}
+
+// ---------------------------------------------------------------------------
 // Factory options
 // ---------------------------------------------------------------------------
 
@@ -186,48 +255,51 @@ export type IncrementalStreamingTtsSource =
   | { engine: StreamingTtsEngine }
   | { engineOptions: TTSInitializeOptions | ModelPathConfig };
 
-export interface IncrementalStreamingTtsOptions {
+export interface IncrementalStreamingTtsFactoryOptions {
   /** Existing streaming engine or options to create one. */
   source: IncrementalStreamingTtsSource;
-  /** Segmentation policy for auto-detecting boundaries. */
+  /** Default segmentation policy (can be overridden per request). */
   segmentation?: SegmentationPolicy;
-  /** Queue policy for segment flow control. */
+  /** Default queue policy (can be overridden per request). */
   queue?: QueuePolicy;
-  /** Stream options forwarded per segment (defaults to playback:false, emitChunks:true). */
-  streamOptions?: TtsStreamOptions;
-  /** Generation options forwarded per segment. */
-  generationOptions?: TtsGenerationOptions;
-  /** Session-level event handler. */
-  onSessionEvent?: (event: SessionEvent) => void;
-  /** Segment-level event handler. */
-  onSegmentEvent?: (event: SegmentEvent) => void;
-  /** Metrics callback, fired on queue depth changes. */
-  onMetrics?: (metrics: IncrementalMetrics) => void;
 }
 
 // ---------------------------------------------------------------------------
-// Engine interface
+// Engine interface (factory-level, mirrors StreamingTtsEngine pattern)
 // ---------------------------------------------------------------------------
 
 export interface IncrementalStreamingTtsEngine {
-  readonly sessionId: SessionId;
-  readonly state: SessionState;
+  readonly instanceId: string;
 
-  /** Push incremental text. May trigger auto-segmentation. */
-  pushText(text: string): void;
+  /**
+   * Start an incremental streaming speech request with native playback.
+   * Returns a controller for pushing text, committing, flushing, and cancelling.
+   * Only one active request at a time.
+   */
+  generateIncrementalSpeechStream(
+    options: TtsGenerationOptions | undefined,
+    handlers: IncrementalStreamHandlers,
+    streamOptions?: TtsStreamOptions,
+    incrementalOptions?: IncrementalRequestOptions
+  ): IncrementalStreamController;
 
-  /** Force-commit the current buffer as a segment. */
-  commit(options?: CommitOptions): void;
+  /**
+   * Start an incremental streaming speech request writing to a file.
+   * Returns a controller for pushing text, committing, flushing, and cancelling.
+   * Only one active request at a time.
+   */
+  generateIncrementalSpeechStreamToFile(
+    options: TtsGenerationOptions | undefined,
+    fileOptions: TtsStreamToFileOptions,
+    handlers: IncrementalStreamToFileHandlers,
+    incrementalOptions?: IncrementalRequestOptions
+  ): IncrementalStreamFileController;
 
-  /** Commit remainder and wait until all segments are processed. */
-  flush(options?: FlushOptions): Promise<void>;
+  /** Model sample rate and number of speakers. */
+  getModelInfo(): Promise<TTSModelInfo>;
+  getSampleRate(): Promise<number>;
+  getNumSpeakers(): Promise<number>;
 
-  /** Cancel generation. */
-  cancel(options?: CancelOptions): Promise<void>;
-
-  /** Current metrics snapshot. */
-  getMetrics(): IncrementalMetrics;
-
-  /** Destroy engine and release resources. */
+  /** Release native TTS resources. Do not use the engine after this. */
   destroy(): Promise<void>;
 }

--- a/src/tts/incremental/types.ts
+++ b/src/tts/incremental/types.ts
@@ -281,7 +281,8 @@ export interface IncrementalStreamingTtsEngine {
   readonly instanceId: string;
 
   /**
-   * Start an incremental streaming speech request with native playback.
+   * Start an incremental streaming speech request (same `TtsStreamOptions` defaults as
+   * `generateSpeechStream`: playback false, emitChunks true when `streamOptions` is omitted).
    * Returns a controller for pushing text, committing, flushing, and cancelling.
    * Only one active request at a time.
    */

--- a/src/tts/incremental/types.ts
+++ b/src/tts/incremental/types.ts
@@ -5,6 +5,7 @@ import type {
   TtsStreamHandlers,
   TtsStreamToFileOptions,
   TtsStreamToFileHandlers,
+  TtsStreamFileEnd,
   TTSInitializeOptions,
   TTSModelInfo,
 } from '../types';
@@ -209,6 +210,14 @@ export interface IncrementalStreamToFileHandlers
   onSessionEvent?: (event: SessionEvent) => void;
   onSegmentEvent?: (event: SegmentEvent) => void;
   onMetrics?: (metrics: IncrementalMetrics) => void;
+  /**
+   * Called for each segment after it has been written to its own file.
+   * Because each segment is written to a unique path, use this to collect
+   * the per-segment file paths (e.g. for later concatenation).
+   */
+  onSegmentFileEnd?: (
+    event: TtsStreamFileEnd & { segmentId: SegmentId }
+  ) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tts/index.ts
+++ b/src/tts/index.ts
@@ -611,8 +611,13 @@ export type { StreamingTtsEngine } from './streamingTypes';
 export { createIncrementalStreamingTTS } from './incremental';
 export type {
   IncrementalStreamingTtsEngine,
-  IncrementalStreamingTtsOptions,
+  IncrementalStreamingTtsFactoryOptions,
   IncrementalStreamingTtsSource,
+  IncrementalStreamController,
+  IncrementalStreamFileController,
+  IncrementalStreamHandlers,
+  IncrementalStreamToFileHandlers,
+  IncrementalRequestOptions,
   IncrementalMetrics,
   SessionId,
   SegmentId,

--- a/src/tts/index.ts
+++ b/src/tts/index.ts
@@ -607,6 +607,28 @@ export function saveAudioFromPCM(
 export { createStreamingTTS } from './streaming';
 export type { StreamingTtsEngine } from './streamingTypes';
 
+// Incremental streaming TTS (higher-level: progressive text feeding + auto-segmentation)
+export { createIncrementalStreamingTTS } from './incremental';
+export type {
+  IncrementalStreamingTtsEngine,
+  IncrementalStreamingTtsOptions,
+  IncrementalStreamingTtsSource,
+  IncrementalMetrics,
+  SessionId,
+  SegmentId,
+  SessionState,
+  SegmentationPolicy,
+  QueuePolicy,
+  QueueMode,
+  OverflowStrategy,
+  CommitOptions,
+  FlushOptions,
+  CancelOptions,
+  CancelScope,
+  SessionEvent,
+  SegmentEvent,
+} from './incremental';
+
 export {
   alignTextToAudio,
   alignTextToTtsSink,


### PR DESCRIPTION
Eight correctness issues in the incremental TTS engine and its documentation, surfaced in code review.

## Engine fixes

- **`latest-wins` drop metrics**: segments dropped by `latest-wins` now emit `reason: 'replaced'` and increment `totalSegmentsReplaced` instead of `totalSegmentsDropped`
- **`cancel({ scope: 'queued' })` lifetime**: no longer prematurely ends the request — only drops queued segments/clears the buffer; `activeRequest` is held until `flush()` or `cancel({ scope: 'all' })`
- **`flush()` after `cancel()` double-fire**: `flushImpl` returns early when state is `'cancelled'`, preventing a second `onEnd`/`completeRequest()` emission
- **`commitImpl` force semantics**: `commit({ force: false })` now respects `minCharsPerSegment` and boundary rules, leaving unmatched text in the buffer; `commit()` / `commit({ force: true })` retain existing forced behaviour
- **`destroy()` leaks**: tracks `activeSessionCancel`; `destroy()` now awaits it to cancel any in-flight native stream before returning
- **File mode segment overwrite**: each segment now writes to a unique path derived from the caller-supplied base (`out_0.wav`, `out_1.wav`, …); `IncrementalStreamToFileHandlers` gains an `onSegmentFileEnd` callback with per-segment file metadata

```ts
const ctrl = inc.generateIncrementalSpeechStreamToFile(opts, fileOptions, {
  onSegmentFileEnd({ segmentId, path, bytesWritten }) {
    segmentFiles.push(path); // collect for later concatenation
  },
});
```

## Docs

- Quick-start table: corrected default for `generateIncrementalSpeechStream` to `playback: true, emitChunks: false` (matches implementation)
- Spelling: "enqueing" → "enqueueing"

## Tests

Added/strengthened test cases for all fixed behaviours: `commit({ force: false })`, `destroy()` with an active request, `flush()` after `cancel()` (no double events), and `cancel({ scope: 'queued' })` state assertions.