### PR TITLE
Feat/add dynamic mmap treshold

### DIFF
--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -144,7 +144,10 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     super.initialize()
     tryInstallJsiBindings()
     com.sherpaonnx.audio.session.PaAudioSessionCoordinator.initialize(reactApplicationContext)
-    PipelineAudioRegistry.initializeWithCacheDir(reactApplicationContext.cacheDir)
+    PipelineAudioRegistry.initializeWithCacheDir(
+      reactApplicationContext,
+      reactApplicationContext.cacheDir
+    )
   }
 
   private fun emitPipelineLiveAudioChunk(event: com.sherpaonnx.audio.pipeline.LiveFramesAppendedEvent) {
@@ -937,7 +940,10 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
           }
 
           val rawSize = numSamples.toLong() * 4
-          val entry = if (rawSize >= com.sherpaonnx.audio.pipeline.PA_FILE_BACKED_THRESHOLD_BYTES) {
+          val threshold = com.sherpaonnx.audio.pipeline.MmapThresholdPolicy.thresholdBytes(
+            com.sherpaonnx.audio.pipeline.ThresholdPathType.FILE_ORIGIN
+          )
+          val entry = if (rawSize >= threshold) {
             // Large file: mmap the temp .f32 directly (zero heap copy)
             com.sherpaonnx.audio.pipeline.PipelineAudioRegistry.createOfflineFromMmapFile(
               tmpF32.absolutePath, numSamples, outputRate, 1

--- a/android/src/main/java/com/sherpaonnx/audio/pipeline/MmapThresholdPolicy.kt
+++ b/android/src/main/java/com/sherpaonnx/audio/pipeline/MmapThresholdPolicy.kt
@@ -1,0 +1,141 @@
+package com.sherpaonnx.audio.pipeline
+
+import android.app.ActivityManager
+import android.content.Context
+import android.util.Log
+
+internal enum class DeviceRamClass {
+  LOW,
+  MID,
+  HIGH,
+  VERY_HIGH,
+}
+
+internal enum class ThresholdPathType {
+  FILE_ORIGIN,
+  HEAP_ORIGIN,
+}
+
+private data class MmapThresholdSnapshot(
+  val ramClass: DeviceRamClass,
+  val fileOriginThresholdBytes: Long,
+  val heapOriginThresholdBytes: Long,
+)
+
+internal object MmapThresholdPolicy {
+  private const val TAG = "MmapThresholdPolicy"
+
+  private const val MB = 1024L * 1024L
+  private const val MIN_THRESHOLD_BYTES = 4L * MB
+  private const val MAX_THRESHOLD_BYTES = 32L * MB
+
+  private const val LOW_RAM_MAX_BYTES = 3L * 1024L * 1024L * 1024L
+  private const val MID_RAM_MAX_BYTES = 6L * 1024L * 1024L * 1024L
+  private const val HIGH_RAM_MAX_BYTES = 12L * 1024L * 1024L * 1024L
+
+  private const val ANDROID_FILE_ORIGIN_BASE_MB = 6.0
+  private const val ANDROID_HEAP_ORIGIN_BASE_MB = 10.0
+
+  private const val MULTIPLIER_LOW = 0.75
+  private const val MULTIPLIER_MID = 1.0
+  private const val MULTIPLIER_HIGH = 1.5
+  private const val MULTIPLIER_VERY_HIGH = 2.0
+
+  private val lock = Any()
+
+  @Volatile
+  private var snapshot: MmapThresholdSnapshot? = null
+
+  @Volatile
+  private var logged = false
+
+  fun initialize(context: Context) {
+    if (snapshot != null) {
+      logPolicyOnce()
+      return
+    }
+    synchronized(lock) {
+      if (snapshot == null) {
+        val ramClass = detectRamClass(context.applicationContext)
+        snapshot = createSnapshot(ramClass)
+      }
+    }
+    logPolicyOnce()
+  }
+
+  fun thresholdBytes(pathType: ThresholdPathType): Long {
+    val s = ensureSnapshot()
+    logPolicyOnce()
+    return when (pathType) {
+      ThresholdPathType.FILE_ORIGIN -> s.fileOriginThresholdBytes
+      ThresholdPathType.HEAP_ORIGIN -> s.heapOriginThresholdBytes
+    }
+  }
+
+  private fun ensureSnapshot(): MmapThresholdSnapshot {
+    snapshot?.let { return it }
+    synchronized(lock) {
+      snapshot?.let { return it }
+      // Fallback if initialize() has not run yet.
+      val fallback = createSnapshot(DeviceRamClass.MID)
+      snapshot = fallback
+      return fallback
+    }
+  }
+
+  private fun detectRamClass(context: Context): DeviceRamClass {
+    return try {
+      val am = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        ?: return DeviceRamClass.MID
+      val info = ActivityManager.MemoryInfo()
+      am.getMemoryInfo(info)
+      classifyRam(info.totalMem)
+    } catch (_: Exception) {
+      DeviceRamClass.MID
+    }
+  }
+
+  private fun classifyRam(totalMemBytes: Long): DeviceRamClass {
+    return when {
+      totalMemBytes <= LOW_RAM_MAX_BYTES -> DeviceRamClass.LOW
+      totalMemBytes <= MID_RAM_MAX_BYTES -> DeviceRamClass.MID
+      totalMemBytes <= HIGH_RAM_MAX_BYTES -> DeviceRamClass.HIGH
+      else -> DeviceRamClass.VERY_HIGH
+    }
+  }
+
+  private fun createSnapshot(ramClass: DeviceRamClass): MmapThresholdSnapshot {
+    val multiplier = when (ramClass) {
+      DeviceRamClass.LOW -> MULTIPLIER_LOW
+      DeviceRamClass.MID -> MULTIPLIER_MID
+      DeviceRamClass.HIGH -> MULTIPLIER_HIGH
+      DeviceRamClass.VERY_HIGH -> MULTIPLIER_VERY_HIGH
+    }
+
+    val fileThreshold = clampThreshold((ANDROID_FILE_ORIGIN_BASE_MB * multiplier * MB).toLong())
+    val heapThreshold = clampThreshold((ANDROID_HEAP_ORIGIN_BASE_MB * multiplier * MB).toLong())
+
+    return MmapThresholdSnapshot(
+      ramClass = ramClass,
+      fileOriginThresholdBytes = fileThreshold,
+      heapOriginThresholdBytes = heapThreshold,
+    )
+  }
+
+  private fun clampThreshold(bytes: Long): Long {
+    return bytes.coerceIn(MIN_THRESHOLD_BYTES, MAX_THRESHOLD_BYTES)
+  }
+
+  private fun logPolicyOnce() {
+    if (logged) return
+    val s = ensureSnapshot()
+    synchronized(lock) {
+      if (logged) return
+      Log.i(
+        TAG,
+        "mmap threshold policy: platform=android ramClass=${s.ramClass} fileOrigin=${s.fileOriginThresholdBytes} heapOrigin=${s.heapOriginThresholdBytes}"
+      )
+      logged = true
+    }
+  }
+}

--- a/android/src/main/java/com/sherpaonnx/audio/pipeline/MmapThresholdPolicy.kt
+++ b/android/src/main/java/com/sherpaonnx/audio/pipeline/MmapThresholdPolicy.kt
@@ -77,9 +77,8 @@ internal object MmapThresholdPolicy {
     synchronized(lock) {
       snapshot?.let { return it }
       // Fallback if initialize() has not run yet.
-      val fallback = createSnapshot(DeviceRamClass.MID)
-      snapshot = fallback
-      return fallback
+      // Do not cache it, so initialize(context) can still detect and persist real RAM class.
+      return createSnapshot(DeviceRamClass.MID)
     }
   }
 

--- a/android/src/main/java/com/sherpaonnx/audio/pipeline/OfflineEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/audio/pipeline/OfflineEntry.kt
@@ -54,7 +54,7 @@ sealed class OfflineEntry {
 
   /**
    * In-memory buffer. All samples are held in a FloatArray on the heap.
-    * Suitable for small to medium audio.
+   * Suitable for small to medium audio.
    *
    * For empty buffers created as output targets (e.g. TTS), [samples] starts as an empty array
    * and is filled exactly once via [adoptSamples].
@@ -104,7 +104,7 @@ sealed class OfflineEntry {
   /**
    * Memory-mapped file-backed buffer. Samples are stored as raw float32 in a temp file
    * and accessed via [MappedByteBuffer] for zero-copy random access.
-    * Used for large buffers (effective threshold is selected by mmap policy).
+   * Used for large buffers (effective threshold is selected by mmap policy).
    */
   class MmapBacked(
     override val bufferId: String,

--- a/android/src/main/java/com/sherpaonnx/audio/pipeline/OfflineEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/audio/pipeline/OfflineEntry.kt
@@ -12,16 +12,13 @@ import java.nio.ByteOrder
 import java.nio.MappedByteBuffer
 import java.nio.channels.FileChannel
 
-/** 10 MB raw PCM threshold. Buffers at or above this size use file-backed mmap. */
-internal const val PA_FILE_BACKED_THRESHOLD_BYTES: Long = 10L * 1024 * 1024
-
 private const val TAG = "OfflineEntry"
 
 /**
  * Offline audio buffer entry in the pipeline registry.
  * Immutable once created. Two backing strategies:
- * - InMemory: FloatArray in heap (small buffers, < 10 MB raw PCM)
- * - MmapBacked: Raw float32 file on disk, memory-mapped for zero-copy random access (≥ 10 MB)
+ * - InMemory: FloatArray in heap (small buffers)
+ * - MmapBacked: Raw float32 file on disk, memory-mapped for zero-copy random access
  */
 sealed class OfflineEntry {
   abstract val bufferId: String
@@ -57,7 +54,7 @@ sealed class OfflineEntry {
 
   /**
    * In-memory buffer. All samples are held in a FloatArray on the heap.
-   * Suitable for small to medium audio (< 10 MB raw PCM).
+    * Suitable for small to medium audio.
    *
    * For empty buffers created as output targets (e.g. TTS), [samples] starts as an empty array
    * and is filled exactly once via [adoptSamples].
@@ -107,7 +104,7 @@ sealed class OfflineEntry {
   /**
    * Memory-mapped file-backed buffer. Samples are stored as raw float32 in a temp file
    * and accessed via [MappedByteBuffer] for zero-copy random access.
-   * Used for large buffers (≥ 10 MB raw PCM) to reduce heap pressure.
+    * Used for large buffers (effective threshold is selected by mmap policy).
    */
   class MmapBacked(
     override val bufferId: String,

--- a/android/src/main/java/com/sherpaonnx/audio/pipeline/PipelineAudioRegistry.kt
+++ b/android/src/main/java/com/sherpaonnx/audio/pipeline/PipelineAudioRegistry.kt
@@ -41,8 +41,8 @@ object PipelineAudioRegistry {
 
   /**
    * Create an offline buffer from Float32 PCM samples (in-memory FloatArray).
-    * Uses mmap for large buffers, in-memory for small ones.
-   * 
+   * Uses mmap for large buffers, in-memory for small ones.
+   *
    * WARNING: For large FloatArrays, this may cause OOM. Prefer file-based APIs
    * (decodeFileToOfflineBuffer, createOfflineFromLive with spool files) for big data.
    */

--- a/android/src/main/java/com/sherpaonnx/audio/pipeline/PipelineAudioRegistry.kt
+++ b/android/src/main/java/com/sherpaonnx/audio/pipeline/PipelineAudioRegistry.kt
@@ -1,5 +1,6 @@
 package com.sherpaonnx.audio.pipeline
 
+import android.content.Context
 import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
@@ -30,8 +31,9 @@ object PipelineAudioRegistry {
   /**
    * Run startup orphan sweep. Call once from module initialize().
    */
-  fun initializeWithCacheDir(dir: File) {
+  fun initializeWithCacheDir(context: Context, dir: File) {
     cacheDir = dir
+    MmapThresholdPolicy.initialize(context.applicationContext)
     OfflineEntry.sweepOrphanedTempFiles(dir)
   }
 
@@ -39,7 +41,7 @@ object PipelineAudioRegistry {
 
   /**
    * Create an offline buffer from Float32 PCM samples (in-memory FloatArray).
-   * Uses mmap for large buffers (≥ 10 MB raw PCM), in-memory for small ones.
+    * Uses mmap for large buffers, in-memory for small ones.
    * 
    * WARNING: For large FloatArrays, this may cause OOM. Prefer file-based APIs
    * (decodeFileToOfflineBuffer, createOfflineFromLive with spool files) for big data.
@@ -55,9 +57,10 @@ object PipelineAudioRegistry {
 
     val bufferId = "off_${UUID.randomUUID()}"
     val rawSize = samples.size.toLong() * 4
+    val threshold = MmapThresholdPolicy.thresholdBytes(ThresholdPathType.HEAP_ORIGIN)
     val dir = cacheDir
 
-    val entry = if (rawSize >= PA_FILE_BACKED_THRESHOLD_BYTES && dir != null) {
+    val entry = if (rawSize >= threshold && dir != null) {
       OfflineEntry.createMmapFromSamples(bufferId, sampleRate, channelCount, samples, dir)
         ?: OfflineEntry.InMemory(bufferId, sampleRate, channelCount, samples)
     } else {
@@ -123,7 +126,7 @@ object PipelineAudioRegistry {
    *
    * @param liveBufferId ID of the live buffer.
    * @param mode How to create the offline buffer:
-   *   - "fullIfSpooled": If live has a spool file, read and convert to mmap if large.
+    *   - "fullIfSpooled": If live has a spool file, use file-origin threshold policy.
    *     Otherwise, snapshot the ring.
    *   - "windowSnapshot": Always snapshot the current ring window (in-memory copy).
    */
@@ -194,13 +197,38 @@ object PipelineAudioRegistry {
         return null
       }
 
-      OfflineEntry.createMmapFromFile(
-        bufferId, sampleRate, channelCount, numSamples,
-        f32File.absolutePath
-      ) ?: run {
+      val rawSize = f32File.length()
+      val threshold = MmapThresholdPolicy.thresholdBytes(ThresholdPathType.FILE_ORIGIN)
+
+      val entry = if (rawSize >= threshold) {
+        OfflineEntry.createMmapFromFile(
+          bufferId,
+          sampleRate,
+          channelCount,
+          numSamples,
+          f32File.absolutePath
+        ) ?: run {
+          f32File.delete()
+          null
+        }
+      } else {
+        val samples = FloatArray(numSamples)
+        java.io.RandomAccessFile(f32File, "r").use { raf ->
+          val bytes = ByteArray(numSamples * 4)
+          raf.readFully(bytes)
+          val bb = java.nio.ByteBuffer.wrap(bytes).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+          for (i in 0 until numSamples) {
+            samples[i] = bb.float
+          }
+        }
         f32File.delete()
-        null
+        OfflineEntry.InMemory(bufferId, sampleRate, channelCount, samples)
       }
+
+      if (entry != null) {
+        offlineEntries[bufferId] = entry
+      }
+      entry
     } catch (e: Exception) {
       Log.w(TAG, "createOfflineFromF32WavSpoolFile failed: ${e.message}")
       f32File.delete()
@@ -219,9 +247,10 @@ object PipelineAudioRegistry {
     samples: FloatArray,
   ): OfflineEntry {
     val rawSize = samples.size.toLong() * 4
+    val threshold = MmapThresholdPolicy.thresholdBytes(ThresholdPathType.HEAP_ORIGIN)
     val dir = cacheDir
 
-    val entry = if (rawSize >= PA_FILE_BACKED_THRESHOLD_BYTES && dir != null) {
+    val entry = if (rawSize >= threshold && dir != null) {
       OfflineEntry.createMmapFromSamples(bufferId, sampleRate, channelCount, samples, dir)
         ?: OfflineEntry.InMemory(bufferId, sampleRate, channelCount, samples)
     } else {
@@ -251,7 +280,8 @@ object PipelineAudioRegistry {
     val entry = offlineEntries[bufferId] ?: return
     if (entry !is OfflineEntry.InMemory) return
     val rawSize = entry.numSamples.toLong() * 4
-    if (rawSize < PA_FILE_BACKED_THRESHOLD_BYTES) return
+    val threshold = MmapThresholdPolicy.thresholdBytes(ThresholdPathType.HEAP_ORIGIN)
+    if (rawSize < threshold) return
     val dir = cacheDir ?: return
 
     val mmapEntry = OfflineEntry.createMmapFromSamples(

--- a/docs/migration/mmap/dynamic-mmap-threshold-implementation-plan.md
+++ b/docs/migration/mmap/dynamic-mmap-threshold-implementation-plan.md
@@ -1,0 +1,464 @@
+# Dynamic mmap threshold — implementation plan
+
+**Status:** Implemented.  
+**Depends on:** [`perf-offline-audio-buffer-mmap-impl-spec.md`](./perf-offline-audio-buffer-mmap-impl-spec.md) (current static 10 MB mmap policy)  
+**Audience:** Native contributors (Kotlin, Objective-C++), SDK maintainers.  
+**Breaking changes:** No public API change required.
+
+---
+
+## 0. Decision summary
+
+Replace the current **static 10 MB** mmap threshold with a **deterministic native policy** derived from exactly three inputs:
+
+1. **Platform** (`android` vs `ios`)
+2. **Total device RAM class**
+3. **Path type** (`file-origin` vs `heap-origin`)
+
+The policy remains intentionally simple:
+
+- No user-facing configuration
+- No sampling of volatile "free RAM right now" values
+- No battery / thermal / CPU heuristics
+- No dependence on audio semantics beyond the already-known raw PCM size
+
+The goal is to keep behavior **predictable**, **testable**, and **better aligned with device class and data origin** than a global fixed threshold.
+
+---
+
+## 1. Motivation
+
+The current implementation hard-codes **10 MB raw PCM** as the cutoff for `InMemory` vs `mmap`-backed offline buffers on both platforms.
+
+That is a solid conservative default, but it ignores two realities:
+
+1. **Platform differences**  
+   Android devices are more heterogeneous and often benefit from earlier file-backing on lower-memory devices. iOS devices are typically more uniform and can tolerate a somewhat higher in-memory cutoff.
+
+2. **Device class differences**  
+   A 10 MB heap allocation is much more significant on a 3 GB device than on a 12 GB device.
+
+3. **Creation-path differences**  
+   File-derived buffers are already close to a file-backed flow, so mmap is attractive earlier. Heap-derived buffers have often already paid the materialization cost, so upgrading to mmap should require a somewhat larger payload.
+
+This plan introduces those distinctions without turning threshold selection into an opaque runtime heuristic.
+
+---
+
+## 2. Scope
+
+### In scope
+
+- Introduce a shared threshold policy model based on:
+  - platform
+  - total device RAM class
+  - path type
+- Replace hard-coded threshold constants in Android and iOS offline-buffer creation paths
+- Use the dynamic threshold consistently for:
+  - file decode → offline buffer
+  - live spool → offline buffer
+  - in-memory sample creation / upgrade paths
+  - enhancement / TTS post-adopt mmap upgrades
+- Surface the effective threshold in debug logging for easier validation
+- Add focused tests for threshold selection and representative call sites
+- Update mmap documentation to reflect the new policy
+
+### Out of scope
+
+- Public TypeScript API for tuning the threshold
+- Dynamic decisions based on current free memory
+- Battery / low power mode / thermal state inputs
+- Storage-pressure-aware threshold changes
+- Per-model or per-feature threshold specialization
+
+---
+
+## 3. Policy model
+
+### 3.1 Inputs
+
+#### Platform
+
+- `android`
+- `ios`
+
+#### Total device RAM class
+
+Use coarse buckets derived from total physical memory:
+
+- `LOW` = `<= 3 GB`
+- `MID` = `4 GB .. 6 GB`
+- `HIGH` = `8 GB .. 12 GB`
+- `VERY_HIGH` = `> 12 GB`
+
+These classes should be computed once and reused. Exact byte boundaries should be centralized in one place per platform.
+
+#### Path type
+
+- `file-origin`
+  - `createOfflineAudioBufferFromFile`
+  - `createOfflineFromLive(... fullIfSpooled ...)`
+  - any future path where samples are still primarily represented as file data
+- `heap-origin`
+  - `createOfflineAudioBufferFromSamples`
+  - `createEntryWithThreshold(samples)`
+  - `upgradeToMmapIfNeeded()`
+  - enhancement / TTS outputs after samples already exist in RAM
+
+### 3.2 Threshold formula
+
+The threshold should be computed as:
+
+```text
+thresholdBytes = clamp(platformBase(pathType) * ramMultiplier(ramClass), min=4 MB, max=32 MB)
+```
+
+### 3.3 Recommended base thresholds
+
+| Platform | Path type | Base threshold |
+|---|---|---:|
+| Android | file-origin | 6 MB |
+| Android | heap-origin | 10 MB |
+| iOS | file-origin | 8 MB |
+| iOS | heap-origin | 12 MB |
+
+### 3.4 Recommended RAM multipliers
+
+| RAM class | Multiplier |
+|---|---:|
+| `LOW` (`<= 3 GB`) | `0.75x` |
+| `MID` (`4..6 GB`) | `1.0x` |
+| `HIGH` (`8..12 GB`) | `1.5x` |
+| `VERY_HIGH` (`> 12 GB`) | `2.0x` |
+
+### 3.5 Example outcomes
+
+| Platform | RAM class | Path type | Computed threshold |
+|---|---|---|---:|
+| Android | `LOW` | file-origin | 4.5 MB |
+| Android | `MID` | heap-origin | 10 MB |
+| Android | `HIGH` | heap-origin | 15 MB |
+| iOS | `MID` | file-origin | 8 MB |
+| iOS | `HIGH` | file-origin | 12 MB |
+| iOS | `VERY_HIGH` | heap-origin | 24 MB |
+
+### 3.6 Rationale for path-type split
+
+`file-origin` should mmap earlier because the flow is already file-centric:
+
+- decode/file/spool paths already touch disk
+- mmap avoids growing the Java / C++ heap unnecessarily
+- these buffers are more likely to benefit from lazy paging and zero-copy reads
+
+`heap-origin` should require a somewhat larger payload before switching:
+
+- the heap materialization cost has often already been paid
+- small-to-medium buffers are simpler to keep in memory
+- late upgrade-to-mmap mainly helps with retention / downstream access, not initial creation
+
+---
+
+## 4. Implementation design
+
+### 4.1 Shared conceptual model
+
+Both native implementations should define the same concepts:
+
+- `DeviceRamClass`
+- `ThresholdPathType`
+- `computeMmapThresholdBytes(pathType)`
+
+The code does not need to be literally shared across platforms, but the behavior should remain aligned and documented in one place.
+
+### 4.2 Android design
+
+Introduce a small policy helper, for example:
+
+- `android/src/main/java/com/sherpaonnx/audio/pipeline/MmapThresholdPolicy.kt`
+
+Responsibilities:
+
+- Read total physical memory using Android APIs
+- Map device memory to `DeviceRamClass`
+- Compute threshold bytes from `platform + ramClass + pathType`
+- Expose simple call sites such as:
+  - `forFileOrigin()`
+  - `forHeapOrigin()`
+
+Preferred memory source:
+
+- `ActivityManager.MemoryInfo.totalMem`
+
+This is stable, cheap, and available on supported Android API levels.
+
+### 4.3 iOS design
+
+Introduce an Objective-C++ / C++ helper near pipeline bridging code, for example:
+
+- static functions in `ios/audio/bridge/SherpaOnnx+PipelineAudio.mm`, or
+- a small dedicated helper file if that keeps the bridge cleaner
+
+Responsibilities mirror Android:
+
+- Read total physical memory
+- Map to `DeviceRamClass`
+- Compute threshold bytes for `file-origin` / `heap-origin`
+
+Preferred memory source:
+
+- `[NSProcessInfo processInfo].physicalMemory`
+
+This is stable and sufficient for the coarse RAM-class model.
+
+### 4.4 Determinism and caching
+
+Threshold computation should be cached after first use per process:
+
+- total device RAM does not change during runtime
+- RAM class does not change during runtime
+- computed thresholds are pure functions of stable inputs
+
+Suggested approach:
+
+- compute RAM class once lazily
+- precompute:
+  - `fileOriginThresholdBytes`
+  - `heapOriginThresholdBytes`
+
+This avoids repeated platform calls and keeps logs stable.
+
+---
+
+## 5. File-by-file change plan
+
+### 5.1 Android
+
+#### `android/src/main/java/com/sherpaonnx/audio/pipeline/OfflineEntry.kt`
+
+- Remove the hard-coded `PA_FILE_BACKED_THRESHOLD_BYTES` constant
+- Keep raw-size calculation local to each decision point
+- If helpful, move only the policy-free entry helpers here and keep threshold selection in the new policy file
+
+#### `android/src/main/java/com/sherpaonnx/audio/pipeline/PipelineAudioRegistry.kt`
+
+Update threshold call sites:
+
+- `createFromDecodedFile(...)`
+  - use `file-origin` threshold
+- `createOfflineFromF32WavSpoolFile(...)`
+  - use `file-origin` threshold if there is a threshold gate before mmap adoption
+- `createEntryWithThreshold(...)`
+  - rename mentally to "createEntryWithPolicy" even if method name stays as-is
+  - use `heap-origin` threshold
+- `upgradeToMmapIfNeeded(...)`
+  - use `heap-origin` threshold
+
+#### `android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt`
+
+Update large-file decode path:
+
+- any direct comparison against `PA_FILE_BACKED_THRESHOLD_BYTES` must use the policy helper
+- file decode paths should use `file-origin`
+
+#### `android/src/main/java/com/sherpaonnx/enhancement/facade/SherpaOnnxEnhancementHelper.kt`
+
+- confirm post-adopt upgrade path uses `heap-origin`
+
+#### `android/src/main/java/com/sherpaonnx/tts/service/TtsBatchGenerationService.kt`
+
+- confirm post-adopt upgrade path uses `heap-origin`
+
+### 5.2 iOS
+
+#### `ios/audio/bridge/SherpaOnnx+PipelineAudio.mm`
+
+- Replace `kPaFileBackedThreshold`
+- Add:
+  - RAM-class computation
+  - `file-origin` threshold accessor
+  - `heap-origin` threshold accessor
+- Update all threshold comparisons:
+  - decoded file path → `file-origin`
+  - live spool path → `file-origin`
+  - `pa_createEntryWithThreshold(...)` → `heap-origin`
+  - `pa_upgradeToMmapIfNeeded(...)` → `heap-origin`
+
+#### `ios/enhancement/bridge/SherpaOnnx+EnhancementOffline.mm`
+
+- confirm post-adopt upgrade path uses `heap-origin`
+
+#### `ios/tts/bridge/SherpaOnnx+TTSBatch.mm`
+
+- confirm post-adopt upgrade path uses `heap-origin`
+
+---
+
+## 6. Recommended code shape
+
+### 6.1 Android pseudocode
+
+```kotlin
+internal enum class DeviceRamClass { LOW, MID, HIGH, VERY_HIGH }
+internal enum class ThresholdPathType { FILE_ORIGIN, HEAP_ORIGIN }
+
+internal object MmapThresholdPolicy {
+  private const val MB = 1024L * 1024L
+
+  fun thresholdBytes(pathType: ThresholdPathType): Long {
+    val baseMb = when (pathType) {
+      ThresholdPathType.FILE_ORIGIN -> 6.0
+      ThresholdPathType.HEAP_ORIGIN -> 10.0
+    }
+    val multiplier = when (deviceRamClass()) {
+      DeviceRamClass.LOW -> 0.75
+      DeviceRamClass.MID -> 1.0
+      DeviceRamClass.HIGH -> 1.5
+      DeviceRamClass.VERY_HIGH -> 2.0
+    }
+    val platformAdjustedBaseMb = baseMb // Android values already baked in
+    return (platformAdjustedBaseMb * multiplier * MB)
+      .toLong()
+      .coerceIn(4L * MB, 32L * MB)
+  }
+}
+```
+
+### 6.2 iOS pseudocode
+
+```cpp
+enum class PaDeviceRamClass { LOW, MID, HIGH, VERY_HIGH };
+enum class PaThresholdPathType { FILE_ORIGIN, HEAP_ORIGIN };
+
+static long pa_computeThresholdBytes(PaThresholdPathType pathType) {
+  double baseMb = 0.0;
+  switch (pathType) {
+    case PaThresholdPathType::FILE_ORIGIN: baseMb = 8.0; break;
+    case PaThresholdPathType::HEAP_ORIGIN: baseMb = 12.0; break;
+  }
+
+  double multiplier = 1.0;
+  switch (pa_deviceRamClass()) {
+    case PaDeviceRamClass::LOW: multiplier = 0.75; break;
+    case PaDeviceRamClass::MID: multiplier = 1.0; break;
+    case PaDeviceRamClass::HIGH: multiplier = 1.5; break;
+    case PaDeviceRamClass::VERY_HIGH: multiplier = 2.0; break;
+  }
+
+  long bytes = (long)(baseMb * multiplier * 1024.0 * 1024.0);
+  return std::min(32L * 1024L * 1024L, std::max(4L * 1024L * 1024L, bytes));
+}
+```
+
+### 6.3 Logging
+
+At first threshold use in a process, log something like:
+
+```text
+[PipelineAudio] mmap threshold policy: platform=android ramClass=MID fileOrigin=6291456 heapOrigin=10485760
+```
+
+This helps verify device classification during development without spamming per-buffer logs.
+
+---
+
+## 7. Testing plan
+
+### 7.1 Unit-level policy tests
+
+Add focused tests that validate:
+
+- RAM byte values map to the expected RAM class
+- `file-origin` threshold is lower than `heap-origin` threshold on the same platform
+- thresholds clamp correctly at 4 MB / 32 MB
+
+Where direct unit testing is awkward, structure helpers so the pure mapping logic is testable separately from platform API calls.
+
+### 7.2 Integration checks
+
+Validate representative boundaries:
+
+1. Android low-RAM simulation
+   - file-origin buffer just below computed threshold → `ram`
+   - just above → `mmap`
+
+2. Android high-RAM simulation
+   - heap-origin upgrade threshold increases as expected
+
+3. iOS mid/high-RAM simulation
+   - file-origin and heap-origin select different thresholds
+
+4. Existing creation paths still behave correctly
+   - `createOfflineAudioBufferFromFile`
+   - `createOfflineFromLive`
+   - `createOfflineAudioBufferFromSamples`
+   - enhancement output
+   - TTS output
+
+### 7.3 Regression checks
+
+- No public TypeScript API changes
+- `storageKind` remains `ram` or `mmap`
+- Temp file lifecycle remains unchanged
+- Small buffers do not regress to unnecessary file I/O
+
+---
+
+## 8. Rollout plan
+
+### Phase 1: Policy helpers
+
+- Add Android threshold policy helper
+- Add iOS threshold policy helper
+- Hard-code the initial policy values from this document
+
+### Phase 2: Replace static constants
+
+- Remove direct use of `10 MB` constants
+- Update all call sites to choose `file-origin` vs `heap-origin`
+
+### Phase 3: Validation
+
+- Build Android
+- Build iOS
+- Run representative manual tests around threshold boundaries
+- Confirm debug logs report expected RAM class and thresholds
+
+### Phase 4: Documentation cleanup
+
+- Update `perf-offline-audio-buffer-mmap-impl-spec.md`
+  - replace the resolved question entry that still says "10 MB"
+  - move dynamic policy out of "future plan" wording
+- Add references from other mmap migration docs if needed
+
+---
+
+## 9. Risks and mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Thresholds are too aggressive on some Android devices | Medium | Medium | Keep coarse conservative bases, clamp to minimum 4 MB, validate on low-memory emulator/device |
+| Thresholds are too lenient on high-memory devices | Low | Low | Policy can be retuned centrally without API changes |
+| Inconsistent path-type selection across call sites | Medium | Medium | Centralize path-type naming and document each call site explicitly |
+| Platform drift between Android and iOS implementations | Medium | Medium | Keep both policies derived from this single spec and log computed values |
+| Hard-to-reproduce behavior near threshold boundaries | Low | Medium | Add boundary-focused tests and one-time startup logging |
+
+---
+
+## 10. Final recommendation
+
+Implement the dynamic threshold now using only:
+
+- platform
+- total device RAM class
+- path type
+
+Do **not** add volatile runtime signals in this iteration.
+
+This yields a threshold policy that is:
+
+- meaningfully smarter than a global 10 MB cutoff
+- still deterministic and easy to reason about
+- aligned with your current mmap architecture
+- cheap to implement on both native platforms
+
+If future tuning is needed, the next step should be **retuning the base values**, not expanding the number of inputs.

--- a/docs/migration/mmap/dynamic-mmap-threshold-implementation-plan.md
+++ b/docs/migration/mmap/dynamic-mmap-threshold-implementation-plan.md
@@ -87,8 +87,8 @@ This plan introduces those distinctions without turning threshold selection into
 Use coarse buckets derived from total physical memory:
 
 - `LOW` = `<= 3 GB`
-- `MID` = `4 GB .. 6 GB`
-- `HIGH` = `8 GB .. 12 GB`
+- `MID` = `> 3 GB and <= 6 GB`
+- `HIGH` = `> 6 GB and <= 12 GB`
 - `VERY_HIGH` = `> 12 GB`
 
 These classes should be computed once and reused. Exact byte boundaries should be centralized in one place per platform.

--- a/docs/migration/mmap/perf-offline-audio-buffer-mmap-impl-spec.md
+++ b/docs/migration/mmap/perf-offline-audio-buffer-mmap-impl-spec.md
@@ -1,9 +1,11 @@
 # File-backed mmap for large offline audio buffers — implementation spec
 
-**Status:** Ready for implementation.  
+**Status:** Implemented.  
 **Supersedes:** [`perf-offline-audio-buffer-backing-spec.md`](./perf-offline-audio-buffer-backing-spec.md) (high-level motivation and goals).  
 **Audience:** Native contributors (Kotlin, Objective-C++), SDK maintainers.  
 **Breaking changes:** Allowed — SDK is pre-release. Changes that simplify internals or improve robustness are welcome.
+
+> **Threshold policy update:** The original fixed 10 MB cutoff in this document has been replaced by the dynamic policy from [`dynamic-mmap-threshold-implementation-plan.md`](./dynamic-mmap-threshold-implementation-plan.md), based on platform, device RAM class, and path type (`file-origin` vs `heap-origin`).
 
 ---
 
@@ -11,7 +13,7 @@
 
 | Question | Decision |
 |---|---|
-| **Exact threshold / per-platform** | Hard-code **10 MB of raw PCM** (`numSamples × bytesPerSample × channels`). A future plan will make it dynamic per platform and device. |
+| **Exact threshold / per-platform** | Use a **dynamic native policy** based on platform, RAM class, and path type. |
 | **Random access requirement** | Yes — JSI slice reads and potential alignment internals need random access. Use **mmap** as the backing strategy. |
 | **Temp file robustness** | Implement a **three-layer** cleanup strategy: deterministic release, startup orphan sweep, and OS-level temp directory semantics. See §4. |
 
@@ -22,7 +24,7 @@
 ### In scope
 
 - Replace `readAllSamples()`-based full-load for file-backed `OfflineEntry` / `PaOfflineEntry` with **mmap**-backed access.
-- Apply the **10 MB threshold** to decide `InMemory` vs `FileBacked` for **all** offline buffer creation paths (not just live-to-offline).
+- Apply the **dynamic threshold policy** to decide `InMemory` vs `FileBacked` for **all** offline buffer creation paths (not just live-to-offline).
 - Enable the **enhancement output** path to produce `FileBacked` buffers when the result exceeds the threshold.
 - Provide a **robust temp file lifecycle** (deterministic cleanup, crash-resilient orphan sweep).
 - Enable **JSI slice access** for file-backed buffers (currently returns `BUFFER_NOT_IN_MEMORY`).
@@ -30,7 +32,7 @@
 
 ### Out of scope
 
-- Dynamic / per-device threshold tuning (future plan).
+- Public TypeScript API for threshold tuning.
 - Live buffer ring or spool changes (unrelated lifecycle).
 - Changes to offline text buffer semantics.
 - Multi-channel (stereo) support — current pipeline is mono-only.
@@ -454,11 +456,16 @@ AlignAccurateFromFloatPcm(model, text, entry->floatPtr(), entry->sampleRate, gra
 
 ```
 rawPcmSize = numSamples × sizeof(float)   // = numSamples × 4 bytes
-threshold  = 10 * 1024 * 1024             // = 10 MB = 10,485,760 bytes
-                                           // = 2,621,440 samples
-                                           // ≈ 164 seconds @ 16 kHz mono
-                                           // ≈ 60 seconds @ 44.1 kHz mono
+thresholdBytes = clamp(platformBase(pathType) × ramMultiplier(ramClass), 4 MB, 32 MB)
 ```
+
+Where:
+
+- `pathType=file-origin`: decode/spool/file-centric creation paths (earlier mmap adoption)
+- `pathType=heap-origin`: FloatArray/in-memory creation and upgrade paths
+- Android bases: `file=6 MB`, `heap=10 MB`
+- iOS bases: `file=8 MB`, `heap=12 MB`
+- RAM multipliers: `LOW=0.75x`, `MID=1.0x`, `HIGH=1.5x`, `VERY_HIGH=2.0x`
 
 ### Application points
 
@@ -466,21 +473,16 @@ The threshold check must be applied at **every** offline buffer creation path:
 
 | Creation path | Current behavior | New behavior |
 |---|---|---|
-| `createOfflineAudioBufferFromFile` (FFmpeg decode) | Always InMemory | Apply threshold after decode |
-| `createOfflineAudioBufferFromSamples` (JSI) | Always InMemory | Apply threshold (copy samples to temp .f32 if large) |
+| `createOfflineAudioBufferFromFile` (FFmpeg decode) | Always InMemory | Apply **file-origin** threshold after decode |
+| `createOfflineAudioBufferFromSamples` (JSI) | Always InMemory | Apply **heap-origin** threshold (copy samples to temp .f32 if large) |
 | `createEmptyOfflineAudioBuffer` (for TTS/enhancement output) | Always InMemory | Create InMemory; **upgrade** to FileBacked after `adoptSamples()` if large (see §7) |
-| `createOfflineFromLive` (fullIfSpooled) | FileBacked only if spool exists | Convert spool → .f32 + mmap if large; InMemory if small |
-| `createOfflineFromLive` (windowSnapshot) | Always InMemory (ring snapshot) | Apply threshold (ring snapshot is typically < 10 MB, but check) |
+| `createOfflineFromLive` (fullIfSpooled) | FileBacked only if spool exists | Convert spool → .f32, apply **file-origin** threshold (mmap if large, InMemory if small) |
+| `createOfflineFromLive` (windowSnapshot) | Always InMemory (ring snapshot) | Apply **heap-origin** threshold |
 
-### Constant location
+### Policy location
 
-```kotlin
-// Android
-internal const val PA_FILE_BACKED_THRESHOLD_BYTES: Long = 10L * 1024 * 1024
-
-// iOS
-static const long kPaFileBackedThreshold = 10L * 1024 * 1024;
-```
+- Android: `MmapThresholdPolicy.thresholdBytes(pathType)` in `MmapThresholdPolicy.kt`
+- iOS: `pa_computeThresholdBytes(pathType)` in `SherpaOnnx+PipelineAudio.mm`
 
 ---
 

--- a/ios/audio/bridge/SherpaOnnx+PipelineAudio.mm
+++ b/ios/audio/bridge/SherpaOnnx+PipelineAudio.mm
@@ -26,6 +26,7 @@
 #include <set>
 #include <fstream>
 #include <functional>
+#include <algorithm>
 #include <cmath>
 #include <atomic>
 #include <cstdio>
@@ -291,7 +292,122 @@ struct PaOfflineEntry {
 std::unordered_map<std::string, std::shared_ptr<PaOfflineEntry>> g_pa_offline;
 std::unordered_map<std::string, std::shared_ptr<PaLiveEntry>> g_pa_live;
 std::mutex g_pa_mutex;
-static const long kPaFileBackedThreshold = 10L * 1024 * 1024; // 10 MB raw PCM
+
+enum class PaDeviceRamClass {
+  LOW,
+  MID,
+  HIGH,
+  VERY_HIGH,
+};
+
+enum class PaThresholdPathType {
+  FILE_ORIGIN,
+  HEAP_ORIGIN,
+};
+
+struct PaThresholdSnapshot {
+  PaDeviceRamClass ramClass = PaDeviceRamClass::MID;
+  long fileOriginThresholdBytes = 8L * 1024L * 1024L;
+  long heapOriginThresholdBytes = 12L * 1024L * 1024L;
+};
+
+static constexpr long kPaMb = 1024L * 1024L;
+static constexpr long kPaMinThresholdBytes = 4L * kPaMb;
+static constexpr long kPaMaxThresholdBytes = 32L * kPaMb;
+
+static constexpr uint64_t kPaLowRamMaxBytes = 3ULL * 1024ULL * 1024ULL * 1024ULL;
+static constexpr uint64_t kPaMidRamMaxBytes = 6ULL * 1024ULL * 1024ULL * 1024ULL;
+static constexpr uint64_t kPaHighRamMaxBytes = 12ULL * 1024ULL * 1024ULL * 1024ULL;
+
+static constexpr double kPaFileOriginBaseMb = 8.0;
+static constexpr double kPaHeapOriginBaseMb = 12.0;
+
+static constexpr double kPaMultiplierLow = 0.75;
+static constexpr double kPaMultiplierMid = 1.0;
+static constexpr double kPaMultiplierHigh = 1.5;
+static constexpr double kPaMultiplierVeryHigh = 2.0;
+
+static std::once_flag gPaThresholdInitOnce;
+static std::atomic<bool> gPaThresholdLogged(false);
+static PaThresholdSnapshot gPaThresholdSnapshot;
+
+static const char *pa_ramClassName(PaDeviceRamClass ramClass) {
+  switch (ramClass) {
+    case PaDeviceRamClass::LOW: return "LOW";
+    case PaDeviceRamClass::MID: return "MID";
+    case PaDeviceRamClass::HIGH: return "HIGH";
+    case PaDeviceRamClass::VERY_HIGH: return "VERY_HIGH";
+  }
+  return "MID";
+}
+
+static PaDeviceRamClass pa_classifyRam(uint64_t totalRamBytes) {
+  if (totalRamBytes <= kPaLowRamMaxBytes) return PaDeviceRamClass::LOW;
+  if (totalRamBytes <= kPaMidRamMaxBytes) return PaDeviceRamClass::MID;
+  if (totalRamBytes <= kPaHighRamMaxBytes) return PaDeviceRamClass::HIGH;
+  return PaDeviceRamClass::VERY_HIGH;
+}
+
+static double pa_multiplierForRamClass(PaDeviceRamClass ramClass) {
+  switch (ramClass) {
+    case PaDeviceRamClass::LOW: return kPaMultiplierLow;
+    case PaDeviceRamClass::MID: return kPaMultiplierMid;
+    case PaDeviceRamClass::HIGH: return kPaMultiplierHigh;
+    case PaDeviceRamClass::VERY_HIGH: return kPaMultiplierVeryHigh;
+  }
+  return kPaMultiplierMid;
+}
+
+static long pa_clampThresholdBytes(long bytes) {
+  return std::max(kPaMinThresholdBytes, std::min(kPaMaxThresholdBytes, bytes));
+}
+
+static void pa_initializeThresholdSnapshot() {
+  uint64_t totalRamBytes = [[NSProcessInfo processInfo] physicalMemory];
+  PaDeviceRamClass ramClass = pa_classifyRam(totalRamBytes);
+  double multiplier = pa_multiplierForRamClass(ramClass);
+
+  long fileThreshold = pa_clampThresholdBytes((long)(kPaFileOriginBaseMb * multiplier * (double)kPaMb));
+  long heapThreshold = pa_clampThresholdBytes((long)(kPaHeapOriginBaseMb * multiplier * (double)kPaMb));
+
+  gPaThresholdSnapshot.ramClass = ramClass;
+  gPaThresholdSnapshot.fileOriginThresholdBytes = fileThreshold;
+  gPaThresholdSnapshot.heapOriginThresholdBytes = heapThreshold;
+}
+
+static const PaThresholdSnapshot &pa_thresholdSnapshot() {
+  std::call_once(gPaThresholdInitOnce, []() {
+    pa_initializeThresholdSnapshot();
+  });
+  return gPaThresholdSnapshot;
+}
+
+static void pa_logThresholdPolicyOnce() {
+  bool expected = false;
+  if (!gPaThresholdLogged.compare_exchange_strong(expected, true)) {
+    return;
+  }
+
+  const auto &snapshot = pa_thresholdSnapshot();
+  RCTLogInfo(
+    @"[PipelineAudio] mmap threshold policy: platform=ios ramClass=%s fileOrigin=%ld heapOrigin=%ld",
+    pa_ramClassName(snapshot.ramClass),
+    snapshot.fileOriginThresholdBytes,
+    snapshot.heapOriginThresholdBytes
+  );
+}
+
+static long pa_computeThresholdBytes(PaThresholdPathType pathType) {
+  const auto &snapshot = pa_thresholdSnapshot();
+  pa_logThresholdPolicyOnce();
+  switch (pathType) {
+    case PaThresholdPathType::FILE_ORIGIN:
+      return snapshot.fileOriginThresholdBytes;
+    case PaThresholdPathType::HEAP_ORIGIN:
+      return snapshot.heapOriginThresholdBytes;
+  }
+  return snapshot.heapOriginThresholdBytes;
+}
 
 static std::string pa_tempDir() {
   return [NSTemporaryDirectory() UTF8String];
@@ -313,7 +429,8 @@ static std::shared_ptr<PaOfflineEntry> pa_createEntryWithThreshold(
   entry->channelCount = channelCount;
 
   long rawSize = (long)samples.size() * sizeof(float);
-  if (rawSize >= kPaFileBackedThreshold) {
+  long threshold = pa_computeThresholdBytes(PaThresholdPathType::HEAP_ORIGIN);
+  if (rawSize >= threshold) {
     auto region = PaMmapRegion::createFromSamples(samples.data(), samples.size(), pa_tempDir(), bufferId);
     if (region) {
       entry->mmapRegion = std::move(region);
@@ -338,7 +455,8 @@ void pa_upgradeToMmapIfNeeded(const std::string &bufferId) {
   }
   if (entry->isMmapBacked()) return;
   long rawSize = (long)entry->samples.size() * sizeof(float);
-  if (rawSize < kPaFileBackedThreshold) return;
+  long threshold = pa_computeThresholdBytes(PaThresholdPathType::HEAP_ORIGIN);
+  if (rawSize < threshold) return;
 
   auto region = PaMmapRegion::createFromSamples(
     entry->samples.data(), entry->samples.size(), pa_tempDir(), bufferId
@@ -362,7 +480,8 @@ void pa_upgradeToMmapIfNeeded(const std::string &bufferId) {
 }
 
 /**
- * Copy raw F32 bytes from a WAV F32 spool file (skip 44-byte header) to a .f32 temp file, then mmap.
+ * Copy raw F32 bytes from a WAV F32 spool file (skip 44-byte header) to a .f32 temp file.
+ * Use file-origin threshold policy to decide between mmap and in-memory storage.
  * Returns the entry on success, or nullptr on failure (caller falls back to ring snapshot).
  */
 static std::shared_ptr<PaOfflineEntry> pa_createOfflineFromF32WavSpool(
@@ -386,13 +505,63 @@ static std::shared_ptr<PaOfflineEntry> pa_createOfflineFromF32WavSpool(
     if (!f32File) return nullptr;
 
     // Raw byte copy (F32→F32, no conversion)
+    int64_t copiedBytes = 0;
     char buf[32768];
     while (wavFile.read(buf, sizeof(buf)) || wavFile.gcount() > 0) {
-      f32File.write(buf, wavFile.gcount());
+      std::streamsize count = wavFile.gcount();
+      if (count <= 0) break;
+      f32File.write(buf, count);
+      copiedBytes += (int64_t)count;
     }
 
     f32File.close();
     wavFile.close();
+
+    if (copiedBytes <= 0) {
+      unlink(f32Path.c_str());
+      return nullptr;
+    }
+
+    long threshold = pa_computeThresholdBytes(PaThresholdPathType::FILE_ORIGIN);
+    if (copiedBytes < threshold) {
+      int sampleCount = (int)(copiedBytes / (int64_t)sizeof(float));
+      if (sampleCount <= 0) {
+        unlink(f32Path.c_str());
+        return nullptr;
+      }
+
+      int fd = open(f32Path.c_str(), O_RDONLY);
+      if (fd < 0) {
+        unlink(f32Path.c_str());
+        return nullptr;
+      }
+
+      std::vector<float> samples((size_t)sampleCount);
+      size_t bytesToRead = (size_t)sampleCount * sizeof(float);
+      uint8_t *dst = reinterpret_cast<uint8_t *>(samples.data());
+      size_t offset = 0;
+      while (offset < bytesToRead) {
+        ssize_t n = read(fd, dst + offset, bytesToRead - offset);
+        if (n < 0) {
+          if (errno == EINTR) continue;
+          close(fd);
+          unlink(f32Path.c_str());
+          return nullptr;
+        }
+        if (n == 0) break;
+        offset += (size_t)n;
+      }
+      close(fd);
+      unlink(f32Path.c_str());
+      if (offset != bytesToRead) return nullptr;
+
+      auto entry = std::make_shared<PaOfflineEntry>();
+      entry->bufferId = bufferId;
+      entry->sampleRate = sampleRate;
+      entry->channelCount = channelCount;
+      entry->samples = std::move(samples);
+      return entry;
+    }
 
     // Mmap the .f32 file
     auto region = PaMmapRegion::mapFile(f32Path);
@@ -864,8 +1033,9 @@ static std::string pa_generateId(const char *prefix) {
       int outputRate = config.targetSampleRate > 0 ? config.targetSampleRate : result.sourceSampleRate;
 
       long rawSize = (long)totalSamplesWritten * sizeof(float);
+      long threshold = pa_computeThresholdBytes(PaThresholdPathType::FILE_ORIGIN);
       std::shared_ptr<PaOfflineEntry> entry;
-      if (rawSize >= kPaFileBackedThreshold) {
+      if (rawSize >= threshold) {
         // Large: mmap the already-written .f32 directly (zero heap copy)
         auto region = PaMmapRegion::mapFile(f32Path);
         if (region) {

--- a/ios/audio/bridge/SherpaOnnx+PipelineAudio.mm
+++ b/ios/audio/bridge/SherpaOnnx+PipelineAudio.mm
@@ -524,6 +524,10 @@ static std::shared_ptr<PaOfflineEntry> pa_createOfflineFromF32WavSpool(
 
     long threshold = pa_computeThresholdBytes(PaThresholdPathType::FILE_ORIGIN);
     if (copiedBytes < threshold) {
+      if ((copiedBytes % (int64_t)sizeof(float)) != 0) {
+        unlink(f32Path.c_str());
+        return nullptr;
+      }
       int sampleCount = (int)(copiedBytes / (int64_t)sizeof(float));
       if (sampleCount <= 0) {
         unlink(f32Path.c_str());


### PR DESCRIPTION
This pull request implements a dynamic threshold policy for deciding when offline audio buffers should use memory-mapped files (mmap) versus in-memory storage in the Android audio pipeline. The previous fixed 10 MB threshold is replaced with a policy that adapts based on device RAM class and buffer creation path, improving memory efficiency and robustness across a wider range of devices. Documentation is also updated to reflect these changes.

**Dynamic mmap threshold policy implementation:**

* Introduced `MmapThresholdPolicy` in `MmapThresholdPolicy.kt`, which computes mmap thresholds dynamically based on device RAM class and buffer creation path (file-origin vs heap-origin). The policy uses platform-specific base values and multipliers, and clamps thresholds between 4 MB and 32 MB. (`[android/src/main/java/com/sherpaonnx/audio/pipeline/MmapThresholdPolicy.ktR1-R141](diffhunk://#diff-5c97a5efafeadbf53a69d6373009b9a0a623289835bea1070b94690523f268d0R1-R141)`)
* Updated all offline buffer creation paths in `PipelineAudioRegistry.kt` and related code to use `MmapThresholdPolicy.thresholdBytes()` instead of the fixed `PA_FILE_BACKED_THRESHOLD_BYTES` constant. This ensures that large audio buffers use mmap only when appropriate for the device and path type. (`[[1]](diffhunk://#diff-6e22647333673288a3d05d535a64fa12e4803e7ab31dca3f6a6e7d38cbb5837fR60-R63)`, `[[2]](diffhunk://#diff-6e22647333673288a3d05d535a64fa12e4803e7ab31dca3f6a6e7d38cbb5837fR200-R231)`, `[[3]](diffhunk://#diff-6e22647333673288a3d05d535a64fa12e4803e7ab31dca3f6a6e7d38cbb5837fR250-R253)`, `[[4]](diffhunk://#diff-6e22647333673288a3d05d535a64fa12e4803e7ab31dca3f6a6e7d38cbb5837fL254-R284)`, [[5]](diffhunk://#diff-879656a663809608669376c509d884bda0e032ec094f58ce4e41a60afbbcf80dL940-R946)

**API and initialization changes:**

* Changed `PipelineAudioRegistry.initializeWithCacheDir` to accept a `Context` parameter and initialize the threshold policy at startup. Updated call sites accordingly. (`[[1]](diffhunk://#diff-6e22647333673288a3d05d535a64fa12e4803e7ab31dca3f6a6e7d38cbb5837fL33-R44)`, [[2]](diffhunk://#diff-879656a663809608669376c509d884bda0e032ec094f58ce4e41a60afbbcf80dL147-R150)`)

**Documentation updates:**

* Updated the implementation spec to describe the new dynamic threshold policy, replacing references to the old 10 MB constant and clarifying the policy's application points and logic. (`[[1]](diffhunk://#diff-90b241205861c61592da4ab47609575466fd88fae794bed1fe05a954d99ea656L3-R16)`, `[[2]](diffhunk://#diff-90b241205861c61592da4ab47609575466fd88fae794bed1fe05a954d99ea656L25-R35)`, `[[3]](diffhunk://#diff-90b241205861c61592da4ab47609575466fd88fae794bed1fe05a954d99ea656L457-R485)`)

**Cleanup and comments:**

* Removed the now-obsolete `PA_FILE_BACKED_THRESHOLD_BYTES` constant and updated comments throughout the codebase to reference the new policy. (`[[1]](diffhunk://#diff-ea6877cb13e17ec0889df8bad608b66e53e8e9c2e0c7c7b5e187c44df6423fc9L15-R21)`, `[[2]](diffhunk://#diff-ea6877cb13e17ec0889df8bad608b66e53e8e9c2e0c7c7b5e187c44df6423fc9L60-R57)`, `[[3]](diffhunk://#diff-ea6877cb13e17ec0889df8bad608b66e53e8e9c2e0c7c7b5e187c44df6423fc9L110-R107)`)

**Other minor changes:**

* Added a missing import in the iOS bridging code for completeness. (`[ios/audio/bridge/SherpaOnnx+PipelineAudio.mmR29](diffhunk://#diff-71d5e16536f04163af32a165f3eb1760ae464dd4af6fadaf8e4ab21192c1d1a4R29)`)