### PR TITLE
Refactor/rework stt detection

### DIFF
--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SOURCES
     jni/model_detect/tts/sherpa-onnx-model-detect-tts.cpp
     jni/model_detect/tts/sherpa-onnx-validate-tts.cpp
     jni/model_detect/tts/sherpa-onnx-tts-wrapper.cpp
+    jni/model_detect/enhancement/sherpa-onnx-enhancement-catalog-metadata.cpp
     jni/model_detect/enhancement/sherpa-onnx-model-detect-enhancement.cpp
     jni/model_detect/enhancement/sherpa-onnx-validate-enhancement.cpp
     jni/model_detect/enhancement/sherpa-onnx-enhancement-wrapper.cpp

--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -86,6 +86,7 @@ set(SOURCES
     jni/model_detect/common/sherpa-onnx-model-detect-helper.cpp
     jni/model_detect/common/sherpa-onnx-detect-jni-common.cpp
     jni/model_detect/common/sherpa-onnx-catalog-metadata.cpp
+    jni/model_detect/stt/sherpa-onnx-stt-catalog-metadata.cpp
     jni/model_detect/stt/sherpa-onnx-model-detect-stt.cpp
     jni/model_detect/stt/sherpa-onnx-validate-stt.cpp
     jni/model_detect/stt/sherpa-onnx-stt-wrapper.cpp

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-detect.h
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-detect.h
@@ -271,6 +271,12 @@ struct EnhancementDetectResult {
     std::vector<DetectedModel> detectedModels;
     EnhancementModelKind selectedKind = EnhancementModelKind::kUnknown;
     EnhancementModelPaths paths;
+    /** Ordered trace of detection mechanisms (see DetectionSource). */
+    std::vector<DetectionSource> detectionSources;
+    /** Heuristic languages from asset/folder name; currently usually empty for enhancement. */
+    std::vector<std::string> derivedLanguages;
+    /** fp16, int8, int8-quantized, unknown — from asset/folder name heuristics. */
+    std::string quantization;
 };
 
 struct AlignmentDetectResult {
@@ -340,9 +346,16 @@ TtsDetectResult DetectTtsModelFromFileList(
     const std::string& modelType = "auto"
 );
 
+/**
+ * Enhancement model detection. Pass at least one of `model_dir` or `asset_name`.
+ * - `model_dir`: absolute path to extracted model (full file scan when directory exists).
+ * - `asset_name`: release asset stem / folder basename; enables name-only detection when no directory.
+ * When both are set, directory scan is used and derived catalog metadata uses `asset_name`.
+ */
 EnhancementDetectResult DetectEnhancementModel(
-    const std::string& modelDir,
-    const std::string& modelType
+    const std::optional<std::string>& model_dir,
+    const std::optional<std::string>& asset_name,
+    const std::string& modelType = "auto"
 );
 
 AlignmentDetectResult DetectAlignmentModel(

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-detect.h
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-detect.h
@@ -239,6 +239,12 @@ struct SttDetectResult {
     SttModelKind selectedKind = SttModelKind::kUnknown;
     bool tokensRequired = true;
     SttModelPaths paths;
+    /** Ordered trace of detection mechanisms (see DetectionSource). */
+    std::vector<DetectionSource> detectionSources;
+    /** Heuristic languages from asset/folder name (release id stem); not from model files. */
+    std::vector<std::string> derivedLanguages;
+    /** fp16, int8, int8-quantized, unknown — from asset/folder name heuristics. */
+    std::string quantization;
 };
 
 struct TtsDetectResult {
@@ -281,10 +287,17 @@ struct AlignmentDetectResult {
     std::string quantization;
 };
 
+/**
+ * STT model detection. Pass at least one of `model_dir` or `asset_name`.
+ * - `model_dir`: absolute path to extracted model (full file scan when directory exists).
+ * - `asset_name`: release asset stem / folder basename (name-only detection when no directory).
+ * When both are set, directory scan is used and derived catalog metadata uses `asset_name`.
+ */
 SttDetectResult DetectSttModel(
-    const std::string& modelDir,
-    const std::optional<bool>& preferInt8,
-    const std::optional<std::string>& modelType,
+    const std::optional<std::string>& model_dir,
+    const std::optional<std::string>& asset_name,
+    const std::string& modelType = "auto",
+    const std::optional<bool>& preferInt8 = std::nullopt,
     bool debug = false
 );
 
@@ -295,8 +308,8 @@ SttDetectResult DetectSttModel(
 SttDetectResult DetectSttModelFromFileList(
     const std::vector<model_detect::FileEntry>& files,
     const std::string& modelDir,
-    const std::optional<bool>& preferInt8 = std::nullopt,
-    const std::optional<std::string>& modelType = std::nullopt
+    const std::string& modelType = "auto",
+    const std::optional<bool>& preferInt8 = std::nullopt
 );
 
 /**

--- a/android/src/main/cpp/jni/model_detect/enhancement/sherpa-onnx-enhancement-catalog-metadata.cpp
+++ b/android/src/main/cpp/jni/model_detect/enhancement/sherpa-onnx-enhancement-catalog-metadata.cpp
@@ -1,0 +1,21 @@
+/**
+ * sherpa-onnx-enhancement-catalog-metadata.cpp
+ *
+ * Thin enhancement-specific wrapper around shared catalog metadata heuristics.
+ */
+#include "sherpa-onnx-enhancement-catalog-metadata.h"
+#include "sherpa-onnx-catalog-metadata.h"
+
+namespace sherpaonnx {
+
+void FillEnhancementDerivedCatalogMetadata(EnhancementDetectResult& r, const std::string& idForHeuristics) {
+    std::string ignoredSizeTier;
+    FillDerivedCatalogMetadata(r.derivedLanguages, r.quantization, ignoredSizeTier, idForHeuristics);
+}
+
+void FillEnhancementDerivedCatalogMetadataUsingModelDirBasename(EnhancementDetectResult& r, const std::string& modelDir) {
+    std::string ignoredSizeTier;
+    FillDerivedCatalogMetadataFromBasename(r.derivedLanguages, r.quantization, ignoredSizeTier, modelDir);
+}
+
+} // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/enhancement/sherpa-onnx-enhancement-catalog-metadata.h
+++ b/android/src/main/cpp/jni/model_detect/enhancement/sherpa-onnx-enhancement-catalog-metadata.h
@@ -1,0 +1,17 @@
+#ifndef SHERPA_ONNX_ENHANCEMENT_CATALOG_METADATA_H
+#define SHERPA_ONNX_ENHANCEMENT_CATALOG_METADATA_H
+
+#include "sherpa-onnx-model-detect.h"
+#include <string>
+
+namespace sherpaonnx {
+
+/** Heuristic languages / quantization from a catalog id or folder basename (no filesystem). */
+void FillEnhancementDerivedCatalogMetadata(EnhancementDetectResult& r, const std::string& idForHeuristics);
+
+/** Same as FillEnhancementDerivedCatalogMetadata using the last path segment of modelDir. */
+void FillEnhancementDerivedCatalogMetadataUsingModelDirBasename(EnhancementDetectResult& r, const std::string& modelDir);
+
+} // namespace sherpaonnx
+
+#endif // SHERPA_ONNX_ENHANCEMENT_CATALOG_METADATA_H

--- a/android/src/main/cpp/jni/model_detect/enhancement/sherpa-onnx-enhancement-wrapper.cpp
+++ b/android/src/main/cpp/jni/model_detect/enhancement/sherpa-onnx-enhancement-wrapper.cpp
@@ -1,6 +1,7 @@
 #include "sherpa-onnx-enhancement-wrapper.h"
 
 #include "sherpa-onnx-detect-jni-common.h"
+#include "sherpa-onnx-model-detect.h"
 
 namespace sherpaonnx {
 namespace {
@@ -48,6 +49,28 @@ jobject EnhancementDetectResultToJava(
     env->DeleteLocalRef(keyDetected);
     env->DeleteLocalRef(detectedList);
   }
+
+  std::vector<std::string> detectionSourceStrings;
+  detectionSourceStrings.reserve(result.detectionSources.size());
+  for (DetectionSource s : result.detectionSources) {
+    detectionSourceStrings.emplace_back(DetectionSourceToLiteral(s));
+  }
+  jobject detectionSourcesList = BuildStringList(env, detectionSourceStrings);
+  if (detectionSourcesList) {
+    jstring keyDetectionSources = env->NewStringUTF("detectionSources");
+    env->CallObjectMethod(map, mapPut, keyDetectionSources, detectionSourcesList);
+    env->DeleteLocalRef(keyDetectionSources);
+    env->DeleteLocalRef(detectionSourcesList);
+  }
+
+  jobject derivedLangs = BuildStringList(env, result.derivedLanguages);
+  if (derivedLangs) {
+    jstring keyLang = env->NewStringUTF("languages");
+    env->CallObjectMethod(map, mapPut, keyLang, derivedLangs);
+    env->DeleteLocalRef(keyLang);
+    env->DeleteLocalRef(derivedLangs);
+  }
+  PutString(env, map, mapPut, "quantization", result.quantization);
 
   jclass hashMapClass = env->FindClass("java/util/HashMap");
   if (hashMapClass) {

--- a/android/src/main/cpp/jni/model_detect/enhancement/sherpa-onnx-model-detect-enhancement.cpp
+++ b/android/src/main/cpp/jni/model_detect/enhancement/sherpa-onnx-model-detect-enhancement.cpp
@@ -1,10 +1,12 @@
 #include "sherpa-onnx-model-detect.h"
 #include "sherpa-onnx-model-detect-helper.h"
+#include "sherpa-onnx-enhancement-catalog-metadata.h"
 #include "sherpa-onnx-validate-enhancement.h"
 
 #include <optional>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 namespace {
 
@@ -16,12 +18,93 @@ sherpaonnx::EnhancementModelKind ParseEnhancementModelType(const std::string& mo
     return sherpaonnx::EnhancementModelKind::kUnknown;
 }
 
+const char* EnhancementKindToTag(sherpaonnx::EnhancementModelKind kind) {
+    switch (kind) {
+        case sherpaonnx::EnhancementModelKind::kGtcrn:
+            return "gtcrn";
+        case sherpaonnx::EnhancementModelKind::kDpdfNet:
+            return "dpdfnet";
+        default:
+            return "unknown";
+    }
+}
+
+void AppendUniqueDetectionSource(
+    std::vector<sherpaonnx::DetectionSource>& out,
+    sherpaonnx::DetectionSource s
+) {
+    if (std::find(out.begin(), out.end(), s) == out.end()) {
+        out.push_back(s);
+    }
+}
+
+std::vector<sherpaonnx::EnhancementModelKind> GetKindsFromDirNameEnhancement(
+    const std::string& modelDir
+) {
+    std::vector<sherpaonnx::EnhancementModelKind> out;
+    size_t pos = modelDir.find_last_of("/\\");
+    std::string base = (pos == std::string::npos) ? modelDir : modelDir.substr(pos + 1);
+    std::string lower = ToLower(base);
+
+    auto add = [&out](sherpaonnx::EnhancementModelKind k) {
+        if (std::find(out.begin(), out.end(), k) == out.end()) {
+            out.push_back(k);
+        }
+    };
+
+    if (lower.find("gtcrn") != std::string::npos) {
+        add(sherpaonnx::EnhancementModelKind::kGtcrn);
+    }
+    if (lower.find("dpdfnet") != std::string::npos || lower.find("dpcrn") != std::string::npos) {
+        add(sherpaonnx::EnhancementModelKind::kDpdfNet);
+    }
+    return out;
+}
+
 sherpaonnx::EnhancementDetectResult DetectEnhancementModelFromFiles(
     const std::vector<FileEntry>& files,
     const std::string& modelDir,
     const std::string& modelType
 ) {
     sherpaonnx::EnhancementDetectResult result;
+
+    const std::string requestedModelType = modelType.empty() ? "auto" : modelType;
+
+    if (files.empty()) {
+        AppendUniqueDetectionSource(result.detectionSources, sherpaonnx::DetectionSource::kNameOnly);
+        std::vector<sherpaonnx::EnhancementModelKind> nameKinds =
+            GetKindsFromDirNameEnhancement(modelDir);
+        for (sherpaonnx::EnhancementModelKind k : nameKinds) {
+            result.detectedModels.push_back({EnhancementKindToTag(k), modelDir});
+        }
+        static constexpr const char* kNameOnlyErr =
+            "Enhancement: Name-only detection cannot validate files; run a full directory scan before createEnhancement.";
+        if (requestedModelType != "auto") {
+            sherpaonnx::EnhancementModelKind selected = ParseEnhancementModelType(requestedModelType);
+            if (selected == sherpaonnx::EnhancementModelKind::kUnknown) {
+                result.error = "Enhancement: unknown model type: " + requestedModelType;
+                return result;
+            }
+            AppendUniqueDetectionSource(result.detectionSources, sherpaonnx::DetectionSource::kExplicitModelType);
+            result.selectedKind = selected;
+            result.detectedModels.clear();
+            result.detectedModels.push_back({EnhancementKindToTag(selected), modelDir});
+            result.ok = false;
+            result.error = kNameOnlyErr;
+            return result;
+        }
+        if (nameKinds.empty()) {
+            result.error = "Enhancement: no model type inferred from directory name (name-only mode).";
+            return result;
+        }
+        result.selectedKind = nameKinds[0];
+        AppendUniqueDetectionSource(result.detectionSources, sherpaonnx::DetectionSource::kDirName);
+        result.ok = false;
+        result.error = kNameOnlyErr;
+        return result;
+    }
+
+    AppendUniqueDetectionSource(result.detectionSources, sherpaonnx::DetectionSource::kFileListing);
 
     const std::string gtcrnModel =
         FindOnnxByAnyToken(files, {"gtcrn"}, std::nullopt);
@@ -36,18 +119,40 @@ sherpaonnx::EnhancementDetectResult DetectEnhancementModelFromFiles(
     }
 
     sherpaonnx::EnhancementModelKind selected = sherpaonnx::EnhancementModelKind::kUnknown;
-    if (modelType == "auto" || modelType.empty()) {
-        if (!gtcrnModel.empty()) {
+    if (requestedModelType == "auto") {
+        std::vector<sherpaonnx::EnhancementModelKind> nameKinds =
+            GetKindsFromDirNameEnhancement(modelDir);
+        bool selectedFromDir = false;
+        if (!nameKinds.empty()) {
+            for (const auto kind : nameKinds) {
+                if (kind == sherpaonnx::EnhancementModelKind::kGtcrn && !gtcrnModel.empty()) {
+                    selected = kind;
+                    selectedFromDir = true;
+                    break;
+                }
+                if (kind == sherpaonnx::EnhancementModelKind::kDpdfNet && !dpdfnetModel.empty()) {
+                    selected = kind;
+                    selectedFromDir = true;
+                    break;
+                }
+            }
+        }
+        if (selectedFromDir) {
+            AppendUniqueDetectionSource(result.detectionSources, sherpaonnx::DetectionSource::kDirName);
+        } else if (!gtcrnModel.empty()) {
             selected = sherpaonnx::EnhancementModelKind::kGtcrn;
+            AppendUniqueDetectionSource(result.detectionSources, sherpaonnx::DetectionSource::kFallbackOrder);
         } else if (!dpdfnetModel.empty()) {
             selected = sherpaonnx::EnhancementModelKind::kDpdfNet;
+            AppendUniqueDetectionSource(result.detectionSources, sherpaonnx::DetectionSource::kFallbackOrder);
         }
     } else {
-        selected = ParseEnhancementModelType(modelType);
+        selected = ParseEnhancementModelType(requestedModelType);
         if (selected == sherpaonnx::EnhancementModelKind::kUnknown) {
-            result.error = "Enhancement: unknown model type: " + modelType;
+            result.error = "Enhancement: unknown model type: " + requestedModelType;
             return result;
         }
+        AppendUniqueDetectionSource(result.detectionSources, sherpaonnx::DetectionSource::kExplicitModelType);
     }
 
     switch (selected) {
@@ -82,10 +187,30 @@ namespace sherpaonnx {
 using namespace model_detect;
 
 EnhancementDetectResult DetectEnhancementModel(
-    const std::string& modelDir,
+    const std::optional<std::string>& model_dir_opt,
+    const std::optional<std::string>& asset_name_opt,
     const std::string& modelType
 ) {
     EnhancementDetectResult result;
+
+    const bool has_dir = model_dir_opt && !model_dir_opt->empty();
+    const bool has_asset = asset_name_opt && !asset_name_opt->empty();
+    const std::string requestedModelType = modelType.empty() ? "auto" : modelType;
+
+    if (!has_dir && !has_asset) {
+        result.error = "Enhancement: modelDir and assetName are both empty";
+        return result;
+    }
+
+    if (!has_dir && has_asset) {
+        const std::string& assetName = *asset_name_opt;
+        const std::string syntheticDir = std::string("m/") + assetName;
+        result = DetectEnhancementModelFromFiles({}, syntheticDir, requestedModelType);
+        FillEnhancementDerivedCatalogMetadata(result, assetName);
+        return result;
+    }
+
+    const std::string& modelDir = *model_dir_opt;
 
     if (modelDir.empty()) {
         result.error = "Enhancement: model directory is empty";
@@ -99,7 +224,13 @@ EnhancementDetectResult DetectEnhancementModel(
     }
 
     const std::vector<model_detect::FileEntry> files = ListFilesRecursive(modelDir, 4);
-    return DetectEnhancementModelFromFiles(files, modelDir, modelType);
+    result = DetectEnhancementModelFromFiles(files, modelDir, requestedModelType);
+    if (has_asset) {
+        FillEnhancementDerivedCatalogMetadata(result, *asset_name_opt);
+    } else {
+        FillEnhancementDerivedCatalogMetadataUsingModelDirBasename(result, modelDir);
+    }
+    return result;
 }
 
 // Test-only: used by host-side model_detect_test; not used in production.

--- a/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-model-detect-stt.cpp
+++ b/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-model-detect-stt.cpp
@@ -33,6 +33,7 @@
  */
 #include "sherpa-onnx-model-detect.h"
 #include "sherpa-onnx-model-detect-helper.h"
+#include "sherpa-onnx-stt-catalog-metadata.h"
 #include "sherpa-onnx-validate-stt.h"
 #include <cstdio>
 #include <cstdlib>
@@ -239,6 +240,19 @@ static std::vector<SttModelKind> GetKindsFromDirName(const std::string& modelDir
 
     return out;
 }
+
+static void AppendUniqueDetectionSource(std::vector<DetectionSource>& out, DetectionSource s) {
+    if (std::find(out.begin(), out.end(), s) == out.end()) {
+        out.push_back(s);
+    }
+}
+
+enum class SttResolutionSource {
+    kUnknown,
+    kExplicitModelType,
+    kDirName,
+    kFallbackOrder,
+};
 
 static SttCandidatePaths GatherSttCandidatePaths(
     const std::vector<model_detect::FileEntry>& files,
@@ -509,14 +523,18 @@ static void CollectDetectedModels(
 }
 
 static SttModelKind ResolveSttKind(
-    const std::optional<std::string>& modelType,
+    const std::string& modelType,
     const SttCapabilities& cap,
     const SttPathHints& hints,
     const SttCandidatePaths& paths,
     const std::string& modelDir,
+    SttResolutionSource* outSource,
     std::string& outError
 ) {
     outError.clear();
+    if (outSource != nullptr) {
+        *outSource = SttResolutionSource::kUnknown;
+    }
     if (hints.isLikelyVad) {
         outError = "VAD models are not yet supported by the React Native SDK.";
         return SttModelKind::kUnknown;
@@ -525,10 +543,10 @@ static SttModelKind ResolveSttKind(
         outError = "TDNN (keyword/yesno) models are not yet supported by the React Native SDK.";
         return SttModelKind::kUnknown;
     }
-    if (modelType.has_value() && modelType.value() != "auto") {
-        SttModelKind selected = ParseSttModelType(modelType.value());
+    if (modelType != "auto") {
+        SttModelKind selected = ParseSttModelType(modelType);
         if (selected == SttModelKind::kUnknown) {
-            outError = "Unknown model type: " + modelType.value();
+            outError = "Unknown model type: " + modelType;
             return SttModelKind::kUnknown;
         }
         if (selected == SttModelKind::kTransducer && !cap.hasTransducer) {
@@ -601,6 +619,9 @@ static SttModelKind ResolveSttKind(
             outError = "Tone CTC model requested but path does not contain 'tone' (as a word), 't-one', or 't_one' (e.g. sherpa-onnx-streaming-t-one-*) in " + modelDir;
             return SttModelKind::kUnknown;
         }
+        if (outSource != nullptr) {
+            *outSource = SttResolutionSource::kExplicitModelType;
+        }
         return selected;
     }
 
@@ -608,41 +629,53 @@ static SttModelKind ResolveSttKind(
     std::vector<SttModelKind> nameCandidates = GetKindsFromDirName(modelDir);
     if (!nameCandidates.empty()) {
         for (SttModelKind k : nameCandidates) {
-            if (CapabilitySupportsKind(k, cap, hints, paths))
+            if (CapabilitySupportsKind(k, cap, hints, paths)) {
+                if (outSource != nullptr) {
+                    *outSource = SttResolutionSource::kDirName;
+                }
                 return k;
+            }
         }
         // Name hinted at a model type but no candidate had required files; fall through to file-only.
     }
 
     // Fallback: no name-based candidates, or none supported – use file-only detection order.
+    auto returnFallback = [outSource](SttModelKind kind) {
+        if (outSource != nullptr) {
+            *outSource = SttResolutionSource::kFallbackOrder;
+        }
+        return kind;
+    };
     if (cap.hasTransducer) {
-        return (hints.isLikelyNemo || hints.isLikelyTdt) ? SttModelKind::kNemoTransducer : SttModelKind::kTransducer;
+        return returnFallback((hints.isLikelyNemo || hints.isLikelyTdt)
+                                  ? SttModelKind::kNemoTransducer
+                                  : SttModelKind::kTransducer);
     }
-    if (hints.isLikelyMoonshine && cap.hasMoonshineV2) return SttModelKind::kMoonshineV2;
-    if (hints.isLikelyMoonshine && cap.hasMoonshine) return SttModelKind::kMoonshine;
+    if (hints.isLikelyMoonshine && cap.hasMoonshineV2) return returnFallback(SttModelKind::kMoonshineV2);
+    if (hints.isLikelyMoonshine && cap.hasMoonshine) return returnFallback(SttModelKind::kMoonshine);
     if (!paths.ctcModel.empty() && (hints.isLikelyToneCtc || hints.isLikelyNemo || hints.isLikelyWenetCtc || hints.isLikelySenseVoice)) {
-        if (hints.isLikelyToneCtc) return SttModelKind::kToneCtc;
-        if (hints.isLikelyNemo) return SttModelKind::kNemoCtc;
-        if (hints.isLikelyWenetCtc) return SttModelKind::kWenetCtc;
-        return SttModelKind::kSenseVoice;
+        if (hints.isLikelyToneCtc) return returnFallback(SttModelKind::kToneCtc);
+        if (hints.isLikelyNemo) return returnFallback(SttModelKind::kNemoCtc);
+        if (hints.isLikelyWenetCtc) return returnFallback(SttModelKind::kWenetCtc);
+        return returnFallback(SttModelKind::kSenseVoice);
     }
-    if (cap.hasFunAsrNano && hints.isLikelyFunAsrNano) return SttModelKind::kFunAsrNano;
-    if (cap.hasFireRedCtc) return SttModelKind::kZipformerCtc;
-    if (!paths.paraformerModel.empty()) return SttModelKind::kParaformer;
-    if (cap.hasCanary) return SttModelKind::kCanary;
-    if (cap.hasFireRedAsr) return SttModelKind::kFireRedAsr;
-    if (cap.hasQwen3Asr && hints.isLikelyQwen3Asr) return SttModelKind::kQwen3Asr;
-    if (cap.hasCohereTranscribe) return SttModelKind::kCohereTranscribe;
-    if (cap.hasWhisper) return SttModelKind::kWhisper;
-    if (cap.hasQwen3Asr) return SttModelKind::kQwen3Asr;
-    if (cap.hasFunAsrNano) return SttModelKind::kFunAsrNano;
-    if (cap.hasMoonshineV2) return SttModelKind::kMoonshineV2;
-    if (cap.hasDolphin) return SttModelKind::kDolphin;
-    if (cap.hasOmnilingual) return SttModelKind::kOmnilingual;
-    if (cap.hasMedAsr) return SttModelKind::kMedAsr;
-    if (cap.hasTeleSpeechCtc) return SttModelKind::kTeleSpeechCtc;
-    if (cap.hasToneCtc) return SttModelKind::kToneCtc;
-    if (!paths.ctcModel.empty()) return SttModelKind::kZipformerCtc;
+    if (cap.hasFunAsrNano && hints.isLikelyFunAsrNano) return returnFallback(SttModelKind::kFunAsrNano);
+    if (cap.hasFireRedCtc) return returnFallback(SttModelKind::kZipformerCtc);
+    if (!paths.paraformerModel.empty()) return returnFallback(SttModelKind::kParaformer);
+    if (cap.hasCanary) return returnFallback(SttModelKind::kCanary);
+    if (cap.hasFireRedAsr) return returnFallback(SttModelKind::kFireRedAsr);
+    if (cap.hasQwen3Asr && hints.isLikelyQwen3Asr) return returnFallback(SttModelKind::kQwen3Asr);
+    if (cap.hasCohereTranscribe) return returnFallback(SttModelKind::kCohereTranscribe);
+    if (cap.hasWhisper) return returnFallback(SttModelKind::kWhisper);
+    if (cap.hasQwen3Asr) return returnFallback(SttModelKind::kQwen3Asr);
+    if (cap.hasFunAsrNano) return returnFallback(SttModelKind::kFunAsrNano);
+    if (cap.hasMoonshineV2) return returnFallback(SttModelKind::kMoonshineV2);
+    if (cap.hasDolphin) return returnFallback(SttModelKind::kDolphin);
+    if (cap.hasOmnilingual) return returnFallback(SttModelKind::kOmnilingual);
+    if (cap.hasMedAsr) return returnFallback(SttModelKind::kMedAsr);
+    if (cap.hasTeleSpeechCtc) return returnFallback(SttModelKind::kTeleSpeechCtc);
+    if (cap.hasToneCtc) return returnFallback(SttModelKind::kToneCtc);
+    if (!paths.ctcModel.empty()) return returnFallback(SttModelKind::kZipformerCtc);
     return SttModelKind::kUnknown;
 }
 
@@ -726,44 +759,57 @@ static void ApplyPathsForSttKind(SttModelKind kind, const SttCandidatePaths& can
     }
 }
 
-} // namespace
-
-SttDetectResult DetectSttModel(
+/** Shared detection logic: runs on a pre-built file list. No filesystem listing. */
+static SttDetectResult DetectSttModelFromFiles(
+    const std::vector<model_detect::FileEntry>& files,
     const std::string& modelDir,
+    const std::string& modelType,
     const std::optional<bool>& preferInt8,
-    const std::optional<std::string>& modelType,
-    bool debug /* = false */
+    bool debug
 ) {
-    using namespace model_detect;
-
     SttDetectResult result;
 
-    LOGI("DetectSttModel: modelDir=%s, modelType=%s, preferInt8=%s",
-         modelDir.c_str(),
-         modelType.has_value() ? modelType->c_str() : "auto",
-         preferInt8.has_value() ? (preferInt8.value() ? "true" : "false") : "unset");
-
     if (modelDir.empty()) {
-        result.error = "Model directory is empty";
-        LOGE("%s", result.error.c_str());
+        result.error = "STT: Model directory is empty";
         return result;
     }
 
-    if (!FileExists(modelDir) || !IsDirectory(modelDir)) {
-        result.error = "Model directory does not exist or is not a directory: " + modelDir;
-        LOGE("%s", result.error.c_str());
-        return result;
-    }
+    const std::string requestedModelType = modelType.empty() ? "auto" : modelType;
 
-    // Depth 4 supports layouts like root/data/lang_bpe_500/tokens.txt (icefall, k2)
-    const int kMaxSearchDepth = 4;
-    const auto files = ListFilesRecursive(modelDir, kMaxSearchDepth);
-    if (debug) {
-        LOGI("DetectSttModel: Found %zu files in %s", files.size(), modelDir.c_str());
-        for (const auto& f : files) {
-            LOGI("  file: %s (size=%llu)", f.path.c_str(), (unsigned long long)f.size);
+    if (files.empty()) {
+        AppendUniqueDetectionSource(result.detectionSources, DetectionSource::kNameOnly);
+        std::vector<SttModelKind> nameKinds = GetKindsFromDirName(modelDir);
+        for (SttModelKind k : nameKinds) {
+            result.detectedModels.push_back({KindToName(k), modelDir});
         }
+        static constexpr const char* kNameOnlyErr =
+            "STT: Name-only detection cannot validate files; run a full directory scan before createSTT.";
+        if (requestedModelType != "auto") {
+            SttModelKind sel = ParseSttModelType(requestedModelType);
+            if (sel == SttModelKind::kUnknown) {
+                result.error = "STT: Unknown model type: " + requestedModelType;
+                return result;
+            }
+            AppendUniqueDetectionSource(result.detectionSources, DetectionSource::kExplicitModelType);
+            result.selectedKind = sel;
+            result.detectedModels.clear();
+            result.detectedModels.push_back({KindToName(sel), modelDir});
+            result.ok = false;
+            result.error = kNameOnlyErr;
+            return result;
+        }
+        if (nameKinds.empty()) {
+            result.error = "STT: No model type inferred from directory name (name-only mode).";
+            return result;
+        }
+        result.selectedKind = nameKinds[0];
+        AppendUniqueDetectionSource(result.detectionSources, DetectionSource::kDirName);
+        result.ok = false;
+        result.error = kNameOnlyErr;
+        return result;
     }
+
+    AppendUniqueDetectionSource(result.detectionSources, DetectionSource::kFileListing);
 
     SttCandidatePaths candidate = GatherSttCandidatePaths(files, modelDir, preferInt8);
     SttPathHints hints = GetSttPathHints(modelDir);
@@ -796,7 +842,29 @@ SttDetectResult DetectSttModel(
 
     CollectDetectedModels(result.detectedModels, cap, hints, candidate, modelDir);
 
-    result.selectedKind = ResolveSttKind(modelType, cap, hints, candidate, modelDir, result.error);
+    SttResolutionSource selectedFrom = SttResolutionSource::kUnknown;
+    result.selectedKind = ResolveSttKind(
+        requestedModelType,
+        cap,
+        hints,
+        candidate,
+        modelDir,
+        &selectedFrom,
+        result.error);
+    switch (selectedFrom) {
+        case SttResolutionSource::kExplicitModelType:
+            AppendUniqueDetectionSource(result.detectionSources, DetectionSource::kExplicitModelType);
+            break;
+        case SttResolutionSource::kDirName:
+            AppendUniqueDetectionSource(result.detectionSources, DetectionSource::kDirName);
+            break;
+        case SttResolutionSource::kFallbackOrder:
+            AppendUniqueDetectionSource(result.detectionSources, DetectionSource::kFallbackOrder);
+            break;
+        case SttResolutionSource::kUnknown:
+            break;
+    }
+
     if (result.selectedKind == SttModelKind::kUnknown) {
         if (IsHardwareSpecificModelDir(modelDir)) {
             result.ok = false;
@@ -812,8 +880,9 @@ SttDetectResult DetectSttModel(
         result.error = "No compatible model type detected in " + modelDir;
         LOGE("%s", result.error.c_str());
         if (debug) {
-            for (const auto& f : files)
+            for (const auto& f : files) {
                 LOGI("  file: %s (size=%llu)", f.path.c_str(), (unsigned long long)f.size);
+            }
         }
         return result;
     }
@@ -823,16 +892,8 @@ SttDetectResult DetectSttModel(
                              result.selectedKind != SttModelKind::kQwen3Asr);
     ApplyPathsForSttKind(result.selectedKind, candidate, result.paths);
 
-    if (!candidate.tokens.empty() && FileExists(candidate.tokens)) {
-        result.paths.tokens = candidate.tokens;
-    } else if (result.tokensRequired) {
-        result.error = "Tokens file not found in " + modelDir;
-        LOGE("%s", result.error.c_str());
-        return result;
-    }
-    if (!candidate.bpeVocab.empty() && FileExists(candidate.bpeVocab)) {
-        result.paths.bpeVocab = candidate.bpeVocab;
-    }
+    result.paths.tokens = candidate.tokens;
+    result.paths.bpeVocab = candidate.bpeVocab;
 
     auto validation = ValidateSttPaths(result.selectedKind, result.paths, modelDir);
     if (!validation.ok) {
@@ -899,59 +960,90 @@ SttDetectResult DetectSttModel(
     return result;
 }
 
-// Test-only: used by host-side model_detect_test; not used in production (Android/iOS use DetectSttModel).
-SttDetectResult DetectSttModelFromFileList(
-    const std::vector<model_detect::FileEntry>& files,
-    const std::string& modelDir,
+} // namespace
+
+SttDetectResult DetectSttModel(
+    const std::optional<std::string>& model_dir_opt,
+    const std::optional<std::string>& asset_name_opt,
+    const std::string& modelType,
     const std::optional<bool>& preferInt8,
-    const std::optional<std::string>& modelType
+    bool debug /* = false */
 ) {
     using namespace model_detect;
 
     SttDetectResult result;
 
-    if (modelDir.empty()) {
-        result.error = "Model directory is empty";
+    const bool has_dir = model_dir_opt && !model_dir_opt->empty();
+    const bool has_asset = asset_name_opt && !asset_name_opt->empty();
+    const std::string requestedModelType = modelType.empty() ? "auto" : modelType;
+
+    if (!has_dir && !has_asset) {
+        result.error = "STT: modelDir and assetName are both empty";
+        LOGE("%s", result.error.c_str());
         return result;
     }
 
-    SttCandidatePaths candidate = GatherSttCandidatePaths(files, modelDir, preferInt8);
-    SttPathHints hints = GetSttPathHints(modelDir);
-    ApplyQnnBinaryModel(files, modelDir, hints, candidate);
-    SttCapabilities cap = ComputeSttCapabilities(candidate, hints);
+    LOGI("DetectSttModel: has_dir=%d has_asset=%d modelType=%s preferInt8=%s",
+         static_cast<int>(has_dir),
+         static_cast<int>(has_asset),
+         requestedModelType.c_str(),
+         preferInt8.has_value() ? (preferInt8.value() ? "true" : "false") : "unset");
 
-    CollectDetectedModels(result.detectedModels, cap, hints, candidate, modelDir);
+    // Asset id only: name-only detection (no filesystem).
+    if (!has_dir && has_asset) {
+        const std::string& assetName = *asset_name_opt;
+        const std::string syntheticDir = std::string("m/") + assetName;
+        result = DetectSttModelFromFiles({}, syntheticDir, requestedModelType, preferInt8, debug);
+        FillSttDerivedCatalogMetadata(result, assetName);
+        LOGI("DetectSttModel: assetName-only path for %s", assetName.c_str());
+        return result;
+    }
 
-    result.selectedKind = ResolveSttKind(modelType, cap, hints, candidate, modelDir, result.error);
-    if (result.selectedKind == SttModelKind::kUnknown) {
-        if (IsHardwareSpecificModelDir(modelDir)) {
-            result.ok = false;
-            result.isHardwareSpecificUnsupported = true;
-            result.error = kHardwareSpecificUnsupportedMessage;
-            return result;
+    const std::string& modelDir = *model_dir_opt;
+
+    if (!FileExists(modelDir) || !IsDirectory(modelDir)) {
+        result.error = "STT: Model directory does not exist or is not a directory: " + modelDir;
+        LOGE("%s", result.error.c_str());
+        return result;
+    }
+
+    // Depth 4 supports layouts like root/data/lang_bpe_500/tokens.txt (icefall, k2)
+    const int kMaxSearchDepth = 4;
+    const auto files = ListFilesRecursive(modelDir, kMaxSearchDepth);
+    if (debug) {
+        LOGI("DetectSttModel: Found %zu files in %s", files.size(), modelDir.c_str());
+        for (const auto& f : files) {
+            LOGI("  file: %s (size=%llu)", f.path.c_str(), (unsigned long long)f.size);
         }
-        if (result.error.empty())
-            result.error = "No compatible model type detected in " + modelDir;
-        result.ok = false;
+    }
+
+    result = DetectSttModelFromFiles(files, modelDir, requestedModelType, preferInt8, debug);
+
+    if (has_asset) {
+        FillSttDerivedCatalogMetadata(result, *asset_name_opt);
+    } else {
+        FillSttDerivedCatalogMetadataUsingModelDirBasename(result, modelDir);
+    }
+
+    if (!result.ok) {
+        if (!result.error.empty()) {
+            LOGE("%s", result.error.c_str());
+        }
         return result;
     }
 
-    result.tokensRequired = (result.selectedKind != SttModelKind::kFunAsrNano &&
-                             result.selectedKind != SttModelKind::kQwen3Asr);
-    ApplyPathsForSttKind(result.selectedKind, candidate, result.paths);
-
-    result.paths.tokens = candidate.tokens;
-    result.paths.bpeVocab = candidate.bpeVocab;
-
-    auto validation = ValidateSttPaths(result.selectedKind, result.paths, modelDir);
-    if (!validation.ok) {
-        result.ok = false;
-        result.error = validation.error;
-        return result;
-    }
-
-    result.ok = true;
+    LOGI("DetectSttModel: detection OK for %s", modelDir.c_str());
     return result;
+}
+
+// Test-only: used by host-side model_detect_test; not used in production (Android/iOS use DetectSttModel).
+SttDetectResult DetectSttModelFromFileList(
+    const std::vector<model_detect::FileEntry>& files,
+    const std::string& modelDir,
+    const std::string& modelType,
+    const std::optional<bool>& preferInt8
+) {
+    return DetectSttModelFromFiles(files, modelDir, modelType, preferInt8, false);
 }
 
 } // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-stt-catalog-metadata.cpp
+++ b/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-stt-catalog-metadata.cpp
@@ -1,0 +1,21 @@
+/**
+ * sherpa-onnx-stt-catalog-metadata.cpp
+ *
+ * Thin STT-specific wrapper around shared catalog metadata heuristics.
+ */
+#include "sherpa-onnx-stt-catalog-metadata.h"
+#include "sherpa-onnx-catalog-metadata.h"
+
+namespace sherpaonnx {
+
+void FillSttDerivedCatalogMetadata(SttDetectResult& r, const std::string& idForHeuristics) {
+    std::string ignoredSizeTier;
+    FillDerivedCatalogMetadata(r.derivedLanguages, r.quantization, ignoredSizeTier, idForHeuristics);
+}
+
+void FillSttDerivedCatalogMetadataUsingModelDirBasename(SttDetectResult& r, const std::string& modelDir) {
+    std::string ignoredSizeTier;
+    FillDerivedCatalogMetadataFromBasename(r.derivedLanguages, r.quantization, ignoredSizeTier, modelDir);
+}
+
+} // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-stt-catalog-metadata.h
+++ b/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-stt-catalog-metadata.h
@@ -1,0 +1,17 @@
+#ifndef SHERPA_ONNX_STT_CATALOG_METADATA_H
+#define SHERPA_ONNX_STT_CATALOG_METADATA_H
+
+#include "sherpa-onnx-model-detect.h"
+#include <string>
+
+namespace sherpaonnx {
+
+/** Heuristic languages / quantization from a catalog id or folder basename (no filesystem). */
+void FillSttDerivedCatalogMetadata(SttDetectResult& r, const std::string& idForHeuristics);
+
+/** Same as FillSttDerivedCatalogMetadata using the last path segment of modelDir. */
+void FillSttDerivedCatalogMetadataUsingModelDirBasename(SttDetectResult& r, const std::string& modelDir);
+
+} // namespace sherpaonnx
+
+#endif // SHERPA_ONNX_STT_CATALOG_METADATA_H

--- a/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-stt-wrapper.cpp
+++ b/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-stt-wrapper.cpp
@@ -64,6 +64,24 @@ jobject SttDetectResultToJava(JNIEnv* env, const SttDetectResult& result) {
     env->DeleteLocalRef(detectedList);
   }
 
+  std::vector<std::string> detectionSourceStrings;
+  detectionSourceStrings.reserve(result.detectionSources.size());
+  for (DetectionSource s : result.detectionSources) {
+    detectionSourceStrings.emplace_back(DetectionSourceToLiteral(s));
+  }
+  jobject detectionSourcesList = BuildStringList(env, detectionSourceStrings);
+  if (detectionSourcesList) {
+    env->CallObjectMethod(map, mapPut, env->NewStringUTF("detectionSources"), detectionSourcesList);
+    env->DeleteLocalRef(detectionSourcesList);
+  }
+
+  jobject derivedLangsList = BuildStringList(env, result.derivedLanguages);
+  if (derivedLangsList) {
+    env->CallObjectMethod(map, mapPut, env->NewStringUTF("languages"), derivedLangsList);
+    env->DeleteLocalRef(derivedLangsList);
+  }
+  PutString(env, map, mapPut, "quantization", result.quantization);
+
   jclass hashMapClass = env->FindClass("java/util/HashMap");
   if (hashMapClass) {
     jobject pathsMap = env->NewObject(hashMapClass, mapInit);

--- a/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-stt-wrapper.cpp
+++ b/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-stt-wrapper.cpp
@@ -60,7 +60,9 @@ jobject SttDetectResultToJava(JNIEnv* env, const SttDetectResult& result) {
 
   jobject detectedList = BuildDetectedModelsList(env, result.detectedModels);
   if (detectedList) {
-    env->CallObjectMethod(map, mapPut, env->NewStringUTF("detectedModels"), detectedList);
+    jstring keyDetected = env->NewStringUTF("detectedModels");
+    env->CallObjectMethod(map, mapPut, keyDetected, detectedList);
+    env->DeleteLocalRef(keyDetected);
     env->DeleteLocalRef(detectedList);
   }
 
@@ -71,13 +73,17 @@ jobject SttDetectResultToJava(JNIEnv* env, const SttDetectResult& result) {
   }
   jobject detectionSourcesList = BuildStringList(env, detectionSourceStrings);
   if (detectionSourcesList) {
-    env->CallObjectMethod(map, mapPut, env->NewStringUTF("detectionSources"), detectionSourcesList);
+    jstring keyDetectionSources = env->NewStringUTF("detectionSources");
+    env->CallObjectMethod(map, mapPut, keyDetectionSources, detectionSourcesList);
+    env->DeleteLocalRef(keyDetectionSources);
     env->DeleteLocalRef(detectionSourcesList);
   }
 
   jobject derivedLangsList = BuildStringList(env, result.derivedLanguages);
   if (derivedLangsList) {
-    env->CallObjectMethod(map, mapPut, env->NewStringUTF("languages"), derivedLangsList);
+    jstring keyLangs = env->NewStringUTF("languages");
+    env->CallObjectMethod(map, mapPut, keyLangs, derivedLangsList);
+    env->DeleteLocalRef(keyLangs);
     env->DeleteLocalRef(derivedLangsList);
   }
   PutString(env, map, mapPut, "quantization", result.quantization);
@@ -119,7 +125,9 @@ jobject SttDetectResultToJava(JNIEnv* env, const SttDetectResult& result) {
       PutString(env, pathsMap, mapPut, "canaryEncoder", result.paths.canaryEncoder);
       PutString(env, pathsMap, mapPut, "canaryDecoder", result.paths.canaryDecoder);
       PutString(env, pathsMap, mapPut, "bpeVocab", result.paths.bpeVocab);
-      env->CallObjectMethod(map, mapPut, env->NewStringUTF("paths"), pathsMap);
+      jstring keyPaths = env->NewStringUTF("paths");
+      env->CallObjectMethod(map, mapPut, keyPaths, pathsMap);
+      env->DeleteLocalRef(keyPaths);
       env->DeleteLocalRef(pathsMap);
     }
   }

--- a/android/src/main/cpp/jni/module/sherpa-onnx-module-jni.cpp
+++ b/android/src/main/cpp/jni/module/sherpa-onnx-module-jni.cpp
@@ -213,23 +213,33 @@ Java_com_sherpaonnx_SherpaOnnxModule_nativeDetectTtsModel(
   return sherpaonnx::TtsDetectResultToJava(env, result);
 }
 
-// Detect enhancement model in directory. Returns HashMap with success, error, detectedModels, modelType, paths.
+// Detect enhancement model from optional directory and/or asset name. Returns HashMap with unified detect fields.
 JNIEXPORT jobject JNICALL
 Java_com_sherpaonnx_SherpaOnnxModule_nativeDetectEnhancementModel(
     JNIEnv* env,
     jobject /* this */,
     jstring j_model_dir,
+    jstring j_asset_name,
     jstring j_model_type) {
-  const char* model_dir_c = env->GetStringUTFChars(j_model_dir, nullptr);
+  std::optional<std::string> model_dir;
+  std::optional<std::string> asset_name;
+  if (j_model_dir) {
+    const char* c = env->GetStringUTFChars(j_model_dir, nullptr);
+    if (c && c[0] != '\0') model_dir = std::string(c);
+    env->ReleaseStringUTFChars(j_model_dir, c);
+  }
+  if (j_asset_name) {
+    const char* c = env->GetStringUTFChars(j_asset_name, nullptr);
+    if (c && c[0] != '\0') asset_name = std::string(c);
+    env->ReleaseStringUTFChars(j_asset_name, c);
+  }
   const char* model_type_c =
       j_model_type ? env->GetStringUTFChars(j_model_type, nullptr) : nullptr;
-  std::string model_dir(model_dir_c ? model_dir_c : "");
   std::string model_type(model_type_c ? model_type_c : "auto");
-  env->ReleaseStringUTFChars(j_model_dir, model_dir_c);
   if (model_type_c) env->ReleaseStringUTFChars(j_model_type, model_type_c);
 
   sherpaonnx::EnhancementDetectResult result =
-      sherpaonnx::DetectEnhancementModel(model_dir, model_type);
+      sherpaonnx::DetectEnhancementModel(model_dir, asset_name, model_type);
   return sherpaonnx::EnhancementDetectResultToJava(env, result);
 }
 

--- a/android/src/main/cpp/jni/module/sherpa-onnx-module-jni.cpp
+++ b/android/src/main/cpp/jni/module/sherpa-onnx-module-jni.cpp
@@ -147,28 +147,41 @@ Java_com_sherpaonnx_SherpaOnnxModule_nativeHasNnapiAccelerator(JNIEnv* /* env */
 #endif
 }
 
-// Detect STT model in directory. Returns HashMap with success, error, detectedModels, modelType, paths.
+// Detect STT model from optional directory and/or asset name. Returns HashMap with unified detect fields.
 JNIEXPORT jobject JNICALL
 Java_com_sherpaonnx_SherpaOnnxModule_nativeDetectSttModel(
     JNIEnv* env,
     jobject /* this */,
     jstring j_model_dir,
+    jstring j_asset_name,
+    jstring j_model_type,
     jboolean j_prefer_int8,
     jboolean j_has_prefer_int8,
-    jstring j_model_type,
     jboolean j_debug) {
-  const char* model_dir_c = env->GetStringUTFChars(j_model_dir, nullptr);
+  std::optional<std::string> model_dir;
+  std::optional<std::string> asset_name;
+  if (j_model_dir) {
+    const char* c = env->GetStringUTFChars(j_model_dir, nullptr);
+    if (c && c[0] != '\0') model_dir = std::string(c);
+    env->ReleaseStringUTFChars(j_model_dir, c);
+  }
+  if (j_asset_name) {
+    const char* c = env->GetStringUTFChars(j_asset_name, nullptr);
+    if (c && c[0] != '\0') asset_name = std::string(c);
+    env->ReleaseStringUTFChars(j_asset_name, c);
+  }
   const char* model_type_c = j_model_type ? env->GetStringUTFChars(j_model_type, nullptr) : nullptr;
-  std::string model_dir(model_dir_c ? model_dir_c : "");
+  std::string model_type(model_type_c ? model_type_c : "auto");
   std::optional<bool> prefer_int8;
   if (j_has_prefer_int8) prefer_int8 = (j_prefer_int8 == JNI_TRUE);
-  std::optional<std::string> model_type_opt;
-  if (model_type_c && model_type_c[0] != '\0') model_type_opt = std::string(model_type_c);
-  env->ReleaseStringUTFChars(j_model_dir, model_dir_c);
   if (model_type_c) env->ReleaseStringUTFChars(j_model_type, model_type_c);
 
   sherpaonnx::SttDetectResult result = sherpaonnx::DetectSttModel(
-      model_dir, prefer_int8, model_type_opt, (j_debug == JNI_TRUE));
+      model_dir,
+      asset_name,
+      model_type,
+      prefer_int8,
+      (j_debug == JNI_TRUE));
   return sherpaonnx::SttDetectResultToJava(env, result);
 }
 

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxEnhancementHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxEnhancementHelper.kt
@@ -21,7 +21,11 @@ import java.util.concurrent.ConcurrentHashMap
 
 internal class SherpaOnnxEnhancementHelper(
   private val context: ReactApplicationContext,
-  private val nativeDetectEnhancementModel: (modelDir: String, modelType: String) -> HashMap<String, Any>?
+  private val nativeDetectEnhancementModel: (
+    modelDir: String?,
+    assetName: String?,
+    modelType: String
+  ) -> HashMap<String, Any>?
 ) {
   private data class EnhancementInstance(
     @Volatile var denoiser: OfflineSpeechDenoiser? = null
@@ -84,11 +88,12 @@ internal class SherpaOnnxEnhancementHelper(
 
   fun detectEnhancementModel(
     modelDir: String,
+    assetName: String?,
     modelType: String?,
     promise: Promise
   ) {
     try {
-      val result = nativeDetectEnhancementModel(modelDir, modelType ?: "auto")
+      val result = nativeDetectEnhancementModel(modelDir, assetName, modelType ?: "auto")
       if (result == null) {
         promise.reject("DETECT_ERROR", "Enhancement model detection returned null")
         return
@@ -97,6 +102,10 @@ internal class SherpaOnnxEnhancementHelper(
       val detectedModels = result["detectedModels"] as? ArrayList<*>
         ?: arrayListOf<HashMap<String, String>>()
       val modelTypeStr = result["modelType"] as? String
+      val detectionSources = result["detectionSources"] as? ArrayList<*>
+      val languages = result["languages"] as? ArrayList<*>
+      val quantization = result["quantization"] as? String
+      val error = result["error"] as? String
 
       val resultMap = Arguments.createMap()
       resultMap.putBoolean("success", success)
@@ -114,11 +123,29 @@ internal class SherpaOnnxEnhancementHelper(
       if (modelTypeStr != null) {
         resultMap.putString("modelType", modelTypeStr)
       }
-      if (!success) {
-        val error = result["error"] as? String
-        if (!error.isNullOrBlank()) {
-          resultMap.putString("error", error)
+      if (!error.isNullOrBlank()) {
+        resultMap.putString("error", error)
+      }
+      if (detectionSources != null && detectionSources.isNotEmpty()) {
+        val sourceArray = Arguments.createArray()
+        for (source in detectionSources) {
+          if (source is String && source.isNotBlank()) {
+            sourceArray.pushString(source)
+          }
         }
+        resultMap.putArray("detectionSources", sourceArray)
+      }
+      if (languages != null && languages.isNotEmpty()) {
+        val languagesArray = Arguments.createArray()
+        for (lang in languages) {
+          if (lang is String && lang.isNotBlank()) {
+            languagesArray.pushString(lang)
+          }
+        }
+        resultMap.putArray("languages", languagesArray)
+      }
+      if (!quantization.isNullOrBlank()) {
+        resultMap.putString("quantization", quantization)
       }
       promise.resolve(resultMap)
     } catch (e: Exception) {
@@ -137,7 +164,7 @@ internal class SherpaOnnxEnhancementHelper(
     promise: Promise
   ) {
     try {
-      val result = nativeDetectEnhancementModel(modelDir, modelType ?: "auto")
+      val result = nativeDetectEnhancementModel(modelDir, null, modelType ?: "auto")
       if (result == null || result["success"] as? Boolean != true) {
         val reason = result?.get("error") as? String ?: "Failed to detect enhancement model"
         promise.reject("ENHANCEMENT_INIT_ERROR", reason)

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -79,7 +79,7 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
   )
   private val enhancementHelper = SherpaOnnxEnhancementHelper(
     reactApplicationContext,
-    { modelDir, modelType -> Companion.nativeDetectEnhancementModel(modelDir, modelType) }
+    { modelDir, assetName, modelType -> Companion.nativeDetectEnhancementModel(modelDir, assetName, modelType) }
   )
   private val archiveHelper = SherpaOnnxArchiveHelper()
   private var pcmCapture: SherpaOnnxPcmCapture? = null
@@ -1201,10 +1201,11 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
 
   override fun detectEnhancementModel(
     modelDir: String,
+    assetName: String?,
     modelType: String?,
     promise: Promise
   ) {
-    enhancementHelper.detectEnhancementModel(modelDir, modelType, promise)
+    enhancementHelper.detectEnhancementModel(modelDir, assetName, modelType, promise)
   }
 
   override fun detectAlignmentModel(
@@ -1514,9 +1515,13 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
       modelType: String?,
     ): HashMap<String, Any>?
 
-    /** Model detection for speech enhancement: returns HashMap with success, error, detectedModels, modelType, paths. */
+    /** Model detection for speech enhancement: optional directory and/or asset name. */
     @JvmStatic
-    private external fun nativeDetectEnhancementModel(modelDir: String, modelType: String): HashMap<String, Any>?
+    private external fun nativeDetectEnhancementModel(
+      modelDir: String?,
+      assetName: String?,
+      modelType: String
+    ): HashMap<String, Any>?
 
     /** Model detection for subtitles/alignment: returns HashMap with success, error, detectedModels, modelType, paths. */
     @JvmStatic

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -49,8 +49,8 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
   private val assetHelper = SherpaOnnxAssetHelper(reactApplicationContext, NAME)
   private val sttHelper = SherpaOnnxSttHelper(
     reactApplicationContext,
-    { modelDir, preferInt8, hasPreferInt8, modelType, debug ->
-      Companion.nativeDetectSttModel(modelDir, preferInt8, hasPreferInt8, modelType, debug)
+    { modelDir, assetName, modelType, preferInt8, hasPreferInt8, debug ->
+      Companion.nativeDetectSttModel(modelDir, assetName, modelType, preferInt8, hasPreferInt8, debug)
     },
     NAME
   )
@@ -404,17 +404,20 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
    */
   override fun detectSttModel(
     modelDir: String,
-    preferInt8: Boolean?,
+    assetName: String?,
     modelType: String?,
+    preferInt8: Boolean?,
+    debug: Boolean?,
     promise: Promise
   ) {
     try {
       val result = Companion.nativeDetectSttModel(
         modelDir,
+        assetName,
+        modelType ?: "auto",
         preferInt8 ?: false,
         preferInt8 != null,
-        modelType ?: "auto",
-        false
+        debug ?: false
       )
       if (result == null) {
         android.util.Log.e(NAME, "DETECT_ERROR: STT model detection returned null")
@@ -426,6 +429,10 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
       val detectedModels = result["detectedModels"] as? ArrayList<*>
         ?: arrayListOf<HashMap<String, String>>()
       val modelTypeStr = result["modelType"] as? String
+      val detectionSources = result["detectionSources"] as? ArrayList<*>
+      val languages = result["languages"] as? ArrayList<*>
+      val quantization = result["quantization"] as? String
+      val error = result["error"] as? String
 
       val resultMap = Arguments.createMap()
       resultMap.putBoolean("success", success)
@@ -444,11 +451,29 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
       if (modelTypeStr != null) {
         resultMap.putString("modelType", modelTypeStr)
       }
-      if (!success) {
-        val error = result["error"] as? String
-        if (!error.isNullOrBlank()) {
-          resultMap.putString("error", error)
+      if (!error.isNullOrBlank()) {
+        resultMap.putString("error", error)
+      }
+      if (detectionSources != null && detectionSources.isNotEmpty()) {
+        val sourceArray = Arguments.createArray()
+        for (source in detectionSources) {
+          if (source is String && source.isNotBlank()) {
+            sourceArray.pushString(source)
+          }
         }
+        resultMap.putArray("detectionSources", sourceArray)
+      }
+      if (languages != null && languages.isNotEmpty()) {
+        val languagesArray = Arguments.createArray()
+        for (lang in languages) {
+          if (lang is String && lang.isNotBlank()) {
+            languagesArray.pushString(lang)
+          }
+        }
+        resultMap.putArray("languages", languagesArray)
+      }
+      if (!quantization.isNullOrBlank()) {
+        resultMap.putString("quantization", quantization)
       }
       promise.resolve(resultMap)
     } catch (e: Exception) {
@@ -1473,10 +1498,11 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     /** Model detection for STT: returns HashMap with success, error, detectedModels, modelType, paths (for Kotlin API config). */
     @JvmStatic
     private external fun nativeDetectSttModel(
-      modelDir: String,
+      modelDir: String?,
+      assetName: String?,
+      modelType: String,
       preferInt8: Boolean,
       hasPreferInt8: Boolean,
-      modelType: String,
       debug: Boolean
     ): HashMap<String, Any>?
 

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxSttHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxSttHelper.kt
@@ -37,10 +37,11 @@ import java.util.concurrent.ConcurrentHashMap
 internal class SherpaOnnxSttHelper(
   private val context: Context,
   private val detectSttModel: (
-    modelDir: String,
+    modelDir: String?,
+    assetName: String?,
+    modelType: String,
     preferInt8: Boolean,
     hasPreferInt8: Boolean,
-    modelType: String,
     debug: Boolean
   ) -> HashMap<String, Any>?,
   private val logTag: String
@@ -202,9 +203,10 @@ internal class SherpaOnnxSttHelper(
 
       val result = detectSttModel(
         modelDir,
+        null,
+        modelType ?: "auto",
         preferInt8 ?: false,
         preferInt8 != null,
-        modelType ?: "auto",
         debug ?: false
       )
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -181,6 +181,26 @@ The TurboModule methods **`batchTtsCatalogHints`** and **`nativeBatchTtsCatalogH
 
 Android and iOS share one native TTS detection implementation. The result map may include **`detectionSources`**: an array of short strings (`fileListing`, `dirName`, `fallbackOrder`, `explicitModelType`, `nameOnly`) describing how the primary model kind was chosen. TypeScript exposes this as optional **`detectionSources?: readonly DetectionSource[]`** on **`detectTtsModel`**. Existing callers can ignore it; narrowing uses **`isDetectionSource`** when parsing unknown payloads.
 
+## STT and Speech Enhancement: model detection (TTS-aligned)
+
+Native detection for **STT** and **Speech Enhancement** now follows the same pattern as **TTS**: optional **`modelDir`** + optional **`assetName`** (at least one required), shared **catalog name heuristics** (**`languages`**, **`quantization`** on the wire), optional **`detectionSources`**, and a **name-only** branch when there is no directory scan ( **`success: false`** until a real folder is used for init — same idea as TTS).
+
+### TurboModule / `NativeSherpaOnnx`
+
+| Method | Before (typical) | After |
+| --- | --- | --- |
+| **`detectSttModel`** | `(modelDir, preferInt8?, modelType?)` | `(modelDir, assetName \| null, modelType?, preferInt8?, debug?)` |
+| **`detectEnhancementModel`** | `(modelDir, modelType?)` | `(modelDir, assetName \| null, modelType?)` |
+
+### Public JS facades (`…/stt`, `…/enhancement`)
+
+| API | Before | After |
+| --- | --- | --- |
+| **`detectSttModel`** | `options`: `preferInt8`, `modelType` only | Also optional **`assetName`** (overrides basename derived from `modelPath.path`), **`debug`**. Result adds optional **`detectionSources`**, **`quantization`**, and **`languages`** as **`PublicLanguageHint[]`** (native raw strings normalized via `resolvePublicLanguageHints`). |
+| **`detectEnhancementModel`** | `options`: `modelType` only | Also optional **`assetName`**. Result adds optional **`detectionSources`**, **`languages`**, **`quantization`** (same shared catalog pipeline as TTS/STT). |
+
+Direct TurboModule callers should pass **`null`** for **`assetName`** when unused. Facades derive a default **`assetName`** from the last segment of **`modelPath.path`** when you omit **`options.assetName`**.
+
 ## Unified TTS `saveAudio` (replacing `saveAudioToFile` / `saveAudioToContentUri`)
 
 The module-level helpers **`saveAudioToFile`** and **`saveAudioToContentUri`** are removed. Use **`saveAudio`** with an explicit target:

--- a/docs/speech-enhancement.md
+++ b/docs/speech-enhancement.md
@@ -15,33 +15,59 @@ import {
   createStreamingEnhancement,
   detectEnhancementModel,
   ENHANCEMENT_MODEL_TYPES,
+  type EnhancementDetectResult,
   type EnhancementInitializeOptions,
 } from 'react-native-sherpa-onnx/enhancement';
 ```
 
 ## Model Detection
 
-Use detection before init when you want to show the detected architecture in UI.
+`ModelPathConfig` is imported from `react-native-sherpa-onnx` (same as TTS/STT): `{ type: 'asset' | 'file' | 'auto', path: string }`.
+
+### `detectEnhancementModel(modelPath, options?)`
 
 ```ts
-const detect = await detectEnhancementModel(
-  { type: 'file', path: '/absolute/path/to/model-dir' },
-  { modelType: 'auto' }
-);
-
-if (!detect.success) {
-  throw new Error(detect.error ?? 'Enhancement detection failed');
-}
-
-console.log(detect.modelType); // "gtcrn" | "dpdfnet"
+function detectEnhancementModel(
+  modelPath: ModelPathConfig,
+  options?: {
+    modelType?: EnhancementModelType | 'auto';
+    /** Release / catalog id for name heuristics when it differs from the folder basename (passed to native after `resolveModelPath`). */
+    assetName?: string;
+  }
+): Promise<EnhancementDetectResult>;
 ```
 
-Detection logic:
+`EnhancementDetectResult` extends the shared detection base (`success`, `error`, `detectedModels`, `modelType`, optional `languages`, `quantization`, `detectionSources`). It does **not** load the denoiser — use it as a **pre-check** before `createEnhancement` (same idea as `detectTtsModel`).
 
-- Scans the model directory recursively for `.onnx`
-- `*gtcrn*` filename -> `gtcrn`
-- `*dpdfnet*` filename -> `dpdfnet`
-- `auto` prefers `gtcrn` when both are present; otherwise selects `dpdfnet` if available
+**Rules (directory scan):**
+
+- Recursively finds `.onnx` under the resolved model directory (depth 4, same family as other detectors).
+- Filename / path contains `gtcrn` → candidate `gtcrn`; contains `dpdfnet` or `dpcrn` → candidate `dpdfnet`.
+- `modelType: 'auto'` (default): prefers **`gtcrn`** if both ONNX stacks are present, else **`dpdfnet`**.
+- **`assetName`**: optional. If omitted, native catalog hints use the **last segment** of `modelPath.path` (with common archive suffixes stripped). If set, that string wins for **languages** / **quantization** when both directory and asset id are passed to native.
+
+**`detectionSources`:** optional ordered trace (`fileListing`, `dirName`, `fallbackOrder`, `explicitModelType`, `nameOnly`). **`nameOnly`** means no file list was scanned (invalid paths for init until you run a full scan) — see native error text when `success` is false.
+
+```ts
+import { detectEnhancementModel } from 'react-native-sherpa-onnx/enhancement';
+
+const modelPath = { type: 'file' as const, path: '/absolute/path/to/enhancement-model-dir' };
+
+const det = await detectEnhancementModel(modelPath, { modelType: 'auto' });
+if (!det.success) {
+  throw new Error(det.error ?? 'Enhancement detection failed');
+}
+// det.modelType === 'gtcrn' | 'dpdfnet'
+// optional: det.languages, det.quantization, det.detectionSources
+```
+
+```ts
+// Same folder on disk, but release id for catalog hints differs from the folder name (e.g. download manager id):
+const det = await detectEnhancementModel(modelPath, {
+  modelType: 'auto',
+  assetName: 'sherpa-onnx-speech-enhancement-gtcrn-int8',
+});
+```
 
 ## Offline Enhancement
 
@@ -102,6 +128,7 @@ await streaming.destroy();
 Main types:
 
 - `EnhancementModelType = 'gtcrn' | 'dpdfnet'`
+- `EnhancementDetectResult` — return type of `detectEnhancementModel()` (alias of `EnhancementDetectModelResult` in `src/types/modelDetect.ts`)
 - `EnhancedAudio = { samples: Float32Array; sampleRate: number }`
 - `EnhancementInitializeOptions`
 - `EnhancementEngine`

--- a/ios/SherpaOnnx+Enhancement.mm
+++ b/ios/SherpaOnnx+Enhancement.mm
@@ -60,6 +60,23 @@ static NSDictionary *enhancementDetectResultToDict(const sherpaonnx::Enhancement
         @"detectedModels": detectedModelsArray,
         @"modelType": enhancementKindToNSString(result.selectedKind),
     } mutableCopy];
+    if (!result.detectionSources.empty()) {
+        NSMutableArray *sources = [NSMutableArray array];
+        for (const auto s : result.detectionSources) {
+            [sources addObject:[NSString stringWithUTF8String:sherpaonnx::DetectionSourceToLiteral(s)] ?: @""];
+        }
+        dict[@"detectionSources"] = sources;
+    }
+    if (!result.derivedLanguages.empty()) {
+        NSMutableArray *langs = [NSMutableArray array];
+        for (const auto& id : result.derivedLanguages) {
+            [langs addObject:[NSString stringWithUTF8String:id.c_str()] ?: @""];
+        }
+        dict[@"languages"] = langs;
+    }
+    if (!result.quantization.empty()) {
+        dict[@"quantization"] = [NSString stringWithUTF8String:result.quantization.c_str()] ?: @"";
+    }
     if (!result.ok && !result.error.empty()) {
         dict[@"error"] = [NSString stringWithUTF8String:result.error.c_str()] ?: @"Enhancement model detection failed";
     }
@@ -71,14 +88,22 @@ static NSDictionary *enhancementDetectResultToDict(const sherpaonnx::Enhancement
 @implementation SherpaOnnx (Enhancement)
 
 - (void)detectEnhancementModel:(NSString *)modelDir
+                     assetName:(NSString *)assetName
                      modelType:(NSString *)modelType
                        resolve:(RCTPromiseResolveBlock)resolve
                         reject:(RCTPromiseRejectBlock)reject
 {
     @try {
-        std::string modelDirStr = (modelDir != nil) ? [modelDir UTF8String] : "";
+        std::optional<std::string> modelDirOpt = std::nullopt;
+        if (modelDir != nil && [modelDir length] > 0) {
+            modelDirOpt = std::string([modelDir UTF8String]);
+        }
+        std::optional<std::string> assetNameOpt = std::nullopt;
+        if (assetName != nil && [assetName length] > 0) {
+            assetNameOpt = std::string([assetName UTF8String]);
+        }
         std::string modelTypeStr = (modelType != nil && [modelType length] > 0) ? [modelType UTF8String] : "auto";
-        auto result = sherpaonnx::DetectEnhancementModel(modelDirStr, modelTypeStr);
+        auto result = sherpaonnx::DetectEnhancementModel(modelDirOpt, assetNameOpt, modelTypeStr);
         resolve(enhancementDetectResultToDict(result));
     } @catch (NSException *exception) {
         reject(@"DETECT_ERROR",

--- a/ios/SherpaOnnx+STT.mm
+++ b/ios/SherpaOnnx+STT.mm
@@ -279,23 +279,32 @@ static NSDictionary *sttResultToDict(const sherpaonnx::SttRecognitionResult& r) 
 }
 
 - (void)detectSttModel:(NSString *)modelDir
-           preferInt8:(NSNumber *)preferInt8
+            assetName:(NSString *)assetName
             modelType:(NSString *)modelType
+           preferInt8:(NSNumber *)preferInt8
+                debug:(NSNumber *)debug
               resolve:(RCTPromiseResolveBlock)resolve
                reject:(RCTPromiseRejectBlock)reject
 {
-    RCTLogInfo(@"Detecting STT model in: %@", modelDir);
+    RCTLogInfo(@"Detecting STT model modelDir=%@ assetName=%@", modelDir, assetName);
     @try {
-        std::string modelDirStr = [modelDir UTF8String];
+        std::optional<std::string> modelDirOpt = std::nullopt;
+        if (modelDir != nil && [modelDir length] > 0) {
+            modelDirOpt = std::string([modelDir UTF8String]);
+        }
+        std::optional<std::string> assetNameOpt = std::nullopt;
+        if (assetName != nil && [assetName length] > 0) {
+            assetNameOpt = std::string([assetName UTF8String]);
+        }
         std::optional<bool> preferInt8Opt = std::nullopt;
         if (preferInt8 != nil) {
             preferInt8Opt = [preferInt8 boolValue];
         }
-        std::optional<std::string> modelTypeOpt = std::nullopt;
-        if (modelType != nil && [modelType length] > 0 && ![modelType isEqualToString:@"auto"]) {
-            modelTypeOpt = [modelType UTF8String];
-        }
-        sherpaonnx::SttDetectResult result = sherpaonnx::DetectSttModel(modelDirStr, preferInt8Opt, modelTypeOpt, false);
+        const std::string modelTypeStr =
+            (modelType != nil && [modelType length] > 0) ? [modelType UTF8String] : "auto";
+        const bool debugVal = (debug != nil && [debug boolValue]);
+        sherpaonnx::SttDetectResult result =
+            sherpaonnx::DetectSttModel(modelDirOpt, assetNameOpt, modelTypeStr, preferInt8Opt, debugVal);
 
         NSMutableDictionary *resultDict = [NSMutableDictionary dictionary];
         resultDict[@"success"] = @(result.ok);
@@ -312,6 +321,23 @@ static NSDictionary *sttResultToDict(const sherpaonnx::SttRecognitionResult& r) 
         }
         resultDict[@"detectedModels"] = detectedModelsArray;
         resultDict[@"modelType"] = sttModelKindToNSString(result.selectedKind);
+        if (!result.derivedLanguages.empty()) {
+            NSMutableArray *langs = [NSMutableArray array];
+            for (const auto& id : result.derivedLanguages) {
+                [langs addObject:[NSString stringWithUTF8String:id.c_str()]];
+            }
+            resultDict[@"languages"] = langs;
+        }
+        if (!result.quantization.empty()) {
+            resultDict[@"quantization"] = [NSString stringWithUTF8String:result.quantization.c_str()];
+        }
+        if (!result.detectionSources.empty()) {
+            NSMutableArray *sources = [NSMutableArray array];
+            for (const auto s : result.detectionSources) {
+                [sources addObject:[NSString stringWithUTF8String:sherpaonnx::DetectionSourceToLiteral(s)]];
+            }
+            resultDict[@"detectionSources"] = sources;
+        }
         resolve(resultDict);
     } @catch (NSException *exception) {
         NSString *errorMsg = [NSString stringWithFormat:@"STT model detection failed: %@", exception.reason];

--- a/ios/SherpaOnnx+STT.mm
+++ b/ios/SherpaOnnx+STT.mm
@@ -286,7 +286,7 @@ static NSDictionary *sttResultToDict(const sherpaonnx::SttRecognitionResult& r) 
               resolve:(RCTPromiseResolveBlock)resolve
                reject:(RCTPromiseRejectBlock)reject
 {
-    RCTLogInfo(@"Detecting STT model modelDir=%@ assetName=%@", modelDir, assetName);
+    RCTLogInfo(@"Detecting STT model: modelDir=%@ assetName=%@", modelDir, assetName);
     @try {
         std::optional<std::string> modelDirOpt = std::nullopt;
         if (modelDir != nil && [modelDir length] > 0) {

--- a/ios/enhancement/sherpa-onnx-enhancement-wrapper.mm
+++ b/ios/enhancement/sherpa-onnx-enhancement-wrapper.mm
@@ -82,7 +82,11 @@ EnhancementInitializeResult EnhancementWrapper::initialize(
         return result;
     }
 
-    auto detect = DetectEnhancementModel(modelDir, modelType);
+    auto detect = DetectEnhancementModel(
+        std::optional<std::string>(modelDir),
+        std::nullopt,
+        modelType
+    );
     result.detectedModels = detect.detectedModels;
     result.modelType = EnhancementKindToString(detect.selectedKind);
     if (!detect.ok) {
@@ -153,7 +157,11 @@ EnhancementInitializeResult OnlineEnhancementWrapper::initialize(
         return result;
     }
 
-    auto detect = DetectEnhancementModel(modelDir, modelType);
+    auto detect = DetectEnhancementModel(
+        std::optional<std::string>(modelDir),
+        std::nullopt,
+        modelType
+    );
     result.detectedModels = detect.detectedModels;
     result.modelType = EnhancementKindToString(detect.selectedKind);
     if (!detect.ok) {

--- a/ios/stt/sherpa-onnx-stt-wrapper.mm
+++ b/ios/stt/sherpa-onnx-stt-wrapper.mm
@@ -193,7 +193,14 @@ SttInitializeResult SttWrapper::initialize(
         config.feat_config.sample_rate = 16000;
         config.feat_config.feature_dim = 80;
 
-        auto detect = DetectSttModel(modelDir, preferInt8, modelType, debug);
+        const std::string detectModelType =
+            (modelType.has_value() && !modelType->empty()) ? *modelType : "auto";
+        auto detect = DetectSttModel(
+            std::optional<std::string>(modelDir),
+            std::nullopt,
+            detectModelType,
+            preferInt8,
+            debug);
         if (!detect.ok) {
             result.error = detect.error;
             LOGE("%s", result.error.c_str());

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -75,17 +75,20 @@ export interface Spec extends TurboModule {
 
   /**
    * Detect STT model type and structure without initializing the recognizer.
-   * Uses the same native file-based detection as initializeStt. Useful to show model-specific
-   * options before init or to query the type for a given path.
-   * @param modelDir - Absolute path to model directory (use resolveModelPath first for asset/file paths)
-   * @param preferInt8 - Optional: true = prefer int8, false = prefer regular, undefined = try int8 first
+   * Uses the same native detection logic as initializeStt.
+   * @param modelDir - Absolute path to extracted model directory, or empty string for asset-name-only detection.
+   * @param assetName - Release asset stem / folder basename (e.g. sherpa-onnx-whisper-tiny); null/empty when scanning modelDir only.
    * @param modelType - Optional: explicit type or 'auto' (default)
-   * @returns Object with success, detectedModels (array of { type, modelDir }), modelType (primary detected type), and optionally isHardwareSpecificUnsupported (true when the model is for unsupported hardware e.g. RK35xx, Ascend)
+   * @param preferInt8 - Optional: true = prefer int8, false = prefer regular, undefined = try int8 first
+   * @param debug - Optional: enable verbose native logging
+   * @returns Object with unified detect fields plus STT-specific `isHardwareSpecificUnsupported`.
    */
   detectSttModel(
     modelDir: string,
+    assetName: string | null,
+    modelType?: string | null,
     preferInt8?: boolean,
-    modelType?: string
+    debug?: boolean
   ): Promise<{
     success: boolean;
     /** Present when success is false (or native included a message). */
@@ -94,6 +97,12 @@ export interface Spec extends TurboModule {
     isHardwareSpecificUnsupported?: boolean;
     detectedModels: Array<{ type: string; modelDir: string }>;
     modelType?: string;
+    /** Raw heuristic language tags from asset/folder name (catalog). */
+    languages?: string[];
+    /** fp16, int8, int8-quantized, unknown — from name heuristics. */
+    quantization?: string;
+    /** Optional trace strings from native (see DetectionSource in src/types/modelDetect.ts). */
+    detectionSources?: string[];
   }>;
 
   /**

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -612,12 +612,16 @@ export interface Spec extends TurboModule {
 
   detectEnhancementModel(
     modelDir: string,
-    modelType?: string
+    assetName: string | null,
+    modelType?: string | null
   ): Promise<{
     success: boolean;
     error?: string;
     detectedModels: Array<{ type: string; modelDir: string }>;
     modelType?: string;
+    languages?: string[];
+    quantization?: string;
+    detectionSources?: string[];
   }>;
 
   initializeEnhancement(

--- a/src/enhancement/index.ts
+++ b/src/enhancement/index.ts
@@ -1,6 +1,6 @@
 import SherpaOnnx from '../NativeSherpaOnnx';
 import type { ModelPathConfig } from '../types';
-import { resolveModelPath } from '../utils';
+import { resolveModelPath, deriveAssetNameFromModelPath } from '../utils';
 import { resolvePublicLanguageHints } from '../model-languages';
 import { ModelCategory } from '../download/types';
 import { isDetectionSource } from './types';
@@ -14,20 +14,6 @@ import type {
 } from './types';
 
 let enhancementInstanceCounter = 0;
-
-function deriveAssetNameFromModelPath(
-  modelPath: ModelPathConfig
-): string | null {
-  const raw = modelPath.path?.trim();
-  if (!raw) return null;
-  const leaf = raw.split(/[\\/]/).filter(Boolean).pop();
-  if (!leaf) return null;
-  return leaf
-    .replace(/\.tar\.bz2$/i, '')
-    .replace(/\.tar\.gz$/i, '')
-    .replace(/\.tgz$/i, '')
-    .replace(/\.zip$/i, '');
-}
 
 function normalizeEnhancedAudio(raw: {
   samples?: number[] | Float32Array;

--- a/src/enhancement/index.ts
+++ b/src/enhancement/index.ts
@@ -1,7 +1,12 @@
 import SherpaOnnx from '../NativeSherpaOnnx';
 import type { ModelPathConfig } from '../types';
 import { resolveModelPath } from '../utils';
+import { resolvePublicLanguageHints } from '../model-languages';
+import { ModelCategory } from '../download/types';
+import { isDetectionSource } from './types';
 import type {
+  DetectedModelEntry,
+  DetectionSource,
   EnhancedAudio,
   EnhancementDetectResult,
   EnhancementEngine,
@@ -9,6 +14,20 @@ import type {
 } from './types';
 
 let enhancementInstanceCounter = 0;
+
+function deriveAssetNameFromModelPath(
+  modelPath: ModelPathConfig
+): string | null {
+  const raw = modelPath.path?.trim();
+  if (!raw) return null;
+  const leaf = raw.split(/[\\/]/).filter(Boolean).pop();
+  if (!leaf) return null;
+  return leaf
+    .replace(/\.tar\.bz2$/i, '')
+    .replace(/\.tar\.gz$/i, '')
+    .replace(/\.tgz$/i, '')
+    .replace(/\.zip$/i, '');
+}
 
 function normalizeEnhancedAudio(raw: {
   samples?: number[] | Float32Array;
@@ -25,21 +44,61 @@ function normalizeEnhancedAudio(raw: {
 
 export async function detectEnhancementModel(
   modelPath: ModelPathConfig,
-  options?: { modelType?: EnhancementInitializeOptions['modelType'] }
+  options?: {
+    modelType?: EnhancementInitializeOptions['modelType'];
+    assetName?: string;
+  }
 ): Promise<EnhancementDetectResult> {
   const resolvedPath = await resolveModelPath(modelPath);
+  const optionAssetName = options?.assetName?.trim();
+  const assetName =
+    optionAssetName && optionAssetName.length > 0
+      ? optionAssetName
+      : deriveAssetNameFromModelPath(modelPath);
   const raw = await SherpaOnnx.detectEnhancementModel(
     resolvedPath,
-    options?.modelType
+    assetName,
+    options?.modelType ?? null
   );
   const err = typeof raw.error === 'string' ? raw.error.trim() : '';
+  const detectedModels: DetectedModelEntry[] = (raw.detectedModels ?? []).map(
+    (m) => ({
+      type: m.type,
+      modelDir: m.modelDir,
+    })
+  );
+  const detectionSources: DetectionSource[] = [];
+  const rawSources = raw.detectionSources;
+  if (Array.isArray(rawSources)) {
+    for (const s of rawSources) {
+      if (typeof s === 'string' && isDetectionSource(s)) {
+        detectionSources.push(s);
+      }
+    }
+  }
+  const rawLanguageStrings =
+    Array.isArray(raw.languages) && raw.languages.length > 0
+      ? raw.languages.filter((x): x is string => typeof x === 'string')
+      : [];
+  const resolvedLanguages = resolvePublicLanguageHints({
+    domain: ModelCategory.Enhancement,
+    modelType: raw.modelType,
+    rawFromNative: rawLanguageStrings,
+  });
+  const quantization =
+    typeof raw.quantization === 'string' && raw.quantization.length > 0
+      ? raw.quantization
+      : undefined;
   return {
     success: raw.success,
     ...(err.length > 0 ? { error: err } : {}),
-    detectedModels: raw.detectedModels ?? [],
+    detectedModels,
     ...(raw.modelType != null && raw.modelType !== ''
       ? { modelType: raw.modelType }
       : {}),
+    ...(resolvedLanguages.length > 0 ? { languages: resolvedLanguages } : {}),
+    ...(quantization != null ? { quantization } : {}),
+    ...(detectionSources.length > 0 ? { detectionSources } : {}),
   };
 }
 

--- a/src/enhancement/types.ts
+++ b/src/enhancement/types.ts
@@ -1,4 +1,14 @@
 import type { ModelPathConfig } from '../types';
+import type { EnhancementDetectModelResult } from '../types/modelDetect';
+
+export {
+  DETECTION_SOURCES,
+  isDetectionSource,
+  type DetectionSource,
+  type DetectedModelEntry,
+  type EnhancementDetectModelResult,
+  type ModelDetectResultBase,
+} from '../types/modelDetect';
 
 export type EnhancementModelType = 'gtcrn' | 'dpdfnet';
 
@@ -20,12 +30,7 @@ export interface EnhancementInitializeOptions {
   debug?: boolean;
 }
 
-export type EnhancementDetectResult = {
-  success: boolean;
-  error?: string;
-  detectedModels: Array<{ type: string; modelDir: string }>;
-  modelType?: string;
-};
+export type EnhancementDetectResult = EnhancementDetectModelResult;
 
 export interface EnhancementEngine {
   readonly instanceId: string;

--- a/src/stt/index.ts
+++ b/src/stt/index.ts
@@ -8,7 +8,7 @@ import type {
   SttRuntimeConfig,
 } from './types';
 import type { ModelPathConfig } from '../types';
-import { resolveModelPath } from '../utils';
+import { resolveModelPath, deriveAssetNameFromModelPath } from '../utils';
 import { resolvePublicLanguageHints } from '../model-languages';
 import { ModelCategory } from '../download/types';
 import {
@@ -40,20 +40,6 @@ function normalizeSttResult(raw: {
     event: typeof raw.event === 'string' ? raw.event : '',
     durations: Array.isArray(raw.durations) ? (raw.durations as number[]) : [],
   };
-}
-
-function deriveAssetNameFromModelPath(
-  modelPath: ModelPathConfig
-): string | null {
-  const raw = modelPath.path?.trim();
-  if (!raw) return null;
-  const leaf = raw.split(/[\\/]/).filter(Boolean).pop();
-  if (!leaf) return null;
-  return leaf
-    .replace(/\.tar\.bz2$/i, '')
-    .replace(/\.tar\.gz$/i, '')
-    .replace(/\.tgz$/i, '')
-    .replace(/\.zip$/i, '');
 }
 
 /**

--- a/src/stt/index.ts
+++ b/src/stt/index.ts
@@ -9,11 +9,14 @@ import type {
 } from './types';
 import type { ModelPathConfig } from '../types';
 import { resolveModelPath } from '../utils';
-import {
-  resolvePublicLanguageHints,
-  type PublicLanguageHint,
-} from '../model-languages';
+import { resolvePublicLanguageHints } from '../model-languages';
 import { ModelCategory } from '../download/types';
+import {
+  isDetectionSource,
+  type DetectionSource,
+  type DetectedModelEntry,
+  type SttDetectModelResult,
+} from '../types/modelDetect';
 
 let sttInstanceCounter = 0;
 
@@ -39,12 +42,26 @@ function normalizeSttResult(raw: {
   };
 }
 
+function deriveAssetNameFromModelPath(
+  modelPath: ModelPathConfig
+): string | null {
+  const raw = modelPath.path?.trim();
+  if (!raw) return null;
+  const leaf = raw.split(/[\\/]/).filter(Boolean).pop();
+  if (!leaf) return null;
+  return leaf
+    .replace(/\.tar\.bz2$/i, '')
+    .replace(/\.tar\.gz$/i, '')
+    .replace(/\.tgz$/i, '')
+    .replace(/\.zip$/i, '');
+}
+
 /**
  * Detect STT model type and structure without initializing the recognizer.
  * Uses the same native file-based detection as createSTT. Stateless; no instance required.
  *
  * @param modelPath - Model path configuration (asset, file, or auto)
- * @param options - Optional preferInt8 and modelType (default: auto)
+ * @param options - Optional preferInt8/modelType plus optional assetName and debug flag
  * @returns Object with success, detectedModels (array of { type, modelDir }), modelType (primary detected type), optional **languages** (`iso6391Hint` for coarse tags; **`id`** for `modelOptions` where applicable), optional error when success is false, and optionally isHardwareSpecificUnsupported
  * @example
  * ```typescript
@@ -57,39 +74,68 @@ function normalizeSttResult(raw: {
  */
 export async function detectSttModel(
   modelPath: ModelPathConfig,
-  options?: { preferInt8?: boolean; modelType?: STTModelType }
-): Promise<{
-  success: boolean;
-  /** Native validation/detect failure. */
-  error?: string;
-  detectedModels: Array<{ type: string; modelDir: string }>;
-  modelType?: string;
-  /** Curated language rows: **`iso6391Hint`** for catalog-style tags; **`id`** for **`modelOptions`** (e.g. Fun-ASR `中文`). Omitted when unknown or empty. */
-  languages?: PublicLanguageHint[];
-  isHardwareSpecificUnsupported?: boolean;
-}> {
+  options?: {
+    preferInt8?: boolean;
+    modelType?: STTModelType;
+    assetName?: string;
+    debug?: boolean;
+  }
+): Promise<SttDetectModelResult> {
   const resolvedPath = await resolveModelPath(modelPath);
+  const optionAssetName = options?.assetName?.trim();
+  const assetName =
+    optionAssetName && optionAssetName.length > 0
+      ? optionAssetName
+      : deriveAssetNameFromModelPath(modelPath);
   const raw = await SherpaOnnx.detectSttModel(
     resolvedPath,
+    assetName,
+    options?.modelType ?? null,
     options?.preferInt8,
-    options?.modelType
+    options?.debug
   );
   const err = typeof raw.error === 'string' ? raw.error.trim() : '';
+  const detectedModels: DetectedModelEntry[] = (raw.detectedModels ?? []).map(
+    (m) => ({
+      type: m.type,
+      modelDir: m.modelDir,
+    })
+  );
   const modelType =
     raw.modelType != null && raw.modelType !== '' ? raw.modelType : undefined;
-  const languageHints =
-    raw.success && modelType != null
-      ? resolvePublicLanguageHints({ domain: ModelCategory.Stt, modelType })
+  const detectionSources: DetectionSource[] = [];
+  const rawSources = raw.detectionSources;
+  if (Array.isArray(rawSources)) {
+    for (const s of rawSources) {
+      if (typeof s === 'string' && isDetectionSource(s)) {
+        detectionSources.push(s);
+      }
+    }
+  }
+  const rawLanguageStrings =
+    Array.isArray(raw.languages) && raw.languages.length > 0
+      ? raw.languages.filter((x): x is string => typeof x === 'string')
       : [];
+  const resolvedLanguages = resolvePublicLanguageHints({
+    domain: ModelCategory.Stt,
+    modelType,
+    rawFromNative: rawLanguageStrings,
+  });
+  const quantization =
+    typeof raw.quantization === 'string' && raw.quantization.length > 0
+      ? raw.quantization
+      : undefined;
   return {
     success: raw.success,
     ...(err.length > 0 ? { error: err } : {}),
     ...(raw.isHardwareSpecificUnsupported === true
       ? { isHardwareSpecificUnsupported: true }
       : {}),
-    detectedModels: raw.detectedModels ?? [],
+    detectedModels,
     ...(modelType != null ? { modelType } : {}),
-    ...(languageHints.length > 0 ? { languages: languageHints } : {}),
+    ...(resolvedLanguages.length > 0 ? { languages: resolvedLanguages } : {}),
+    ...(quantization != null ? { quantization } : {}),
+    ...(detectionSources.length > 0 ? { detectionSources } : {}),
   };
 }
 
@@ -278,6 +324,7 @@ export type {
   SttEngine,
   SttInitResult,
 } from './types';
+export type { SttDetectModelResult } from '../types/modelDetect';
 export {
   STT_MODEL_TYPES,
   STT_HOTWORDS_MODEL_TYPES,

--- a/src/stt/streaming.ts
+++ b/src/stt/streaming.ts
@@ -162,6 +162,8 @@ export async function createStreamingSTT(
   if (options.modelType === 'auto' || options.modelType === undefined) {
     const detectResult = await SherpaOnnx.detectSttModel(
       resolvedPath,
+      null,
+      undefined,
       undefined,
       undefined
     );

--- a/src/types/modelDetect.ts
+++ b/src/types/modelDetect.ts
@@ -51,6 +51,13 @@ export interface TtsDetectModelResult extends ModelDetectResultBase {
   lexiconLanguageCandidates?: string[];
 }
 
+// ─── STT extension ──────────────────────────────────────────────────────
+
+export interface SttDetectModelResult extends ModelDetectResultBase {
+  /** True when model targets unsupported hardware-specific acceleration (RK35xx, Ascend, CANN). */
+  isHardwareSpecificUnsupported?: boolean;
+}
+
 // ─── Alignment extension ────────────────────────────────────────────────
 
 export interface AlignmentDetectModelResult extends ModelDetectResultBase {

--- a/src/types/modelDetect.ts
+++ b/src/types/modelDetect.ts
@@ -58,6 +58,15 @@ export interface SttDetectModelResult extends ModelDetectResultBase {
   isHardwareSpecificUnsupported?: boolean;
 }
 
+// ─── Enhancement extension ─────────────────────────────────────────────
+
+export interface EnhancementDetectModelResult extends ModelDetectResultBase {
+  /** Resolved model file path from detection. */
+  paths?: {
+    model?: string;
+  };
+}
+
 // ─── Alignment extension ────────────────────────────────────────────────
 
 export interface AlignmentDetectModelResult extends ModelDetectResultBase {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,28 @@ import { resolveActualModelDir } from './download/validation';
  */
 
 /**
+ * Derive a bare asset name from a ModelPathConfig by stripping the path to its
+ * last segment and removing common archive suffixes (.tar.bz2, .tar.gz, .tgz, .zip).
+ * Returns null when no usable name can be derived.
+ *
+ * @param modelPath - Model path configuration
+ * @returns Derived asset name string, or null
+ */
+export function deriveAssetNameFromModelPath(
+  modelPath: ModelPathConfig
+): string | null {
+  const raw = modelPath.path?.trim();
+  if (!raw) return null;
+  const leaf = raw.split(/[\\/]/).filter(Boolean).pop();
+  if (!leaf) return null;
+  return leaf
+    .replace(/\.tar\.bz2$/i, '')
+    .replace(/\.tar\.gz$/i, '')
+    .replace(/\.tgz$/i, '')
+    .replace(/\.zip$/i, '');
+}
+
+/**
  * Get the default model directory path for the current platform.
  * This is a logical name (e.g. `'Documents/models'` on iOS), not an absolute path.
  * On iOS, when using file-based models without PAD, pass an absolute base path to

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -15,6 +15,7 @@ set(JNI_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../android/src/main/cpp/jni")
 set(PRODUCTION_SOURCES
   "${MODEL_DETECT_DIR}/common/sherpa-onnx-model-detect-helper.cpp"
   "${MODEL_DETECT_DIR}/common/sherpa-onnx-catalog-metadata.cpp"
+  "${MODEL_DETECT_DIR}/stt/sherpa-onnx-stt-catalog-metadata.cpp"
   "${MODEL_DETECT_DIR}/stt/sherpa-onnx-model-detect-stt.cpp"
   "${MODEL_DETECT_DIR}/tts/sherpa-onnx-tts-catalog-metadata.cpp"
   "${MODEL_DETECT_DIR}/tts/sherpa-onnx-model-detect-tts.cpp"

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PRODUCTION_SOURCES
   "${MODEL_DETECT_DIR}/stt/sherpa-onnx-model-detect-stt.cpp"
   "${MODEL_DETECT_DIR}/tts/sherpa-onnx-tts-catalog-metadata.cpp"
   "${MODEL_DETECT_DIR}/tts/sherpa-onnx-model-detect-tts.cpp"
+  "${MODEL_DETECT_DIR}/enhancement/sherpa-onnx-enhancement-catalog-metadata.cpp"
   "${MODEL_DETECT_DIR}/enhancement/sherpa-onnx-model-detect-enhancement.cpp"
   "${MODEL_DETECT_DIR}/stt/sherpa-onnx-validate-stt.cpp"
   "${MODEL_DETECT_DIR}/tts/sherpa-onnx-validate-tts.cpp"

--- a/test/cpp/model_detect/model_detect_test.cpp
+++ b/test/cpp/model_detect/model_detect_test.cpp
@@ -380,9 +380,53 @@ TEST(ModelDetectValidation, SttTransducerOptionalBpeVocab) {
     EXPECT_EQ(result.selectedKind, sherpaonnx::SttModelKind::kTransducer);
 }
 
-// ============================================================
-// TTS validation: missing required files
-// ============================================================
+TEST(ModelDetectValidation, SttNameOnlyEmptyFilesAutoUsesDirName) {
+    std::vector<FE> files;
+    const std::string dir = "test-models/sherpa-onnx-whisper-tiny-en";
+    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, "auto", std::nullopt);
+    EXPECT_FALSE(result.ok) << "Name-only mode must not validate without a file listing";
+    EXPECT_EQ(result.selectedKind, sherpaonnx::SttModelKind::kWhisper);
+    EXPECT_NE(std::find(result.detectionSources.begin(), result.detectionSources.end(),
+                        sherpaonnx::DetectionSource::kNameOnly),
+              result.detectionSources.end());
+    EXPECT_NE(std::find(result.detectionSources.begin(), result.detectionSources.end(),
+                        sherpaonnx::DetectionSource::kDirName),
+              result.detectionSources.end());
+}
+
+TEST(ModelDetectValidation, SttNameOnlyEmptyFilesExplicit) {
+    std::vector<FE> files;
+    const std::string dir = "test-models/some-asr-model";
+    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, "paraformer", std::nullopt);
+    EXPECT_FALSE(result.ok);
+    EXPECT_EQ(result.selectedKind, sherpaonnx::SttModelKind::kParaformer);
+    EXPECT_NE(std::find(result.detectionSources.begin(), result.detectionSources.end(),
+                        sherpaonnx::DetectionSource::kNameOnly),
+              result.detectionSources.end());
+    EXPECT_NE(std::find(result.detectionSources.begin(), result.detectionSources.end(),
+                        sherpaonnx::DetectionSource::kExplicitModelType),
+              result.detectionSources.end());
+}
+
+TEST(ModelDetectValidation, SttFullScanDetectionSourcesExplicit) {
+    const std::string dir = "test-models/zipformer";
+    std::vector<FE> files = {
+        MakeEntry(dir, "encoder-epoch-99-avg-1.onnx"),
+        MakeEntry(dir, "decoder-epoch-99-avg-1.onnx"),
+        MakeEntry(dir, "joiner-epoch-99-avg-1.onnx"),
+        MakeEntry(dir, "tokens.txt"),
+    };
+    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, "transducer", std::nullopt);
+    EXPECT_TRUE(result.ok) << result.error;
+    EXPECT_NE(std::find(result.detectionSources.begin(), result.detectionSources.end(),
+                        sherpaonnx::DetectionSource::kFileListing),
+              result.detectionSources.end());
+    EXPECT_NE(std::find(result.detectionSources.begin(), result.detectionSources.end(),
+                        sherpaonnx::DetectionSource::kExplicitModelType),
+              result.detectionSources.end());
+}
+
+
 
 TEST(ModelDetectValidation, TtsKokoroMissingEspeakData) {
     const std::string dir = "test-models/kokoro-v1.0";

--- a/test/cpp/model_detect/model_detect_test.cpp
+++ b/test/cpp/model_detect/model_detect_test.cpp
@@ -111,7 +111,7 @@ TEST(ModelDetectTest, DetectSttFromFileListMatchesExpected) {
         if (expectedType == "unsupported") {
             auto files = model_detect_test::BuildFileEntriesFromPathLines(block.modelDir, block.pathLines);
             auto result = sherpaonnx::DetectSttModelFromFileList(
-                files, block.modelDir, std::nullopt, "auto");
+                files, block.modelDir, "auto", std::nullopt);
             EXPECT_FALSE(result.ok)
                 << "Asset " << block.assetName
                 << ": unsupported must not report ok=true so initialization is not attempted.";
@@ -131,7 +131,7 @@ TEST(ModelDetectTest, DetectSttFromFileListMatchesExpected) {
 
         auto files = model_detect_test::BuildFileEntriesFromPathLines(block.modelDir, block.pathLines);
         auto result = sherpaonnx::DetectSttModelFromFileList(
-            files, block.modelDir, std::nullopt, "auto");
+            files, block.modelDir, "auto", std::nullopt);
 
         ASSERT_TRUE(result.ok) << "Asset " << block.assetName << ": " << result.error;
         EXPECT_EQ(static_cast<int>(result.selectedKind), static_cast<int>(expectedKind))
@@ -310,7 +310,7 @@ TEST(ModelDetectValidation, SttTransducerMissingEncoderRejected) {
         MakeEntry(dir, "joiner-epoch-99-avg-1.onnx"),
         MakeEntry(dir, "tokens.txt"),
     };
-    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, std::nullopt, "transducer");
+    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, "transducer", std::nullopt);
     EXPECT_FALSE(result.ok) << "Should fail when encoder is missing (capability check)";
 }
 
@@ -320,7 +320,7 @@ TEST(ModelDetectValidation, SttWhisperMissingTokensValidation) {
         MakeEntry(dir, "encoder.onnx"),
         MakeEntry(dir, "decoder.onnx"),
     };
-    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, std::nullopt, "whisper");
+    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, "whisper", std::nullopt);
     EXPECT_FALSE(result.ok) << "Should fail when tokens is missing";
     EXPECT_NE(result.error.find("tokens"), std::string::npos)
         << "Validation error should mention 'tokens': " << result.error;
@@ -331,7 +331,7 @@ TEST(ModelDetectValidation, SttParaformerMissingTokensValidation) {
     std::vector<FE> files = {
         MakeEntry(dir, "model.onnx"),
     };
-    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, std::nullopt, "paraformer");
+    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, "paraformer", std::nullopt);
     EXPECT_FALSE(result.ok) << "Should fail when tokens is missing for paraformer";
     EXPECT_NE(result.error.find("tokens"), std::string::npos)
         << "Validation error should mention 'tokens': " << result.error;
@@ -344,7 +344,7 @@ TEST(ModelDetectValidation, SttFireRedMissingTokensValidation) {
         MakeEntry(dir, "decoder.onnx"),
         MakeEntry(dir, "joiner.onnx"),
     };
-    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, std::nullopt, "fire_red_asr");
+    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, "fire_red_asr", std::nullopt);
     EXPECT_FALSE(result.ok) << "Should fail when tokens is missing for Fire Red ASR";
     EXPECT_NE(result.error.find("tokens"), std::string::npos)
         << "Validation error should mention 'tokens': " << result.error;
@@ -357,7 +357,7 @@ TEST(ModelDetectValidation, SttTransducerMissingTokens) {
         MakeEntry(dir, "decoder-epoch-99-avg-1.onnx"),
         MakeEntry(dir, "joiner-epoch-99-avg-1.onnx"),
     };
-    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, std::nullopt, "transducer");
+    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, "transducer", std::nullopt);
     EXPECT_FALSE(result.ok) << "Should fail when tokens.txt is missing";
     EXPECT_NE(result.error.find("tokens"), std::string::npos)
         << "Error should mention 'tokens': " << result.error;
@@ -375,7 +375,7 @@ TEST(ModelDetectValidation, SttTransducerOptionalBpeVocab) {
         MakeEntry(dir, "joiner-epoch-99-avg-1.onnx"),
         MakeEntry(dir, "tokens.txt"),
     };
-    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, std::nullopt, "transducer");
+    auto result = sherpaonnx::DetectSttModelFromFileList(files, dir, "transducer", std::nullopt);
     EXPECT_TRUE(result.ok) << "Should succeed without optional bpeVocab: " << result.error;
     EXPECT_EQ(result.selectedKind, sherpaonnx::SttModelKind::kTransducer);
 }


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the enhancement and STT (speech-to-text) model detection system in the Android JNI layer. The main changes add richer metadata to detection results, unify and extend detection heuristics, and improve the flexibility and clarity of the detection APIs. The most notable updates are the addition of new metadata fields for detection traceability, introduction of catalog metadata heuristics for enhancement models, and significant API changes for consistency and extensibility.

**Enhancements to Detection Metadata and Heuristics:**

* Added new fields to `SttDetectResult` and `EnhancementDetectResult` to track the ordered trace of detection mechanisms (`detectionSources`), derived languages, and quantization heuristics. This enables better debugging and downstream usage of detection results. [[1]](diffhunk://#diff-b2e00e259c9662981a35077c768b1452d664a9d53fc34c85c9721ca3de4a0f41R242-R247) [[2]](diffhunk://#diff-b2e00e259c9662981a35077c768b1452d664a9d53fc34c85c9721ca3de4a0f41R274-R279)
* Implemented catalog metadata heuristics for enhancement models, mirroring the approach already used for STT and TTS. This includes new helper files (`sherpa-onnx-enhancement-catalog-metadata.cpp/h`) and logic to fill in derived languages and quantization based on asset or directory names. [[1]](diffhunk://#diff-db0414a8d8adce921e898638ad6f4e53487f2844ee43b21e1c2a61504c6dbeb5R1-R21) [[2]](diffhunk://#diff-d4241d29d7f1272d9590f49c1927b9f8267275dfb8a0870969100919b4a8a3cbR1-R17) [[3]](diffhunk://#diff-10d73a72c6c1a736debd7a8e00e26291be47220aaa0b8d073ce0bea8750bc27fR3-R9) [[4]](diffhunk://#diff-10d73a72c6c1a736debd7a8e00e26291be47220aaa0b8d073ce0bea8750bc27fL102-R233)

**API and Interface Improvements:**

* Changed the detection API signatures for both STT and enhancement models to accept optional `model_dir` and `asset_name` parameters, allowing for more flexible detection (directory scan, name-only heuristics, or both). The function logic now uses these parameters to determine the detection path and catalog metadata source. [[1]](diffhunk://#diff-b2e00e259c9662981a35077c768b1452d664a9d53fc34c85c9721ca3de4a0f41R296-R306) [[2]](diffhunk://#diff-b2e00e259c9662981a35077c768b1452d664a9d53fc34c85c9721ca3de4a0f41L298-R318) [[3]](diffhunk://#diff-b2e00e259c9662981a35077c768b1452d664a9d53fc34c85c9721ca3de4a0f41R349-R358) [[4]](diffhunk://#diff-10d73a72c6c1a736debd7a8e00e26291be47220aaa0b8d073ce0bea8750bc27fL85-R214)
* Updated the JNI wrapper for enhancement detection to expose the new metadata fields (`detectionSources`, `languages`, `quantization`) to Java, making the richer detection information available to the Android layer.

**Detection Logic and Heuristics:**

* Refactored enhancement model detection logic to record the sources of detection (e.g., name-only, directory name, file listing, explicit model type), and to use directory or asset name heuristics for model kind selection and metadata extraction. [[1]](diffhunk://#diff-10d73a72c6c1a736debd7a8e00e26291be47220aaa0b8d073ce0bea8750bc27fR21-R108) [[2]](diffhunk://#diff-10d73a72c6c1a736debd7a8e00e26291be47220aaa0b8d073ce0bea8750bc27fL39-R155) [[3]](diffhunk://#diff-10d73a72c6c1a736debd7a8e00e26291be47220aaa0b8d073ce0bea8750bc27fL102-R233)
* Added similar logic to STT detection to track detection sources and unify resolution heuristics, improving traceability and reliability. [[1]](diffhunk://#diff-4196d43dc70a35316c9f7bcf09a7587879dab0e55a710fcbb809f458d4931f01R244-R256) [[2]](diffhunk://#diff-4196d43dc70a35316c9f7bcf09a7587879dab0e55a710fcbb809f458d4931f01L512-R537) [[3]](diffhunk://#diff-4196d43dc70a35316c9f7bcf09a7587879dab0e55a710fcbb809f458d4931f01L528-R549)

**Build System Update:**

* Registered new source files for enhancement and STT catalog metadata heuristics in the build system (`CMakeLists.txt`).

These changes collectively make the model detection process more robust, transparent, and extensible, and provide better introspection for debugging and feature development.