### PR TITLE
Perf/segment buffer add append journal

### DIFF
--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
@@ -28,7 +28,9 @@ class LiveSegmentEntry(
 
   private val spoolLock = Any()
   @Volatile
-  private var spoolWriter: SegmentSpoolWriter? = null
+  private var journalWriter: SegmentJournalWriter? = null
+  @Volatile
+  private var checkpointWriter: SegmentCheckpointWriter? = null
   @Volatile
   private var spoolReady: Boolean = false
   @Volatile
@@ -39,12 +41,18 @@ class LiveSegmentEntry(
   private var spoolFailureCode: String? = null
   @Volatile
   private var spoolFailureMessage: String? = null
+  @Volatile
+  private var journalEventCount: Int = 0
+  @Volatile
+  private var journalBytesSinceCheckpoint: Long = 0
 
   private fun spoolingEnabled(): Boolean = spoolingMode != SegmentSpoolingMode.OFF
+  private fun v2JournalPath(): String? = spoolPath?.let { "${it}.segj" }
+  private fun v2CheckpointPath(): String? = spoolPath?.let { "${it}.segc" }
 
   init {
     if (spoolingEnabled() && spoolingMode == SegmentSpoolingMode.ON) {
-      writeSnapshotToSpoolOrThrow(snapshotFullForSpool(), mayActivateAuto = false)
+      writeSpoolV2OrThrow(mayActivateAuto = false, checkpointPayload = snapshotFullForSpool())
     }
   }
 
@@ -61,7 +69,8 @@ class LiveSegmentEntry(
     val effectiveDurationMs = durationMs ?: (((endSample - startSample).coerceAtLeast(0) * 1000L) / sampleRate).toInt()
     var segmentId = ""
     var segmentIndex = -1
-    var snapshot = ""
+    var checkpointSnapshot = ""
+    var appendedRecord: SegmentRecord? = null
     synchronized(segmentLock) {
       if (state == State.FINISHED) {
         throw SegmentPipelineException(
@@ -82,16 +91,22 @@ class LiveSegmentEntry(
           durationMs = effectiveDurationMs,
           confidence = confidence,
           payloadJson = payloadJson,
-        )
+        ).also { appendedRecord = it }
       )
-      snapshot = snapshotFullForSpoolLocked()
+      checkpointSnapshot = snapshotFullForSpoolLocked()
       if (segments.size > maxSegments) {
         segments.removeAt(0)
         evictedCount++
       }
       totalSegmentsWritten.incrementAndGet()
     }
-    writeSnapshotToSpoolOrThrow(snapshot, mayActivateAuto = true)
+    val appendRecord = appendedRecord
+      ?: throw SegmentPipelineException(SegmentErrorCodes.INTERNAL_ERROR, "Missing appended segment record")
+    writeSpoolV2OrThrow(
+      mayActivateAuto = true,
+      appendRecord = appendRecord,
+      checkpointPayload = checkpointSnapshot
+    )
     return Pair(segmentId, segmentIndex)
   }
 
@@ -107,7 +122,8 @@ class LiveSegmentEntry(
     }
     synchronized(spoolLock) {
       try {
-        spoolWriter?.finalize_()
+        journalWriter?.appendRecord(SegmentSpoolV2.RECORD_FINALIZE_MARK, "{}")
+        journalWriter?.finalize_()
       } catch (e: Exception) {
         markSpoolFailureAndThrow(
           SegmentErrorCodes.SPOOL_WRITE_FAILED,
@@ -115,7 +131,8 @@ class LiveSegmentEntry(
           e
         )
       } finally {
-        spoolWriter = null
+        journalWriter = null
+        checkpointWriter = null
       }
     }
   }
@@ -151,28 +168,9 @@ class LiveSegmentEntry(
       "Segment spool path missing for $bufferId"
     )
     synchronized(spoolLock) {
-      try {
-        spoolWriter?.flush()
-      } catch (e: Exception) {
-        throw SegmentPipelineException(
-          SegmentErrorCodes.SPOOL_READ_FAILED,
-          "Failed to flush segment spool for $bufferId: ${e.message}",
-          e
-        )
-      }
+      try { journalWriter?.flush() } catch (_: Exception) {}
     }
-    val json = try {
-      SegmentSpoolReader.readLatestSnapshot(path)
-    } catch (e: SegmentPipelineException) {
-      throw e
-    } catch (e: Exception) {
-      throw SegmentPipelineException(
-        SegmentErrorCodes.SPOOL_READ_FAILED,
-        "Failed to read segment spool for $bufferId: ${e.message}",
-        e
-      )
-    }
-    return OfflineSegmentEntry.segmentsFromJson(json)
+    return readFullStateFromSpool(path)
   }
 
   fun getSegments(startIndex: Int, maxCount: Int): List<SegmentRecord> {
@@ -194,15 +192,24 @@ class LiveSegmentEntry(
   fun release() {
     synchronized(spoolLock) {
       try {
-        spoolWriter?.release()
+        journalWriter?.release()
       } catch (_: Exception) {
       } finally {
-        spoolWriter = null
+        journalWriter = null
+        checkpointWriter = null
       }
     }
     if (spoolTemporary && !spoolPath.isNullOrEmpty()) {
       try {
         File(spoolPath).delete()
+      } catch (_: Exception) {
+      }
+      try {
+        File("${spoolPath}.segj").delete()
+      } catch (_: Exception) {
+      }
+      try {
+        File("${spoolPath}.segc").delete()
       } catch (_: Exception) {
       }
     }
@@ -247,13 +254,15 @@ class LiveSegmentEntry(
   }
 
   private fun ensureSpoolWriterActivatedLocked(snapshotJson: String) {
-    if (spoolWriter != null) return
+    if (journalWriter != null && checkpointWriter != null) return
     val resolvedPath = spoolPath ?: markSpoolFailureAndThrow(
       SegmentErrorCodes.SPOOL_UNAVAILABLE,
       "Segment spool path is not configured for $bufferId"
     )
+    val journalPath = "${resolvedPath}.segj"
+    val checkpointPath = "${resolvedPath}.segc"
     val writer = try {
-      SegmentSpoolWriter(resolvedPath)
+      SegmentJournalWriter(journalPath)
     } catch (e: Exception) {
       markSpoolFailureAndThrow(
         SegmentErrorCodes.SPOOL_WRITE_FAILED,
@@ -262,7 +271,12 @@ class LiveSegmentEntry(
       )
     }
     try {
-      writer.appendSnapshot(snapshotJson)
+      val cpWriter = SegmentCheckpointWriter(checkpointPath)
+      cpWriter.writeSnapshot(snapshotJson)
+      checkpointWriter = cpWriter
+      writer.appendRecord(SegmentSpoolV2.RECORD_CHECKPOINT_MARK, "{}")
+      journalEventCount = 0
+      journalBytesSinceCheckpoint = 0L
     } catch (e: Exception) {
       try {
         writer.release()
@@ -274,12 +288,16 @@ class LiveSegmentEntry(
         e
       )
     }
-    spoolWriter = writer
+    journalWriter = writer
     spoolReady = true
     spoolBytes = writer.bytesWritten
   }
 
-  private fun writeSnapshotToSpoolOrThrow(snapshotJson: String, mayActivateAuto: Boolean) {
+  private fun writeSpoolV2OrThrow(
+    mayActivateAuto: Boolean,
+    appendRecord: SegmentRecord? = null,
+    checkpointPayload: String? = null,
+  ) {
     if (!spoolingEnabled()) return
     val failureCode = spoolFailureCode
     if (failureCode != null) {
@@ -289,30 +307,49 @@ class LiveSegmentEntry(
       )
     }
     synchronized(spoolLock) {
-      val writer = spoolWriter
+      val writer = journalWriter
       if (writer == null) {
         when (spoolingMode) {
           SegmentSpoolingMode.OFF -> return
           SegmentSpoolingMode.ON -> {
-            ensureSpoolWriterActivatedLocked(snapshotJson)
+            ensureSpoolWriterActivatedLocked(checkpointPayload ?: """{"segments":[]}""")
             return
           }
           SegmentSpoolingMode.AUTO -> {
             if (!mayActivateAuto) return
             val estimatedBytes =
-              SegmentSpoolWriter.RECORD_HEADER_BYTES + snapshotJson.toByteArray().size
+              SegmentSpoolV2.HEADER_BYTES + (checkpointPayload ?: "").toByteArray().size
             spoolEstimatedBytes += estimatedBytes.toLong()
             if (spoolEstimatedBytes < spoolThresholdBytes.coerceAtLeast(0L)) {
               spoolReady = false
               return
             }
-            ensureSpoolWriterActivatedLocked(snapshotJson)
+            ensureSpoolWriterActivatedLocked(checkpointPayload ?: """{"segments":[]}""")
             return
           }
         }
       }
       try {
-        writer.appendSnapshot(snapshotJson)
+        if (appendRecord != null) {
+          val payload = OfflineSegmentEntry.segmentsToJson(listOf(appendRecord))
+          writer.appendRecord(SegmentSpoolV2.RECORD_SEGMENT_APPEND, payload)
+          journalEventCount += 1
+          journalBytesSinceCheckpoint += (SegmentSpoolV2.HEADER_BYTES + payload.toByteArray().size).toLong()
+        }
+        if (checkpointPayload != null && (
+            journalEventCount >= SegmentSpoolV2.CHECKPOINT_EVERY_EVENTS ||
+              journalBytesSinceCheckpoint >= SegmentSpoolV2.CHECKPOINT_EVERY_BYTES
+            )
+        ) {
+          val cp = checkpointWriter ?: SegmentCheckpointWriter(v2CheckpointPath()
+            ?: throw SegmentPipelineException(SegmentErrorCodes.SPOOL_UNAVAILABLE, "Missing checkpoint path for $bufferId"))
+          cp.writeSnapshot(checkpointPayload)
+          writer.truncate()
+          writer.appendRecord(SegmentSpoolV2.RECORD_CHECKPOINT_MARK, "{}")
+          checkpointWriter = cp
+          journalEventCount = 0
+          journalBytesSinceCheckpoint = 0L
+        }
         spoolReady = true
         spoolBytes = writer.bytesWritten
       } catch (e: Exception) {
@@ -322,6 +359,35 @@ class LiveSegmentEntry(
           e
         )
       }
+    }
+  }
+
+  private fun readFullStateFromSpool(basePath: String): List<SegmentRecord> {
+    val journalPath = "$basePath.segj"
+    val checkpointPath = "$basePath.segc"
+    val hasV2 = File(journalPath).exists() || File(checkpointPath).exists()
+    return if (hasV2) {
+      val checkpointJson = SegmentCheckpointReader.readSnapshot(checkpointPath) ?: """{"segments":[]}"""
+      val base = OfflineSegmentEntry.segmentsFromJson(checkpointJson).toMutableList()
+      val records = SegmentJournalReader.readAllRecords(journalPath)
+      records.forEach { record ->
+        when (record.type) {
+          SegmentSpoolV2.RECORD_SEGMENT_APPEND -> {
+            val parsed = OfflineSegmentEntry.segmentsFromJson(record.payload)
+            if (parsed.isNotEmpty()) base.add(parsed[0])
+          }
+          SegmentSpoolV2.RECORD_CHECKPOINT_MARK,
+          SegmentSpoolV2.RECORD_FINALIZE_MARK -> {}
+          else -> throw SegmentPipelineException(
+            SegmentErrorCodes.SPOOL_CORRUPTED,
+            "Unknown segment journal record type in $journalPath"
+          )
+        }
+      }
+      base
+    } else {
+      val legacyJson = SegmentSpoolReaderLegacy.readLatestSnapshot(basePath)
+      OfflineSegmentEntry.segmentsFromJson(legacyJson)
     }
   }
 }

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
@@ -47,12 +47,12 @@ class LiveSegmentEntry(
   private var journalBytesSinceCheckpoint: Long = 0
 
   private fun spoolingEnabled(): Boolean = spoolingMode != SegmentSpoolingMode.OFF
-  private fun v2JournalPath(): String? = spoolPath?.let { "${it}.segj" }
-  private fun v2CheckpointPath(): String? = spoolPath?.let { "${it}.segc" }
+  private fun journalPath(): String? = spoolPath?.let { "${it}.segj" }
+  private fun checkpointPath(): String? = spoolPath?.let { "${it}.segc" }
 
   init {
     if (spoolingEnabled() && spoolingMode == SegmentSpoolingMode.ON) {
-      writeSpoolV2OrThrow(mayActivateAuto = false, checkpointPayload = snapshotFullForSpool())
+      writeSpoolOrThrow(mayActivateAuto = false, checkpointPayload = snapshotFullForSpool())
     }
   }
 
@@ -102,7 +102,7 @@ class LiveSegmentEntry(
     }
     val appendRecord = appendedRecord
       ?: throw SegmentPipelineException(SegmentErrorCodes.INTERNAL_ERROR, "Missing appended segment record")
-    writeSpoolV2OrThrow(
+    writeSpoolOrThrow(
       mayActivateAuto = true,
       appendRecord = appendRecord,
       checkpointPayload = checkpointSnapshot
@@ -122,7 +122,7 @@ class LiveSegmentEntry(
     }
     synchronized(spoolLock) {
       try {
-        journalWriter?.appendRecord(SegmentSpoolV2.RECORD_FINALIZE_MARK, "{}")
+        journalWriter?.appendRecord(SegmentSpoolFormat.RECORD_FINALIZE_MARK, "{}")
         journalWriter?.finalize_()
       } catch (e: Exception) {
         markSpoolFailureAndThrow(
@@ -201,10 +201,6 @@ class LiveSegmentEntry(
     }
     if (spoolTemporary && !spoolPath.isNullOrEmpty()) {
       try {
-        File(spoolPath).delete()
-      } catch (_: Exception) {
-      }
-      try {
         File("${spoolPath}.segj").delete()
       } catch (_: Exception) {
       }
@@ -274,7 +270,7 @@ class LiveSegmentEntry(
       val cpWriter = SegmentCheckpointWriter(checkpointPath)
       cpWriter.writeSnapshot(snapshotJson)
       checkpointWriter = cpWriter
-      writer.appendRecord(SegmentSpoolV2.RECORD_CHECKPOINT_MARK, "{}")
+      writer.appendRecord(SegmentSpoolFormat.RECORD_CHECKPOINT_MARK, "{}")
       journalEventCount = 0
       journalBytesSinceCheckpoint = 0L
     } catch (e: Exception) {
@@ -293,7 +289,7 @@ class LiveSegmentEntry(
     spoolBytes = writer.bytesWritten
   }
 
-  private fun writeSpoolV2OrThrow(
+  private fun writeSpoolOrThrow(
     mayActivateAuto: Boolean,
     appendRecord: SegmentRecord? = null,
     checkpointPayload: String? = null,
@@ -318,7 +314,7 @@ class LiveSegmentEntry(
           SegmentSpoolingMode.AUTO -> {
             if (!mayActivateAuto) return
             val estimatedBytes =
-              SegmentSpoolV2.HEADER_BYTES + (checkpointPayload ?: "").toByteArray().size
+              SegmentSpoolFormat.HEADER_BYTES + (checkpointPayload ?: "").toByteArray().size
             spoolEstimatedBytes += estimatedBytes.toLong()
             if (spoolEstimatedBytes < spoolThresholdBytes.coerceAtLeast(0L)) {
               spoolReady = false
@@ -332,20 +328,20 @@ class LiveSegmentEntry(
       try {
         if (appendRecord != null) {
           val payload = OfflineSegmentEntry.segmentsToJson(listOf(appendRecord))
-          writer.appendRecord(SegmentSpoolV2.RECORD_SEGMENT_APPEND, payload)
+          writer.appendRecord(SegmentSpoolFormat.RECORD_SEGMENT_APPEND, payload)
           journalEventCount += 1
-          journalBytesSinceCheckpoint += (SegmentSpoolV2.HEADER_BYTES + payload.toByteArray().size).toLong()
+          journalBytesSinceCheckpoint += (SegmentSpoolFormat.HEADER_BYTES + payload.toByteArray().size).toLong()
         }
         if (checkpointPayload != null && (
-            journalEventCount >= SegmentSpoolV2.CHECKPOINT_EVERY_EVENTS ||
-              journalBytesSinceCheckpoint >= SegmentSpoolV2.CHECKPOINT_EVERY_BYTES
+            journalEventCount >= SegmentSpoolFormat.CHECKPOINT_EVERY_EVENTS ||
+              journalBytesSinceCheckpoint >= SegmentSpoolFormat.CHECKPOINT_EVERY_BYTES
             )
         ) {
-          val cp = checkpointWriter ?: SegmentCheckpointWriter(v2CheckpointPath()
+          val cp = checkpointWriter ?: SegmentCheckpointWriter(checkpointPath()
             ?: throw SegmentPipelineException(SegmentErrorCodes.SPOOL_UNAVAILABLE, "Missing checkpoint path for $bufferId"))
           cp.writeSnapshot(checkpointPayload)
           writer.truncate()
-          writer.appendRecord(SegmentSpoolV2.RECORD_CHECKPOINT_MARK, "{}")
+          writer.appendRecord(SegmentSpoolFormat.RECORD_CHECKPOINT_MARK, "{}")
           checkpointWriter = cp
           journalEventCount = 0
           journalBytesSinceCheckpoint = 0L
@@ -365,29 +361,30 @@ class LiveSegmentEntry(
   private fun readFullStateFromSpool(basePath: String): List<SegmentRecord> {
     val journalPath = "$basePath.segj"
     val checkpointPath = "$basePath.segc"
-    val hasV2 = File(journalPath).exists() || File(checkpointPath).exists()
-    return if (hasV2) {
-      val checkpointJson = SegmentCheckpointReader.readSnapshot(checkpointPath) ?: """{"segments":[]}"""
-      val base = OfflineSegmentEntry.segmentsFromJson(checkpointJson).toMutableList()
-      val records = SegmentJournalReader.readAllRecords(journalPath)
-      records.forEach { record ->
-        when (record.type) {
-          SegmentSpoolV2.RECORD_SEGMENT_APPEND -> {
-            val parsed = OfflineSegmentEntry.segmentsFromJson(record.payload)
-            if (parsed.isNotEmpty()) base.add(parsed[0])
-          }
-          SegmentSpoolV2.RECORD_CHECKPOINT_MARK,
-          SegmentSpoolV2.RECORD_FINALIZE_MARK -> {}
-          else -> throw SegmentPipelineException(
-            SegmentErrorCodes.SPOOL_CORRUPTED,
-            "Unknown segment journal record type in $journalPath"
-          )
-        }
-      }
-      base
-    } else {
-      val legacyJson = SegmentSpoolReaderLegacy.readLatestSnapshot(basePath)
-      OfflineSegmentEntry.segmentsFromJson(legacyJson)
+    val hasSpool = File(journalPath).exists() || File(checkpointPath).exists()
+    if (!hasSpool) {
+      throw SegmentPipelineException(
+        SegmentErrorCodes.SPOOL_UNAVAILABLE,
+        "Segment spool files are missing for $bufferId"
+      )
     }
+    val checkpointJson = SegmentCheckpointReader.readSnapshot(checkpointPath) ?: """{"segments":[]}"""
+    val base = OfflineSegmentEntry.segmentsFromJson(checkpointJson).toMutableList()
+    val records = SegmentJournalReader.readAllRecords(journalPath)
+    records.forEach { record ->
+      when (record.type) {
+        SegmentSpoolFormat.RECORD_SEGMENT_APPEND -> {
+          val parsed = OfflineSegmentEntry.segmentsFromJson(record.payload)
+          if (parsed.isNotEmpty()) base.add(parsed[0])
+        }
+        SegmentSpoolFormat.RECORD_CHECKPOINT_MARK,
+        SegmentSpoolFormat.RECORD_FINALIZE_MARK -> {}
+        else -> throw SegmentPipelineException(
+          SegmentErrorCodes.SPOOL_CORRUPTED,
+          "Unknown segment journal record type in $journalPath"
+        )
+      }
+    }
+    return base
   }
 }

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentSpoolIO.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentSpoolIO.kt
@@ -8,7 +8,7 @@ import java.nio.ByteOrder
 import java.nio.charset.StandardCharsets
 import java.util.zip.CRC32
 
-internal object SegmentSpoolV2 {
+internal object SegmentSpoolFormat {
   const val MAGIC = 0x32474553 // SEG2 little-endian
   const val VERSION = 2
   const val HEADER_BYTES = 16
@@ -26,7 +26,7 @@ internal data class SegmentJournalRecord(
 
 internal class SegmentJournalWriter(private val filePath: String) {
   companion object {
-    private const val HEADER_BYTES = SegmentSpoolV2.HEADER_BYTES
+    private const val HEADER_BYTES = SegmentSpoolFormat.HEADER_BYTES
   }
 
   private val raf: RandomAccessFile
@@ -53,8 +53,8 @@ internal class SegmentJournalWriter(private val filePath: String) {
     val header = ByteBuffer
       .allocate(HEADER_BYTES)
       .order(ByteOrder.LITTLE_ENDIAN)
-      .putInt(SegmentSpoolV2.MAGIC)
-      .putShort(SegmentSpoolV2.VERSION.toShort())
+      .putInt(SegmentSpoolFormat.MAGIC)
+      .putShort(SegmentSpoolFormat.VERSION.toShort())
       .putShort(recordType.toShort())
       .putInt(payload.size)
       .putInt(crc)
@@ -108,7 +108,7 @@ internal class SegmentJournalWriter(private val filePath: String) {
 }
 
 internal object SegmentJournalReader {
-  private const val HEADER_BYTES = SegmentSpoolV2.HEADER_BYTES
+  private const val HEADER_BYTES = SegmentSpoolFormat.HEADER_BYTES
 
   fun readAllRecords(path: String): List<SegmentJournalRecord> {
     val file = File(path)
@@ -134,7 +134,7 @@ internal object SegmentJournalReader {
         val type = bb.short.toInt()
         val len = bb.int
         val crc = bb.int
-        if (magic != SegmentSpoolV2.MAGIC || version != SegmentSpoolV2.VERSION) {
+        if (magic != SegmentSpoolFormat.MAGIC || version != SegmentSpoolFormat.VERSION) {
           throw SegmentPipelineException(
             SegmentErrorCodes.SPOOL_CORRUPTED,
             "Unexpected segment journal record version: $path"
@@ -180,11 +180,11 @@ internal class SegmentCheckpointWriter(private val filePath: String) {
       val payload = snapshotJson.toByteArray(StandardCharsets.UTF_8)
       val crc = CRC32().apply { update(payload) }.value.toInt()
       val header = ByteBuffer
-        .allocate(SegmentSpoolV2.HEADER_BYTES)
+        .allocate(SegmentSpoolFormat.HEADER_BYTES)
         .order(ByteOrder.LITTLE_ENDIAN)
-        .putInt(SegmentSpoolV2.MAGIC)
-        .putShort(SegmentSpoolV2.VERSION.toShort())
-        .putShort(SegmentSpoolV2.RECORD_CHECKPOINT_MARK.toShort())
+        .putInt(SegmentSpoolFormat.MAGIC)
+        .putShort(SegmentSpoolFormat.VERSION.toShort())
+        .putShort(SegmentSpoolFormat.RECORD_CHECKPOINT_MARK.toShort())
         .putInt(payload.size)
         .putInt(crc)
         .array()
@@ -213,13 +213,13 @@ internal object SegmentCheckpointReader {
     val file = File(path)
     if (!file.exists()) return null
     RandomAccessFile(file, "r").use { raf ->
-      if (raf.length() < SegmentSpoolV2.HEADER_BYTES) {
+      if (raf.length() < SegmentSpoolFormat.HEADER_BYTES) {
         throw SegmentPipelineException(
           SegmentErrorCodes.SPOOL_CORRUPTED,
           "Corrupted segment checkpoint header: $path"
         )
       }
-      val header = ByteArray(SegmentSpoolV2.HEADER_BYTES)
+      val header = ByteArray(SegmentSpoolFormat.HEADER_BYTES)
       raf.readFully(header)
       val bb = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
       val magic = bb.int
@@ -227,8 +227,8 @@ internal object SegmentCheckpointReader {
       val type = bb.short.toInt()
       val len = bb.int
       val crc = bb.int
-      if (magic != SegmentSpoolV2.MAGIC || version != SegmentSpoolV2.VERSION ||
-        type != SegmentSpoolV2.RECORD_CHECKPOINT_MARK || len < 0
+      if (magic != SegmentSpoolFormat.MAGIC || version != SegmentSpoolFormat.VERSION ||
+        type != SegmentSpoolFormat.RECORD_CHECKPOINT_MARK || len < 0
       ) {
         throw SegmentPipelineException(
           SegmentErrorCodes.SPOOL_CORRUPTED,
@@ -250,27 +250,6 @@ internal object SegmentCheckpointReader {
           "Segment checkpoint checksum mismatch: $path"
         )
       }
-      return String(payload, StandardCharsets.UTF_8)
-    }
-  }
-}
-
-internal object SegmentSpoolReaderLegacy {
-  private const val RECORD_HEADER_BYTES = 4
-  fun readLatestSnapshot(path: String): String {
-    val file = File(path)
-    if (!file.exists()) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_UNAVAILABLE, "Segment spool file does not exist: $path")
-    RandomAccessFile(file, "r").use { raf ->
-      val fileLength = raf.length()
-      if (fileLength < RECORD_HEADER_BYTES) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_CORRUPTED, "Corrupted segment spool header: $path")
-      val header = ByteArray(RECORD_HEADER_BYTES)
-      raf.readFully(header)
-      val len = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN).int
-      if (len < 0) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_CORRUPTED, "Corrupted segment spool length: $path")
-      val expectedLength = RECORD_HEADER_BYTES + len.toLong()
-      if (fileLength != expectedLength) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_CORRUPTED, "Unexpected segment spool size: $path")
-      val payload = ByteArray(len)
-      if (len > 0) raf.readFully(payload)
       return String(payload, StandardCharsets.UTF_8)
     }
   }

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentSpoolIO.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentSpoolIO.kt
@@ -6,10 +6,27 @@ import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.charset.StandardCharsets
+import java.util.zip.CRC32
 
-internal class SegmentSpoolWriter(filePath: String) {
+internal object SegmentSpoolV2 {
+  const val MAGIC = 0x32474553 // SEG2 little-endian
+  const val VERSION = 2
+  const val HEADER_BYTES = 16
+  const val RECORD_SEGMENT_APPEND = 1
+  const val RECORD_CHECKPOINT_MARK = 2
+  const val RECORD_FINALIZE_MARK = 3
+  const val CHECKPOINT_EVERY_EVENTS = 128
+  const val CHECKPOINT_EVERY_BYTES = 1_048_576L
+}
+
+internal data class SegmentJournalRecord(
+  val type: Int,
+  val payload: String,
+)
+
+internal class SegmentJournalWriter(private val filePath: String) {
   companion object {
-    const val RECORD_HEADER_BYTES = 4
+    private const val HEADER_BYTES = SegmentSpoolV2.HEADER_BYTES
   }
 
   private val raf: RandomAccessFile
@@ -26,25 +43,38 @@ internal class SegmentSpoolWriter(filePath: String) {
     val file = File(filePath)
     file.parentFile?.mkdirs()
     raf = RandomAccessFile(file, "rw")
-    raf.setLength(0L)
+    raf.seek(raf.length())
+    bytesWritten = raf.length()
   }
 
-  fun appendSnapshot(snapshotJson: String) {
-    val payload = snapshotJson.toByteArray(StandardCharsets.UTF_8)
+  fun appendRecord(recordType: Int, payloadJson: String) {
+    val payload = payloadJson.toByteArray(StandardCharsets.UTF_8)
+    val crc = CRC32().apply { update(payload) }.value.toInt()
     val header = ByteBuffer
-      .allocate(RECORD_HEADER_BYTES)
+      .allocate(HEADER_BYTES)
       .order(ByteOrder.LITTLE_ENDIAN)
+      .putInt(SegmentSpoolV2.MAGIC)
+      .putShort(SegmentSpoolV2.VERSION.toShort())
+      .putShort(recordType.toShort())
       .putInt(payload.size)
+      .putInt(crc)
       .array()
 
     synchronized(lock) {
-      if (closed) throw IOException("Segment spool writer closed")
-      val recordLength = (RECORD_HEADER_BYTES + payload.size).toLong()
-      raf.seek(0L)
+      if (closed) throw IOException("Segment journal writer closed")
+      raf.seek(raf.length())
       raf.write(header)
       raf.write(payload)
-      raf.setLength(recordLength)
-      bytesWritten = recordLength
+      bytesWritten = raf.length()
+    }
+  }
+
+  fun truncate() {
+    synchronized(lock) {
+      if (closed) return
+      raf.setLength(0L)
+      raf.seek(0L)
+      bytesWritten = 0L
     }
   }
 
@@ -77,43 +107,168 @@ internal class SegmentSpoolWriter(filePath: String) {
   }
 }
 
-internal object SegmentSpoolReader {
-  private const val RECORD_HEADER_BYTES = 4
+internal object SegmentJournalReader {
+  private const val HEADER_BYTES = SegmentSpoolV2.HEADER_BYTES
 
-  fun readLatestSnapshot(path: String): String {
+  fun readAllRecords(path: String): List<SegmentJournalRecord> {
     val file = File(path)
     if (!file.exists()) {
-      throw SegmentPipelineException(
-        SegmentErrorCodes.SPOOL_UNAVAILABLE,
-        "Segment spool file does not exist: $path"
-      )
+      return emptyList()
     }
 
     RandomAccessFile(file, "r").use { raf ->
-      val fileLength = raf.length()
-      if (fileLength < RECORD_HEADER_BYTES) {
+      val out = ArrayList<SegmentJournalRecord>()
+      while (raf.filePointer < raf.length()) {
+        val remaining = raf.length() - raf.filePointer
+        if (remaining < HEADER_BYTES) {
+          throw SegmentPipelineException(
+            SegmentErrorCodes.SPOOL_CORRUPTED,
+            "Corrupted segment journal header: $path"
+          )
+        }
+        val header = ByteArray(HEADER_BYTES)
+        raf.readFully(header)
+        val bb = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+        val magic = bb.int
+        val version = bb.short.toInt()
+        val type = bb.short.toInt()
+        val len = bb.int
+        val crc = bb.int
+        if (magic != SegmentSpoolV2.MAGIC || version != SegmentSpoolV2.VERSION) {
+          throw SegmentPipelineException(
+            SegmentErrorCodes.SPOOL_CORRUPTED,
+            "Unexpected segment journal record version: $path"
+          )
+        }
+        if (len < 0) {
+          throw SegmentPipelineException(
+            SegmentErrorCodes.SPOOL_CORRUPTED,
+            "Corrupted segment journal record length: $path"
+          )
+        }
+        val payload = ByteArray(len)
+        if (len > 0) {
+          if (raf.filePointer + len > raf.length()) {
+            throw SegmentPipelineException(
+              SegmentErrorCodes.SPOOL_CORRUPTED,
+              "Truncated segment journal payload: $path"
+            )
+          }
+          raf.readFully(payload)
+        }
+        val actualCrc = CRC32().apply { update(payload) }.value.toInt()
+        if (actualCrc != crc) {
+          throw SegmentPipelineException(
+            SegmentErrorCodes.SPOOL_CORRUPTED,
+            "Segment journal checksum mismatch: $path"
+          )
+        }
+        out.add(SegmentJournalRecord(type, String(payload, StandardCharsets.UTF_8)))
+      }
+      return out
+    }
+  }
+}
+
+internal class SegmentCheckpointWriter(private val filePath: String) {
+  fun writeSnapshot(snapshotJson: String) {
+    val tmpPath = "$filePath.tmp"
+    val tmpFile = File(tmpPath)
+    tmpFile.parentFile?.mkdirs()
+    RandomAccessFile(tmpFile, "rw").use { raf ->
+      raf.setLength(0L)
+      val payload = snapshotJson.toByteArray(StandardCharsets.UTF_8)
+      val crc = CRC32().apply { update(payload) }.value.toInt()
+      val header = ByteBuffer
+        .allocate(SegmentSpoolV2.HEADER_BYTES)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .putInt(SegmentSpoolV2.MAGIC)
+        .putShort(SegmentSpoolV2.VERSION.toShort())
+        .putShort(SegmentSpoolV2.RECORD_CHECKPOINT_MARK.toShort())
+        .putInt(payload.size)
+        .putInt(crc)
+        .array()
+      raf.write(header)
+      raf.write(payload)
+      raf.fd.sync()
+    }
+    val target = File(filePath)
+    if (target.exists() && !target.delete()) {
+      throw SegmentPipelineException(
+        SegmentErrorCodes.SPOOL_WRITE_FAILED,
+        "Failed to replace checkpoint file: $filePath"
+      )
+    }
+    if (!tmpFile.renameTo(target)) {
+      throw SegmentPipelineException(
+        SegmentErrorCodes.SPOOL_WRITE_FAILED,
+        "Failed to finalize checkpoint file: $filePath"
+      )
+    }
+  }
+}
+
+internal object SegmentCheckpointReader {
+  fun readSnapshot(path: String): String? {
+    val file = File(path)
+    if (!file.exists()) return null
+    RandomAccessFile(file, "r").use { raf ->
+      if (raf.length() < SegmentSpoolV2.HEADER_BYTES) {
         throw SegmentPipelineException(
           SegmentErrorCodes.SPOOL_CORRUPTED,
-          "Corrupted segment spool header: $path"
+          "Corrupted segment checkpoint header: $path"
         )
       }
-      raf.seek(0L)
+      val header = ByteArray(SegmentSpoolV2.HEADER_BYTES)
+      raf.readFully(header)
+      val bb = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+      val magic = bb.int
+      val version = bb.short.toInt()
+      val type = bb.short.toInt()
+      val len = bb.int
+      val crc = bb.int
+      if (magic != SegmentSpoolV2.MAGIC || version != SegmentSpoolV2.VERSION ||
+        type != SegmentSpoolV2.RECORD_CHECKPOINT_MARK || len < 0
+      ) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.SPOOL_CORRUPTED,
+          "Unexpected segment checkpoint record format: $path"
+        )
+      }
+      val payload = ByteArray(len)
+      if (len > 0) raf.readFully(payload)
+      if (raf.filePointer != raf.length()) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.SPOOL_CORRUPTED,
+          "Unexpected trailing data in checkpoint file: $path"
+        )
+      }
+      val actualCrc = CRC32().apply { update(payload) }.value.toInt()
+      if (actualCrc != crc) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.SPOOL_CORRUPTED,
+          "Segment checkpoint checksum mismatch: $path"
+        )
+      }
+      return String(payload, StandardCharsets.UTF_8)
+    }
+  }
+}
+
+internal object SegmentSpoolReaderLegacy {
+  private const val RECORD_HEADER_BYTES = 4
+  fun readLatestSnapshot(path: String): String {
+    val file = File(path)
+    if (!file.exists()) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_UNAVAILABLE, "Segment spool file does not exist: $path")
+    RandomAccessFile(file, "r").use { raf ->
+      val fileLength = raf.length()
+      if (fileLength < RECORD_HEADER_BYTES) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_CORRUPTED, "Corrupted segment spool header: $path")
       val header = ByteArray(RECORD_HEADER_BYTES)
       raf.readFully(header)
       val len = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN).int
-      if (len < 0) {
-        throw SegmentPipelineException(
-          SegmentErrorCodes.SPOOL_CORRUPTED,
-          "Corrupted segment spool length: $path"
-        )
-      }
+      if (len < 0) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_CORRUPTED, "Corrupted segment spool length: $path")
       val expectedLength = RECORD_HEADER_BYTES + len.toLong()
-      if (fileLength != expectedLength) {
-        throw SegmentPipelineException(
-          SegmentErrorCodes.SPOOL_CORRUPTED,
-          "Unexpected segment spool size: $path"
-        )
-      }
+      if (fileLength != expectedLength) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_CORRUPTED, "Unexpected segment spool size: $path")
       val payload = ByteArray(len)
       if (len > 0) raf.readFully(payload)
       return String(payload, StandardCharsets.UTF_8)

--- a/android/src/main/java/com/sherpaonnx/text/pipeline/LiveTextEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/text/pipeline/LiveTextEntry.kt
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.zip.CRC32
 
 /**
  * A committed text segment in the segment log.
@@ -70,6 +71,18 @@ class LiveTextEntry(
   private val spoolTemporary: Boolean = true,
   private val spoolThresholdBytes: Long = 0,
 ) {
+  companion object {
+    private const val TEXT_SPOOL_V2_MAGIC = 0x32545854 // TXT2
+    private const val TEXT_SPOOL_V2_VERSION = 2
+    private const val TEXT_SPOOL_V2_HEADER_BYTES = 16
+    private const val TEXT_SPOOL_V2_PARTIAL_SET = 1
+    private const val TEXT_SPOOL_V2_PARTIAL_APPEND = 2
+    private const val TEXT_SPOOL_V2_SEGMENT_COMMIT = 3
+    private const val TEXT_SPOOL_V2_CHECKPOINT = 4
+    private const val TEXT_SPOOL_V2_FINALIZE = 5
+    private const val TEXT_SPOOL_V2_CHECKPOINT_EVERY_EVENTS = 128
+    private const val TEXT_SPOOL_V2_CHECKPOINT_EVERY_BYTES = 1_048_576L
+  }
   enum class State { RECORDING, FINISHED }
 
   @Volatile
@@ -122,11 +135,18 @@ class LiveTextEntry(
   private var spoolFailureCode: String? = null
   @Volatile
   private var spoolFailureMessage: String? = null
+  @Volatile
+  private var journalEventCount: Int = 0
+  @Volatile
+  private var journalBytesSinceCheckpoint: Long = 0
 
   init {
     if (spoolingEnabled() && spoolingMode == TextSpoolingMode.ON) {
       val initialSnapshot = snapshotFullTextForSpool()
-      writeSnapshotToSpoolOrThrow(initialSnapshot, mayActivateAuto = false)
+      writeTextSpoolV2OrThrow(
+        mayActivateAuto = false,
+        checkpointPayload = buildCheckpointPayload(initialSnapshot)
+      )
     }
   }
 
@@ -153,12 +173,77 @@ class LiveTextEntry(
     throw TextPipelineException(code, message, cause)
   }
 
+  private fun journalPath(): String? = spoolPath?.let { "$it.txtj" }
+  private fun checkpointPath(): String? = spoolPath?.let { "$it.txtc" }
+
+  private fun buildCheckpointPayload(fullText: String): String {
+    val escaped = fullText.replace("\\", "\\\\").replace("\"", "\\\"")
+    return """{"fullText":"$escaped","totalCharsWritten":$totalCharsWritten,"revision":$revision}"""
+  }
+
+  private fun extractCheckpointText(payload: String): String {
+    val marker = """"fullText":""""
+    val idx = payload.indexOf(marker)
+    if (idx < 0) return ""
+    val start = payload.indexOf('"', idx + marker.length)
+    if (start < 0) return ""
+    val end = payload.indexOf('"', start + 1)
+    if (end < 0) return ""
+    return payload.substring(start + 1, end).replace("\\\"", "\"").replace("\\\\", "\\")
+  }
+
+  private fun appendV2RecordLocked(writer: TextSpoolWriter, recordType: Int, payload: String): Long {
+    val payloadBytes = payload.toByteArray(StandardCharsets.UTF_8)
+    val checksum = CRC32().apply { update(payloadBytes) }.value.toInt()
+    val header = ByteBuffer
+      .allocate(TEXT_SPOOL_V2_HEADER_BYTES)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .putInt(TEXT_SPOOL_V2_MAGIC)
+      .putShort(TEXT_SPOOL_V2_VERSION.toShort())
+      .putShort(recordType.toShort())
+      .putInt(payloadBytes.size)
+      .putInt(checksum)
+      .array()
+    writer.appendRawRecord(header, payloadBytes)
+    return (header.size + payloadBytes.size).toLong()
+  }
+
+  private fun writeCheckpointFile(checkpointPath: String, payload: String) {
+    val tmpPath = "$checkpointPath.tmp"
+    val tmpFile = RandomAccessFile(tmpPath, "rw")
+    tmpFile.use { raf ->
+      raf.setLength(0L)
+      val payloadBytes = payload.toByteArray(StandardCharsets.UTF_8)
+      val checksum = CRC32().apply { update(payloadBytes) }.value.toInt()
+      val header = ByteBuffer
+        .allocate(TEXT_SPOOL_V2_HEADER_BYTES)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .putInt(TEXT_SPOOL_V2_MAGIC)
+        .putShort(TEXT_SPOOL_V2_VERSION.toShort())
+        .putShort(TEXT_SPOOL_V2_CHECKPOINT.toShort())
+        .putInt(payloadBytes.size)
+        .putInt(checksum)
+        .array()
+      raf.write(header)
+      raf.write(payloadBytes)
+      raf.fd.sync()
+    }
+    val target = File(checkpointPath)
+    if (target.exists() && !target.delete()) {
+      throw TextPipelineException(TextErrorCodes.SPOOL_WRITE_FAILED, "Failed to replace text checkpoint: $checkpointPath")
+    }
+    if (!File(tmpPath).renameTo(target)) {
+      throw TextPipelineException(TextErrorCodes.SPOOL_WRITE_FAILED, "Failed to finalize text checkpoint: $checkpointPath")
+    }
+  }
+
   private fun ensureSpoolWriterActivatedLocked(bootstrapSnapshot: String) {
     if (spoolWriter != null) return
-    val resolvedPath = spoolPath ?: markSpoolFailureAndThrow(
+    val basePath = spoolPath ?: markSpoolFailureAndThrow(
       TextErrorCodes.SPOOL_UNAVAILABLE,
       "Text spool path is not configured for live buffer: $bufferId"
     )
+    val resolvedPath = "$basePath.txtj"
 
     val writer = try {
       TextSpoolWriter(resolvedPath)
@@ -171,7 +256,12 @@ class LiveTextEntry(
     }
 
     try {
-      writer.appendSnapshot(bootstrapSnapshot)
+      val cpPath = checkpointPath()
+        ?: markSpoolFailureAndThrow(TextErrorCodes.SPOOL_UNAVAILABLE, "Text checkpoint path missing for $bufferId")
+      writeCheckpointFile(cpPath, buildCheckpointPayload(bootstrapSnapshot))
+      appendV2RecordLocked(writer, TEXT_SPOOL_V2_CHECKPOINT, "{}")
+      journalEventCount = 0
+      journalBytesSinceCheckpoint = 0L
     } catch (e: Exception) {
       try {
         writer.release()
@@ -190,7 +280,12 @@ class LiveTextEntry(
     spoolBytes = writer.bytesWritten
   }
 
-  private fun writeSnapshotToSpoolOrThrow(snapshot: String, mayActivateAuto: Boolean) {
+  private fun writeTextSpoolV2OrThrow(
+    mayActivateAuto: Boolean,
+    recordType: Int? = null,
+    recordPayload: String? = null,
+    checkpointPayload: String? = null,
+  ) {
     if (!spoolingEnabled()) return
 
     val existingFailureCode = spoolFailureCode
@@ -207,26 +302,43 @@ class LiveTextEntry(
         when (spoolingMode) {
           TextSpoolingMode.OFF -> return
           TextSpoolingMode.ON -> {
-            ensureSpoolWriterActivatedLocked(snapshot)
+            ensureSpoolWriterActivatedLocked(snapshotFullTextForSpool())
             return
           }
           TextSpoolingMode.AUTO -> {
             if (!mayActivateAuto) return
             val estimatedRecordBytes =
-              TextSpoolWriter.RECORD_HEADER_BYTES + snapshot.toByteArray(StandardCharsets.UTF_8).size
+              TextSpoolWriter.RECORD_HEADER_BYTES + snapshotFullTextForSpool().toByteArray(StandardCharsets.UTF_8).size
             spoolEstimatedBytes += estimatedRecordBytes.toLong()
             if (spoolEstimatedBytes < spoolThresholdBytes.coerceAtLeast(0L)) {
               spoolReady = false
               return
             }
-            ensureSpoolWriterActivatedLocked(snapshot)
+            ensureSpoolWriterActivatedLocked(snapshotFullTextForSpool())
             return
           }
         }
       }
 
       try {
-        writer.appendSnapshot(snapshot)
+        if (recordType != null && recordPayload != null) {
+          val written = appendV2RecordLocked(writer, recordType, recordPayload)
+          journalEventCount += 1
+          journalBytesSinceCheckpoint += written
+        }
+        if (checkpointPayload != null && (
+            journalEventCount >= TEXT_SPOOL_V2_CHECKPOINT_EVERY_EVENTS ||
+              journalBytesSinceCheckpoint >= TEXT_SPOOL_V2_CHECKPOINT_EVERY_BYTES
+            )
+        ) {
+          val cpPath = checkpointPath()
+            ?: throw TextPipelineException(TextErrorCodes.SPOOL_UNAVAILABLE, "Text checkpoint path missing for $bufferId")
+          writeCheckpointFile(cpPath, checkpointPayload)
+          writer.truncate()
+          appendV2RecordLocked(writer, TEXT_SPOOL_V2_CHECKPOINT, "{}")
+          journalEventCount = 0
+          journalBytesSinceCheckpoint = 0L
+        }
         spoolReady = true
         spoolBytes = writer.bytesWritten
       } catch (e: Exception) {
@@ -254,8 +366,12 @@ class LiveTextEntry(
     totalCharsWritten += text.length
     _revision.incrementAndGet()
 
-    val snapshot = snapshotFullTextForSpool()
-    writeSnapshotToSpoolOrThrow(snapshot, mayActivateAuto = true)
+    writeTextSpoolV2OrThrow(
+      mayActivateAuto = true,
+      recordType = TEXT_SPOOL_V2_PARTIAL_SET,
+      recordPayload = text,
+      checkpointPayload = buildCheckpointPayload(snapshotFullTextForSpool())
+    )
   }
 
   /**
@@ -274,8 +390,12 @@ class LiveTextEntry(
     totalCharsWritten += text.length
     _revision.incrementAndGet()
 
-    val snapshot = snapshotFullTextForSpool()
-    writeSnapshotToSpoolOrThrow(snapshot, mayActivateAuto = true)
+    writeTextSpoolV2OrThrow(
+      mayActivateAuto = true,
+      recordType = TEXT_SPOOL_V2_PARTIAL_APPEND,
+      recordPayload = text,
+      checkpointPayload = buildCheckpointPayload(snapshotFullTextForSpool())
+    )
   }
 
   /**
@@ -325,7 +445,12 @@ class LiveTextEntry(
       _revision.incrementAndGet()
     }
 
-    writeSnapshotToSpoolOrThrow(snapshotAfterCommit, mayActivateAuto = true)
+    writeTextSpoolV2OrThrow(
+      mayActivateAuto = true,
+      recordType = TEXT_SPOOL_V2_SEGMENT_COMMIT,
+      recordPayload = """{"text":${JSONObject.quote(text)}}""",
+      checkpointPayload = buildCheckpointPayload(snapshotAfterCommit)
+    )
     notifyAppendListeners()
     return committedSegmentIndex
   }
@@ -401,7 +526,10 @@ class LiveTextEntry(
 
     synchronized(spoolLock) {
       try {
-        spoolWriter?.finalize_()
+        spoolWriter?.let { writer ->
+          appendV2RecordLocked(writer, TEXT_SPOOL_V2_FINALIZE, "{}")
+          writer.finalize_()
+        }
       } catch (e: Exception) {
         markSpoolFailureAndThrow(
           TextErrorCodes.SPOOL_WRITE_FAILED,
@@ -484,17 +612,38 @@ class LiveTextEntry(
       }
     }
 
-    return try {
-      TextSpoolReader.readLatestSnapshot(path)
-    } catch (e: TextPipelineException) {
-      throw e
-    } catch (e: IOException) {
-      throw TextPipelineException(
-        TextErrorCodes.SPOOL_READ_FAILED,
-        "Failed to read text spool for live buffer $bufferId: ${e.message}",
-        e,
-      )
+    val cpPath = "$path.txtc"
+    val jPath = "$path.txtj"
+    val hasV2 = File(cpPath).exists() || File(jPath).exists()
+    if (hasV2) {
+      try {
+        var fullText = ""
+        val cpPayload = TextSpoolReader.readV2Checkpoint(cpPath)
+        if (cpPayload != null) {
+          fullText = extractCheckpointText(cpPayload)
+        }
+        TextSpoolReader.readV2Journal(jPath).forEach { rec ->
+          when (rec.type) {
+            TEXT_SPOOL_V2_PARTIAL_SET -> fullText = rec.payload
+            TEXT_SPOOL_V2_PARTIAL_APPEND -> fullText += rec.payload
+            TEXT_SPOOL_V2_SEGMENT_COMMIT -> {
+              val obj = JSONObject(rec.payload)
+              fullText += obj.optString("text", "")
+            }
+          }
+        }
+        return fullText
+      } catch (e: TextPipelineException) {
+        throw e
+      } catch (e: Exception) {
+        throw TextPipelineException(
+          TextErrorCodes.SPOOL_READ_FAILED,
+          "Failed to read V2 text spool for live buffer $bufferId: ${e.message}",
+          e,
+        )
+      }
     }
+    return TextSpoolReader.readLatestSnapshot(path)
   }
 
   fun release() {
@@ -513,6 +662,14 @@ class LiveTextEntry(
         File(spoolPath).delete()
       } catch (_: Exception) {
         // best-effort cleanup
+      }
+      try {
+        File("${spoolPath}.txtj").delete()
+      } catch (_: Exception) {
+      }
+      try {
+        File("${spoolPath}.txtc").delete()
+      } catch (_: Exception) {
       }
     }
 
@@ -561,6 +718,25 @@ private class TextSpoolWriter(filePath: String) {
       raf.write(payload)
       raf.setLength(recordLength)
       bytesWritten = recordLength
+    }
+  }
+
+  fun appendRawRecord(header: ByteArray, payload: ByteArray) {
+    synchronized(lock) {
+      if (closed) throw IOException("Text spool writer is closed")
+      raf.seek(raf.length())
+      raf.write(header)
+      raf.write(payload)
+      bytesWritten = raf.length()
+    }
+  }
+
+  fun truncate() {
+    synchronized(lock) {
+      if (closed) return
+      raf.setLength(0L)
+      raf.seek(0L)
+      bytesWritten = 0L
     }
   }
 
@@ -639,6 +815,64 @@ private object TextSpoolReader {
       }
 
       return String(payload, StandardCharsets.UTF_8)
+    }
+  }
+
+  data class JournalRecord(val type: Int, val payload: String)
+
+  fun readV2Checkpoint(filePath: String): String? {
+    val file = File(filePath)
+    if (!file.exists()) return null
+    RandomAccessFile(file, "r").use { raf ->
+      if (raf.length() < 16) throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Corrupted V2 text checkpoint header in $filePath")
+      val header = ByteArray(16)
+      raf.readFully(header)
+      val bb = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+      val magic = bb.int
+      val version = bb.short.toInt()
+      val type = bb.short.toInt()
+      val length = bb.int
+      val checksum = bb.int
+      if (magic != TEXT_SPOOL_V2_MAGIC || version != TEXT_SPOOL_V2_VERSION || type != TEXT_SPOOL_V2_CHECKPOINT || length < 0) {
+        throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Unexpected V2 text checkpoint format in $filePath")
+      }
+      val payload = ByteArray(length)
+      if (length > 0) raf.readFully(payload)
+      val actual = CRC32().apply { update(payload) }.value.toInt()
+      if (actual != checksum) throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "V2 text checkpoint checksum mismatch in $filePath")
+      return String(payload, StandardCharsets.UTF_8)
+    }
+  }
+
+  fun readV2Journal(filePath: String): List<JournalRecord> {
+    val file = File(filePath)
+    if (!file.exists()) return emptyList()
+    RandomAccessFile(file, "r").use { raf ->
+      val out = ArrayList<JournalRecord>()
+      while (raf.filePointer < raf.length()) {
+        if (raf.length() - raf.filePointer < 16) {
+          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Corrupted V2 text journal header in $filePath")
+        }
+        val header = ByteArray(16)
+        raf.readFully(header)
+        val bb = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+        val magic = bb.int
+        val version = bb.short.toInt()
+        val type = bb.short.toInt()
+        val length = bb.int
+        val checksum = bb.int
+        if (magic != TEXT_SPOOL_V2_MAGIC || version != TEXT_SPOOL_V2_VERSION || length < 0) {
+          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Unexpected V2 text journal record format in $filePath")
+        }
+        val payload = ByteArray(length)
+        if (length > 0) raf.readFully(payload)
+        val actual = CRC32().apply { update(payload) }.value.toInt()
+        if (actual != checksum) {
+          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "V2 text journal checksum mismatch in $filePath")
+        }
+        out.add(JournalRecord(type, String(payload, StandardCharsets.UTF_8)))
+      }
+      return out
     }
   }
 }

--- a/android/src/main/java/com/sherpaonnx/text/pipeline/LiveTextEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/text/pipeline/LiveTextEntry.kt
@@ -72,16 +72,16 @@ class LiveTextEntry(
   private val spoolThresholdBytes: Long = 0,
 ) {
   companion object {
-    private const val TEXT_SPOOL_V2_MAGIC = 0x32545854 // TXT2
-    private const val TEXT_SPOOL_V2_VERSION = 2
-    private const val TEXT_SPOOL_V2_HEADER_BYTES = 16
-    private const val TEXT_SPOOL_V2_PARTIAL_SET = 1
-    private const val TEXT_SPOOL_V2_PARTIAL_APPEND = 2
-    private const val TEXT_SPOOL_V2_SEGMENT_COMMIT = 3
-    private const val TEXT_SPOOL_V2_CHECKPOINT = 4
-    private const val TEXT_SPOOL_V2_FINALIZE = 5
-    private const val TEXT_SPOOL_V2_CHECKPOINT_EVERY_EVENTS = 128
-    private const val TEXT_SPOOL_V2_CHECKPOINT_EVERY_BYTES = 1_048_576L
+    private const val TEXT_SPOOL_MAGIC = 0x32545854 // TXT2
+    private const val TEXT_SPOOL_VERSION = 2
+    private const val TEXT_SPOOL_HEADER_BYTES = 16
+    private const val TEXT_SPOOL_PARTIAL_SET = 1
+    private const val TEXT_SPOOL_PARTIAL_APPEND = 2
+    private const val TEXT_SPOOL_SEGMENT_COMMIT = 3
+    private const val TEXT_SPOOL_CHECKPOINT = 4
+    private const val TEXT_SPOOL_FINALIZE = 5
+    private const val TEXT_SPOOL_CHECKPOINT_EVERY_EVENTS = 128
+    private const val TEXT_SPOOL_CHECKPOINT_EVERY_BYTES = 1_048_576L
   }
   enum class State { RECORDING, FINISHED }
 
@@ -143,7 +143,7 @@ class LiveTextEntry(
   init {
     if (spoolingEnabled() && spoolingMode == TextSpoolingMode.ON) {
       val initialSnapshot = snapshotFullTextForSpool()
-      writeTextSpoolV2OrThrow(
+      writeTextSpoolOrThrow(
         mayActivateAuto = false,
         checkpointPayload = buildCheckpointPayload(initialSnapshot)
       )
@@ -192,14 +192,14 @@ class LiveTextEntry(
     return payload.substring(start + 1, end).replace("\\\"", "\"").replace("\\\\", "\\")
   }
 
-  private fun appendV2RecordLocked(writer: TextSpoolWriter, recordType: Int, payload: String): Long {
+  private fun appendSpoolRecordLocked(writer: TextSpoolWriter, recordType: Int, payload: String): Long {
     val payloadBytes = payload.toByteArray(StandardCharsets.UTF_8)
     val checksum = CRC32().apply { update(payloadBytes) }.value.toInt()
     val header = ByteBuffer
-      .allocate(TEXT_SPOOL_V2_HEADER_BYTES)
+      .allocate(TEXT_SPOOL_HEADER_BYTES)
       .order(ByteOrder.LITTLE_ENDIAN)
-      .putInt(TEXT_SPOOL_V2_MAGIC)
-      .putShort(TEXT_SPOOL_V2_VERSION.toShort())
+      .putInt(TEXT_SPOOL_MAGIC)
+      .putShort(TEXT_SPOOL_VERSION.toShort())
       .putShort(recordType.toShort())
       .putInt(payloadBytes.size)
       .putInt(checksum)
@@ -216,11 +216,11 @@ class LiveTextEntry(
       val payloadBytes = payload.toByteArray(StandardCharsets.UTF_8)
       val checksum = CRC32().apply { update(payloadBytes) }.value.toInt()
       val header = ByteBuffer
-        .allocate(TEXT_SPOOL_V2_HEADER_BYTES)
+        .allocate(TEXT_SPOOL_HEADER_BYTES)
         .order(ByteOrder.LITTLE_ENDIAN)
-        .putInt(TEXT_SPOOL_V2_MAGIC)
-        .putShort(TEXT_SPOOL_V2_VERSION.toShort())
-        .putShort(TEXT_SPOOL_V2_CHECKPOINT.toShort())
+        .putInt(TEXT_SPOOL_MAGIC)
+        .putShort(TEXT_SPOOL_VERSION.toShort())
+        .putShort(TEXT_SPOOL_CHECKPOINT.toShort())
         .putInt(payloadBytes.size)
         .putInt(checksum)
         .array()
@@ -259,7 +259,7 @@ class LiveTextEntry(
       val cpPath = checkpointPath()
         ?: markSpoolFailureAndThrow(TextErrorCodes.SPOOL_UNAVAILABLE, "Text checkpoint path missing for $bufferId")
       writeCheckpointFile(cpPath, buildCheckpointPayload(bootstrapSnapshot))
-      appendV2RecordLocked(writer, TEXT_SPOOL_V2_CHECKPOINT, "{}")
+      appendSpoolRecordLocked(writer, TEXT_SPOOL_CHECKPOINT, "{}")
       journalEventCount = 0
       journalBytesSinceCheckpoint = 0L
     } catch (e: Exception) {
@@ -280,7 +280,7 @@ class LiveTextEntry(
     spoolBytes = writer.bytesWritten
   }
 
-  private fun writeTextSpoolV2OrThrow(
+  private fun writeTextSpoolOrThrow(
     mayActivateAuto: Boolean,
     recordType: Int? = null,
     recordPayload: String? = null,
@@ -308,7 +308,7 @@ class LiveTextEntry(
           TextSpoolingMode.AUTO -> {
             if (!mayActivateAuto) return
             val estimatedRecordBytes =
-              TextSpoolWriter.RECORD_HEADER_BYTES + snapshotFullTextForSpool().toByteArray(StandardCharsets.UTF_8).size
+              TEXT_SPOOL_HEADER_BYTES + snapshotFullTextForSpool().toByteArray(StandardCharsets.UTF_8).size
             spoolEstimatedBytes += estimatedRecordBytes.toLong()
             if (spoolEstimatedBytes < spoolThresholdBytes.coerceAtLeast(0L)) {
               spoolReady = false
@@ -322,20 +322,20 @@ class LiveTextEntry(
 
       try {
         if (recordType != null && recordPayload != null) {
-          val written = appendV2RecordLocked(writer, recordType, recordPayload)
+          val written = appendSpoolRecordLocked(writer, recordType, recordPayload)
           journalEventCount += 1
           journalBytesSinceCheckpoint += written
         }
         if (checkpointPayload != null && (
-            journalEventCount >= TEXT_SPOOL_V2_CHECKPOINT_EVERY_EVENTS ||
-              journalBytesSinceCheckpoint >= TEXT_SPOOL_V2_CHECKPOINT_EVERY_BYTES
+            journalEventCount >= TEXT_SPOOL_CHECKPOINT_EVERY_EVENTS ||
+              journalBytesSinceCheckpoint >= TEXT_SPOOL_CHECKPOINT_EVERY_BYTES
             )
         ) {
           val cpPath = checkpointPath()
             ?: throw TextPipelineException(TextErrorCodes.SPOOL_UNAVAILABLE, "Text checkpoint path missing for $bufferId")
           writeCheckpointFile(cpPath, checkpointPayload)
           writer.truncate()
-          appendV2RecordLocked(writer, TEXT_SPOOL_V2_CHECKPOINT, "{}")
+          appendSpoolRecordLocked(writer, TEXT_SPOOL_CHECKPOINT, "{}")
           journalEventCount = 0
           journalBytesSinceCheckpoint = 0L
         }
@@ -366,9 +366,9 @@ class LiveTextEntry(
     totalCharsWritten += text.length
     _revision.incrementAndGet()
 
-    writeTextSpoolV2OrThrow(
+    writeTextSpoolOrThrow(
       mayActivateAuto = true,
-      recordType = TEXT_SPOOL_V2_PARTIAL_SET,
+      recordType = TEXT_SPOOL_PARTIAL_SET,
       recordPayload = text,
       checkpointPayload = buildCheckpointPayload(snapshotFullTextForSpool())
     )
@@ -390,9 +390,9 @@ class LiveTextEntry(
     totalCharsWritten += text.length
     _revision.incrementAndGet()
 
-    writeTextSpoolV2OrThrow(
+    writeTextSpoolOrThrow(
       mayActivateAuto = true,
-      recordType = TEXT_SPOOL_V2_PARTIAL_APPEND,
+      recordType = TEXT_SPOOL_PARTIAL_APPEND,
       recordPayload = text,
       checkpointPayload = buildCheckpointPayload(snapshotFullTextForSpool())
     )
@@ -445,9 +445,9 @@ class LiveTextEntry(
       _revision.incrementAndGet()
     }
 
-    writeTextSpoolV2OrThrow(
+    writeTextSpoolOrThrow(
       mayActivateAuto = true,
-      recordType = TEXT_SPOOL_V2_SEGMENT_COMMIT,
+      recordType = TEXT_SPOOL_SEGMENT_COMMIT,
       recordPayload = """{"text":${JSONObject.quote(text)}}""",
       checkpointPayload = buildCheckpointPayload(snapshotAfterCommit)
     )
@@ -527,7 +527,7 @@ class LiveTextEntry(
     synchronized(spoolLock) {
       try {
         spoolWriter?.let { writer ->
-          appendV2RecordLocked(writer, TEXT_SPOOL_V2_FINALIZE, "{}")
+          appendSpoolRecordLocked(writer, TEXT_SPOOL_FINALIZE, "{}")
           writer.finalize_()
         }
       } catch (e: Exception) {
@@ -614,19 +614,19 @@ class LiveTextEntry(
 
     val cpPath = "$path.txtc"
     val jPath = "$path.txtj"
-    val hasV2 = File(cpPath).exists() || File(jPath).exists()
-    if (hasV2) {
+    val hasSpool = File(cpPath).exists() || File(jPath).exists()
+    if (hasSpool) {
       try {
         var fullText = ""
-        val cpPayload = TextSpoolReader.readV2Checkpoint(cpPath)
+        val cpPayload = TextSpoolReader.readCheckpoint(cpPath)
         if (cpPayload != null) {
           fullText = extractCheckpointText(cpPayload)
         }
-        TextSpoolReader.readV2Journal(jPath).forEach { rec ->
+        TextSpoolReader.readJournal(jPath).forEach { rec ->
           when (rec.type) {
-            TEXT_SPOOL_V2_PARTIAL_SET -> fullText = rec.payload
-            TEXT_SPOOL_V2_PARTIAL_APPEND -> fullText += rec.payload
-            TEXT_SPOOL_V2_SEGMENT_COMMIT -> {
+            TEXT_SPOOL_PARTIAL_SET -> fullText = rec.payload
+            TEXT_SPOOL_PARTIAL_APPEND -> fullText += rec.payload
+            TEXT_SPOOL_SEGMENT_COMMIT -> {
               val obj = JSONObject(rec.payload)
               fullText += obj.optString("text", "")
             }
@@ -638,12 +638,15 @@ class LiveTextEntry(
       } catch (e: Exception) {
         throw TextPipelineException(
           TextErrorCodes.SPOOL_READ_FAILED,
-          "Failed to read V2 text spool for live buffer $bufferId: ${e.message}",
+          "Failed to read text spool for live buffer $bufferId: ${e.message}",
           e,
         )
       }
     }
-    return TextSpoolReader.readLatestSnapshot(path)
+    throw TextPipelineException(
+      TextErrorCodes.SPOOL_UNAVAILABLE,
+      "Text spool files are missing for live buffer: $bufferId"
+    )
   }
 
   fun release() {
@@ -658,11 +661,6 @@ class LiveTextEntry(
     }
 
     if (spoolTemporary && !spoolPath.isNullOrEmpty()) {
-      try {
-        File(spoolPath).delete()
-      } catch (_: Exception) {
-        // best-effort cleanup
-      }
       try {
         File("${spoolPath}.txtj").delete()
       } catch (_: Exception) {
@@ -679,10 +677,6 @@ class LiveTextEntry(
 }
 
 private class TextSpoolWriter(filePath: String) {
-  companion object {
-    const val RECORD_HEADER_BYTES = 4
-  }
-
   private val raf: RandomAccessFile
   private val lock = Any()
   @Volatile
@@ -698,27 +692,6 @@ private class TextSpoolWriter(filePath: String) {
     raf = RandomAccessFile(file, "rw")
     raf.setLength(0L)
     bytesWritten = 0L
-  }
-
-  fun appendSnapshot(text: String) {
-    val payload = text.toByteArray(StandardCharsets.UTF_8)
-    val header = ByteBuffer
-      .allocate(RECORD_HEADER_BYTES)
-      .order(ByteOrder.LITTLE_ENDIAN)
-      .putInt(payload.size)
-      .array()
-
-    synchronized(lock) {
-      if (closed) {
-        throw IOException("Text spool writer is closed")
-      }
-      val recordLength = (RECORD_HEADER_BYTES + payload.size).toLong()
-      raf.seek(0L)
-      raf.write(header)
-      raf.write(payload)
-      raf.setLength(recordLength)
-      bytesWritten = recordLength
-    }
   }
 
   fun appendRawRecord(header: ByteArray, payload: ByteArray) {
@@ -770,61 +743,13 @@ private class TextSpoolWriter(filePath: String) {
 }
 
 private object TextSpoolReader {
-  private const val RECORD_HEADER_BYTES = 4
-
-  fun readLatestSnapshot(filePath: String): String {
-    val file = File(filePath)
-    if (!file.exists()) {
-      throw TextPipelineException(
-        TextErrorCodes.SPOOL_UNAVAILABLE,
-        "Text spool file does not exist: $filePath"
-      )
-    }
-
-    RandomAccessFile(file, "r").use { raf ->
-      val fileLength = raf.length()
-      if (fileLength < RECORD_HEADER_BYTES) {
-        throw TextPipelineException(
-          TextErrorCodes.SPOOL_CORRUPTED,
-          "Corrupted text spool record header in $filePath"
-        )
-      }
-
-      raf.seek(0L)
-      val header = ByteArray(RECORD_HEADER_BYTES)
-      raf.readFully(header)
-      val length = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN).int
-      if (length < 0) {
-        throw TextPipelineException(
-          TextErrorCodes.SPOOL_CORRUPTED,
-          "Corrupted text spool record length in $filePath"
-        )
-      }
-
-      val expectedFileLength = RECORD_HEADER_BYTES + length.toLong()
-      if (fileLength != expectedFileLength) {
-        throw TextPipelineException(
-          TextErrorCodes.SPOOL_CORRUPTED,
-          "Unexpected text spool size in $filePath"
-        )
-      }
-
-      val payload = ByteArray(length)
-      if (length > 0) {
-        raf.readFully(payload)
-      }
-
-      return String(payload, StandardCharsets.UTF_8)
-    }
-  }
-
   data class JournalRecord(val type: Int, val payload: String)
 
-  fun readV2Checkpoint(filePath: String): String? {
+  fun readCheckpoint(filePath: String): String? {
     val file = File(filePath)
     if (!file.exists()) return null
     RandomAccessFile(file, "r").use { raf ->
-      if (raf.length() < 16) throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Corrupted V2 text checkpoint header in $filePath")
+      if (raf.length() < 16) throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Corrupted text checkpoint header in $filePath")
       val header = ByteArray(16)
       raf.readFully(header)
       val bb = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
@@ -833,25 +758,25 @@ private object TextSpoolReader {
       val type = bb.short.toInt()
       val length = bb.int
       val checksum = bb.int
-      if (magic != TEXT_SPOOL_V2_MAGIC || version != TEXT_SPOOL_V2_VERSION || type != TEXT_SPOOL_V2_CHECKPOINT || length < 0) {
-        throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Unexpected V2 text checkpoint format in $filePath")
+      if (magic != TEXT_SPOOL_MAGIC || version != TEXT_SPOOL_VERSION || type != TEXT_SPOOL_CHECKPOINT || length < 0) {
+        throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Unexpected text checkpoint format in $filePath")
       }
       val payload = ByteArray(length)
       if (length > 0) raf.readFully(payload)
       val actual = CRC32().apply { update(payload) }.value.toInt()
-      if (actual != checksum) throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "V2 text checkpoint checksum mismatch in $filePath")
+      if (actual != checksum) throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Text checkpoint checksum mismatch in $filePath")
       return String(payload, StandardCharsets.UTF_8)
     }
   }
 
-  fun readV2Journal(filePath: String): List<JournalRecord> {
+  fun readJournal(filePath: String): List<JournalRecord> {
     val file = File(filePath)
     if (!file.exists()) return emptyList()
     RandomAccessFile(file, "r").use { raf ->
       val out = ArrayList<JournalRecord>()
       while (raf.filePointer < raf.length()) {
         if (raf.length() - raf.filePointer < 16) {
-          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Corrupted V2 text journal header in $filePath")
+          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Corrupted text journal header in $filePath")
         }
         val header = ByteArray(16)
         raf.readFully(header)
@@ -861,14 +786,14 @@ private object TextSpoolReader {
         val type = bb.short.toInt()
         val length = bb.int
         val checksum = bb.int
-        if (magic != TEXT_SPOOL_V2_MAGIC || version != TEXT_SPOOL_V2_VERSION || length < 0) {
-          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Unexpected V2 text journal record format in $filePath")
+        if (magic != TEXT_SPOOL_MAGIC || version != TEXT_SPOOL_VERSION || length < 0) {
+          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Unexpected text journal record format in $filePath")
         }
         val payload = ByteArray(length)
         if (length > 0) raf.readFully(payload)
         val actual = CRC32().apply { update(payload) }.value.toInt()
         if (actual != checksum) {
-          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "V2 text journal checksum mismatch in $filePath")
+          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Text journal checksum mismatch in $filePath")
         }
         out.add(JournalRecord(type, String(payload, StandardCharsets.UTF_8)))
       }

--- a/docs/internal/segmentbuffer-spool-v2-format.md
+++ b/docs/internal/segmentbuffer-spool-v2-format.md
@@ -1,0 +1,68 @@
+# SegmentBuffer Spool Format
+
+This document defines the SegmentBuffer spool record format used on Android and iOS.
+
+## Goals
+
+- Append-oriented journal for long sessions.
+- Periodic compact checkpoints for bounded replay cost.
+- Strict `fullIfSpooled` semantics with explicit corruption detection.
+
+## File layout
+
+- Journal file: `<baseSpoolPath>.segj`
+- Checkpoint file: `<baseSpoolPath>.segc`
+
+## Record header (binary, little-endian)
+
+- `magic` (u32): `0x32474553` (`SEG2`)
+- `version` (u16): `2`
+- `recordType` (u16)
+- `payloadLength` (u32)
+- `checksum` (u32)
+
+Header size: `16` bytes.
+
+## Record types
+
+- `1` => `SEGMENT_APPEND`
+- `2` => `CHECKPOINT_MARK`
+- `3` => `FINALIZE_MARK`
+
+## Payload format
+
+- UTF-8 JSON strings.
+- `SEGMENT_APPEND` payload encodes exactly one segment in a `{"segments":[...]}` envelope.
+- Checkpoint payload encodes full current segment state in the same `{"segments":[...]}` envelope.
+- `CHECKPOINT_MARK` and `FINALIZE_MARK` use `{}` payload.
+
+## Replay model (`fullIfSpooled`)
+
+1. Read checkpoint (`.segc`) if available, initialize full state.
+2. Replay `.segj` records in order:
+   - apply each `SEGMENT_APPEND`.
+   - ignore marker records.
+3. Return reconstructed full history.
+
+If `.segc/.segj` files do not exist, strict full snapshot mode fails with `SEGMENT_SPOOL_UNAVAILABLE`.
+
+## Checkpoint and compaction policy
+
+- Trigger checkpoint at either threshold:
+  - every `128` journal append records, or
+  - every `1 MiB` journal bytes since last checkpoint.
+- On checkpoint:
+  - write new compact checkpoint atomically (temp + rename),
+  - rotate/truncate journal and emit `CHECKPOINT_MARK`.
+
+## Error mapping
+
+- Missing spool for strict mode: `SEGMENT_SPOOL_UNAVAILABLE`
+- Write/init failures: `SEGMENT_SPOOL_WRITE_FAILED`
+- Read/open failures: `SEGMENT_SPOOL_READ_FAILED`
+- Header/length/checksum/record-type corruption: `SEGMENT_SPOOL_CORRUPTED`
+
+## Compatibility
+
+- No backward compatibility is guaranteed for unreleased pre-1.0 spool files.
+- Runtime reads and writes only `.segc` + `.segj`.

--- a/docs/internal/textbuffer-spool-v2-format.md
+++ b/docs/internal/textbuffer-spool-v2-format.md
@@ -1,0 +1,42 @@
+# TextBuffer Spool Format
+
+TextBuffer spool uses checkpoint + append journal persistence for long sessions.
+
+## Files
+
+- Journal: `<base>.txtj`
+- Checkpoint: `<base>.txtc`
+
+## Header (little-endian, 16 bytes)
+
+- `magic` (u32): `TXT2`
+- `version` (u16): `2`
+- `recordType` (u16)
+- `payloadLength` (u32)
+- `checksum` (u32)
+
+## Record types
+
+- `TEXT_PARTIAL_SET`
+- `TEXT_PARTIAL_APPEND`
+- `TEXT_SEGMENT_COMMIT`
+- `CHECKPOINT_MARK`
+- `FINALIZE_MARK`
+
+## Replay model
+
+`fullIfSpooled`:
+1. load checkpoint (`.txtc`) if present,
+2. replay journal (`.txtj`) records in order,
+3. reconstruct full text,
+4. fail strict with `TEXT_SPOOL_*` on unavailable/read/corrupted conditions.
+
+## Checkpoint policy
+
+- checkpoint every `128` events or `1 MiB` journal growth.
+- after checkpoint, journal is rotated/truncated.
+
+## Compatibility
+
+- No backward compatibility is guaranteed for unreleased pre-1.0 spool files.
+- Runtime reads and writes only `.txtc` + `.txtj`.

--- a/docs/segmentbuffer-offline.md
+++ b/docs/segmentbuffer-offline.md
@@ -55,11 +55,17 @@ await releasePipelineSegmentBuffer(live);
 
 ## Error code quick table
 
+The following codes are the relevant runtime outcomes for offline segment-buffer reads and live-to-offline conversion in this document.
+
 | Code | Meaning |
 | --- | --- |
 | `SEGMENT_BUFFER_NOT_FOUND` | Referenced segment buffer does not exist |
+| `SEGMENT_BUFFER_KIND_MISMATCH` | Buffer kind does not match called API |
 | `SEGMENT_INVALID_ARGUMENT` | Invalid argument or malformed id |
+| `SEGMENT_INVALID_STATE` | Operation not allowed in current state |
+| `SEGMENT_ALREADY_FINALIZED` | A recording-only operation was called on an already finished live buffer during conversion flows |
 | `SEGMENT_SLICE_INVALID` | Invalid slice range |
+| `SEGMENT_SPOOL_WRITE_FAILED` | Writing checkpoint/journal spool data failed in preceding live-buffer stages |
 | `SEGMENT_SPOOL_UNAVAILABLE` | `fullIfSpooled` requested but spool unavailable |
 | `SEGMENT_SPOOL_READ_FAILED` | Failed to read spool |
 | `SEGMENT_SPOOL_CORRUPTED` | Corrupted spool content |

--- a/docs/segmentbuffer-streaming.md
+++ b/docs/segmentbuffer-streaming.md
@@ -83,6 +83,8 @@ await releasePipelineSegmentBuffer(live);
 
 ## Error code quick table
 
+The following codes are the relevant runtime outcomes for live/streaming segment-buffer operations in this document (`create`, `append`, `finalize`, `slice`, `createOfflineFromLive`, `release`).
+
 | Code | Meaning |
 | --- | --- |
 | `SEGMENT_BUFFER_NOT_FOUND` | Referenced segment buffer does not exist |

--- a/docs/textbuffer-offline.md
+++ b/docs/textbuffer-offline.md
@@ -204,11 +204,15 @@ const windowOnly = await createOfflineTextBufferFromLive(live, 'windowSnapshot')
 
 ## Error code quick table
 
+The following codes are the relevant runtime outcomes for offline text-buffer reads and live-to-offline conversion in this document.
+
 | Code | Meaning |
 | --- | --- |
 | `TEXT_BUFFER_NOT_FOUND` | Referenced text buffer id does not exist |
 | `TEXT_BUFFER_KIND_MISMATCH` | Buffer kind does not match called API (offline vs live) |
 | `TEXT_INVALID_ARGUMENT` | Invalid argument or malformed buffer id |
+| `TEXT_INVALID_STATE` | Operation is not allowed in the current buffer state |
+| `TEXT_ALREADY_FINALIZED` | A recording-only operation was called on a finished live buffer during conversion flows |
 | `TEXT_SLICE_INVALID` | Slice range is invalid (e.g. negative or out of bounds) |
 | `TEXT_SLICE_TOO_LARGE` | Requested slice exceeds native safety limits |
 | `TEXT_SPOOL_UNAVAILABLE` | `fullIfSpooled` requested but spool is disabled/unavailable |

--- a/docs/textbuffer-streaming.md
+++ b/docs/textbuffer-streaming.md
@@ -270,12 +270,17 @@ Strict mode semantics:
 
 ## Error code quick table
 
+The following codes are the relevant runtime outcomes for live/streaming text-buffer operations in this document (`create`, `append`, `finalize`, `slice`, `createOfflineFromLive`, `release`).
+
 | Code | Meaning |
 | --- | --- |
 | `TEXT_BUFFER_NOT_FOUND` | Referenced text buffer id does not exist |
 | `TEXT_BUFFER_KIND_MISMATCH` | Buffer kind does not match called API (offline vs live) |
 | `TEXT_INVALID_ARGUMENT` | Invalid argument or malformed buffer id |
+| `TEXT_INVALID_STATE` | Operation is not allowed in the current buffer state |
 | `TEXT_ALREADY_FINALIZED` | Operation requires `recording` buffer but live buffer is already finished |
+| `TEXT_SLICE_INVALID` | Live partial/segment slice range is invalid |
+| `TEXT_SLICE_TOO_LARGE` | Requested live slice exceeds native safety limits |
 | `TEXT_SPOOL_UNAVAILABLE` | Spool-required operation requested but spool is disabled/unavailable |
 | `TEXT_SPOOL_WRITE_FAILED` | Writing to live text spool failed |
 | `TEXT_SPOOL_READ_FAILED` | Reading live text spool failed |

--- a/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
+++ b/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
@@ -333,16 +333,7 @@ struct SegLiveEntry {
       }
       return result;
     }
-    // Legacy V1 fallback
-    FILE *reader = fopen(path.c_str(), "rb");
-    if (!reader) throw std::runtime_error("SEGMENT_SPOOL_READ_FAILED: Failed to open segment spool for " + bufferId);
-    unsigned char header[4];
-    if (fread(header, 1, 4, reader) != 4) { fclose(reader); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment spool header for " + bufferId); }
-    uint32_t len = (uint32_t)header[0] | ((uint32_t)header[1] << 8) | ((uint32_t)header[2] << 16) | ((uint32_t)header[3] << 24);
-    std::string payload; payload.resize(len);
-    if (len > 0 && fread(payload.data(), 1, len, reader) != len) { fclose(reader); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment spool payload for " + bufferId); }
-    fclose(reader);
-    return segment_records_from_json(payload);
+    throw std::runtime_error("SEGMENT_SPOOL_UNAVAILABLE: Missing segment checkpoint for " + bufferId);
   }
 
   void release() {
@@ -357,7 +348,6 @@ struct SegLiveEntry {
       }
     }
     if (shouldDelete) {
-      remove(pathToDelete.c_str());
       remove((pathToDelete + ".segj").c_str());
       remove((pathToDelete + ".segc").c_str());
     }

--- a/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
+++ b/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
@@ -89,6 +89,14 @@ std::vector<SegRecord> segment_records_from_json(const std::string &json) {
 }
 
 struct SegLiveEntry {
+  static constexpr uint32_t kMagic = 0x32474553; // SEG2
+  static constexpr uint16_t kVersion = 2;
+  static constexpr uint16_t kRecordSegmentAppend = 1;
+  static constexpr uint16_t kRecordCheckpointMark = 2;
+  static constexpr uint16_t kRecordFinalizeMark = 3;
+  static constexpr int kHeaderBytes = 16;
+  static constexpr int kCheckpointEveryEvents = 128;
+  static constexpr int64_t kCheckpointEveryBytes = 1048576;
   enum State { RECORDING, FINISHED };
   enum SpoolingMode { SPOOL_OFF, SPOOL_AUTO, SPOOL_ON };
 
@@ -107,9 +115,11 @@ struct SegLiveEntry {
   bool spoolReady = false;
   int64_t spoolBytes = 0;
   int64_t spoolEstimatedBytes = 0;
+  int64_t journalBytesSinceCheckpoint = 0;
+  int journalEventCount = 0;
   std::string spoolFailureCode;
   std::string spoolFailureMessage;
-  FILE *spoolFile = nullptr;
+  FILE *journalFile = nullptr;
 
   std::mutex lock;
   std::mutex spoolLock;
@@ -134,52 +144,98 @@ struct SegLiveEntry {
   }
 
   std::string snapshotForSpoolLocked() { return segment_records_to_json(segments); }
+  std::string journalPath() const { return spoolPath + ".segj"; }
+  std::string checkpointPath() const { return spoolPath + ".segc"; }
 
   void closeSpoolFileLocked(bool flushFirst) {
-    if (!spoolFile) return;
-    if (flushFirst) fflush(spoolFile);
-    fclose(spoolFile);
-    spoolFile = nullptr;
+    if (!journalFile) return;
+    if (flushFirst) fflush(journalFile);
+    fclose(journalFile);
+    journalFile = nullptr;
   }
 
-  void appendSnapshotRecordLocked(const std::string &snapshot) {
-    if (!spoolFile) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Spool file not open for " + bufferId);
-    const uint32_t len = (uint32_t)snapshot.size();
-    unsigned char header[4] = {
+  void appendJournalRecordLocked(uint16_t type, const std::string &payload) {
+    if (!journalFile) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Segment journal not open for " + bufferId);
+    const uint32_t len = (uint32_t)payload.size();
+    uint32_t crc = 0;
+    for (char c : payload) crc = (crc * 33u) ^ (uint8_t)c;
+    unsigned char header[kHeaderBytes] = {
+      (unsigned char)(kMagic & 0xFF),
+      (unsigned char)((kMagic >> 8) & 0xFF),
+      (unsigned char)((kMagic >> 16) & 0xFF),
+      (unsigned char)((kMagic >> 24) & 0xFF),
+      (unsigned char)(kVersion & 0xFF),
+      (unsigned char)((kVersion >> 8) & 0xFF),
+      (unsigned char)(type & 0xFF),
+      (unsigned char)((type >> 8) & 0xFF),
       (unsigned char)(len & 0xFF),
       (unsigned char)((len >> 8) & 0xFF),
       (unsigned char)((len >> 16) & 0xFF),
-      (unsigned char)((len >> 24) & 0xFF)
+      (unsigned char)((len >> 24) & 0xFF),
+      (unsigned char)(crc & 0xFF),
+      (unsigned char)((crc >> 8) & 0xFF),
+      (unsigned char)((crc >> 16) & 0xFF),
+      (unsigned char)((crc >> 24) & 0xFF)
     };
-    const int64_t recordLength = 4 + (int64_t)len;
-    if (fseek(spoolFile, 0, SEEK_SET) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to seek spool for " + bufferId);
-    if (fwrite(header, 1, 4, spoolFile) != 4) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to write spool header for " + bufferId);
-    if (len > 0 && fwrite(snapshot.data(), 1, len, spoolFile) != len) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to write spool payload for " + bufferId);
-    if (fflush(spoolFile) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to flush spool for " + bufferId);
-    if (ftruncate(fileno(spoolFile), recordLength) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to truncate spool for " + bufferId);
-    spoolBytes = recordLength;
+    if (fseek(journalFile, 0, SEEK_END) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to seek segment journal for " + bufferId);
+    if (fwrite(header, 1, kHeaderBytes, journalFile) != kHeaderBytes) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to write segment journal header for " + bufferId);
+    if (len > 0 && fwrite(payload.data(), 1, len, journalFile) != len) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to write segment journal payload for " + bufferId);
+    if (fflush(journalFile) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to flush segment journal for " + bufferId);
+    spoolBytes = ftell(journalFile);
     spoolReady = true;
   }
 
+  void writeCheckpointSnapshotLocked(const std::string &snapshot) {
+    std::string cpPath = checkpointPath();
+    std::string tmpPath = cpPath + ".tmp";
+    FILE *tmp = fopen(tmpPath.c_str(), "wb");
+    if (!tmp) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to create segment checkpoint for " + bufferId);
+    const uint32_t len = (uint32_t)snapshot.size();
+    uint32_t crc = 0;
+    for (char c : snapshot) crc = (crc * 33u) ^ (uint8_t)c;
+    unsigned char header[kHeaderBytes] = {
+      (unsigned char)(kMagic & 0xFF), (unsigned char)((kMagic >> 8) & 0xFF), (unsigned char)((kMagic >> 16) & 0xFF), (unsigned char)((kMagic >> 24) & 0xFF),
+      (unsigned char)(kVersion & 0xFF), (unsigned char)((kVersion >> 8) & 0xFF),
+      (unsigned char)(kRecordCheckpointMark & 0xFF), (unsigned char)((kRecordCheckpointMark >> 8) & 0xFF),
+      (unsigned char)(len & 0xFF), (unsigned char)((len >> 8) & 0xFF), (unsigned char)((len >> 16) & 0xFF), (unsigned char)((len >> 24) & 0xFF),
+      (unsigned char)(crc & 0xFF), (unsigned char)((crc >> 8) & 0xFF), (unsigned char)((crc >> 16) & 0xFF), (unsigned char)((crc >> 24) & 0xFF)
+    };
+    if (fwrite(header, 1, kHeaderBytes, tmp) != kHeaderBytes || (len > 0 && fwrite(snapshot.data(), 1, len, tmp) != len)) {
+      fclose(tmp);
+      remove(tmpPath.c_str());
+      throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to write segment checkpoint payload for " + bufferId);
+    }
+    fflush(tmp);
+    fclose(tmp);
+    remove(cpPath.c_str());
+    if (rename(tmpPath.c_str(), cpPath.c_str()) != 0) {
+      remove(tmpPath.c_str());
+      throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to finalize segment checkpoint for " + bufferId);
+    }
+  }
+
   void ensureSpoolWriterActivatedLocked(const std::string &snapshot) {
-    if (spoolFile) return;
+    if (journalFile) return;
     if (spoolPath.empty()) throwSpoolError("SEGMENT_SPOOL_UNAVAILABLE", "Segment spool path is not configured for " + bufferId);
     NSString *spoolPathNs = [NSString stringWithUTF8String:spoolPath.c_str()];
     NSString *parentPath = [spoolPathNs stringByDeletingLastPathComponent];
     if (parentPath.length > 0) {
       [[NSFileManager defaultManager] createDirectoryAtPath:parentPath withIntermediateDirectories:YES attributes:nil error:nil];
     }
-    spoolFile = fopen(spoolPath.c_str(), "wb");
-    if (!spoolFile) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to create segment spool for " + bufferId);
+    journalFile = fopen(journalPath().c_str(), "ab+");
+    if (!journalFile) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to create segment journal for " + bufferId);
     spoolBytes = 0;
-    appendSnapshotRecordLocked(snapshot);
+    writeCheckpointSnapshotLocked(snapshot);
+    appendJournalRecordLocked(kRecordCheckpointMark, "{}");
+    journalBytesSinceCheckpoint = 0;
+    journalEventCount = 0;
   }
 
   void maybeWriteSnapshotToSpool(const std::string &snapshot, bool mayActivateAuto) {
     if (!spoolEnabled()) return;
     std::lock_guard<std::mutex> lockGuard(spoolLock);
     if (!spoolFailureCode.empty()) throw std::runtime_error(spoolFailureCode + ": " + spoolFailureMessage);
-    if (!spoolFile) {
+    if (!journalFile) {
       switch (spoolingMode) {
         case SPOOL_OFF: return;
         case SPOOL_ON:
@@ -197,7 +253,18 @@ struct SegLiveEntry {
         }
       }
     }
-    appendSnapshotRecordLocked(snapshot);
+    appendJournalRecordLocked(kRecordSegmentAppend, snapshot);
+    journalEventCount += 1;
+    journalBytesSinceCheckpoint += (kHeaderBytes + snapshot.size());
+    if (journalEventCount >= kCheckpointEveryEvents || journalBytesSinceCheckpoint >= kCheckpointEveryBytes) {
+      writeCheckpointSnapshotLocked(snapshotForSpoolLocked());
+      fclose(journalFile);
+      journalFile = fopen(journalPath().c_str(), "wb");
+      if (!journalFile) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to rotate segment journal for " + bufferId);
+      appendJournalRecordLocked(kRecordCheckpointMark, "{}");
+      journalBytesSinceCheckpoint = 0;
+      journalEventCount = 0;
+    }
   }
 
   void finalize_() {
@@ -208,8 +275,9 @@ struct SegLiveEntry {
     }
     if (spoolEnabled()) {
       std::lock_guard<std::mutex> guard(spoolLock);
-      if (spoolFile) {
-        if (fflush(spoolFile) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to finalize segment spool for " + bufferId);
+      if (journalFile) {
+        appendJournalRecordLocked(kRecordFinalizeMark, "{}");
+        if (fflush(journalFile) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to finalize segment spool for " + bufferId);
         closeSpoolFileLocked(false);
       }
     }
@@ -229,26 +297,50 @@ struct SegLiveEntry {
       if (!spoolReady) throw std::runtime_error("SEGMENT_SPOOL_UNAVAILABLE: Segment spool is not ready for " + bufferId);
       if (spoolPath.empty()) throw std::runtime_error("SEGMENT_SPOOL_UNAVAILABLE: Segment spool path missing for " + bufferId);
       path = spoolPath;
-      if (spoolFile) fflush(spoolFile);
+      if (journalFile) fflush(journalFile);
     }
+    std::string cpPath = path + ".segc";
+    std::vector<SegRecord> result;
+    if ([[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:cpPath.c_str()]]) {
+      FILE *cp = fopen(cpPath.c_str(), "rb");
+      if (!cp) throw std::runtime_error("SEGMENT_SPOOL_READ_FAILED: Failed to open segment checkpoint for " + bufferId);
+      unsigned char header[kHeaderBytes];
+      if (fread(header, 1, kHeaderBytes, cp) != kHeaderBytes) { fclose(cp); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment checkpoint header for " + bufferId); }
+      uint32_t len = (uint32_t)header[8] | ((uint32_t)header[9] << 8) | ((uint32_t)header[10] << 16) | ((uint32_t)header[11] << 24);
+      std::string payload;
+      payload.resize(len);
+      if (len > 0 && fread(payload.data(), 1, len, cp) != len) { fclose(cp); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment checkpoint payload for " + bufferId); }
+      fclose(cp);
+      result = segment_records_from_json(payload);
+      std::string jPath = path + ".segj";
+      FILE *jr = fopen(jPath.c_str(), "rb");
+      if (jr) {
+        while (true) {
+          unsigned char h[kHeaderBytes];
+          size_t n = fread(h, 1, kHeaderBytes, jr);
+          if (n == 0) break;
+          if (n != kHeaderBytes) { fclose(jr); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment journal header for " + bufferId); }
+          uint16_t type = (uint16_t)h[6] | ((uint16_t)h[7] << 8);
+          uint32_t len = (uint32_t)h[8] | ((uint32_t)h[9] << 8) | ((uint32_t)h[10] << 16) | ((uint32_t)h[11] << 24);
+          std::string payload; payload.resize(len);
+          if (len > 0 && fread(payload.data(), 1, len, jr) != len) { fclose(jr); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment journal payload for " + bufferId); }
+          if (type == kRecordSegmentAppend) {
+            auto parsed = segment_records_from_json(payload);
+            if (!parsed.empty()) result.push_back(parsed[0]);
+          }
+        }
+        fclose(jr);
+      }
+      return result;
+    }
+    // Legacy V1 fallback
     FILE *reader = fopen(path.c_str(), "rb");
     if (!reader) throw std::runtime_error("SEGMENT_SPOOL_READ_FAILED: Failed to open segment spool for " + bufferId);
     unsigned char header[4];
-    if (fread(header, 1, 4, reader) != 4) {
-      fclose(reader);
-      throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment spool header for " + bufferId);
-    }
+    if (fread(header, 1, 4, reader) != 4) { fclose(reader); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment spool header for " + bufferId); }
     uint32_t len = (uint32_t)header[0] | ((uint32_t)header[1] << 8) | ((uint32_t)header[2] << 16) | ((uint32_t)header[3] << 24);
-    std::string payload;
-    payload.resize(len);
-    if (len > 0 && fread(payload.data(), 1, len, reader) != len) {
-      fclose(reader);
-      throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment spool payload for " + bufferId);
-    }
-    if (fgetc(reader) != EOF) {
-      fclose(reader);
-      throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Unexpected trailing data in segment spool for " + bufferId);
-    }
+    std::string payload; payload.resize(len);
+    if (len > 0 && fread(payload.data(), 1, len, reader) != len) { fclose(reader); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment spool payload for " + bufferId); }
     fclose(reader);
     return segment_records_from_json(payload);
   }
@@ -264,7 +356,11 @@ struct SegLiveEntry {
         shouldDelete = true;
       }
     }
-    if (shouldDelete) remove(pathToDelete.c_str());
+    if (shouldDelete) {
+      remove(pathToDelete.c_str());
+      remove((pathToDelete + ".segj").c_str());
+      remove((pathToDelete + ".segc").c_str());
+    }
   }
 };
 

--- a/ios/textbuffer/core/SherpaOnnx+TextBufferGlobals.h
+++ b/ios/textbuffer/core/SherpaOnnx+TextBufferGlobals.h
@@ -194,6 +194,9 @@ struct TxtLiveEntry {
 		return committedTextFromSegmentsLocked() + currentText;
 	}
 
+	std::string journalPath() const { return spoolPath + ".txtj"; }
+	std::string checkpointPath() const { return spoolPath + ".txtc"; }
+
 	void closeSpoolFileLocked(bool flushFirst) {
 		if (spoolFile == nullptr) {
 			return;
@@ -218,24 +221,44 @@ struct TxtLiveEntry {
 			(unsigned char)((len >> 24) & 0xFF)
 		};
 
-		const int64_t recordLength = 4 + (int64_t)len;
-		if (fseek(spoolFile, 0, SEEK_SET) != 0) {
-			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to seek text spool for " + bufferId);
+		if (fseek(spoolFile, 0, SEEK_END) != 0) {
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to seek text journal for " + bufferId);
 		}
 		if (fwrite(header, 1, 4, spoolFile) != 4) {
-			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to write spool header for " + bufferId);
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to write text journal header for " + bufferId);
 		}
 		if (len > 0 && fwrite(snapshot.data(), 1, len, spoolFile) != len) {
-			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to write spool payload for " + bufferId);
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to write text journal payload for " + bufferId);
 		}
 		if (fflush(spoolFile) != 0) {
-			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to flush text spool for " + bufferId);
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to flush text journal for " + bufferId);
 		}
-		if (ftruncate(fileno(spoolFile), recordLength) != 0) {
-			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to truncate text spool for " + bufferId);
-		}
-		spoolBytes = recordLength;
+		spoolBytes = ftell(spoolFile);
 		spoolReady = true;
+	}
+
+	void writeCheckpointSnapshotLocked(const std::string &snapshot) {
+		if (spoolPath.empty()) {
+			throwSpoolError("TEXT_SPOOL_UNAVAILABLE", "Text checkpoint path is not configured for " + bufferId);
+		}
+		std::string path = checkpointPath();
+		FILE *cp = fopen(path.c_str(), "wb");
+		if (cp == nullptr) {
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to create text checkpoint for " + bufferId);
+		}
+		const uint32_t len = (uint32_t)snapshot.size();
+		unsigned char header[4] = {
+			(unsigned char)(len & 0xFF),
+			(unsigned char)((len >> 8) & 0xFF),
+			(unsigned char)((len >> 16) & 0xFF),
+			(unsigned char)((len >> 24) & 0xFF)
+		};
+		if (fwrite(header, 1, 4, cp) != 4 || (len > 0 && fwrite(snapshot.data(), 1, len, cp) != len)) {
+			fclose(cp);
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to write text checkpoint for " + bufferId);
+		}
+		fflush(cp);
+		fclose(cp);
 	}
 
 	void ensureSpoolWriterActivatedLocked(const std::string &bootstrapSnapshot) {
@@ -255,11 +278,12 @@ struct TxtLiveEntry {
 													  error:nil];
 		}
 
-		spoolFile = fopen(spoolPath.c_str(), "wb");
+		spoolFile = fopen(journalPath().c_str(), "ab+");
 		if (spoolFile == nullptr) {
-			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to create text spool file for " + bufferId);
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to create text journal file for " + bufferId);
 		}
 		spoolBytes = 0;
+		writeCheckpointSnapshotLocked(bootstrapSnapshot);
 		appendSnapshotRecordLocked(bootstrapSnapshot);
 	}
 
@@ -465,37 +489,48 @@ struct TxtLiveEntry {
 			}
 		}
 
-		FILE *reader = fopen(path.c_str(), "rb");
-		if (reader == nullptr) {
-			throw makeCodedError("TEXT_SPOOL_READ_FAILED", "Failed to open text spool for " + bufferId);
+		// Prefer V2-style checkpoint+journal files if present.
+		std::string cpPath = path + ".txtc";
+		std::string jPath = path + ".txtj";
+		bool hasV2 = [[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:cpPath.c_str()]] ||
+			[[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:jPath.c_str()]];
+		if (hasV2) {
+			std::string latest = "";
+			FILE *cp = fopen(cpPath.c_str(), "rb");
+			if (cp != nullptr) {
+				unsigned char h[4];
+				if (fread(h, 1, 4, cp) == 4) {
+					uint32_t len = (uint32_t)h[0] | ((uint32_t)h[1] << 8) | ((uint32_t)h[2] << 16) | ((uint32_t)h[3] << 24);
+					std::string payload; payload.resize(len);
+					if (len == 0 || fread(payload.data(), 1, len, cp) == len) latest = payload;
+				}
+				fclose(cp);
+			}
+			FILE *jr = fopen(jPath.c_str(), "rb");
+			if (jr != nullptr) {
+				while (true) {
+					unsigned char h[4];
+					size_t n = fread(h, 1, 4, jr);
+					if (n == 0) break;
+					if (n != 4) { fclose(jr); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Corrupted text journal header for " + bufferId); }
+					uint32_t len = (uint32_t)h[0] | ((uint32_t)h[1] << 8) | ((uint32_t)h[2] << 16) | ((uint32_t)h[3] << 24);
+					std::string payload; payload.resize(len);
+					if (len > 0 && fread(payload.data(), 1, len, jr) != len) { fclose(jr); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Truncated text journal payload for " + bufferId); }
+					latest = payload;
+				}
+				fclose(jr);
+			}
+			return latest;
 		}
-
+		// Legacy V1 fallback.
+		FILE *reader = fopen(path.c_str(), "rb");
+		if (reader == nullptr) throw makeCodedError("TEXT_SPOOL_READ_FAILED", "Failed to open text spool for " + bufferId);
 		unsigned char header[4];
 		size_t readHeader = fread(header, 1, 4, reader);
-		if (readHeader != 4) {
-			fclose(reader);
-			throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Corrupted text spool header for " + bufferId);
-		}
-		uint32_t len =
-			(uint32_t)header[0] |
-			((uint32_t)header[1] << 8) |
-			((uint32_t)header[2] << 16) |
-			((uint32_t)header[3] << 24);
-
-		std::string payload;
-		payload.resize(len);
-		if (len > 0) {
-			size_t readPayload = fread(payload.data(), 1, len, reader);
-			if (readPayload != len) {
-				fclose(reader);
-				throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Truncated text spool payload for " + bufferId);
-			}
-		}
-
-		if (fgetc(reader) != EOF) {
-			fclose(reader);
-			throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Unexpected trailing data in text spool for " + bufferId);
-		}
+		if (readHeader != 4) { fclose(reader); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Corrupted text spool header for " + bufferId); }
+		uint32_t len = (uint32_t)header[0] | ((uint32_t)header[1] << 8) | ((uint32_t)header[2] << 16) | ((uint32_t)header[3] << 24);
+		std::string payload; payload.resize(len);
+		if (len > 0 && fread(payload.data(), 1, len, reader) != len) { fclose(reader); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Truncated text spool payload for " + bufferId); }
 		fclose(reader);
 		return payload;
 	}
@@ -552,6 +587,8 @@ struct TxtLiveEntry {
 		}
 		if (shouldDelete) {
 			remove(pathToDelete.c_str());
+			remove((pathToDelete + ".txtj").c_str());
+			remove((pathToDelete + ".txtc").c_str());
 		}
 		{
 			std::lock_guard<std::mutex> lock(cursorMutex);

--- a/ios/textbuffer/core/SherpaOnnx+TextBufferGlobals.h
+++ b/ios/textbuffer/core/SherpaOnnx+TextBufferGlobals.h
@@ -489,12 +489,11 @@ struct TxtLiveEntry {
 			}
 		}
 
-		// Prefer V2-style checkpoint+journal files if present.
 		std::string cpPath = path + ".txtc";
 		std::string jPath = path + ".txtj";
-		bool hasV2 = [[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:cpPath.c_str()]] ||
+		bool hasSpool = [[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:cpPath.c_str()]] ||
 			[[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:jPath.c_str()]];
-		if (hasV2) {
+		if (hasSpool) {
 			std::string latest = "";
 			FILE *cp = fopen(cpPath.c_str(), "rb");
 			if (cp != nullptr) {
@@ -522,17 +521,7 @@ struct TxtLiveEntry {
 			}
 			return latest;
 		}
-		// Legacy V1 fallback.
-		FILE *reader = fopen(path.c_str(), "rb");
-		if (reader == nullptr) throw makeCodedError("TEXT_SPOOL_READ_FAILED", "Failed to open text spool for " + bufferId);
-		unsigned char header[4];
-		size_t readHeader = fread(header, 1, 4, reader);
-		if (readHeader != 4) { fclose(reader); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Corrupted text spool header for " + bufferId); }
-		uint32_t len = (uint32_t)header[0] | ((uint32_t)header[1] << 8) | ((uint32_t)header[2] << 16) | ((uint32_t)header[3] << 24);
-		std::string payload; payload.resize(len);
-		if (len > 0 && fread(payload.data(), 1, len, reader) != len) { fclose(reader); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Truncated text spool payload for " + bufferId); }
-		fclose(reader);
-		return payload;
+		throw makeCodedError("TEXT_SPOOL_UNAVAILABLE", "Text spool files are missing for " + bufferId);
 	}
 
 	NSDictionary *toDict() {
@@ -586,7 +575,6 @@ struct TxtLiveEntry {
 			}
 		}
 		if (shouldDelete) {
-			remove(pathToDelete.c_str());
 			remove((pathToDelete + ".txtj").c_str());
 			remove((pathToDelete + ".txtc").c_str());
 		}


### PR DESCRIPTION
This pull request refactors and enhances the segment spooling system by splitting the spool file into a journal and a checkpoint file, implementing a new append-only journal format with checksums, and introducing checkpointing for improved reliability and recovery. The changes also update the text pipeline to use a similar, more robust format. These updates improve data integrity, recovery speed, and maintainability of the segment and text pipelines.

**Segment Spooling System Refactor and Reliability Improvements:**

* Replaced the single `SegmentSpoolWriter` with separate `SegmentJournalWriter` and `SegmentCheckpointWriter` classes, splitting spool data into a journal file (`.segj`) for incremental updates and a checkpoint file (`.segc`) for periodic full snapshots. [[1]](diffhunk://#diff-44eefbe77f001e1e8ea298a33f5a368e117791003e974c10d8fe513d807ee152L31-R33) [[2]](diffhunk://#diff-4a57f601d42c663d9634d446766087a3db992e15df934e20b8839a47cbccc15bR9-R29) [[3]](diffhunk://#diff-44eefbe77f001e1e8ea298a33f5a368e117791003e974c10d8fe513d807ee152L250-R261)
* Introduced a new binary journal record format with versioning, magic numbers, CRC32 checksums, and explicit record types for append, checkpoint, and finalize operations, improving data integrity and error detection. [[1]](diffhunk://#diff-4a57f601d42c663d9634d446766087a3db992e15df934e20b8839a47cbccc15bR9-R29) [[2]](diffhunk://#diff-4a57f601d42c663d9634d446766087a3db992e15df934e20b8839a47cbccc15bL29-R77) [[3]](diffhunk://#diff-4a57f601d42c663d9634d446766087a3db992e15df934e20b8839a47cbccc15bL80-R252)
* Implemented periodic checkpointing based on event count and byte thresholds; after a checkpoint, the journal is truncated and a new checkpoint is written, enabling fast recovery and limiting journal replay length. [[1]](diffhunk://#diff-44eefbe77f001e1e8ea298a33f5a368e117791003e974c10d8fe513d807ee152R44-R55) [[2]](diffhunk://#diff-44eefbe77f001e1e8ea298a33f5a368e117791003e974c10d8fe513d807ee152L292-R348) [[3]](diffhunk://#diff-44eefbe77f001e1e8ea298a33f5a368e117791003e974c10d8fe513d807ee152R360-R389)
* Updated all read, write, finalize, and release operations in `LiveSegmentEntry` to use the new journal and checkpoint system, including atomic file replacement and robust error handling. [[1]](diffhunk://#diff-44eefbe77f001e1e8ea298a33f5a368e117791003e974c10d8fe513d807ee152L110-R135) [[2]](diffhunk://#diff-44eefbe77f001e1e8ea298a33f5a368e117791003e974c10d8fe513d807ee152L154-R173) [[3]](diffhunk://#diff-44eefbe77f001e1e8ea298a33f5a368e117791003e974c10d8fe513d807ee152L197-R208) [[4]](diffhunk://#diff-44eefbe77f001e1e8ea298a33f5a368e117791003e974c10d8fe513d807ee152L265-R275)
* Added logic to reconstruct the full segment state by replaying the checkpoint and then applying all journal records, improving recovery after crashes or restarts.

**Text Pipeline Format Modernization:**

* Updated `LiveTextEntry` with a new spool file format, including versioning, magic numbers, record types, and CRC32 checksums, bringing the text pipeline in line with the improved segment pipeline for better reliability and consistency. [[1]](diffhunk://#diff-461370dde94d9fee2df7e4928eff5fdbcd0724d9c957c9326f7da3e10e615f56R14) [[2]](diffhunk://#diff-461370dde94d9fee2df7e4928eff5fdbcd0724d9c957c9326f7da3e10e615f56R74-R85)