### PR TITLE
Feat/add segment buffer

### DIFF
--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -151,6 +151,9 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     com.sherpaonnx.text.pipeline.TextPipelineRegistry.initializeWithCacheDir(
       reactApplicationContext.cacheDir
     )
+    com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry.initializeWithCacheDir(
+      reactApplicationContext.cacheDir
+    )
   }
 
   private fun emitPipelineLiveAudioChunk(event: com.sherpaonnx.audio.pipeline.LiveFramesAppendedEvent) {
@@ -184,6 +187,7 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     pcmPlayerService.shutdown()
     com.sherpaonnx.audio.session.PaAudioSessionCoordinator.resetAll()
     com.sherpaonnx.text.pipeline.TextPipelineRegistry.releaseAll()
+    com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry.releaseAll()
   }
 
   /**
@@ -2422,6 +2426,232 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
       promise.resolve(entry.segmentCount)
     } catch (e: Exception) {
       promise.reject(com.sherpaonnx.text.pipeline.TextErrorCodes.INTERNAL_ERROR, e.message, e)
+    }
+  }
+
+  // ==================== Pipeline Segment Buffers ====================
+
+  override fun createLiveSegmentBuffer(options: ReadableMap, promise: Promise) {
+    try {
+      val sourceAudioBufferId =
+        if (options.hasKey("sourceAudioBufferId") && !options.isNull("sourceAudioBufferId")) {
+          options.getString("sourceAudioBufferId")
+        } else {
+          null
+        }
+      val maxSegments =
+        if (options.hasKey("maxSegments") && !options.isNull("maxSegments")) {
+          options.getDouble("maxSegments").toInt()
+        } else {
+          1000
+        }
+      val spoolingMode = if (options.hasKey("spoolingMode") && !options.isNull("spoolingMode")) {
+        options.getString("spoolingMode")
+      } else {
+        "on"
+      }
+      val spoolingPath = if (options.hasKey("spoolingPath") && !options.isNull("spoolingPath")) {
+        options.getString("spoolingPath")
+      } else {
+        null
+      }
+      val spoolingTemporary =
+        if (options.hasKey("spoolingTemporary") && !options.isNull("spoolingTemporary")) {
+          options.getBoolean("spoolingTemporary")
+        } else {
+          null
+        }
+      val spoolingThresholdBytes =
+        if (options.hasKey("spoolingThresholdBytes") && !options.isNull("spoolingThresholdBytes")) {
+          options.getDouble("spoolingThresholdBytes").toLong()
+        } else {
+          null
+        }
+      val entry = com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry.createLive(
+        sourceAudioBufferId = sourceAudioBufferId,
+        maxSegments = maxSegments,
+        spoolingModeRaw = spoolingMode,
+        spoolingPath = spoolingPath,
+        spoolingTemporary = spoolingTemporary,
+        spoolingThresholdBytes = spoolingThresholdBytes
+      )
+      promise.resolve(entry.toWritableMap())
+    } catch (e: com.sherpaonnx.segment.pipeline.SegmentPipelineException) {
+      promise.reject(e.code, e.message, e)
+    } catch (e: Exception) {
+      promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.INTERNAL_ERROR, e.message, e)
+    }
+  }
+
+  override fun createEmptyOfflineSegmentBuffer(options: ReadableMap?, promise: Promise) {
+    try {
+      val sourceAudioBufferId =
+        if (options != null && options.hasKey("sourceAudioBufferId") && !options.isNull("sourceAudioBufferId")) {
+          options.getString("sourceAudioBufferId")
+        } else {
+          null
+        }
+      val entry = com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry.createEmptyOffline(sourceAudioBufferId)
+      promise.resolve(entry.toWritableMap())
+    } catch (e: com.sherpaonnx.segment.pipeline.SegmentPipelineException) {
+      promise.reject(e.code, e.message, e)
+    } catch (e: Exception) {
+      promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.INTERNAL_ERROR, e.message, e)
+    }
+  }
+
+  override fun appendLiveSegment(
+    liveBufferId: String,
+    kind: String,
+    sourceAudioBufferId: String,
+    startSample: Double,
+    endSample: Double,
+    sampleRate: Double,
+    durationMs: Double?,
+    confidence: Double?,
+    payload: ReadableMap?,
+    promise: Promise
+  ) {
+    try {
+      val entry = com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry.getLive(liveBufferId)
+      if (entry == null) {
+        promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.BUFFER_NOT_FOUND, "Live segment buffer not found: $liveBufferId")
+        return
+      }
+      val result = entry.appendSegment(
+        kind = kind,
+        sourceAudioBufferId = sourceAudioBufferId,
+        startSample = startSample.toInt(),
+        endSample = endSample.toInt(),
+        sampleRate = sampleRate.toInt(),
+        durationMs = durationMs?.toInt(),
+        confidence = confidence,
+        payloadJson = payload?.toHashMap()?.let { org.json.JSONObject(it as Map<*, *>).toString() }
+      )
+      val out = Arguments.createMap()
+      out.putString("segmentId", result.first)
+      out.putInt("segmentIndex", result.second)
+      promise.resolve(out)
+    } catch (e: com.sherpaonnx.segment.pipeline.SegmentPipelineException) {
+      promise.reject(e.code, e.message, e)
+    } catch (e: Exception) {
+      promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.INTERNAL_ERROR, e.message, e)
+    }
+  }
+
+  override fun finalizeLiveSegmentBuffer(liveBufferId: String, promise: Promise) {
+    try {
+      val entry = com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry.getLive(liveBufferId)
+      if (entry == null) {
+        promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.BUFFER_NOT_FOUND, "Live segment buffer not found: $liveBufferId")
+        return
+      }
+      entry.finalize_()
+      promise.resolve(null)
+    } catch (e: com.sherpaonnx.segment.pipeline.SegmentPipelineException) {
+      promise.reject(e.code, e.message, e)
+    } catch (e: Exception) {
+      promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.INTERNAL_ERROR, e.message, e)
+    }
+  }
+
+  override fun createOfflineSegmentBufferFromLive(liveBufferId: String, mode: String?, promise: Promise) {
+    try {
+      val entry = com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry.createOfflineFromLive(
+        liveBufferId,
+        mode ?: "fullIfSpooled"
+      )
+      promise.resolve(entry.toWritableMap())
+    } catch (e: com.sherpaonnx.segment.pipeline.SegmentPipelineException) {
+      promise.reject(e.code, e.message, e)
+    } catch (e: Exception) {
+      promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.INTERNAL_ERROR, e.message, e)
+    }
+  }
+
+  override fun getPipelineSegmentBufferInfo(bufferId: String, promise: Promise) {
+    try {
+      val offline = com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry.getOffline(bufferId)
+      if (offline != null) {
+        promise.resolve(offline.toWritableMap())
+        return
+      }
+      val live = com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry.getLive(bufferId)
+      if (live != null) {
+        promise.resolve(live.toWritableMap())
+        return
+      }
+      promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.BUFFER_NOT_FOUND, "Segment buffer not found: $bufferId")
+    } catch (e: Exception) {
+      promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.INTERNAL_ERROR, e.message, e)
+    }
+  }
+
+  override fun getOfflineSegmentBufferSegments(
+    bufferId: String,
+    start: Double,
+    maxCount: Double,
+    promise: Promise
+  ) {
+    try {
+      val entry = com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry.getOffline(bufferId)
+      if (entry == null) {
+        promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.BUFFER_NOT_FOUND, "Offline segment buffer not found: $bufferId")
+        return
+      }
+      val segments = entry.snapshotSegments(start.toInt(), maxCount.toInt())
+      val out = Arguments.createMap()
+      out.putArray("segments", com.sherpaonnx.segment.pipeline.OfflineSegmentEntry.toWritableArray(segments))
+      promise.resolve(out)
+    } catch (e: com.sherpaonnx.segment.pipeline.SegmentPipelineException) {
+      promise.reject(e.code, e.message, e)
+    } catch (e: Exception) {
+      promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.INTERNAL_ERROR, e.message, e)
+    }
+  }
+
+  override fun getLiveSegmentBufferSegments(
+    liveBufferId: String,
+    startIndex: Double,
+    maxCount: Double,
+    promise: Promise
+  ) {
+    try {
+      val entry = com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry.getLive(liveBufferId)
+      if (entry == null) {
+        promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.BUFFER_NOT_FOUND, "Live segment buffer not found: $liveBufferId")
+        return
+      }
+      val segments = entry.getSegments(startIndex.toInt(), maxCount.toInt())
+      val out = Arguments.createMap()
+      out.putArray("segments", com.sherpaonnx.segment.pipeline.OfflineSegmentEntry.toWritableArray(segments))
+      promise.resolve(out)
+    } catch (e: com.sherpaonnx.segment.pipeline.SegmentPipelineException) {
+      promise.reject(e.code, e.message, e)
+    } catch (e: Exception) {
+      promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.INTERNAL_ERROR, e.message, e)
+    }
+  }
+
+  override fun getLiveSegmentBufferSegmentCount(liveBufferId: String, promise: Promise) {
+    try {
+      val entry = com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry.getLive(liveBufferId)
+      if (entry == null) {
+        promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.BUFFER_NOT_FOUND, "Live segment buffer not found: $liveBufferId")
+        return
+      }
+      promise.resolve(entry.segmentCount())
+    } catch (e: Exception) {
+      promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.INTERNAL_ERROR, e.message, e)
+    }
+  }
+
+  override fun releasePipelineSegmentBuffer(bufferId: String, promise: Promise) {
+    try {
+      com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry.release(bufferId)
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject(com.sherpaonnx.segment.pipeline.SegmentErrorCodes.INTERNAL_ERROR, e.message, e)
     }
   }
 

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
@@ -1,0 +1,327 @@
+package com.sherpaonnx.segment.pipeline
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import java.io.File
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicLong
+
+class LiveSegmentEntry(
+  val bufferId: String,
+  private val sourceAudioBufferId: String? = null,
+  private val maxSegments: Int = 1000,
+  private val spoolingMode: SegmentSpoolingMode = SegmentSpoolingMode.ON,
+  private val spoolPath: String? = null,
+  private val spoolTemporary: Boolean = true,
+  private val spoolThresholdBytes: Long = 0,
+) {
+  enum class State { RECORDING, FINISHED }
+
+  @Volatile
+  var state: State = State.RECORDING
+    private set
+
+  private val segmentLock = Any()
+  private val segments = ArrayList<SegmentRecord>()
+  private var evictedCount: Long = 0
+  private val totalSegmentsWritten = AtomicLong(0)
+
+  private val spoolLock = Any()
+  @Volatile
+  private var spoolWriter: SegmentSpoolWriter? = null
+  @Volatile
+  private var spoolReady: Boolean = false
+  @Volatile
+  private var spoolBytes: Long = 0
+  @Volatile
+  private var spoolEstimatedBytes: Long = 0
+  @Volatile
+  private var spoolFailureCode: String? = null
+  @Volatile
+  private var spoolFailureMessage: String? = null
+
+  private fun spoolingEnabled(): Boolean = spoolingMode != SegmentSpoolingMode.OFF
+
+  init {
+    if (spoolingEnabled() && spoolingMode == SegmentSpoolingMode.ON) {
+      writeSnapshotToSpoolOrThrow(snapshotFullForSpool(), mayActivateAuto = false)
+    }
+  }
+
+  fun appendSegment(
+    kind: String,
+    sourceAudioBufferId: String,
+    startSample: Int,
+    endSample: Int,
+    sampleRate: Int,
+    durationMs: Int?,
+    confidence: Double?,
+    payloadJson: String?,
+  ): Pair<String, Int> {
+    val effectiveDurationMs = durationMs ?: (((endSample - startSample).coerceAtLeast(0) * 1000L) / sampleRate).toInt()
+    var segmentId = ""
+    var segmentIndex = -1
+    var snapshot = ""
+    synchronized(segmentLock) {
+      if (state == State.FINISHED) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.ALREADY_FINALIZED,
+          "Live segment buffer is finalized: $bufferId"
+        )
+      }
+      segmentId = "seg_${UUID.randomUUID()}"
+      segmentIndex = (evictedCount + segments.size).toInt()
+      segments.add(
+        SegmentRecord(
+          id = segmentId,
+          kind = kind,
+          sourceAudioBufferId = sourceAudioBufferId,
+          startSample = startSample,
+          endSample = endSample,
+          sampleRate = sampleRate,
+          durationMs = effectiveDurationMs,
+          confidence = confidence,
+          payloadJson = payloadJson,
+        )
+      )
+      snapshot = snapshotFullForSpoolLocked()
+      if (segments.size > maxSegments) {
+        segments.removeAt(0)
+        evictedCount++
+      }
+      totalSegmentsWritten.incrementAndGet()
+    }
+    writeSnapshotToSpoolOrThrow(snapshot, mayActivateAuto = true)
+    return Pair(segmentId, segmentIndex)
+  }
+
+  fun finalize_() {
+    synchronized(segmentLock) {
+      if (state == State.FINISHED) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.ALREADY_FINALIZED,
+          "Already finalized: $bufferId"
+        )
+      }
+      state = State.FINISHED
+    }
+    synchronized(spoolLock) {
+      try {
+        spoolWriter?.finalize_()
+      } catch (e: Exception) {
+        markSpoolFailureAndThrow(
+          SegmentErrorCodes.SPOOL_WRITE_FAILED,
+          "Failed to finalize segment spool for $bufferId: ${e.message}",
+          e
+        )
+      } finally {
+        spoolWriter = null
+      }
+    }
+  }
+
+  fun snapshotWindow(): List<SegmentRecord> {
+    synchronized(segmentLock) {
+      return segments.toList()
+    }
+  }
+
+  fun snapshotFullIfSpooled(): List<SegmentRecord> {
+    if (!spoolingEnabled()) {
+      throw SegmentPipelineException(
+        SegmentErrorCodes.SPOOL_UNAVAILABLE,
+        "Segment spooling is disabled for $bufferId"
+      )
+    }
+    val failure = spoolFailureCode
+    if (failure != null) {
+      throw SegmentPipelineException(
+        failure,
+        spoolFailureMessage ?: "Segment spool unavailable for $bufferId"
+      )
+    }
+    if (!spoolReady) {
+      throw SegmentPipelineException(
+        SegmentErrorCodes.SPOOL_UNAVAILABLE,
+        "Segment spool is not ready for $bufferId"
+      )
+    }
+    val path = spoolPath ?: throw SegmentPipelineException(
+      SegmentErrorCodes.SPOOL_UNAVAILABLE,
+      "Segment spool path missing for $bufferId"
+    )
+    synchronized(spoolLock) {
+      try {
+        spoolWriter?.flush()
+      } catch (e: Exception) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.SPOOL_READ_FAILED,
+          "Failed to flush segment spool for $bufferId: ${e.message}",
+          e
+        )
+      }
+    }
+    val json = try {
+      SegmentSpoolReader.readLatestSnapshot(path)
+    } catch (e: SegmentPipelineException) {
+      throw e
+    } catch (e: Exception) {
+      throw SegmentPipelineException(
+        SegmentErrorCodes.SPOOL_READ_FAILED,
+        "Failed to read segment spool for $bufferId: ${e.message}",
+        e
+      )
+    }
+    return OfflineSegmentEntry.segmentsFromJson(json)
+  }
+
+  fun getSegments(startIndex: Int, maxCount: Int): List<SegmentRecord> {
+    synchronized(segmentLock) {
+      if (startIndex < 0 || maxCount < 0) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.SLICE_INVALID,
+          "Invalid segment slice range start=$startIndex maxCount=$maxCount"
+        )
+      }
+      if (startIndex >= segments.size) return emptyList()
+      val end = minOf(startIndex + maxCount, segments.size)
+      return segments.subList(startIndex, end).toList()
+    }
+  }
+
+  fun segmentCount(): Int = synchronized(segmentLock) { segments.size }
+
+  fun release() {
+    synchronized(spoolLock) {
+      try {
+        spoolWriter?.release()
+      } catch (_: Exception) {
+      } finally {
+        spoolWriter = null
+      }
+    }
+    if (spoolTemporary && !spoolPath.isNullOrEmpty()) {
+      try {
+        File(spoolPath).delete()
+      } catch (_: Exception) {
+      }
+    }
+  }
+
+  fun toWritableMap(): WritableMap {
+    val map = Arguments.createMap()
+    map.putString("bufferId", bufferId)
+    map.putString("kind", "liveSegmentBuffer")
+    map.putString("state", if (state == State.RECORDING) "recording" else "finished")
+    map.putInt("segmentCount", segmentCount())
+    map.putDouble("totalSegmentsWritten", totalSegmentsWritten.get().toDouble())
+    if (!sourceAudioBufferId.isNullOrEmpty()) {
+      map.putString("sourceAudioBufferId", sourceAudioBufferId)
+    }
+    map.putString("spoolMode", spoolingMode.rawValue())
+    map.putBoolean("spoolEnabled", spoolingEnabled())
+    map.putBoolean("spoolReady", spoolReady)
+    map.putDouble("spoolBytes", spoolBytes.toDouble())
+    if (!spoolPath.isNullOrEmpty()) {
+      map.putString("spoolPath", spoolPath)
+    }
+    return map
+  }
+
+  private fun snapshotFullForSpool(): String = synchronized(segmentLock) {
+    snapshotFullForSpoolLocked()
+  }
+
+  private fun snapshotFullForSpoolLocked(): String {
+    return OfflineSegmentEntry.segmentsToJson(segments)
+  }
+
+  private fun markSpoolFailureAndThrow(
+    code: String,
+    message: String,
+    cause: Throwable? = null,
+  ): Nothing {
+    spoolFailureCode = code
+    spoolFailureMessage = message
+    throw SegmentPipelineException(code, message, cause)
+  }
+
+  private fun ensureSpoolWriterActivatedLocked(snapshotJson: String) {
+    if (spoolWriter != null) return
+    val resolvedPath = spoolPath ?: markSpoolFailureAndThrow(
+      SegmentErrorCodes.SPOOL_UNAVAILABLE,
+      "Segment spool path is not configured for $bufferId"
+    )
+    val writer = try {
+      SegmentSpoolWriter(resolvedPath)
+    } catch (e: Exception) {
+      markSpoolFailureAndThrow(
+        SegmentErrorCodes.SPOOL_WRITE_FAILED,
+        "Failed to create segment spool for $bufferId: ${e.message}",
+        e
+      )
+    }
+    try {
+      writer.appendSnapshot(snapshotJson)
+    } catch (e: Exception) {
+      try {
+        writer.release()
+      } catch (_: Exception) {
+      }
+      markSpoolFailureAndThrow(
+        SegmentErrorCodes.SPOOL_WRITE_FAILED,
+        "Failed to initialize segment spool for $bufferId: ${e.message}",
+        e
+      )
+    }
+    spoolWriter = writer
+    spoolReady = true
+    spoolBytes = writer.bytesWritten
+  }
+
+  private fun writeSnapshotToSpoolOrThrow(snapshotJson: String, mayActivateAuto: Boolean) {
+    if (!spoolingEnabled()) return
+    val failureCode = spoolFailureCode
+    if (failureCode != null) {
+      throw SegmentPipelineException(
+        failureCode,
+        spoolFailureMessage ?: "Segment spool unavailable for $bufferId"
+      )
+    }
+    synchronized(spoolLock) {
+      val writer = spoolWriter
+      if (writer == null) {
+        when (spoolingMode) {
+          SegmentSpoolingMode.OFF -> return
+          SegmentSpoolingMode.ON -> {
+            ensureSpoolWriterActivatedLocked(snapshotJson)
+            return
+          }
+          SegmentSpoolingMode.AUTO -> {
+            if (!mayActivateAuto) return
+            val estimatedBytes =
+              SegmentSpoolWriter.RECORD_HEADER_BYTES + snapshotJson.toByteArray().size
+            spoolEstimatedBytes += estimatedBytes.toLong()
+            if (spoolEstimatedBytes < spoolThresholdBytes.coerceAtLeast(0L)) {
+              spoolReady = false
+              return
+            }
+            ensureSpoolWriterActivatedLocked(snapshotJson)
+            return
+          }
+        }
+      }
+      try {
+        writer.appendSnapshot(snapshotJson)
+        spoolReady = true
+        spoolBytes = writer.bytesWritten
+      } catch (e: Exception) {
+        markSpoolFailureAndThrow(
+          SegmentErrorCodes.SPOOL_WRITE_FAILED,
+          "Failed to write segment spool for $bufferId: ${e.message}",
+          e
+        )
+      }
+    }
+  }
+}

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
@@ -28,7 +28,9 @@ class LiveSegmentEntry(
 
   private val spoolLock = Any()
   @Volatile
-  private var spoolWriter: SegmentSpoolWriter? = null
+  private var journalWriter: SegmentJournalWriter? = null
+  @Volatile
+  private var checkpointWriter: SegmentCheckpointWriter? = null
   @Volatile
   private var spoolReady: Boolean = false
   @Volatile
@@ -39,12 +41,18 @@ class LiveSegmentEntry(
   private var spoolFailureCode: String? = null
   @Volatile
   private var spoolFailureMessage: String? = null
+  @Volatile
+  private var journalEventCount: Int = 0
+  @Volatile
+  private var journalBytesSinceCheckpoint: Long = 0
 
   private fun spoolingEnabled(): Boolean = spoolingMode != SegmentSpoolingMode.OFF
+  private fun v2JournalPath(): String? = spoolPath?.let { "${it}.segj" }
+  private fun v2CheckpointPath(): String? = spoolPath?.let { "${it}.segc" }
 
   init {
     if (spoolingEnabled() && spoolingMode == SegmentSpoolingMode.ON) {
-      writeSnapshotToSpoolOrThrow(snapshotFullForSpool(), mayActivateAuto = false)
+      writeSpoolV2OrThrow(mayActivateAuto = false, checkpointPayload = snapshotFullForSpool())
     }
   }
 
@@ -61,7 +69,8 @@ class LiveSegmentEntry(
     val effectiveDurationMs = durationMs ?: (((endSample - startSample).coerceAtLeast(0) * 1000L) / sampleRate).toInt()
     var segmentId = ""
     var segmentIndex = -1
-    var snapshot = ""
+    var checkpointSnapshot = ""
+    var appendedRecord: SegmentRecord? = null
     synchronized(segmentLock) {
       if (state == State.FINISHED) {
         throw SegmentPipelineException(
@@ -82,16 +91,22 @@ class LiveSegmentEntry(
           durationMs = effectiveDurationMs,
           confidence = confidence,
           payloadJson = payloadJson,
-        )
+        ).also { appendedRecord = it }
       )
-      snapshot = snapshotFullForSpoolLocked()
+      checkpointSnapshot = snapshotFullForSpoolLocked()
       if (segments.size > maxSegments) {
         segments.removeAt(0)
         evictedCount++
       }
       totalSegmentsWritten.incrementAndGet()
     }
-    writeSnapshotToSpoolOrThrow(snapshot, mayActivateAuto = true)
+    val appendRecord = appendedRecord
+      ?: throw SegmentPipelineException(SegmentErrorCodes.INTERNAL_ERROR, "Missing appended segment record")
+    writeSpoolV2OrThrow(
+      mayActivateAuto = true,
+      appendRecord = appendRecord,
+      checkpointPayload = checkpointSnapshot
+    )
     return Pair(segmentId, segmentIndex)
   }
 
@@ -107,7 +122,8 @@ class LiveSegmentEntry(
     }
     synchronized(spoolLock) {
       try {
-        spoolWriter?.finalize_()
+        journalWriter?.appendRecord(SegmentSpoolV2.RECORD_FINALIZE_MARK, "{}")
+        journalWriter?.finalize_()
       } catch (e: Exception) {
         markSpoolFailureAndThrow(
           SegmentErrorCodes.SPOOL_WRITE_FAILED,
@@ -115,7 +131,8 @@ class LiveSegmentEntry(
           e
         )
       } finally {
-        spoolWriter = null
+        journalWriter = null
+        checkpointWriter = null
       }
     }
   }
@@ -151,28 +168,9 @@ class LiveSegmentEntry(
       "Segment spool path missing for $bufferId"
     )
     synchronized(spoolLock) {
-      try {
-        spoolWriter?.flush()
-      } catch (e: Exception) {
-        throw SegmentPipelineException(
-          SegmentErrorCodes.SPOOL_READ_FAILED,
-          "Failed to flush segment spool for $bufferId: ${e.message}",
-          e
-        )
-      }
+      try { journalWriter?.flush() } catch (_: Exception) {}
     }
-    val json = try {
-      SegmentSpoolReader.readLatestSnapshot(path)
-    } catch (e: SegmentPipelineException) {
-      throw e
-    } catch (e: Exception) {
-      throw SegmentPipelineException(
-        SegmentErrorCodes.SPOOL_READ_FAILED,
-        "Failed to read segment spool for $bufferId: ${e.message}",
-        e
-      )
-    }
-    return OfflineSegmentEntry.segmentsFromJson(json)
+    return readFullStateFromSpool(path)
   }
 
   fun getSegments(startIndex: Int, maxCount: Int): List<SegmentRecord> {
@@ -194,15 +192,24 @@ class LiveSegmentEntry(
   fun release() {
     synchronized(spoolLock) {
       try {
-        spoolWriter?.release()
+        journalWriter?.release()
       } catch (_: Exception) {
       } finally {
-        spoolWriter = null
+        journalWriter = null
+        checkpointWriter = null
       }
     }
     if (spoolTemporary && !spoolPath.isNullOrEmpty()) {
       try {
         File(spoolPath).delete()
+      } catch (_: Exception) {
+      }
+      try {
+        File("${spoolPath}.segj").delete()
+      } catch (_: Exception) {
+      }
+      try {
+        File("${spoolPath}.segc").delete()
       } catch (_: Exception) {
       }
     }
@@ -247,13 +254,15 @@ class LiveSegmentEntry(
   }
 
   private fun ensureSpoolWriterActivatedLocked(snapshotJson: String) {
-    if (spoolWriter != null) return
+    if (journalWriter != null && checkpointWriter != null) return
     val resolvedPath = spoolPath ?: markSpoolFailureAndThrow(
       SegmentErrorCodes.SPOOL_UNAVAILABLE,
       "Segment spool path is not configured for $bufferId"
     )
+    val journalPath = "${resolvedPath}.segj"
+    val checkpointPath = "${resolvedPath}.segc"
     val writer = try {
-      SegmentSpoolWriter(resolvedPath)
+      SegmentJournalWriter(journalPath)
     } catch (e: Exception) {
       markSpoolFailureAndThrow(
         SegmentErrorCodes.SPOOL_WRITE_FAILED,
@@ -262,7 +271,12 @@ class LiveSegmentEntry(
       )
     }
     try {
-      writer.appendSnapshot(snapshotJson)
+      val cpWriter = SegmentCheckpointWriter(checkpointPath)
+      cpWriter.writeSnapshot(snapshotJson)
+      checkpointWriter = cpWriter
+      writer.appendRecord(SegmentSpoolV2.RECORD_CHECKPOINT_MARK, "{}")
+      journalEventCount = 0
+      journalBytesSinceCheckpoint = 0L
     } catch (e: Exception) {
       try {
         writer.release()
@@ -274,12 +288,16 @@ class LiveSegmentEntry(
         e
       )
     }
-    spoolWriter = writer
+    journalWriter = writer
     spoolReady = true
     spoolBytes = writer.bytesWritten
   }
 
-  private fun writeSnapshotToSpoolOrThrow(snapshotJson: String, mayActivateAuto: Boolean) {
+  private fun writeSpoolV2OrThrow(
+    mayActivateAuto: Boolean,
+    appendRecord: SegmentRecord? = null,
+    checkpointPayload: String? = null,
+  ) {
     if (!spoolingEnabled()) return
     val failureCode = spoolFailureCode
     if (failureCode != null) {
@@ -289,30 +307,49 @@ class LiveSegmentEntry(
       )
     }
     synchronized(spoolLock) {
-      val writer = spoolWriter
+      val writer = journalWriter
       if (writer == null) {
         when (spoolingMode) {
           SegmentSpoolingMode.OFF -> return
           SegmentSpoolingMode.ON -> {
-            ensureSpoolWriterActivatedLocked(snapshotJson)
+            ensureSpoolWriterActivatedLocked(checkpointPayload ?: """{"segments":[]}""")
             return
           }
           SegmentSpoolingMode.AUTO -> {
             if (!mayActivateAuto) return
             val estimatedBytes =
-              SegmentSpoolWriter.RECORD_HEADER_BYTES + snapshotJson.toByteArray().size
+              SegmentSpoolV2.HEADER_BYTES + (checkpointPayload ?: "").toByteArray().size
             spoolEstimatedBytes += estimatedBytes.toLong()
             if (spoolEstimatedBytes < spoolThresholdBytes.coerceAtLeast(0L)) {
               spoolReady = false
               return
             }
-            ensureSpoolWriterActivatedLocked(snapshotJson)
+            ensureSpoolWriterActivatedLocked(checkpointPayload ?: """{"segments":[]}""")
             return
           }
         }
       }
       try {
-        writer.appendSnapshot(snapshotJson)
+        if (appendRecord != null) {
+          val payload = OfflineSegmentEntry.segmentsToJson(listOf(appendRecord))
+          writer.appendRecord(SegmentSpoolV2.RECORD_SEGMENT_APPEND, payload)
+          journalEventCount += 1
+          journalBytesSinceCheckpoint += (SegmentSpoolV2.HEADER_BYTES + payload.toByteArray().size).toLong()
+        }
+        if (checkpointPayload != null && (
+            journalEventCount >= SegmentSpoolV2.CHECKPOINT_EVERY_EVENTS ||
+              journalBytesSinceCheckpoint >= SegmentSpoolV2.CHECKPOINT_EVERY_BYTES
+            )
+        ) {
+          val cp = checkpointWriter ?: SegmentCheckpointWriter(v2CheckpointPath()
+            ?: throw SegmentPipelineException(SegmentErrorCodes.SPOOL_UNAVAILABLE, "Missing checkpoint path for $bufferId"))
+          cp.writeSnapshot(checkpointPayload)
+          writer.truncate()
+          writer.appendRecord(SegmentSpoolV2.RECORD_CHECKPOINT_MARK, "{}")
+          checkpointWriter = cp
+          journalEventCount = 0
+          journalBytesSinceCheckpoint = 0L
+        }
         spoolReady = true
         spoolBytes = writer.bytesWritten
       } catch (e: Exception) {
@@ -322,6 +359,35 @@ class LiveSegmentEntry(
           e
         )
       }
+    }
+  }
+
+  private fun readFullStateFromSpool(basePath: String): List<SegmentRecord> {
+    val journalPath = "$basePath.segj"
+    val checkpointPath = "$basePath.segc"
+    val hasV2 = File(journalPath).exists() || File(checkpointPath).exists()
+    return if (hasV2) {
+      val checkpointJson = SegmentCheckpointReader.readSnapshot(checkpointPath) ?: """{"segments":[]}"""
+      val base = OfflineSegmentEntry.segmentsFromJson(checkpointJson).toMutableList()
+      val records = SegmentJournalReader.readAllRecords(journalPath)
+      records.forEach { record ->
+        when (record.type) {
+          SegmentSpoolV2.RECORD_SEGMENT_APPEND -> {
+            val parsed = OfflineSegmentEntry.segmentsFromJson(record.payload)
+            if (parsed.isNotEmpty()) base.add(parsed[0])
+          }
+          SegmentSpoolV2.RECORD_CHECKPOINT_MARK,
+          SegmentSpoolV2.RECORD_FINALIZE_MARK -> {}
+          else -> throw SegmentPipelineException(
+            SegmentErrorCodes.SPOOL_CORRUPTED,
+            "Unknown segment journal record type in $journalPath"
+          )
+        }
+      }
+      base
+    } else {
+      val legacyJson = SegmentSpoolReaderLegacy.readLatestSnapshot(basePath)
+      OfflineSegmentEntry.segmentsFromJson(legacyJson)
     }
   }
 }

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 class LiveSegmentEntry(
   val bufferId: String,
-  private val sourceAudioBufferId: String? = null,
+  val sourceAudioBufferId: String? = null,
   private val maxSegments: Int = 1000,
   private val spoolingMode: SegmentSpoolingMode = SegmentSpoolingMode.ON,
   private val spoolPath: String? = null,
@@ -66,6 +66,25 @@ class LiveSegmentEntry(
     confidence: Double?,
     payloadJson: String?,
   ): Pair<String, Int> {
+    if (sampleRate <= 0) {
+      throw SegmentPipelineException(
+        SegmentErrorCodes.INVALID_ARGUMENT,
+        "sampleRate must be > 0; received $sampleRate"
+      )
+    }
+    if (endSample < startSample) {
+      throw SegmentPipelineException(
+        SegmentErrorCodes.INVALID_ARGUMENT,
+        "endSample must be >= startSample; received startSample=$startSample endSample=$endSample"
+      )
+    }
+    if (durationMs != null && durationMs < 0) {
+      throw SegmentPipelineException(
+        SegmentErrorCodes.INVALID_ARGUMENT,
+        "durationMs must be >= 0 when provided; received $durationMs"
+      )
+    }
+
     val effectiveDurationMs = durationMs ?: (((endSample - startSample).coerceAtLeast(0) * 1000L) / sampleRate).toInt()
     var segmentId = ""
     var segmentIndex = -1

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
@@ -47,12 +47,12 @@ class LiveSegmentEntry(
   private var journalBytesSinceCheckpoint: Long = 0
 
   private fun spoolingEnabled(): Boolean = spoolingMode != SegmentSpoolingMode.OFF
-  private fun v2JournalPath(): String? = spoolPath?.let { "${it}.segj" }
-  private fun v2CheckpointPath(): String? = spoolPath?.let { "${it}.segc" }
+  private fun journalPath(): String? = spoolPath?.let { "${it}.segj" }
+  private fun checkpointPath(): String? = spoolPath?.let { "${it}.segc" }
 
   init {
     if (spoolingEnabled() && spoolingMode == SegmentSpoolingMode.ON) {
-      writeSpoolV2OrThrow(mayActivateAuto = false, checkpointPayload = snapshotFullForSpool())
+      writeSpoolOrThrow(mayActivateAuto = false, checkpointPayload = snapshotFullForSpool())
     }
   }
 
@@ -102,7 +102,7 @@ class LiveSegmentEntry(
     }
     val appendRecord = appendedRecord
       ?: throw SegmentPipelineException(SegmentErrorCodes.INTERNAL_ERROR, "Missing appended segment record")
-    writeSpoolV2OrThrow(
+    writeSpoolOrThrow(
       mayActivateAuto = true,
       appendRecord = appendRecord,
       checkpointPayload = checkpointSnapshot
@@ -122,7 +122,7 @@ class LiveSegmentEntry(
     }
     synchronized(spoolLock) {
       try {
-        journalWriter?.appendRecord(SegmentSpoolV2.RECORD_FINALIZE_MARK, "{}")
+        journalWriter?.appendRecord(SegmentSpoolFormat.RECORD_FINALIZE_MARK, "{}")
         journalWriter?.finalize_()
       } catch (e: Exception) {
         markSpoolFailureAndThrow(
@@ -201,10 +201,6 @@ class LiveSegmentEntry(
     }
     if (spoolTemporary && !spoolPath.isNullOrEmpty()) {
       try {
-        File(spoolPath).delete()
-      } catch (_: Exception) {
-      }
-      try {
         File("${spoolPath}.segj").delete()
       } catch (_: Exception) {
       }
@@ -274,7 +270,7 @@ class LiveSegmentEntry(
       val cpWriter = SegmentCheckpointWriter(checkpointPath)
       cpWriter.writeSnapshot(snapshotJson)
       checkpointWriter = cpWriter
-      writer.appendRecord(SegmentSpoolV2.RECORD_CHECKPOINT_MARK, "{}")
+      writer.appendRecord(SegmentSpoolFormat.RECORD_CHECKPOINT_MARK, "{}")
       journalEventCount = 0
       journalBytesSinceCheckpoint = 0L
     } catch (e: Exception) {
@@ -293,7 +289,7 @@ class LiveSegmentEntry(
     spoolBytes = writer.bytesWritten
   }
 
-  private fun writeSpoolV2OrThrow(
+  private fun writeSpoolOrThrow(
     mayActivateAuto: Boolean,
     appendRecord: SegmentRecord? = null,
     checkpointPayload: String? = null,
@@ -318,7 +314,7 @@ class LiveSegmentEntry(
           SegmentSpoolingMode.AUTO -> {
             if (!mayActivateAuto) return
             val estimatedBytes =
-              SegmentSpoolV2.HEADER_BYTES + (checkpointPayload ?: "").toByteArray().size
+              SegmentSpoolFormat.HEADER_BYTES + (checkpointPayload ?: "").toByteArray().size
             spoolEstimatedBytes += estimatedBytes.toLong()
             if (spoolEstimatedBytes < spoolThresholdBytes.coerceAtLeast(0L)) {
               spoolReady = false
@@ -332,20 +328,20 @@ class LiveSegmentEntry(
       try {
         if (appendRecord != null) {
           val payload = OfflineSegmentEntry.segmentsToJson(listOf(appendRecord))
-          writer.appendRecord(SegmentSpoolV2.RECORD_SEGMENT_APPEND, payload)
+          writer.appendRecord(SegmentSpoolFormat.RECORD_SEGMENT_APPEND, payload)
           journalEventCount += 1
-          journalBytesSinceCheckpoint += (SegmentSpoolV2.HEADER_BYTES + payload.toByteArray().size).toLong()
+          journalBytesSinceCheckpoint += (SegmentSpoolFormat.HEADER_BYTES + payload.toByteArray().size).toLong()
         }
         if (checkpointPayload != null && (
-            journalEventCount >= SegmentSpoolV2.CHECKPOINT_EVERY_EVENTS ||
-              journalBytesSinceCheckpoint >= SegmentSpoolV2.CHECKPOINT_EVERY_BYTES
+            journalEventCount >= SegmentSpoolFormat.CHECKPOINT_EVERY_EVENTS ||
+              journalBytesSinceCheckpoint >= SegmentSpoolFormat.CHECKPOINT_EVERY_BYTES
             )
         ) {
-          val cp = checkpointWriter ?: SegmentCheckpointWriter(v2CheckpointPath()
+          val cp = checkpointWriter ?: SegmentCheckpointWriter(checkpointPath()
             ?: throw SegmentPipelineException(SegmentErrorCodes.SPOOL_UNAVAILABLE, "Missing checkpoint path for $bufferId"))
           cp.writeSnapshot(checkpointPayload)
           writer.truncate()
-          writer.appendRecord(SegmentSpoolV2.RECORD_CHECKPOINT_MARK, "{}")
+          writer.appendRecord(SegmentSpoolFormat.RECORD_CHECKPOINT_MARK, "{}")
           checkpointWriter = cp
           journalEventCount = 0
           journalBytesSinceCheckpoint = 0L
@@ -365,29 +361,30 @@ class LiveSegmentEntry(
   private fun readFullStateFromSpool(basePath: String): List<SegmentRecord> {
     val journalPath = "$basePath.segj"
     val checkpointPath = "$basePath.segc"
-    val hasV2 = File(journalPath).exists() || File(checkpointPath).exists()
-    return if (hasV2) {
-      val checkpointJson = SegmentCheckpointReader.readSnapshot(checkpointPath) ?: """{"segments":[]}"""
-      val base = OfflineSegmentEntry.segmentsFromJson(checkpointJson).toMutableList()
-      val records = SegmentJournalReader.readAllRecords(journalPath)
-      records.forEach { record ->
-        when (record.type) {
-          SegmentSpoolV2.RECORD_SEGMENT_APPEND -> {
-            val parsed = OfflineSegmentEntry.segmentsFromJson(record.payload)
-            if (parsed.isNotEmpty()) base.add(parsed[0])
-          }
-          SegmentSpoolV2.RECORD_CHECKPOINT_MARK,
-          SegmentSpoolV2.RECORD_FINALIZE_MARK -> {}
-          else -> throw SegmentPipelineException(
-            SegmentErrorCodes.SPOOL_CORRUPTED,
-            "Unknown segment journal record type in $journalPath"
-          )
-        }
-      }
-      base
-    } else {
-      val legacyJson = SegmentSpoolReaderLegacy.readLatestSnapshot(basePath)
-      OfflineSegmentEntry.segmentsFromJson(legacyJson)
+    val hasSpool = File(journalPath).exists() || File(checkpointPath).exists()
+    if (!hasSpool) {
+      throw SegmentPipelineException(
+        SegmentErrorCodes.SPOOL_UNAVAILABLE,
+        "Segment spool files are missing for $bufferId"
+      )
     }
+    val checkpointJson = SegmentCheckpointReader.readSnapshot(checkpointPath) ?: """{"segments":[]}"""
+    val base = OfflineSegmentEntry.segmentsFromJson(checkpointJson).toMutableList()
+    val records = SegmentJournalReader.readAllRecords(journalPath)
+    records.forEach { record ->
+      when (record.type) {
+        SegmentSpoolFormat.RECORD_SEGMENT_APPEND -> {
+          val parsed = OfflineSegmentEntry.segmentsFromJson(record.payload)
+          if (parsed.isNotEmpty()) base.add(parsed[0])
+        }
+        SegmentSpoolFormat.RECORD_CHECKPOINT_MARK,
+        SegmentSpoolFormat.RECORD_FINALIZE_MARK -> {}
+        else -> throw SegmentPipelineException(
+          SegmentErrorCodes.SPOOL_CORRUPTED,
+          "Unknown segment journal record type in $journalPath"
+        )
+      }
+    }
+    return base
   }
 }

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/OfflineSegmentEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/OfflineSegmentEntry.kt
@@ -1,0 +1,140 @@
+package com.sherpaonnx.segment.pipeline
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableArray
+import com.facebook.react.bridge.WritableMap
+import org.json.JSONArray
+import org.json.JSONObject
+
+class OfflineSegmentEntry(
+  val bufferId: String,
+  private val sourceAudioBufferId: String? = null,
+) {
+  @Volatile
+  private var populated = false
+  private val lock = Any()
+  private var segments: List<SegmentRecord> = emptyList()
+
+  fun populate(records: List<SegmentRecord>) {
+    synchronized(lock) {
+      if (populated) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.INVALID_STATE,
+          "Offline segment buffer already populated: $bufferId"
+        )
+      }
+      segments = records.toList()
+      populated = true
+    }
+  }
+
+  fun snapshotSegments(start: Int = 0, maxCount: Int = Int.MAX_VALUE): List<SegmentRecord> {
+    synchronized(lock) {
+      if (start < 0 || maxCount < 0) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.SLICE_INVALID,
+          "Invalid segment slice range start=$start maxCount=$maxCount"
+        )
+      }
+      if (start >= segments.size) return emptyList()
+      val end = minOf(start + maxCount, segments.size)
+      return segments.subList(start, end)
+    }
+  }
+
+  fun toWritableMap(): WritableMap {
+    val map = Arguments.createMap()
+    map.putString("bufferId", bufferId)
+    map.putString("kind", "offlineSegmentBuffer")
+    map.putString("state", "immutable")
+    map.putInt("segmentCount", synchronized(lock) { segments.size })
+    if (!sourceAudioBufferId.isNullOrEmpty()) {
+      map.putString("sourceAudioBufferId", sourceAudioBufferId)
+    }
+    return map
+  }
+
+  companion object {
+    fun toWritableArray(records: List<SegmentRecord>): WritableArray {
+      val arr = Arguments.createArray()
+      for (r in records) {
+        val item = Arguments.createMap()
+        item.putString("id", r.id)
+        item.putString("kind", r.kind)
+        item.putString("sourceAudioBufferId", r.sourceAudioBufferId)
+        item.putInt("startSample", r.startSample)
+        item.putInt("endSample", r.endSample)
+        item.putInt("sampleRate", r.sampleRate)
+        item.putInt("durationMs", r.durationMs)
+        if (r.confidence != null) item.putDouble("confidence", r.confidence)
+        if (!r.payloadJson.isNullOrEmpty()) {
+          item.putMap("payload", jsonStringToWritableMap(r.payloadJson))
+        }
+        arr.pushMap(item)
+      }
+      return arr
+    }
+
+    fun segmentsToJson(records: List<SegmentRecord>): String {
+      val root = JSONObject()
+      val arr = JSONArray()
+      for (r in records) {
+        val obj = JSONObject()
+        obj.put("id", r.id)
+        obj.put("kind", r.kind)
+        obj.put("sourceAudioBufferId", r.sourceAudioBufferId)
+        obj.put("startSample", r.startSample)
+        obj.put("endSample", r.endSample)
+        obj.put("sampleRate", r.sampleRate)
+        obj.put("durationMs", r.durationMs)
+        if (r.confidence != null) obj.put("confidence", r.confidence)
+        if (!r.payloadJson.isNullOrEmpty()) obj.put("payload", JSONObject(r.payloadJson))
+        arr.put(obj)
+      }
+      root.put("segments", arr)
+      return root.toString()
+    }
+
+    fun segmentsFromJson(json: String): List<SegmentRecord> {
+      val root = JSONObject(json)
+      val arr = root.optJSONArray("segments") ?: JSONArray()
+      val out = ArrayList<SegmentRecord>(arr.length())
+      for (i in 0 until arr.length()) {
+        val obj = arr.getJSONObject(i)
+        out.add(
+          SegmentRecord(
+            id = obj.optString("id"),
+            kind = obj.optString("kind", "speech"),
+            sourceAudioBufferId = obj.optString("sourceAudioBufferId"),
+            startSample = obj.optInt("startSample"),
+            endSample = obj.optInt("endSample"),
+            sampleRate = obj.optInt("sampleRate"),
+            durationMs = obj.optInt("durationMs"),
+            confidence = if (obj.has("confidence")) obj.optDouble("confidence") else null,
+            payloadJson = if (obj.has("payload")) obj.optJSONObject("payload")?.toString() else null,
+          )
+        )
+      }
+      return out
+    }
+
+    private fun jsonStringToWritableMap(json: String): WritableMap {
+      val obj = JSONObject(json)
+      val map = Arguments.createMap()
+      val it = obj.keys()
+      while (it.hasNext()) {
+        val key = it.next()
+        when (val value = obj.get(key)) {
+          is String -> map.putString(key, value)
+          is Boolean -> map.putBoolean(key, value)
+          is Int -> map.putInt(key, value)
+          is Long -> map.putDouble(key, value.toDouble())
+          is Double -> map.putDouble(key, value)
+          is JSONObject -> map.putMap(key, jsonStringToWritableMap(value.toString()))
+          else -> map.putString(key, value.toString())
+        }
+      }
+      return map
+    }
+  }
+}

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentErrorCodes.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentErrorCodes.kt
@@ -1,0 +1,22 @@
+package com.sherpaonnx.segment.pipeline
+
+object SegmentErrorCodes {
+  const val BUFFER_NOT_FOUND = "SEGMENT_BUFFER_NOT_FOUND"
+  const val BUFFER_KIND_MISMATCH = "SEGMENT_BUFFER_KIND_MISMATCH"
+  const val INVALID_ARGUMENT = "SEGMENT_INVALID_ARGUMENT"
+  const val INVALID_STATE = "SEGMENT_INVALID_STATE"
+  const val ALREADY_FINALIZED = "SEGMENT_ALREADY_FINALIZED"
+  const val SLICE_INVALID = "SEGMENT_SLICE_INVALID"
+  const val INTERNAL_ERROR = "SEGMENT_INTERNAL_ERROR"
+
+  const val SPOOL_UNAVAILABLE = "SEGMENT_SPOOL_UNAVAILABLE"
+  const val SPOOL_WRITE_FAILED = "SEGMENT_SPOOL_WRITE_FAILED"
+  const val SPOOL_READ_FAILED = "SEGMENT_SPOOL_READ_FAILED"
+  const val SPOOL_CORRUPTED = "SEGMENT_SPOOL_CORRUPTED"
+}
+
+class SegmentPipelineException(
+  val code: String,
+  override val message: String,
+  cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentModels.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentModels.kt
@@ -1,0 +1,39 @@
+package com.sherpaonnx.segment.pipeline
+
+data class SegmentRecord(
+  val id: String,
+  val kind: String,
+  val sourceAudioBufferId: String,
+  val startSample: Int,
+  val endSample: Int,
+  val sampleRate: Int,
+  val durationMs: Int,
+  val confidence: Double? = null,
+  val payloadJson: String? = null,
+)
+
+enum class SegmentSpoolingMode {
+  OFF,
+  AUTO,
+  ON;
+
+  fun rawValue(): String = when (this) {
+    OFF -> "off"
+    AUTO -> "auto"
+    ON -> "on"
+  }
+
+  companion object {
+    fun fromRaw(raw: String?): SegmentSpoolingMode {
+      return when (raw?.trim()?.lowercase()) {
+        "off" -> OFF
+        "auto" -> AUTO
+        "on", null, "" -> ON
+        else -> throw SegmentPipelineException(
+          SegmentErrorCodes.INVALID_ARGUMENT,
+          "Invalid segment spooling mode: $raw. Use 'off', 'auto', or 'on'."
+        )
+      }
+    }
+  }
+}

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentPipelineRegistry.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentPipelineRegistry.kt
@@ -77,7 +77,7 @@ object SegmentPipelineRegistry {
       )
     }
     val id = newId("seg_off")
-    val entry = OfflineSegmentEntry(id)
+    val entry = OfflineSegmentEntry(id, live.sourceAudioBufferId)
     entry.populate(records)
     offlineMap[id] = entry
     return entry

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentPipelineRegistry.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentPipelineRegistry.kt
@@ -1,0 +1,105 @@
+package com.sherpaonnx.segment.pipeline
+
+import java.io.File
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+object SegmentPipelineRegistry {
+  private val offlineMap = ConcurrentHashMap<String, OfflineSegmentEntry>()
+  private val liveMap = ConcurrentHashMap<String, LiveSegmentEntry>()
+  private var cacheDir: File? = null
+
+  fun initializeWithCacheDir(cacheDir: File) {
+    this.cacheDir = cacheDir
+  }
+
+  private fun requireCacheDir(): File {
+    return cacheDir ?: throw SegmentPipelineException(
+      SegmentErrorCodes.INTERNAL_ERROR,
+      "SegmentPipelineRegistry not initialized with cacheDir"
+    )
+  }
+
+  private fun newId(prefix: String): String = "${prefix}_${UUID.randomUUID()}"
+
+  fun createLive(
+    sourceAudioBufferId: String?,
+    maxSegments: Int,
+    spoolingModeRaw: String?,
+    spoolingPath: String?,
+    spoolingTemporary: Boolean?,
+    spoolingThresholdBytes: Long?,
+  ): LiveSegmentEntry {
+    val id = newId("seg_live")
+    val mode = SegmentSpoolingMode.fromRaw(spoolingModeRaw)
+    val tempDir = requireCacheDir()
+    val effectivePath = if (mode == SegmentSpoolingMode.OFF) {
+      null
+    } else {
+      spoolingPath ?: File(tempDir, "seg_spool_${System.currentTimeMillis()}_${UUID.randomUUID()}.json").absolutePath
+    }
+    val temporary = spoolingTemporary ?: spoolingPath.isNullOrEmpty()
+    val entry = LiveSegmentEntry(
+      bufferId = id,
+      sourceAudioBufferId = sourceAudioBufferId,
+      maxSegments = maxSegments.coerceAtLeast(1),
+      spoolingMode = mode,
+      spoolPath = effectivePath,
+      spoolTemporary = temporary,
+      spoolThresholdBytes = spoolingThresholdBytes ?: 0L,
+    )
+    liveMap[id] = entry
+    return entry
+  }
+
+  fun createEmptyOffline(sourceAudioBufferId: String?): OfflineSegmentEntry {
+    val id = newId("seg_off")
+    val entry = OfflineSegmentEntry(id, sourceAudioBufferId)
+    entry.populate(emptyList())
+    offlineMap[id] = entry
+    return entry
+  }
+
+  fun createOfflineFromLive(
+    liveBufferId: String,
+    mode: String = "fullIfSpooled",
+  ): OfflineSegmentEntry {
+    val live = getLive(liveBufferId) ?: throw SegmentPipelineException(
+      SegmentErrorCodes.BUFFER_NOT_FOUND,
+      "Live segment buffer not found: $liveBufferId"
+    )
+    val records = when (mode) {
+      "windowSnapshot" -> live.snapshotWindow()
+      "fullIfSpooled" -> live.snapshotFullIfSpooled()
+      else -> throw SegmentPipelineException(
+        SegmentErrorCodes.INVALID_ARGUMENT,
+        "Unknown mode: $mode. Use 'fullIfSpooled' or 'windowSnapshot'."
+      )
+    }
+    val id = newId("seg_off")
+    val entry = OfflineSegmentEntry(id)
+    entry.populate(records)
+    offlineMap[id] = entry
+    return entry
+  }
+
+  fun getOffline(bufferId: String): OfflineSegmentEntry? = offlineMap[bufferId]
+  fun getLive(bufferId: String): LiveSegmentEntry? = liveMap[bufferId]
+
+  fun release(bufferId: String) {
+    liveMap.remove(bufferId)?.release()
+    offlineMap.remove(bufferId)
+  }
+
+  fun releaseAll() {
+    val liveEntries = liveMap.values.toList()
+    liveMap.clear()
+    offlineMap.clear()
+    liveEntries.forEach {
+      try {
+        it.release()
+      } catch (_: Exception) {
+      }
+    }
+  }
+}

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentSpoolIO.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentSpoolIO.kt
@@ -8,7 +8,7 @@ import java.nio.ByteOrder
 import java.nio.charset.StandardCharsets
 import java.util.zip.CRC32
 
-internal object SegmentSpoolV2 {
+internal object SegmentSpoolFormat {
   const val MAGIC = 0x32474553 // SEG2 little-endian
   const val VERSION = 2
   const val HEADER_BYTES = 16
@@ -26,7 +26,7 @@ internal data class SegmentJournalRecord(
 
 internal class SegmentJournalWriter(private val filePath: String) {
   companion object {
-    private const val HEADER_BYTES = SegmentSpoolV2.HEADER_BYTES
+    private const val HEADER_BYTES = SegmentSpoolFormat.HEADER_BYTES
   }
 
   private val raf: RandomAccessFile
@@ -53,8 +53,8 @@ internal class SegmentJournalWriter(private val filePath: String) {
     val header = ByteBuffer
       .allocate(HEADER_BYTES)
       .order(ByteOrder.LITTLE_ENDIAN)
-      .putInt(SegmentSpoolV2.MAGIC)
-      .putShort(SegmentSpoolV2.VERSION.toShort())
+      .putInt(SegmentSpoolFormat.MAGIC)
+      .putShort(SegmentSpoolFormat.VERSION.toShort())
       .putShort(recordType.toShort())
       .putInt(payload.size)
       .putInt(crc)
@@ -108,7 +108,7 @@ internal class SegmentJournalWriter(private val filePath: String) {
 }
 
 internal object SegmentJournalReader {
-  private const val HEADER_BYTES = SegmentSpoolV2.HEADER_BYTES
+  private const val HEADER_BYTES = SegmentSpoolFormat.HEADER_BYTES
 
   fun readAllRecords(path: String): List<SegmentJournalRecord> {
     val file = File(path)
@@ -134,7 +134,7 @@ internal object SegmentJournalReader {
         val type = bb.short.toInt()
         val len = bb.int
         val crc = bb.int
-        if (magic != SegmentSpoolV2.MAGIC || version != SegmentSpoolV2.VERSION) {
+        if (magic != SegmentSpoolFormat.MAGIC || version != SegmentSpoolFormat.VERSION) {
           throw SegmentPipelineException(
             SegmentErrorCodes.SPOOL_CORRUPTED,
             "Unexpected segment journal record version: $path"
@@ -180,11 +180,11 @@ internal class SegmentCheckpointWriter(private val filePath: String) {
       val payload = snapshotJson.toByteArray(StandardCharsets.UTF_8)
       val crc = CRC32().apply { update(payload) }.value.toInt()
       val header = ByteBuffer
-        .allocate(SegmentSpoolV2.HEADER_BYTES)
+        .allocate(SegmentSpoolFormat.HEADER_BYTES)
         .order(ByteOrder.LITTLE_ENDIAN)
-        .putInt(SegmentSpoolV2.MAGIC)
-        .putShort(SegmentSpoolV2.VERSION.toShort())
-        .putShort(SegmentSpoolV2.RECORD_CHECKPOINT_MARK.toShort())
+        .putInt(SegmentSpoolFormat.MAGIC)
+        .putShort(SegmentSpoolFormat.VERSION.toShort())
+        .putShort(SegmentSpoolFormat.RECORD_CHECKPOINT_MARK.toShort())
         .putInt(payload.size)
         .putInt(crc)
         .array()
@@ -213,13 +213,13 @@ internal object SegmentCheckpointReader {
     val file = File(path)
     if (!file.exists()) return null
     RandomAccessFile(file, "r").use { raf ->
-      if (raf.length() < SegmentSpoolV2.HEADER_BYTES) {
+      if (raf.length() < SegmentSpoolFormat.HEADER_BYTES) {
         throw SegmentPipelineException(
           SegmentErrorCodes.SPOOL_CORRUPTED,
           "Corrupted segment checkpoint header: $path"
         )
       }
-      val header = ByteArray(SegmentSpoolV2.HEADER_BYTES)
+      val header = ByteArray(SegmentSpoolFormat.HEADER_BYTES)
       raf.readFully(header)
       val bb = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
       val magic = bb.int
@@ -227,8 +227,8 @@ internal object SegmentCheckpointReader {
       val type = bb.short.toInt()
       val len = bb.int
       val crc = bb.int
-      if (magic != SegmentSpoolV2.MAGIC || version != SegmentSpoolV2.VERSION ||
-        type != SegmentSpoolV2.RECORD_CHECKPOINT_MARK || len < 0
+      if (magic != SegmentSpoolFormat.MAGIC || version != SegmentSpoolFormat.VERSION ||
+        type != SegmentSpoolFormat.RECORD_CHECKPOINT_MARK || len < 0
       ) {
         throw SegmentPipelineException(
           SegmentErrorCodes.SPOOL_CORRUPTED,
@@ -250,27 +250,6 @@ internal object SegmentCheckpointReader {
           "Segment checkpoint checksum mismatch: $path"
         )
       }
-      return String(payload, StandardCharsets.UTF_8)
-    }
-  }
-}
-
-internal object SegmentSpoolReaderLegacy {
-  private const val RECORD_HEADER_BYTES = 4
-  fun readLatestSnapshot(path: String): String {
-    val file = File(path)
-    if (!file.exists()) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_UNAVAILABLE, "Segment spool file does not exist: $path")
-    RandomAccessFile(file, "r").use { raf ->
-      val fileLength = raf.length()
-      if (fileLength < RECORD_HEADER_BYTES) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_CORRUPTED, "Corrupted segment spool header: $path")
-      val header = ByteArray(RECORD_HEADER_BYTES)
-      raf.readFully(header)
-      val len = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN).int
-      if (len < 0) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_CORRUPTED, "Corrupted segment spool length: $path")
-      val expectedLength = RECORD_HEADER_BYTES + len.toLong()
-      if (fileLength != expectedLength) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_CORRUPTED, "Unexpected segment spool size: $path")
-      val payload = ByteArray(len)
-      if (len > 0) raf.readFully(payload)
       return String(payload, StandardCharsets.UTF_8)
     }
   }

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentSpoolIO.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentSpoolIO.kt
@@ -6,10 +6,27 @@ import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.charset.StandardCharsets
+import java.util.zip.CRC32
 
-internal class SegmentSpoolWriter(filePath: String) {
+internal object SegmentSpoolV2 {
+  const val MAGIC = 0x32474553 // SEG2 little-endian
+  const val VERSION = 2
+  const val HEADER_BYTES = 16
+  const val RECORD_SEGMENT_APPEND = 1
+  const val RECORD_CHECKPOINT_MARK = 2
+  const val RECORD_FINALIZE_MARK = 3
+  const val CHECKPOINT_EVERY_EVENTS = 128
+  const val CHECKPOINT_EVERY_BYTES = 1_048_576L
+}
+
+internal data class SegmentJournalRecord(
+  val type: Int,
+  val payload: String,
+)
+
+internal class SegmentJournalWriter(private val filePath: String) {
   companion object {
-    const val RECORD_HEADER_BYTES = 4
+    private const val HEADER_BYTES = SegmentSpoolV2.HEADER_BYTES
   }
 
   private val raf: RandomAccessFile
@@ -26,25 +43,38 @@ internal class SegmentSpoolWriter(filePath: String) {
     val file = File(filePath)
     file.parentFile?.mkdirs()
     raf = RandomAccessFile(file, "rw")
-    raf.setLength(0L)
+    raf.seek(raf.length())
+    bytesWritten = raf.length()
   }
 
-  fun appendSnapshot(snapshotJson: String) {
-    val payload = snapshotJson.toByteArray(StandardCharsets.UTF_8)
+  fun appendRecord(recordType: Int, payloadJson: String) {
+    val payload = payloadJson.toByteArray(StandardCharsets.UTF_8)
+    val crc = CRC32().apply { update(payload) }.value.toInt()
     val header = ByteBuffer
-      .allocate(RECORD_HEADER_BYTES)
+      .allocate(HEADER_BYTES)
       .order(ByteOrder.LITTLE_ENDIAN)
+      .putInt(SegmentSpoolV2.MAGIC)
+      .putShort(SegmentSpoolV2.VERSION.toShort())
+      .putShort(recordType.toShort())
       .putInt(payload.size)
+      .putInt(crc)
       .array()
 
     synchronized(lock) {
-      if (closed) throw IOException("Segment spool writer closed")
-      val recordLength = (RECORD_HEADER_BYTES + payload.size).toLong()
-      raf.seek(0L)
+      if (closed) throw IOException("Segment journal writer closed")
+      raf.seek(raf.length())
       raf.write(header)
       raf.write(payload)
-      raf.setLength(recordLength)
-      bytesWritten = recordLength
+      bytesWritten = raf.length()
+    }
+  }
+
+  fun truncate() {
+    synchronized(lock) {
+      if (closed) return
+      raf.setLength(0L)
+      raf.seek(0L)
+      bytesWritten = 0L
     }
   }
 
@@ -77,43 +107,168 @@ internal class SegmentSpoolWriter(filePath: String) {
   }
 }
 
-internal object SegmentSpoolReader {
-  private const val RECORD_HEADER_BYTES = 4
+internal object SegmentJournalReader {
+  private const val HEADER_BYTES = SegmentSpoolV2.HEADER_BYTES
 
-  fun readLatestSnapshot(path: String): String {
+  fun readAllRecords(path: String): List<SegmentJournalRecord> {
     val file = File(path)
     if (!file.exists()) {
-      throw SegmentPipelineException(
-        SegmentErrorCodes.SPOOL_UNAVAILABLE,
-        "Segment spool file does not exist: $path"
-      )
+      return emptyList()
     }
 
     RandomAccessFile(file, "r").use { raf ->
-      val fileLength = raf.length()
-      if (fileLength < RECORD_HEADER_BYTES) {
+      val out = ArrayList<SegmentJournalRecord>()
+      while (raf.filePointer < raf.length()) {
+        val remaining = raf.length() - raf.filePointer
+        if (remaining < HEADER_BYTES) {
+          throw SegmentPipelineException(
+            SegmentErrorCodes.SPOOL_CORRUPTED,
+            "Corrupted segment journal header: $path"
+          )
+        }
+        val header = ByteArray(HEADER_BYTES)
+        raf.readFully(header)
+        val bb = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+        val magic = bb.int
+        val version = bb.short.toInt()
+        val type = bb.short.toInt()
+        val len = bb.int
+        val crc = bb.int
+        if (magic != SegmentSpoolV2.MAGIC || version != SegmentSpoolV2.VERSION) {
+          throw SegmentPipelineException(
+            SegmentErrorCodes.SPOOL_CORRUPTED,
+            "Unexpected segment journal record version: $path"
+          )
+        }
+        if (len < 0) {
+          throw SegmentPipelineException(
+            SegmentErrorCodes.SPOOL_CORRUPTED,
+            "Corrupted segment journal record length: $path"
+          )
+        }
+        val payload = ByteArray(len)
+        if (len > 0) {
+          if (raf.filePointer + len > raf.length()) {
+            throw SegmentPipelineException(
+              SegmentErrorCodes.SPOOL_CORRUPTED,
+              "Truncated segment journal payload: $path"
+            )
+          }
+          raf.readFully(payload)
+        }
+        val actualCrc = CRC32().apply { update(payload) }.value.toInt()
+        if (actualCrc != crc) {
+          throw SegmentPipelineException(
+            SegmentErrorCodes.SPOOL_CORRUPTED,
+            "Segment journal checksum mismatch: $path"
+          )
+        }
+        out.add(SegmentJournalRecord(type, String(payload, StandardCharsets.UTF_8)))
+      }
+      return out
+    }
+  }
+}
+
+internal class SegmentCheckpointWriter(private val filePath: String) {
+  fun writeSnapshot(snapshotJson: String) {
+    val tmpPath = "$filePath.tmp"
+    val tmpFile = File(tmpPath)
+    tmpFile.parentFile?.mkdirs()
+    RandomAccessFile(tmpFile, "rw").use { raf ->
+      raf.setLength(0L)
+      val payload = snapshotJson.toByteArray(StandardCharsets.UTF_8)
+      val crc = CRC32().apply { update(payload) }.value.toInt()
+      val header = ByteBuffer
+        .allocate(SegmentSpoolV2.HEADER_BYTES)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .putInt(SegmentSpoolV2.MAGIC)
+        .putShort(SegmentSpoolV2.VERSION.toShort())
+        .putShort(SegmentSpoolV2.RECORD_CHECKPOINT_MARK.toShort())
+        .putInt(payload.size)
+        .putInt(crc)
+        .array()
+      raf.write(header)
+      raf.write(payload)
+      raf.fd.sync()
+    }
+    val target = File(filePath)
+    if (target.exists() && !target.delete()) {
+      throw SegmentPipelineException(
+        SegmentErrorCodes.SPOOL_WRITE_FAILED,
+        "Failed to replace checkpoint file: $filePath"
+      )
+    }
+    if (!tmpFile.renameTo(target)) {
+      throw SegmentPipelineException(
+        SegmentErrorCodes.SPOOL_WRITE_FAILED,
+        "Failed to finalize checkpoint file: $filePath"
+      )
+    }
+  }
+}
+
+internal object SegmentCheckpointReader {
+  fun readSnapshot(path: String): String? {
+    val file = File(path)
+    if (!file.exists()) return null
+    RandomAccessFile(file, "r").use { raf ->
+      if (raf.length() < SegmentSpoolV2.HEADER_BYTES) {
         throw SegmentPipelineException(
           SegmentErrorCodes.SPOOL_CORRUPTED,
-          "Corrupted segment spool header: $path"
+          "Corrupted segment checkpoint header: $path"
         )
       }
-      raf.seek(0L)
+      val header = ByteArray(SegmentSpoolV2.HEADER_BYTES)
+      raf.readFully(header)
+      val bb = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+      val magic = bb.int
+      val version = bb.short.toInt()
+      val type = bb.short.toInt()
+      val len = bb.int
+      val crc = bb.int
+      if (magic != SegmentSpoolV2.MAGIC || version != SegmentSpoolV2.VERSION ||
+        type != SegmentSpoolV2.RECORD_CHECKPOINT_MARK || len < 0
+      ) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.SPOOL_CORRUPTED,
+          "Unexpected segment checkpoint record format: $path"
+        )
+      }
+      val payload = ByteArray(len)
+      if (len > 0) raf.readFully(payload)
+      if (raf.filePointer != raf.length()) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.SPOOL_CORRUPTED,
+          "Unexpected trailing data in checkpoint file: $path"
+        )
+      }
+      val actualCrc = CRC32().apply { update(payload) }.value.toInt()
+      if (actualCrc != crc) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.SPOOL_CORRUPTED,
+          "Segment checkpoint checksum mismatch: $path"
+        )
+      }
+      return String(payload, StandardCharsets.UTF_8)
+    }
+  }
+}
+
+internal object SegmentSpoolReaderLegacy {
+  private const val RECORD_HEADER_BYTES = 4
+  fun readLatestSnapshot(path: String): String {
+    val file = File(path)
+    if (!file.exists()) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_UNAVAILABLE, "Segment spool file does not exist: $path")
+    RandomAccessFile(file, "r").use { raf ->
+      val fileLength = raf.length()
+      if (fileLength < RECORD_HEADER_BYTES) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_CORRUPTED, "Corrupted segment spool header: $path")
       val header = ByteArray(RECORD_HEADER_BYTES)
       raf.readFully(header)
       val len = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN).int
-      if (len < 0) {
-        throw SegmentPipelineException(
-          SegmentErrorCodes.SPOOL_CORRUPTED,
-          "Corrupted segment spool length: $path"
-        )
-      }
+      if (len < 0) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_CORRUPTED, "Corrupted segment spool length: $path")
       val expectedLength = RECORD_HEADER_BYTES + len.toLong()
-      if (fileLength != expectedLength) {
-        throw SegmentPipelineException(
-          SegmentErrorCodes.SPOOL_CORRUPTED,
-          "Unexpected segment spool size: $path"
-        )
-      }
+      if (fileLength != expectedLength) throw SegmentPipelineException(SegmentErrorCodes.SPOOL_CORRUPTED, "Unexpected segment spool size: $path")
       val payload = ByteArray(len)
       if (len > 0) raf.readFully(payload)
       return String(payload, StandardCharsets.UTF_8)

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentSpoolIO.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/SegmentSpoolIO.kt
@@ -1,0 +1,122 @@
+package com.sherpaonnx.segment.pipeline
+
+import java.io.File
+import java.io.IOException
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.StandardCharsets
+
+internal class SegmentSpoolWriter(filePath: String) {
+  companion object {
+    const val RECORD_HEADER_BYTES = 4
+  }
+
+  private val raf: RandomAccessFile
+  private val lock = Any()
+
+  @Volatile
+  private var closed = false
+
+  @Volatile
+  var bytesWritten: Long = 0
+    private set
+
+  init {
+    val file = File(filePath)
+    file.parentFile?.mkdirs()
+    raf = RandomAccessFile(file, "rw")
+    raf.setLength(0L)
+  }
+
+  fun appendSnapshot(snapshotJson: String) {
+    val payload = snapshotJson.toByteArray(StandardCharsets.UTF_8)
+    val header = ByteBuffer
+      .allocate(RECORD_HEADER_BYTES)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .putInt(payload.size)
+      .array()
+
+    synchronized(lock) {
+      if (closed) throw IOException("Segment spool writer closed")
+      val recordLength = (RECORD_HEADER_BYTES + payload.size).toLong()
+      raf.seek(0L)
+      raf.write(header)
+      raf.write(payload)
+      raf.setLength(recordLength)
+      bytesWritten = recordLength
+    }
+  }
+
+  fun flush() {
+    synchronized(lock) {
+      if (closed) return
+      raf.fd.sync()
+      bytesWritten = raf.length()
+    }
+  }
+
+  fun finalize_() {
+    synchronized(lock) {
+      if (closed) return
+      raf.fd.sync()
+      raf.close()
+      closed = true
+    }
+  }
+
+  fun release() {
+    synchronized(lock) {
+      if (closed) return
+      try {
+        raf.close()
+      } finally {
+        closed = true
+      }
+    }
+  }
+}
+
+internal object SegmentSpoolReader {
+  private const val RECORD_HEADER_BYTES = 4
+
+  fun readLatestSnapshot(path: String): String {
+    val file = File(path)
+    if (!file.exists()) {
+      throw SegmentPipelineException(
+        SegmentErrorCodes.SPOOL_UNAVAILABLE,
+        "Segment spool file does not exist: $path"
+      )
+    }
+
+    RandomAccessFile(file, "r").use { raf ->
+      val fileLength = raf.length()
+      if (fileLength < RECORD_HEADER_BYTES) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.SPOOL_CORRUPTED,
+          "Corrupted segment spool header: $path"
+        )
+      }
+      raf.seek(0L)
+      val header = ByteArray(RECORD_HEADER_BYTES)
+      raf.readFully(header)
+      val len = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN).int
+      if (len < 0) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.SPOOL_CORRUPTED,
+          "Corrupted segment spool length: $path"
+        )
+      }
+      val expectedLength = RECORD_HEADER_BYTES + len.toLong()
+      if (fileLength != expectedLength) {
+        throw SegmentPipelineException(
+          SegmentErrorCodes.SPOOL_CORRUPTED,
+          "Unexpected segment spool size: $path"
+        )
+      }
+      val payload = ByteArray(len)
+      if (len > 0) raf.readFully(payload)
+      return String(payload, StandardCharsets.UTF_8)
+    }
+  }
+}

--- a/android/src/main/java/com/sherpaonnx/text/pipeline/LiveTextEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/text/pipeline/LiveTextEntry.kt
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.zip.CRC32
 
 /**
  * A committed text segment in the segment log.
@@ -70,6 +71,18 @@ class LiveTextEntry(
   private val spoolTemporary: Boolean = true,
   private val spoolThresholdBytes: Long = 0,
 ) {
+  companion object {
+    private const val TEXT_SPOOL_V2_MAGIC = 0x32545854 // TXT2
+    private const val TEXT_SPOOL_V2_VERSION = 2
+    private const val TEXT_SPOOL_V2_HEADER_BYTES = 16
+    private const val TEXT_SPOOL_V2_PARTIAL_SET = 1
+    private const val TEXT_SPOOL_V2_PARTIAL_APPEND = 2
+    private const val TEXT_SPOOL_V2_SEGMENT_COMMIT = 3
+    private const val TEXT_SPOOL_V2_CHECKPOINT = 4
+    private const val TEXT_SPOOL_V2_FINALIZE = 5
+    private const val TEXT_SPOOL_V2_CHECKPOINT_EVERY_EVENTS = 128
+    private const val TEXT_SPOOL_V2_CHECKPOINT_EVERY_BYTES = 1_048_576L
+  }
   enum class State { RECORDING, FINISHED }
 
   @Volatile
@@ -122,11 +135,18 @@ class LiveTextEntry(
   private var spoolFailureCode: String? = null
   @Volatile
   private var spoolFailureMessage: String? = null
+  @Volatile
+  private var journalEventCount: Int = 0
+  @Volatile
+  private var journalBytesSinceCheckpoint: Long = 0
 
   init {
     if (spoolingEnabled() && spoolingMode == TextSpoolingMode.ON) {
       val initialSnapshot = snapshotFullTextForSpool()
-      writeSnapshotToSpoolOrThrow(initialSnapshot, mayActivateAuto = false)
+      writeTextSpoolV2OrThrow(
+        mayActivateAuto = false,
+        checkpointPayload = buildCheckpointPayload(initialSnapshot)
+      )
     }
   }
 
@@ -153,12 +173,77 @@ class LiveTextEntry(
     throw TextPipelineException(code, message, cause)
   }
 
+  private fun journalPath(): String? = spoolPath?.let { "$it.txtj" }
+  private fun checkpointPath(): String? = spoolPath?.let { "$it.txtc" }
+
+  private fun buildCheckpointPayload(fullText: String): String {
+    val escaped = fullText.replace("\\", "\\\\").replace("\"", "\\\"")
+    return """{"fullText":"$escaped","totalCharsWritten":$totalCharsWritten,"revision":$revision}"""
+  }
+
+  private fun extractCheckpointText(payload: String): String {
+    val marker = """"fullText":""""
+    val idx = payload.indexOf(marker)
+    if (idx < 0) return ""
+    val start = payload.indexOf('"', idx + marker.length)
+    if (start < 0) return ""
+    val end = payload.indexOf('"', start + 1)
+    if (end < 0) return ""
+    return payload.substring(start + 1, end).replace("\\\"", "\"").replace("\\\\", "\\")
+  }
+
+  private fun appendV2RecordLocked(writer: TextSpoolWriter, recordType: Int, payload: String): Long {
+    val payloadBytes = payload.toByteArray(StandardCharsets.UTF_8)
+    val checksum = CRC32().apply { update(payloadBytes) }.value.toInt()
+    val header = ByteBuffer
+      .allocate(TEXT_SPOOL_V2_HEADER_BYTES)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .putInt(TEXT_SPOOL_V2_MAGIC)
+      .putShort(TEXT_SPOOL_V2_VERSION.toShort())
+      .putShort(recordType.toShort())
+      .putInt(payloadBytes.size)
+      .putInt(checksum)
+      .array()
+    writer.appendRawRecord(header, payloadBytes)
+    return (header.size + payloadBytes.size).toLong()
+  }
+
+  private fun writeCheckpointFile(checkpointPath: String, payload: String) {
+    val tmpPath = "$checkpointPath.tmp"
+    val tmpFile = RandomAccessFile(tmpPath, "rw")
+    tmpFile.use { raf ->
+      raf.setLength(0L)
+      val payloadBytes = payload.toByteArray(StandardCharsets.UTF_8)
+      val checksum = CRC32().apply { update(payloadBytes) }.value.toInt()
+      val header = ByteBuffer
+        .allocate(TEXT_SPOOL_V2_HEADER_BYTES)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .putInt(TEXT_SPOOL_V2_MAGIC)
+        .putShort(TEXT_SPOOL_V2_VERSION.toShort())
+        .putShort(TEXT_SPOOL_V2_CHECKPOINT.toShort())
+        .putInt(payloadBytes.size)
+        .putInt(checksum)
+        .array()
+      raf.write(header)
+      raf.write(payloadBytes)
+      raf.fd.sync()
+    }
+    val target = File(checkpointPath)
+    if (target.exists() && !target.delete()) {
+      throw TextPipelineException(TextErrorCodes.SPOOL_WRITE_FAILED, "Failed to replace text checkpoint: $checkpointPath")
+    }
+    if (!File(tmpPath).renameTo(target)) {
+      throw TextPipelineException(TextErrorCodes.SPOOL_WRITE_FAILED, "Failed to finalize text checkpoint: $checkpointPath")
+    }
+  }
+
   private fun ensureSpoolWriterActivatedLocked(bootstrapSnapshot: String) {
     if (spoolWriter != null) return
-    val resolvedPath = spoolPath ?: markSpoolFailureAndThrow(
+    val basePath = spoolPath ?: markSpoolFailureAndThrow(
       TextErrorCodes.SPOOL_UNAVAILABLE,
       "Text spool path is not configured for live buffer: $bufferId"
     )
+    val resolvedPath = "$basePath.txtj"
 
     val writer = try {
       TextSpoolWriter(resolvedPath)
@@ -171,7 +256,12 @@ class LiveTextEntry(
     }
 
     try {
-      writer.appendSnapshot(bootstrapSnapshot)
+      val cpPath = checkpointPath()
+        ?: markSpoolFailureAndThrow(TextErrorCodes.SPOOL_UNAVAILABLE, "Text checkpoint path missing for $bufferId")
+      writeCheckpointFile(cpPath, buildCheckpointPayload(bootstrapSnapshot))
+      appendV2RecordLocked(writer, TEXT_SPOOL_V2_CHECKPOINT, "{}")
+      journalEventCount = 0
+      journalBytesSinceCheckpoint = 0L
     } catch (e: Exception) {
       try {
         writer.release()
@@ -190,7 +280,12 @@ class LiveTextEntry(
     spoolBytes = writer.bytesWritten
   }
 
-  private fun writeSnapshotToSpoolOrThrow(snapshot: String, mayActivateAuto: Boolean) {
+  private fun writeTextSpoolV2OrThrow(
+    mayActivateAuto: Boolean,
+    recordType: Int? = null,
+    recordPayload: String? = null,
+    checkpointPayload: String? = null,
+  ) {
     if (!spoolingEnabled()) return
 
     val existingFailureCode = spoolFailureCode
@@ -207,26 +302,43 @@ class LiveTextEntry(
         when (spoolingMode) {
           TextSpoolingMode.OFF -> return
           TextSpoolingMode.ON -> {
-            ensureSpoolWriterActivatedLocked(snapshot)
+            ensureSpoolWriterActivatedLocked(snapshotFullTextForSpool())
             return
           }
           TextSpoolingMode.AUTO -> {
             if (!mayActivateAuto) return
             val estimatedRecordBytes =
-              TextSpoolWriter.RECORD_HEADER_BYTES + snapshot.toByteArray(StandardCharsets.UTF_8).size
+              TextSpoolWriter.RECORD_HEADER_BYTES + snapshotFullTextForSpool().toByteArray(StandardCharsets.UTF_8).size
             spoolEstimatedBytes += estimatedRecordBytes.toLong()
             if (spoolEstimatedBytes < spoolThresholdBytes.coerceAtLeast(0L)) {
               spoolReady = false
               return
             }
-            ensureSpoolWriterActivatedLocked(snapshot)
+            ensureSpoolWriterActivatedLocked(snapshotFullTextForSpool())
             return
           }
         }
       }
 
       try {
-        writer.appendSnapshot(snapshot)
+        if (recordType != null && recordPayload != null) {
+          val written = appendV2RecordLocked(writer, recordType, recordPayload)
+          journalEventCount += 1
+          journalBytesSinceCheckpoint += written
+        }
+        if (checkpointPayload != null && (
+            journalEventCount >= TEXT_SPOOL_V2_CHECKPOINT_EVERY_EVENTS ||
+              journalBytesSinceCheckpoint >= TEXT_SPOOL_V2_CHECKPOINT_EVERY_BYTES
+            )
+        ) {
+          val cpPath = checkpointPath()
+            ?: throw TextPipelineException(TextErrorCodes.SPOOL_UNAVAILABLE, "Text checkpoint path missing for $bufferId")
+          writeCheckpointFile(cpPath, checkpointPayload)
+          writer.truncate()
+          appendV2RecordLocked(writer, TEXT_SPOOL_V2_CHECKPOINT, "{}")
+          journalEventCount = 0
+          journalBytesSinceCheckpoint = 0L
+        }
         spoolReady = true
         spoolBytes = writer.bytesWritten
       } catch (e: Exception) {
@@ -254,8 +366,12 @@ class LiveTextEntry(
     totalCharsWritten += text.length
     _revision.incrementAndGet()
 
-    val snapshot = snapshotFullTextForSpool()
-    writeSnapshotToSpoolOrThrow(snapshot, mayActivateAuto = true)
+    writeTextSpoolV2OrThrow(
+      mayActivateAuto = true,
+      recordType = TEXT_SPOOL_V2_PARTIAL_SET,
+      recordPayload = text,
+      checkpointPayload = buildCheckpointPayload(snapshotFullTextForSpool())
+    )
   }
 
   /**
@@ -274,8 +390,12 @@ class LiveTextEntry(
     totalCharsWritten += text.length
     _revision.incrementAndGet()
 
-    val snapshot = snapshotFullTextForSpool()
-    writeSnapshotToSpoolOrThrow(snapshot, mayActivateAuto = true)
+    writeTextSpoolV2OrThrow(
+      mayActivateAuto = true,
+      recordType = TEXT_SPOOL_V2_PARTIAL_APPEND,
+      recordPayload = text,
+      checkpointPayload = buildCheckpointPayload(snapshotFullTextForSpool())
+    )
   }
 
   /**
@@ -325,7 +445,12 @@ class LiveTextEntry(
       _revision.incrementAndGet()
     }
 
-    writeSnapshotToSpoolOrThrow(snapshotAfterCommit, mayActivateAuto = true)
+    writeTextSpoolV2OrThrow(
+      mayActivateAuto = true,
+      recordType = TEXT_SPOOL_V2_SEGMENT_COMMIT,
+      recordPayload = """{"text":${JSONObject.quote(text)}}""",
+      checkpointPayload = buildCheckpointPayload(snapshotAfterCommit)
+    )
     notifyAppendListeners()
     return committedSegmentIndex
   }
@@ -401,7 +526,10 @@ class LiveTextEntry(
 
     synchronized(spoolLock) {
       try {
-        spoolWriter?.finalize_()
+        spoolWriter?.let { writer ->
+          appendV2RecordLocked(writer, TEXT_SPOOL_V2_FINALIZE, "{}")
+          writer.finalize_()
+        }
       } catch (e: Exception) {
         markSpoolFailureAndThrow(
           TextErrorCodes.SPOOL_WRITE_FAILED,
@@ -484,17 +612,38 @@ class LiveTextEntry(
       }
     }
 
-    return try {
-      TextSpoolReader.readLatestSnapshot(path)
-    } catch (e: TextPipelineException) {
-      throw e
-    } catch (e: IOException) {
-      throw TextPipelineException(
-        TextErrorCodes.SPOOL_READ_FAILED,
-        "Failed to read text spool for live buffer $bufferId: ${e.message}",
-        e,
-      )
+    val cpPath = "$path.txtc"
+    val jPath = "$path.txtj"
+    val hasV2 = File(cpPath).exists() || File(jPath).exists()
+    if (hasV2) {
+      try {
+        var fullText = ""
+        val cpPayload = TextSpoolReader.readV2Checkpoint(cpPath)
+        if (cpPayload != null) {
+          fullText = extractCheckpointText(cpPayload)
+        }
+        TextSpoolReader.readV2Journal(jPath).forEach { rec ->
+          when (rec.type) {
+            TEXT_SPOOL_V2_PARTIAL_SET -> fullText = rec.payload
+            TEXT_SPOOL_V2_PARTIAL_APPEND -> fullText += rec.payload
+            TEXT_SPOOL_V2_SEGMENT_COMMIT -> {
+              val obj = JSONObject(rec.payload)
+              fullText += obj.optString("text", "")
+            }
+          }
+        }
+        return fullText
+      } catch (e: TextPipelineException) {
+        throw e
+      } catch (e: Exception) {
+        throw TextPipelineException(
+          TextErrorCodes.SPOOL_READ_FAILED,
+          "Failed to read V2 text spool for live buffer $bufferId: ${e.message}",
+          e,
+        )
+      }
     }
+    return TextSpoolReader.readLatestSnapshot(path)
   }
 
   fun release() {
@@ -513,6 +662,14 @@ class LiveTextEntry(
         File(spoolPath).delete()
       } catch (_: Exception) {
         // best-effort cleanup
+      }
+      try {
+        File("${spoolPath}.txtj").delete()
+      } catch (_: Exception) {
+      }
+      try {
+        File("${spoolPath}.txtc").delete()
+      } catch (_: Exception) {
       }
     }
 
@@ -561,6 +718,25 @@ private class TextSpoolWriter(filePath: String) {
       raf.write(payload)
       raf.setLength(recordLength)
       bytesWritten = recordLength
+    }
+  }
+
+  fun appendRawRecord(header: ByteArray, payload: ByteArray) {
+    synchronized(lock) {
+      if (closed) throw IOException("Text spool writer is closed")
+      raf.seek(raf.length())
+      raf.write(header)
+      raf.write(payload)
+      bytesWritten = raf.length()
+    }
+  }
+
+  fun truncate() {
+    synchronized(lock) {
+      if (closed) return
+      raf.setLength(0L)
+      raf.seek(0L)
+      bytesWritten = 0L
     }
   }
 
@@ -639,6 +815,64 @@ private object TextSpoolReader {
       }
 
       return String(payload, StandardCharsets.UTF_8)
+    }
+  }
+
+  data class JournalRecord(val type: Int, val payload: String)
+
+  fun readV2Checkpoint(filePath: String): String? {
+    val file = File(filePath)
+    if (!file.exists()) return null
+    RandomAccessFile(file, "r").use { raf ->
+      if (raf.length() < 16) throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Corrupted V2 text checkpoint header in $filePath")
+      val header = ByteArray(16)
+      raf.readFully(header)
+      val bb = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+      val magic = bb.int
+      val version = bb.short.toInt()
+      val type = bb.short.toInt()
+      val length = bb.int
+      val checksum = bb.int
+      if (magic != TEXT_SPOOL_V2_MAGIC || version != TEXT_SPOOL_V2_VERSION || type != TEXT_SPOOL_V2_CHECKPOINT || length < 0) {
+        throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Unexpected V2 text checkpoint format in $filePath")
+      }
+      val payload = ByteArray(length)
+      if (length > 0) raf.readFully(payload)
+      val actual = CRC32().apply { update(payload) }.value.toInt()
+      if (actual != checksum) throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "V2 text checkpoint checksum mismatch in $filePath")
+      return String(payload, StandardCharsets.UTF_8)
+    }
+  }
+
+  fun readV2Journal(filePath: String): List<JournalRecord> {
+    val file = File(filePath)
+    if (!file.exists()) return emptyList()
+    RandomAccessFile(file, "r").use { raf ->
+      val out = ArrayList<JournalRecord>()
+      while (raf.filePointer < raf.length()) {
+        if (raf.length() - raf.filePointer < 16) {
+          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Corrupted V2 text journal header in $filePath")
+        }
+        val header = ByteArray(16)
+        raf.readFully(header)
+        val bb = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+        val magic = bb.int
+        val version = bb.short.toInt()
+        val type = bb.short.toInt()
+        val length = bb.int
+        val checksum = bb.int
+        if (magic != TEXT_SPOOL_V2_MAGIC || version != TEXT_SPOOL_V2_VERSION || length < 0) {
+          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Unexpected V2 text journal record format in $filePath")
+        }
+        val payload = ByteArray(length)
+        if (length > 0) raf.readFully(payload)
+        val actual = CRC32().apply { update(payload) }.value.toInt()
+        if (actual != checksum) {
+          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "V2 text journal checksum mismatch in $filePath")
+        }
+        out.add(JournalRecord(type, String(payload, StandardCharsets.UTF_8)))
+      }
+      return out
     }
   }
 }

--- a/android/src/main/java/com/sherpaonnx/text/pipeline/LiveTextEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/text/pipeline/LiveTextEntry.kt
@@ -72,16 +72,16 @@ class LiveTextEntry(
   private val spoolThresholdBytes: Long = 0,
 ) {
   companion object {
-    private const val TEXT_SPOOL_V2_MAGIC = 0x32545854 // TXT2
-    private const val TEXT_SPOOL_V2_VERSION = 2
-    private const val TEXT_SPOOL_V2_HEADER_BYTES = 16
-    private const val TEXT_SPOOL_V2_PARTIAL_SET = 1
-    private const val TEXT_SPOOL_V2_PARTIAL_APPEND = 2
-    private const val TEXT_SPOOL_V2_SEGMENT_COMMIT = 3
-    private const val TEXT_SPOOL_V2_CHECKPOINT = 4
-    private const val TEXT_SPOOL_V2_FINALIZE = 5
-    private const val TEXT_SPOOL_V2_CHECKPOINT_EVERY_EVENTS = 128
-    private const val TEXT_SPOOL_V2_CHECKPOINT_EVERY_BYTES = 1_048_576L
+    private const val TEXT_SPOOL_MAGIC = 0x32545854 // TXT2
+    private const val TEXT_SPOOL_VERSION = 2
+    private const val TEXT_SPOOL_HEADER_BYTES = 16
+    private const val TEXT_SPOOL_PARTIAL_SET = 1
+    private const val TEXT_SPOOL_PARTIAL_APPEND = 2
+    private const val TEXT_SPOOL_SEGMENT_COMMIT = 3
+    private const val TEXT_SPOOL_CHECKPOINT = 4
+    private const val TEXT_SPOOL_FINALIZE = 5
+    private const val TEXT_SPOOL_CHECKPOINT_EVERY_EVENTS = 128
+    private const val TEXT_SPOOL_CHECKPOINT_EVERY_BYTES = 1_048_576L
   }
   enum class State { RECORDING, FINISHED }
 
@@ -143,7 +143,7 @@ class LiveTextEntry(
   init {
     if (spoolingEnabled() && spoolingMode == TextSpoolingMode.ON) {
       val initialSnapshot = snapshotFullTextForSpool()
-      writeTextSpoolV2OrThrow(
+      writeTextSpoolOrThrow(
         mayActivateAuto = false,
         checkpointPayload = buildCheckpointPayload(initialSnapshot)
       )
@@ -192,14 +192,14 @@ class LiveTextEntry(
     return payload.substring(start + 1, end).replace("\\\"", "\"").replace("\\\\", "\\")
   }
 
-  private fun appendV2RecordLocked(writer: TextSpoolWriter, recordType: Int, payload: String): Long {
+  private fun appendSpoolRecordLocked(writer: TextSpoolWriter, recordType: Int, payload: String): Long {
     val payloadBytes = payload.toByteArray(StandardCharsets.UTF_8)
     val checksum = CRC32().apply { update(payloadBytes) }.value.toInt()
     val header = ByteBuffer
-      .allocate(TEXT_SPOOL_V2_HEADER_BYTES)
+      .allocate(TEXT_SPOOL_HEADER_BYTES)
       .order(ByteOrder.LITTLE_ENDIAN)
-      .putInt(TEXT_SPOOL_V2_MAGIC)
-      .putShort(TEXT_SPOOL_V2_VERSION.toShort())
+      .putInt(TEXT_SPOOL_MAGIC)
+      .putShort(TEXT_SPOOL_VERSION.toShort())
       .putShort(recordType.toShort())
       .putInt(payloadBytes.size)
       .putInt(checksum)
@@ -216,11 +216,11 @@ class LiveTextEntry(
       val payloadBytes = payload.toByteArray(StandardCharsets.UTF_8)
       val checksum = CRC32().apply { update(payloadBytes) }.value.toInt()
       val header = ByteBuffer
-        .allocate(TEXT_SPOOL_V2_HEADER_BYTES)
+        .allocate(TEXT_SPOOL_HEADER_BYTES)
         .order(ByteOrder.LITTLE_ENDIAN)
-        .putInt(TEXT_SPOOL_V2_MAGIC)
-        .putShort(TEXT_SPOOL_V2_VERSION.toShort())
-        .putShort(TEXT_SPOOL_V2_CHECKPOINT.toShort())
+        .putInt(TEXT_SPOOL_MAGIC)
+        .putShort(TEXT_SPOOL_VERSION.toShort())
+        .putShort(TEXT_SPOOL_CHECKPOINT.toShort())
         .putInt(payloadBytes.size)
         .putInt(checksum)
         .array()
@@ -259,7 +259,7 @@ class LiveTextEntry(
       val cpPath = checkpointPath()
         ?: markSpoolFailureAndThrow(TextErrorCodes.SPOOL_UNAVAILABLE, "Text checkpoint path missing for $bufferId")
       writeCheckpointFile(cpPath, buildCheckpointPayload(bootstrapSnapshot))
-      appendV2RecordLocked(writer, TEXT_SPOOL_V2_CHECKPOINT, "{}")
+      appendSpoolRecordLocked(writer, TEXT_SPOOL_CHECKPOINT, "{}")
       journalEventCount = 0
       journalBytesSinceCheckpoint = 0L
     } catch (e: Exception) {
@@ -280,7 +280,7 @@ class LiveTextEntry(
     spoolBytes = writer.bytesWritten
   }
 
-  private fun writeTextSpoolV2OrThrow(
+  private fun writeTextSpoolOrThrow(
     mayActivateAuto: Boolean,
     recordType: Int? = null,
     recordPayload: String? = null,
@@ -308,7 +308,7 @@ class LiveTextEntry(
           TextSpoolingMode.AUTO -> {
             if (!mayActivateAuto) return
             val estimatedRecordBytes =
-              TextSpoolWriter.RECORD_HEADER_BYTES + snapshotFullTextForSpool().toByteArray(StandardCharsets.UTF_8).size
+              TEXT_SPOOL_HEADER_BYTES + snapshotFullTextForSpool().toByteArray(StandardCharsets.UTF_8).size
             spoolEstimatedBytes += estimatedRecordBytes.toLong()
             if (spoolEstimatedBytes < spoolThresholdBytes.coerceAtLeast(0L)) {
               spoolReady = false
@@ -322,20 +322,20 @@ class LiveTextEntry(
 
       try {
         if (recordType != null && recordPayload != null) {
-          val written = appendV2RecordLocked(writer, recordType, recordPayload)
+          val written = appendSpoolRecordLocked(writer, recordType, recordPayload)
           journalEventCount += 1
           journalBytesSinceCheckpoint += written
         }
         if (checkpointPayload != null && (
-            journalEventCount >= TEXT_SPOOL_V2_CHECKPOINT_EVERY_EVENTS ||
-              journalBytesSinceCheckpoint >= TEXT_SPOOL_V2_CHECKPOINT_EVERY_BYTES
+            journalEventCount >= TEXT_SPOOL_CHECKPOINT_EVERY_EVENTS ||
+              journalBytesSinceCheckpoint >= TEXT_SPOOL_CHECKPOINT_EVERY_BYTES
             )
         ) {
           val cpPath = checkpointPath()
             ?: throw TextPipelineException(TextErrorCodes.SPOOL_UNAVAILABLE, "Text checkpoint path missing for $bufferId")
           writeCheckpointFile(cpPath, checkpointPayload)
           writer.truncate()
-          appendV2RecordLocked(writer, TEXT_SPOOL_V2_CHECKPOINT, "{}")
+          appendSpoolRecordLocked(writer, TEXT_SPOOL_CHECKPOINT, "{}")
           journalEventCount = 0
           journalBytesSinceCheckpoint = 0L
         }
@@ -366,9 +366,9 @@ class LiveTextEntry(
     totalCharsWritten += text.length
     _revision.incrementAndGet()
 
-    writeTextSpoolV2OrThrow(
+    writeTextSpoolOrThrow(
       mayActivateAuto = true,
-      recordType = TEXT_SPOOL_V2_PARTIAL_SET,
+      recordType = TEXT_SPOOL_PARTIAL_SET,
       recordPayload = text,
       checkpointPayload = buildCheckpointPayload(snapshotFullTextForSpool())
     )
@@ -390,9 +390,9 @@ class LiveTextEntry(
     totalCharsWritten += text.length
     _revision.incrementAndGet()
 
-    writeTextSpoolV2OrThrow(
+    writeTextSpoolOrThrow(
       mayActivateAuto = true,
-      recordType = TEXT_SPOOL_V2_PARTIAL_APPEND,
+      recordType = TEXT_SPOOL_PARTIAL_APPEND,
       recordPayload = text,
       checkpointPayload = buildCheckpointPayload(snapshotFullTextForSpool())
     )
@@ -445,9 +445,9 @@ class LiveTextEntry(
       _revision.incrementAndGet()
     }
 
-    writeTextSpoolV2OrThrow(
+    writeTextSpoolOrThrow(
       mayActivateAuto = true,
-      recordType = TEXT_SPOOL_V2_SEGMENT_COMMIT,
+      recordType = TEXT_SPOOL_SEGMENT_COMMIT,
       recordPayload = """{"text":${JSONObject.quote(text)}}""",
       checkpointPayload = buildCheckpointPayload(snapshotAfterCommit)
     )
@@ -527,7 +527,7 @@ class LiveTextEntry(
     synchronized(spoolLock) {
       try {
         spoolWriter?.let { writer ->
-          appendV2RecordLocked(writer, TEXT_SPOOL_V2_FINALIZE, "{}")
+          appendSpoolRecordLocked(writer, TEXT_SPOOL_FINALIZE, "{}")
           writer.finalize_()
         }
       } catch (e: Exception) {
@@ -614,19 +614,19 @@ class LiveTextEntry(
 
     val cpPath = "$path.txtc"
     val jPath = "$path.txtj"
-    val hasV2 = File(cpPath).exists() || File(jPath).exists()
-    if (hasV2) {
+    val hasSpool = File(cpPath).exists() || File(jPath).exists()
+    if (hasSpool) {
       try {
         var fullText = ""
-        val cpPayload = TextSpoolReader.readV2Checkpoint(cpPath)
+        val cpPayload = TextSpoolReader.readCheckpoint(cpPath)
         if (cpPayload != null) {
           fullText = extractCheckpointText(cpPayload)
         }
-        TextSpoolReader.readV2Journal(jPath).forEach { rec ->
+        TextSpoolReader.readJournal(jPath).forEach { rec ->
           when (rec.type) {
-            TEXT_SPOOL_V2_PARTIAL_SET -> fullText = rec.payload
-            TEXT_SPOOL_V2_PARTIAL_APPEND -> fullText += rec.payload
-            TEXT_SPOOL_V2_SEGMENT_COMMIT -> {
+            TEXT_SPOOL_PARTIAL_SET -> fullText = rec.payload
+            TEXT_SPOOL_PARTIAL_APPEND -> fullText += rec.payload
+            TEXT_SPOOL_SEGMENT_COMMIT -> {
               val obj = JSONObject(rec.payload)
               fullText += obj.optString("text", "")
             }
@@ -638,12 +638,15 @@ class LiveTextEntry(
       } catch (e: Exception) {
         throw TextPipelineException(
           TextErrorCodes.SPOOL_READ_FAILED,
-          "Failed to read V2 text spool for live buffer $bufferId: ${e.message}",
+          "Failed to read text spool for live buffer $bufferId: ${e.message}",
           e,
         )
       }
     }
-    return TextSpoolReader.readLatestSnapshot(path)
+    throw TextPipelineException(
+      TextErrorCodes.SPOOL_UNAVAILABLE,
+      "Text spool files are missing for live buffer: $bufferId"
+    )
   }
 
   fun release() {
@@ -658,11 +661,6 @@ class LiveTextEntry(
     }
 
     if (spoolTemporary && !spoolPath.isNullOrEmpty()) {
-      try {
-        File(spoolPath).delete()
-      } catch (_: Exception) {
-        // best-effort cleanup
-      }
       try {
         File("${spoolPath}.txtj").delete()
       } catch (_: Exception) {
@@ -679,10 +677,6 @@ class LiveTextEntry(
 }
 
 private class TextSpoolWriter(filePath: String) {
-  companion object {
-    const val RECORD_HEADER_BYTES = 4
-  }
-
   private val raf: RandomAccessFile
   private val lock = Any()
   @Volatile
@@ -698,27 +692,6 @@ private class TextSpoolWriter(filePath: String) {
     raf = RandomAccessFile(file, "rw")
     raf.setLength(0L)
     bytesWritten = 0L
-  }
-
-  fun appendSnapshot(text: String) {
-    val payload = text.toByteArray(StandardCharsets.UTF_8)
-    val header = ByteBuffer
-      .allocate(RECORD_HEADER_BYTES)
-      .order(ByteOrder.LITTLE_ENDIAN)
-      .putInt(payload.size)
-      .array()
-
-    synchronized(lock) {
-      if (closed) {
-        throw IOException("Text spool writer is closed")
-      }
-      val recordLength = (RECORD_HEADER_BYTES + payload.size).toLong()
-      raf.seek(0L)
-      raf.write(header)
-      raf.write(payload)
-      raf.setLength(recordLength)
-      bytesWritten = recordLength
-    }
   }
 
   fun appendRawRecord(header: ByteArray, payload: ByteArray) {
@@ -770,61 +743,13 @@ private class TextSpoolWriter(filePath: String) {
 }
 
 private object TextSpoolReader {
-  private const val RECORD_HEADER_BYTES = 4
-
-  fun readLatestSnapshot(filePath: String): String {
-    val file = File(filePath)
-    if (!file.exists()) {
-      throw TextPipelineException(
-        TextErrorCodes.SPOOL_UNAVAILABLE,
-        "Text spool file does not exist: $filePath"
-      )
-    }
-
-    RandomAccessFile(file, "r").use { raf ->
-      val fileLength = raf.length()
-      if (fileLength < RECORD_HEADER_BYTES) {
-        throw TextPipelineException(
-          TextErrorCodes.SPOOL_CORRUPTED,
-          "Corrupted text spool record header in $filePath"
-        )
-      }
-
-      raf.seek(0L)
-      val header = ByteArray(RECORD_HEADER_BYTES)
-      raf.readFully(header)
-      val length = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN).int
-      if (length < 0) {
-        throw TextPipelineException(
-          TextErrorCodes.SPOOL_CORRUPTED,
-          "Corrupted text spool record length in $filePath"
-        )
-      }
-
-      val expectedFileLength = RECORD_HEADER_BYTES + length.toLong()
-      if (fileLength != expectedFileLength) {
-        throw TextPipelineException(
-          TextErrorCodes.SPOOL_CORRUPTED,
-          "Unexpected text spool size in $filePath"
-        )
-      }
-
-      val payload = ByteArray(length)
-      if (length > 0) {
-        raf.readFully(payload)
-      }
-
-      return String(payload, StandardCharsets.UTF_8)
-    }
-  }
-
   data class JournalRecord(val type: Int, val payload: String)
 
-  fun readV2Checkpoint(filePath: String): String? {
+  fun readCheckpoint(filePath: String): String? {
     val file = File(filePath)
     if (!file.exists()) return null
     RandomAccessFile(file, "r").use { raf ->
-      if (raf.length() < 16) throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Corrupted V2 text checkpoint header in $filePath")
+      if (raf.length() < 16) throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Corrupted text checkpoint header in $filePath")
       val header = ByteArray(16)
       raf.readFully(header)
       val bb = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
@@ -833,25 +758,25 @@ private object TextSpoolReader {
       val type = bb.short.toInt()
       val length = bb.int
       val checksum = bb.int
-      if (magic != TEXT_SPOOL_V2_MAGIC || version != TEXT_SPOOL_V2_VERSION || type != TEXT_SPOOL_V2_CHECKPOINT || length < 0) {
-        throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Unexpected V2 text checkpoint format in $filePath")
+      if (magic != TEXT_SPOOL_MAGIC || version != TEXT_SPOOL_VERSION || type != TEXT_SPOOL_CHECKPOINT || length < 0) {
+        throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Unexpected text checkpoint format in $filePath")
       }
       val payload = ByteArray(length)
       if (length > 0) raf.readFully(payload)
       val actual = CRC32().apply { update(payload) }.value.toInt()
-      if (actual != checksum) throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "V2 text checkpoint checksum mismatch in $filePath")
+      if (actual != checksum) throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Text checkpoint checksum mismatch in $filePath")
       return String(payload, StandardCharsets.UTF_8)
     }
   }
 
-  fun readV2Journal(filePath: String): List<JournalRecord> {
+  fun readJournal(filePath: String): List<JournalRecord> {
     val file = File(filePath)
     if (!file.exists()) return emptyList()
     RandomAccessFile(file, "r").use { raf ->
       val out = ArrayList<JournalRecord>()
       while (raf.filePointer < raf.length()) {
         if (raf.length() - raf.filePointer < 16) {
-          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Corrupted V2 text journal header in $filePath")
+          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Corrupted text journal header in $filePath")
         }
         val header = ByteArray(16)
         raf.readFully(header)
@@ -861,14 +786,14 @@ private object TextSpoolReader {
         val type = bb.short.toInt()
         val length = bb.int
         val checksum = bb.int
-        if (magic != TEXT_SPOOL_V2_MAGIC || version != TEXT_SPOOL_V2_VERSION || length < 0) {
-          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Unexpected V2 text journal record format in $filePath")
+        if (magic != TEXT_SPOOL_MAGIC || version != TEXT_SPOOL_VERSION || length < 0) {
+          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Unexpected text journal record format in $filePath")
         }
         val payload = ByteArray(length)
         if (length > 0) raf.readFully(payload)
         val actual = CRC32().apply { update(payload) }.value.toInt()
         if (actual != checksum) {
-          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "V2 text journal checksum mismatch in $filePath")
+          throw TextPipelineException(TextErrorCodes.SPOOL_CORRUPTED, "Text journal checksum mismatch in $filePath")
         }
         out.add(JournalRecord(type, String(payload, StandardCharsets.UTF_8)))
       }

--- a/docs/internal/segmentbuffer-spool-v2-format.md
+++ b/docs/internal/segmentbuffer-spool-v2-format.md
@@ -1,0 +1,68 @@
+# SegmentBuffer Spool Format
+
+This document defines the SegmentBuffer spool record format used on Android and iOS.
+
+## Goals
+
+- Append-oriented journal for long sessions.
+- Periodic compact checkpoints for bounded replay cost.
+- Strict `fullIfSpooled` semantics with explicit corruption detection.
+
+## File layout
+
+- Journal file: `<baseSpoolPath>.segj`
+- Checkpoint file: `<baseSpoolPath>.segc`
+
+## Record header (binary, little-endian)
+
+- `magic` (u32): `0x32474553` (`SEG2`)
+- `version` (u16): `2`
+- `recordType` (u16)
+- `payloadLength` (u32)
+- `checksum` (u32)
+
+Header size: `16` bytes.
+
+## Record types
+
+- `1` => `SEGMENT_APPEND`
+- `2` => `CHECKPOINT_MARK`
+- `3` => `FINALIZE_MARK`
+
+## Payload format
+
+- UTF-8 JSON strings.
+- `SEGMENT_APPEND` payload encodes exactly one segment in a `{"segments":[...]}` envelope.
+- Checkpoint payload encodes full current segment state in the same `{"segments":[...]}` envelope.
+- `CHECKPOINT_MARK` and `FINALIZE_MARK` use `{}` payload.
+
+## Replay model (`fullIfSpooled`)
+
+1. Read checkpoint (`.segc`) if available, initialize full state.
+2. Replay `.segj` records in order:
+   - apply each `SEGMENT_APPEND`.
+   - ignore marker records.
+3. Return reconstructed full history.
+
+If `.segc/.segj` files do not exist, strict full snapshot mode fails with `SEGMENT_SPOOL_UNAVAILABLE`.
+
+## Checkpoint and compaction policy
+
+- Trigger checkpoint at either threshold:
+  - every `128` journal append records, or
+  - every `1 MiB` journal bytes since last checkpoint.
+- On checkpoint:
+  - write new compact checkpoint atomically (temp + rename),
+  - rotate/truncate journal and emit `CHECKPOINT_MARK`.
+
+## Error mapping
+
+- Missing spool for strict mode: `SEGMENT_SPOOL_UNAVAILABLE`
+- Write/init failures: `SEGMENT_SPOOL_WRITE_FAILED`
+- Read/open failures: `SEGMENT_SPOOL_READ_FAILED`
+- Header/length/checksum/record-type corruption: `SEGMENT_SPOOL_CORRUPTED`
+
+## Compatibility
+
+- No backward compatibility is guaranteed for unreleased pre-1.0 spool files.
+- Runtime reads and writes only `.segc` + `.segj`.

--- a/docs/internal/textbuffer-spool-v2-format.md
+++ b/docs/internal/textbuffer-spool-v2-format.md
@@ -1,0 +1,42 @@
+# TextBuffer Spool Format
+
+TextBuffer spool uses checkpoint + append journal persistence for long sessions.
+
+## Files
+
+- Journal: `<base>.txtj`
+- Checkpoint: `<base>.txtc`
+
+## Header (little-endian, 16 bytes)
+
+- `magic` (u32): `TXT2`
+- `version` (u16): `2`
+- `recordType` (u16)
+- `payloadLength` (u32)
+- `checksum` (u32)
+
+## Record types
+
+- `TEXT_PARTIAL_SET`
+- `TEXT_PARTIAL_APPEND`
+- `TEXT_SEGMENT_COMMIT`
+- `CHECKPOINT_MARK`
+- `FINALIZE_MARK`
+
+## Replay model
+
+`fullIfSpooled`:
+1. load checkpoint (`.txtc`) if present,
+2. replay journal (`.txtj`) records in order,
+3. reconstruct full text,
+4. fail strict with `TEXT_SPOOL_*` on unavailable/read/corrupted conditions.
+
+## Checkpoint policy
+
+- checkpoint every `128` events or `1 MiB` journal growth.
+- after checkpoint, journal is rotated/truncated.
+
+## Compatibility
+
+- No backward compatibility is guaranteed for unreleased pre-1.0 spool files.
+- Runtime reads and writes only `.txtc` + `.txtj`.

--- a/docs/segmentbuffer-offline.md
+++ b/docs/segmentbuffer-offline.md
@@ -55,11 +55,17 @@ await releasePipelineSegmentBuffer(live);
 
 ## Error code quick table
 
+The following codes are the relevant runtime outcomes for offline segment-buffer reads and live-to-offline conversion in this document.
+
 | Code | Meaning |
 | --- | --- |
 | `SEGMENT_BUFFER_NOT_FOUND` | Referenced segment buffer does not exist |
+| `SEGMENT_BUFFER_KIND_MISMATCH` | Buffer kind does not match called API |
 | `SEGMENT_INVALID_ARGUMENT` | Invalid argument or malformed id |
+| `SEGMENT_INVALID_STATE` | Operation not allowed in current state |
+| `SEGMENT_ALREADY_FINALIZED` | A recording-only operation was called on an already finished live buffer during conversion flows |
 | `SEGMENT_SLICE_INVALID` | Invalid slice range |
+| `SEGMENT_SPOOL_WRITE_FAILED` | Writing checkpoint/journal spool data failed in preceding live-buffer stages |
 | `SEGMENT_SPOOL_UNAVAILABLE` | `fullIfSpooled` requested but spool unavailable |
 | `SEGMENT_SPOOL_READ_FAILED` | Failed to read spool |
 | `SEGMENT_SPOOL_CORRUPTED` | Corrupted spool content |

--- a/docs/segmentbuffer-offline.md
+++ b/docs/segmentbuffer-offline.md
@@ -1,0 +1,66 @@
+# Pipeline segment buffers — offline (`segmentbuffer`)
+
+**Offline segment buffers** are immutable snapshots that can be consumed by batch pipelines and export flows.
+
+**Import path:** `react-native-sherpa-onnx/segmentbuffer`
+
+---
+
+## Concepts
+
+Offline segment buffers are typically created from a live segment buffer using:
+- `windowSnapshot` for current in-memory window
+- `fullIfSpooled` for strict spool-backed full history
+
+---
+
+## Quick start: read offline segments
+
+```ts
+import {
+  createLiveSegmentBuffer,
+  appendLiveSegment,
+  createOfflineSegmentBufferFromLive,
+  getOfflineSegmentBufferSegments,
+  releasePipelineSegmentBuffer,
+} from 'react-native-sherpa-onnx/segmentbuffer';
+
+const live = await createLiveSegmentBuffer({ spooling: { mode: 'on' } });
+await appendLiveSegment(live, {
+  sourceAudioBufferId: 'live_abc',
+  startSample: 3200,
+  endSample: 9600,
+  sampleRate: 16000,
+});
+
+const offline = await createOfflineSegmentBufferFromLive(live, 'fullIfSpooled');
+const segments = await getOfflineSegmentBufferSegments(offline, 0, 128);
+console.log(segments.map((s) => `${s.startSample}-${s.endSample}`));
+
+await releasePipelineSegmentBuffer(offline);
+await releasePipelineSegmentBuffer(live);
+```
+
+---
+
+## API reference
+
+- `createEmptyOfflineSegmentBuffer(options?)`
+- `createOfflineSegmentBufferFromLive(liveBuffer, mode?)`
+- `getOfflineSegmentBufferSegments(buffer, start?, maxCount?)`
+- `getPipelineSegmentBufferInfo(buffer)`
+- `releasePipelineSegmentBuffer(buffer)`
+
+---
+
+## Error code quick table
+
+| Code | Meaning |
+| --- | --- |
+| `SEGMENT_BUFFER_NOT_FOUND` | Referenced segment buffer does not exist |
+| `SEGMENT_INVALID_ARGUMENT` | Invalid argument or malformed id |
+| `SEGMENT_SLICE_INVALID` | Invalid slice range |
+| `SEGMENT_SPOOL_UNAVAILABLE` | `fullIfSpooled` requested but spool unavailable |
+| `SEGMENT_SPOOL_READ_FAILED` | Failed to read spool |
+| `SEGMENT_SPOOL_CORRUPTED` | Corrupted spool content |
+| `SEGMENT_INTERNAL_ERROR` | Generic native failure |

--- a/docs/segmentbuffer-streaming.md
+++ b/docs/segmentbuffer-streaming.md
@@ -83,6 +83,8 @@ await releasePipelineSegmentBuffer(live);
 
 ## Error code quick table
 
+The following codes are the relevant runtime outcomes for live/streaming segment-buffer operations in this document (`create`, `append`, `finalize`, `slice`, `createOfflineFromLive`, `release`).
+
 | Code | Meaning |
 | --- | --- |
 | `SEGMENT_BUFFER_NOT_FOUND` | Referenced segment buffer does not exist |

--- a/docs/segmentbuffer-streaming.md
+++ b/docs/segmentbuffer-streaming.md
@@ -1,0 +1,98 @@
+# Pipeline segment buffers — live / streaming (`segmentbuffer`)
+
+**Live segment buffers** store incremental segment events for long-running pipelines such as VAD and future streaming alignment flows.
+
+**Import path:** `react-native-sherpa-onnx/segmentbuffer`
+
+---
+
+## Concepts
+
+| Kind | What it is | Typical use |
+| --- | --- | --- |
+| **Live segment buffer** | Mutable segment stream (`recording` -> `finished`) with bounded in-memory log and optional spool-backed full history. | VAD live segmentation, real-time subtitle boundaries, incremental post-processing. |
+| **Offline segment buffer** | Immutable snapshot of segments. | Batch consumers, export, deterministic replay. |
+
+`fullIfSpooled` is strict: if spool is unavailable, conversion rejects with `SEGMENT_SPOOL_*`.
+
+---
+
+## Quick start: append + snapshot
+
+```ts
+import {
+  createLiveSegmentBuffer,
+  appendLiveSegment,
+  finalizeLiveSegmentBuffer,
+  createOfflineSegmentBufferFromLive,
+  getLiveSegmentBufferSegmentCount,
+  getLiveSegmentBufferSegments,
+  releasePipelineSegmentBuffer,
+} from 'react-native-sherpa-onnx/segmentbuffer';
+
+const live = await createLiveSegmentBuffer({
+  sourceAudioBufferId: 'live_123',
+  maxSegments: 2048,
+  spooling: { mode: 'on' },
+});
+
+await appendLiveSegment(live, {
+  sourceAudioBufferId: 'live_123',
+  startSample: 0,
+  endSample: 16000,
+  sampleRate: 16000,
+  confidence: 0.93,
+});
+
+const count = await getLiveSegmentBufferSegmentCount(live);
+const latest = await getLiveSegmentBufferSegments(live, 0, count);
+console.log(latest.length);
+
+await finalizeLiveSegmentBuffer(live);
+const offline = await createOfflineSegmentBufferFromLive(live, 'fullIfSpooled');
+
+await releasePipelineSegmentBuffer(offline);
+await releasePipelineSegmentBuffer(live);
+```
+
+---
+
+## API reference
+
+### Create and lifecycle
+
+- `createLiveSegmentBuffer(options?)`
+- `createEmptyOfflineSegmentBuffer(options?)`
+- `finalizeLiveSegmentBuffer(liveBuffer)`
+- `releasePipelineSegmentBuffer(buffer)`
+
+### Write and read
+
+- `appendLiveSegment(liveBuffer, segment)`
+- `getLiveSegmentBufferSegmentCount(liveBuffer)`
+- `getLiveSegmentBufferSegments(liveBuffer, startIndex, maxCount)`
+- `getOfflineSegmentBufferSegments(offlineBuffer, start?, maxCount?)`
+
+### Conversion
+
+- `createOfflineSegmentBufferFromLive(liveBuffer, mode?)`
+  - `windowSnapshot`
+  - `fullIfSpooled` (strict)
+
+---
+
+## Error code quick table
+
+| Code | Meaning |
+| --- | --- |
+| `SEGMENT_BUFFER_NOT_FOUND` | Referenced segment buffer does not exist |
+| `SEGMENT_BUFFER_KIND_MISMATCH` | Buffer kind does not match called API |
+| `SEGMENT_INVALID_ARGUMENT` | Invalid argument or malformed buffer id |
+| `SEGMENT_INVALID_STATE` | Operation not allowed in current state |
+| `SEGMENT_ALREADY_FINALIZED` | Live buffer already finalized |
+| `SEGMENT_SLICE_INVALID` | Invalid segment slice range |
+| `SEGMENT_SPOOL_UNAVAILABLE` | `fullIfSpooled` requested but spool unavailable |
+| `SEGMENT_SPOOL_WRITE_FAILED` | Spool write failed |
+| `SEGMENT_SPOOL_READ_FAILED` | Spool read failed |
+| `SEGMENT_SPOOL_CORRUPTED` | Spool data is corrupted |
+| `SEGMENT_INTERNAL_ERROR` | Generic native segment buffer failure |

--- a/docs/textbuffer-offline.md
+++ b/docs/textbuffer-offline.md
@@ -204,11 +204,15 @@ const windowOnly = await createOfflineTextBufferFromLive(live, 'windowSnapshot')
 
 ## Error code quick table
 
+The following codes are the relevant runtime outcomes for offline text-buffer reads and live-to-offline conversion in this document.
+
 | Code | Meaning |
 | --- | --- |
 | `TEXT_BUFFER_NOT_FOUND` | Referenced text buffer id does not exist |
 | `TEXT_BUFFER_KIND_MISMATCH` | Buffer kind does not match called API (offline vs live) |
 | `TEXT_INVALID_ARGUMENT` | Invalid argument or malformed buffer id |
+| `TEXT_INVALID_STATE` | Operation is not allowed in the current buffer state |
+| `TEXT_ALREADY_FINALIZED` | A recording-only operation was called on a finished live buffer during conversion flows |
 | `TEXT_SLICE_INVALID` | Slice range is invalid (e.g. negative or out of bounds) |
 | `TEXT_SLICE_TOO_LARGE` | Requested slice exceeds native safety limits |
 | `TEXT_SPOOL_UNAVAILABLE` | `fullIfSpooled` requested but spool is disabled/unavailable |

--- a/docs/textbuffer-streaming.md
+++ b/docs/textbuffer-streaming.md
@@ -270,12 +270,17 @@ Strict mode semantics:
 
 ## Error code quick table
 
+The following codes are the relevant runtime outcomes for live/streaming text-buffer operations in this document (`create`, `append`, `finalize`, `slice`, `createOfflineFromLive`, `release`).
+
 | Code | Meaning |
 | --- | --- |
 | `TEXT_BUFFER_NOT_FOUND` | Referenced text buffer id does not exist |
 | `TEXT_BUFFER_KIND_MISMATCH` | Buffer kind does not match called API (offline vs live) |
 | `TEXT_INVALID_ARGUMENT` | Invalid argument or malformed buffer id |
+| `TEXT_INVALID_STATE` | Operation is not allowed in the current buffer state |
 | `TEXT_ALREADY_FINALIZED` | Operation requires `recording` buffer but live buffer is already finished |
+| `TEXT_SLICE_INVALID` | Live partial/segment slice range is invalid |
+| `TEXT_SLICE_TOO_LARGE` | Requested live slice exceeds native safety limits |
 | `TEXT_SPOOL_UNAVAILABLE` | Spool-required operation requested but spool is disabled/unavailable |
 | `TEXT_SPOOL_WRITE_FAILED` | Writing to live text spool failed |
 | `TEXT_SPOOL_READ_FAILED` | Reading live text spool failed |

--- a/docs/vad.md
+++ b/docs/vad.md
@@ -1,14 +1,18 @@
 # Voice Activity Detection (VAD)
 
-This feature is not yet supported in the React Native SDK.
+VAD engine APIs are being migrated to a new streaming-first model.
 
-## Quick Usage
+## Current status
 
-There is no VAD API available yet. This page will be updated once VAD support ships.
+- Legacy placeholder functions are being replaced as part of the VAD migration.
+- `SegmentBuffer` is now the core output primitive for VAD-oriented pipelines.
+- Public SegmentBuffer docs:
+  - [segmentbuffer-streaming.md](segmentbuffer-streaming.md)
+  - [segmentbuffer-offline.md](segmentbuffer-offline.md)
 
-## Status
+## Migration docs
 
-- Planned for a future release
-- API and configuration are not available yet
+- [VAD spec](migration/vad/vad-spec.md)
+- [VAD TypeScript API proposal](migration/vad/typescript-api-proposal.md)
 
-Follow the project roadmap or open an issue to track progress.
+This page will be expanded with full VAD runtime usage once the engine migration is finalized.

--- a/ios/SherpaOnnx.mm
+++ b/ios/SherpaOnnx.mm
@@ -19,6 +19,7 @@
 #include "pcm/PcmPlayerRegistry.h"
 #include "audio/pipeline/SherpaOnnx+PipelineAudioGlobals.h"
 #include "textbuffer/core/SherpaOnnx+TextBufferGlobals.h"
+#include "segmentbuffer/core/SherpaOnnx+SegmentBufferGlobals.h"
 #if __has_include("SherpaOnnx-Swift.h")
 #import "SherpaOnnx-Swift.h"
 #endif
@@ -52,6 +53,7 @@ extern void paMicStopQueue(void);
 {
     paMicStopQueue();
     txt_release_all_entries();
+    seg_release_all_entries();
     pcmPlayerDestroyAll();
     [[PaAudioSessionCoordinator shared] resetAll];
     [super invalidate];

--- a/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
+++ b/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
@@ -333,16 +333,7 @@ struct SegLiveEntry {
       }
       return result;
     }
-    // Legacy V1 fallback
-    FILE *reader = fopen(path.c_str(), "rb");
-    if (!reader) throw std::runtime_error("SEGMENT_SPOOL_READ_FAILED: Failed to open segment spool for " + bufferId);
-    unsigned char header[4];
-    if (fread(header, 1, 4, reader) != 4) { fclose(reader); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment spool header for " + bufferId); }
-    uint32_t len = (uint32_t)header[0] | ((uint32_t)header[1] << 8) | ((uint32_t)header[2] << 16) | ((uint32_t)header[3] << 24);
-    std::string payload; payload.resize(len);
-    if (len > 0 && fread(payload.data(), 1, len, reader) != len) { fclose(reader); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment spool payload for " + bufferId); }
-    fclose(reader);
-    return segment_records_from_json(payload);
+    throw std::runtime_error("SEGMENT_SPOOL_UNAVAILABLE: Missing segment checkpoint for " + bufferId);
   }
 
   void release() {
@@ -357,7 +348,6 @@ struct SegLiveEntry {
       }
     }
     if (shouldDelete) {
-      remove(pathToDelete.c_str());
       remove((pathToDelete + ".segj").c_str());
       remove((pathToDelete + ".segc").c_str());
     }

--- a/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
+++ b/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
@@ -1,0 +1,718 @@
+#import "../../SherpaOnnx.h"
+#include "../core/SherpaOnnx+SegmentBufferGlobals.h"
+
+#ifdef __cplusplus
+#include <algorithm>
+#include <cstdio>
+#include <random>
+#include <sstream>
+#include <unistd.h>
+
+std::unordered_map<std::string, std::shared_ptr<SegOfflineEntry>> g_seg_offline;
+std::unordered_map<std::string, std::shared_ptr<SegLiveEntry>> g_seg_live;
+std::mutex g_seg_mutex;
+
+namespace {
+std::string seg_uuid() {
+  static const char *kHex = "0123456789abcdef";
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dis(0, 15);
+  int groups[] = {8, 4, 4, 4, 12};
+  std::stringstream ss;
+  for (size_t g = 0; g < 5; ++g) {
+    if (g > 0) ss << "-";
+    for (int i = 0; i < groups[g]; ++i) ss << kHex[dis(gen)];
+  }
+  return ss.str();
+}
+
+std::string seg_new_id(const std::string &prefix) {
+  return prefix + "_" + seg_uuid();
+}
+
+std::string segment_records_to_json(const std::vector<SegRecord> &segments) {
+  NSMutableArray *arr = [NSMutableArray arrayWithCapacity:segments.size()];
+  for (const auto &s : segments) {
+    NSMutableDictionary *item = [NSMutableDictionary dictionary];
+    item[@"id"] = [NSString stringWithUTF8String:s.id.c_str()];
+    item[@"kind"] = [NSString stringWithUTF8String:s.kind.c_str()];
+    item[@"sourceAudioBufferId"] = [NSString stringWithUTF8String:s.sourceAudioBufferId.c_str()];
+    item[@"startSample"] = @(s.startSample);
+    item[@"endSample"] = @(s.endSample);
+    item[@"sampleRate"] = @(s.sampleRate);
+    item[@"durationMs"] = @(s.durationMs);
+    if (s.hasConfidence) item[@"confidence"] = @(s.confidence);
+    if (!s.payloadJson.empty()) {
+      NSData *payloadData = [[NSString stringWithUTF8String:s.payloadJson.c_str()] dataUsingEncoding:NSUTF8StringEncoding];
+      NSDictionary *payloadObj = payloadData ? [NSJSONSerialization JSONObjectWithData:payloadData options:0 error:nil] : nil;
+      if (payloadObj) item[@"payload"] = payloadObj;
+    }
+    [arr addObject:item];
+  }
+  NSDictionary *root = @{@"segments": arr};
+  NSData *data = [NSJSONSerialization dataWithJSONObject:root options:0 error:nil];
+  return data ? std::string((const char *)data.bytes, data.length) : std::string("{\"segments\":[]}");
+}
+
+std::vector<SegRecord> segment_records_from_json(const std::string &json) {
+  std::vector<SegRecord> out;
+  NSData *data = [[NSString stringWithUTF8String:json.c_str()] dataUsingEncoding:NSUTF8StringEncoding];
+  if (!data) return out;
+  NSDictionary *root = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+  if (![root isKindOfClass:[NSDictionary class]]) return out;
+  NSArray *arr = root[@"segments"];
+  if (![arr isKindOfClass:[NSArray class]]) return out;
+  out.reserve(arr.count);
+  for (id obj in arr) {
+    if (![obj isKindOfClass:[NSDictionary class]]) continue;
+    NSDictionary *d = (NSDictionary *)obj;
+    SegRecord r;
+    r.id = [d[@"id"] isKindOfClass:[NSString class]] ? [d[@"id"] UTF8String] : "";
+    r.kind = [d[@"kind"] isKindOfClass:[NSString class]] ? [d[@"kind"] UTF8String] : "speech";
+    r.sourceAudioBufferId = [d[@"sourceAudioBufferId"] isKindOfClass:[NSString class]] ? [d[@"sourceAudioBufferId"] UTF8String] : "";
+    r.startSample = [d[@"startSample"] respondsToSelector:@selector(intValue)] ? [d[@"startSample"] intValue] : 0;
+    r.endSample = [d[@"endSample"] respondsToSelector:@selector(intValue)] ? [d[@"endSample"] intValue] : 0;
+    r.sampleRate = [d[@"sampleRate"] respondsToSelector:@selector(intValue)] ? [d[@"sampleRate"] intValue] : 0;
+    r.durationMs = [d[@"durationMs"] respondsToSelector:@selector(intValue)] ? [d[@"durationMs"] intValue] : 0;
+    if ([d[@"confidence"] respondsToSelector:@selector(doubleValue)]) {
+      r.hasConfidence = true;
+      r.confidence = [d[@"confidence"] doubleValue];
+    }
+    if ([d[@"payload"] isKindOfClass:[NSDictionary class]]) {
+      NSData *payloadData = [NSJSONSerialization dataWithJSONObject:d[@"payload"] options:0 error:nil];
+      if (payloadData) r.payloadJson = std::string((const char *)payloadData.bytes, payloadData.length);
+    }
+    out.push_back(std::move(r));
+  }
+  return out;
+}
+
+struct SegLiveEntry {
+  enum State { RECORDING, FINISHED };
+  enum SpoolingMode { SPOOL_OFF, SPOOL_AUTO, SPOOL_ON };
+
+  std::string bufferId;
+  State state = RECORDING;
+  std::string sourceAudioBufferId;
+  std::vector<SegRecord> segments;
+  int maxSegments = 1000;
+  int64_t evictedCount = 0;
+  int64_t totalSegmentsWritten = 0;
+
+  SpoolingMode spoolingMode = SPOOL_ON;
+  std::string spoolPath;
+  bool spoolTemporary = true;
+  int64_t spoolThresholdBytes = 0;
+  bool spoolReady = false;
+  int64_t spoolBytes = 0;
+  int64_t spoolEstimatedBytes = 0;
+  std::string spoolFailureCode;
+  std::string spoolFailureMessage;
+  FILE *spoolFile = nullptr;
+
+  std::mutex lock;
+  std::mutex spoolLock;
+
+  ~SegLiveEntry() { release(); }
+
+  static std::string modeRaw(SpoolingMode mode) {
+    switch (mode) {
+      case SPOOL_OFF: return "off";
+      case SPOOL_AUTO: return "auto";
+      case SPOOL_ON: return "on";
+    }
+    return "off";
+  }
+
+  bool spoolEnabled() const { return spoolingMode != SPOOL_OFF; }
+
+  [[noreturn]] void throwSpoolError(const std::string &code, const std::string &message) {
+    spoolFailureCode = code;
+    spoolFailureMessage = message;
+    throw std::runtime_error(code + ": " + message);
+  }
+
+  std::string snapshotForSpoolLocked() { return segment_records_to_json(segments); }
+
+  void closeSpoolFileLocked(bool flushFirst) {
+    if (!spoolFile) return;
+    if (flushFirst) fflush(spoolFile);
+    fclose(spoolFile);
+    spoolFile = nullptr;
+  }
+
+  void appendSnapshotRecordLocked(const std::string &snapshot) {
+    if (!spoolFile) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Spool file not open for " + bufferId);
+    const uint32_t len = (uint32_t)snapshot.size();
+    unsigned char header[4] = {
+      (unsigned char)(len & 0xFF),
+      (unsigned char)((len >> 8) & 0xFF),
+      (unsigned char)((len >> 16) & 0xFF),
+      (unsigned char)((len >> 24) & 0xFF)
+    };
+    const int64_t recordLength = 4 + (int64_t)len;
+    if (fseek(spoolFile, 0, SEEK_SET) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to seek spool for " + bufferId);
+    if (fwrite(header, 1, 4, spoolFile) != 4) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to write spool header for " + bufferId);
+    if (len > 0 && fwrite(snapshot.data(), 1, len, spoolFile) != len) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to write spool payload for " + bufferId);
+    if (fflush(spoolFile) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to flush spool for " + bufferId);
+    if (ftruncate(fileno(spoolFile), recordLength) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to truncate spool for " + bufferId);
+    spoolBytes = recordLength;
+    spoolReady = true;
+  }
+
+  void ensureSpoolWriterActivatedLocked(const std::string &snapshot) {
+    if (spoolFile) return;
+    if (spoolPath.empty()) throwSpoolError("SEGMENT_SPOOL_UNAVAILABLE", "Segment spool path is not configured for " + bufferId);
+    NSString *spoolPathNs = [NSString stringWithUTF8String:spoolPath.c_str()];
+    NSString *parentPath = [spoolPathNs stringByDeletingLastPathComponent];
+    if (parentPath.length > 0) {
+      [[NSFileManager defaultManager] createDirectoryAtPath:parentPath withIntermediateDirectories:YES attributes:nil error:nil];
+    }
+    spoolFile = fopen(spoolPath.c_str(), "wb");
+    if (!spoolFile) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to create segment spool for " + bufferId);
+    spoolBytes = 0;
+    appendSnapshotRecordLocked(snapshot);
+  }
+
+  void maybeWriteSnapshotToSpool(const std::string &snapshot, bool mayActivateAuto) {
+    if (!spoolEnabled()) return;
+    std::lock_guard<std::mutex> lockGuard(spoolLock);
+    if (!spoolFailureCode.empty()) throw std::runtime_error(spoolFailureCode + ": " + spoolFailureMessage);
+    if (!spoolFile) {
+      switch (spoolingMode) {
+        case SPOOL_OFF: return;
+        case SPOOL_ON:
+          ensureSpoolWriterActivatedLocked(snapshot);
+          return;
+        case SPOOL_AUTO: {
+          if (!mayActivateAuto) return;
+          spoolEstimatedBytes += (int64_t)(4 + snapshot.size());
+          if (spoolEstimatedBytes < std::max<int64_t>(0, spoolThresholdBytes)) {
+            spoolReady = false;
+            return;
+          }
+          ensureSpoolWriterActivatedLocked(snapshot);
+          return;
+        }
+      }
+    }
+    appendSnapshotRecordLocked(snapshot);
+  }
+
+  void finalize_() {
+    {
+      std::lock_guard<std::mutex> stateLock(lock);
+      if (state == FINISHED) throw std::runtime_error("SEGMENT_ALREADY_FINALIZED: Already finalized: " + bufferId);
+      state = FINISHED;
+    }
+    if (spoolEnabled()) {
+      std::lock_guard<std::mutex> guard(spoolLock);
+      if (spoolFile) {
+        if (fflush(spoolFile) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to finalize segment spool for " + bufferId);
+        closeSpoolFileLocked(false);
+      }
+    }
+  }
+
+  std::vector<SegRecord> snapshotWindow() {
+    std::lock_guard<std::mutex> guard(lock);
+    return segments;
+  }
+
+  std::vector<SegRecord> snapshotFullIfSpooled() {
+    if (!spoolEnabled()) throw std::runtime_error("SEGMENT_SPOOL_UNAVAILABLE: Segment spooling is disabled for " + bufferId);
+    std::string path;
+    {
+      std::lock_guard<std::mutex> guard(spoolLock);
+      if (!spoolFailureCode.empty()) throw std::runtime_error(spoolFailureCode + ": " + spoolFailureMessage);
+      if (!spoolReady) throw std::runtime_error("SEGMENT_SPOOL_UNAVAILABLE: Segment spool is not ready for " + bufferId);
+      if (spoolPath.empty()) throw std::runtime_error("SEGMENT_SPOOL_UNAVAILABLE: Segment spool path missing for " + bufferId);
+      path = spoolPath;
+      if (spoolFile) fflush(spoolFile);
+    }
+    FILE *reader = fopen(path.c_str(), "rb");
+    if (!reader) throw std::runtime_error("SEGMENT_SPOOL_READ_FAILED: Failed to open segment spool for " + bufferId);
+    unsigned char header[4];
+    if (fread(header, 1, 4, reader) != 4) {
+      fclose(reader);
+      throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment spool header for " + bufferId);
+    }
+    uint32_t len = (uint32_t)header[0] | ((uint32_t)header[1] << 8) | ((uint32_t)header[2] << 16) | ((uint32_t)header[3] << 24);
+    std::string payload;
+    payload.resize(len);
+    if (len > 0 && fread(payload.data(), 1, len, reader) != len) {
+      fclose(reader);
+      throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment spool payload for " + bufferId);
+    }
+    if (fgetc(reader) != EOF) {
+      fclose(reader);
+      throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Unexpected trailing data in segment spool for " + bufferId);
+    }
+    fclose(reader);
+    return segment_records_from_json(payload);
+  }
+
+  void release() {
+    std::string pathToDelete;
+    bool shouldDelete = false;
+    {
+      std::lock_guard<std::mutex> guard(spoolLock);
+      closeSpoolFileLocked(false);
+      if (spoolTemporary && !spoolPath.empty()) {
+        pathToDelete = spoolPath;
+        shouldDelete = true;
+      }
+    }
+    if (shouldDelete) remove(pathToDelete.c_str());
+  }
+};
+
+static NSDictionary *segRecordToDict(const SegRecord &r) {
+  NSMutableDictionary *dict = [@{
+    @"id": [NSString stringWithUTF8String:r.id.c_str()],
+    @"kind": [NSString stringWithUTF8String:r.kind.c_str()],
+    @"sourceAudioBufferId": [NSString stringWithUTF8String:r.sourceAudioBufferId.c_str()],
+    @"startSample": @(r.startSample),
+    @"endSample": @(r.endSample),
+    @"sampleRate": @(r.sampleRate),
+    @"durationMs": @(r.durationMs),
+  } mutableCopy];
+  if (r.hasConfidence) dict[@"confidence"] = @(r.confidence);
+  if (!r.payloadJson.empty()) {
+    NSData *payloadData = [[NSString stringWithUTF8String:r.payloadJson.c_str()] dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *payloadObj = payloadData ? [NSJSONSerialization JSONObjectWithData:payloadData options:0 error:nil] : nil;
+    if (payloadObj) dict[@"payload"] = payloadObj;
+  }
+  return dict;
+}
+} // namespace
+
+void seg_release_all_entries() {
+  std::unordered_map<std::string, std::shared_ptr<SegLiveEntry>> liveEntries;
+  {
+    std::lock_guard<std::mutex> lock(g_seg_mutex);
+    liveEntries.swap(g_seg_live);
+    g_seg_offline.clear();
+  }
+  for (auto &pair : liveEntries) {
+    try { pair.second->release(); } catch (...) {}
+  }
+}
+#endif
+
+@implementation SherpaOnnx (SegmentBuffer)
+
+- (void)createLiveSegmentBuffer:(NSDictionary *)options
+                        resolve:(RCTPromiseResolveBlock)resolve
+                         reject:(RCTPromiseRejectBlock)reject
+{
+#ifdef __cplusplus
+  try {
+    NSDictionary *opts = [options isKindOfClass:[NSDictionary class]] ? options : @{};
+    auto entry = std::make_shared<SegLiveEntry>();
+    entry->bufferId = seg_new_id("seg_live");
+    entry->sourceAudioBufferId = [opts[@"sourceAudioBufferId"] isKindOfClass:[NSString class]] ? [opts[@"sourceAudioBufferId"] UTF8String] : "";
+    entry->maxSegments = [opts[@"maxSegments"] respondsToSelector:@selector(intValue)] ? std::max(1, [opts[@"maxSegments"] intValue]) : 1000;
+    NSString *modeRaw = [opts[@"spoolingMode"] isKindOfClass:[NSString class]] ? opts[@"spoolingMode"] : @"on";
+    if ([modeRaw isEqualToString:@"off"]) entry->spoolingMode = SegLiveEntry::SPOOL_OFF;
+    else if ([modeRaw isEqualToString:@"auto"]) entry->spoolingMode = SegLiveEntry::SPOOL_AUTO;
+    else entry->spoolingMode = SegLiveEntry::SPOOL_ON;
+
+    NSString *spoolPath = [opts[@"spoolingPath"] isKindOfClass:[NSString class]] ? opts[@"spoolingPath"] : nil;
+    if (entry->spoolingMode != SegLiveEntry::SPOOL_OFF) {
+      if (spoolPath.length > 0) {
+        entry->spoolPath = spoolPath.UTF8String;
+      } else {
+        NSString *tmp = [NSTemporaryDirectory() stringByAppendingPathComponent:
+                         [NSString stringWithFormat:@"seg_spool_%@.json", [NSUUID UUID].UUIDString]];
+        entry->spoolPath = tmp.UTF8String;
+      }
+    }
+    if ([opts[@"spoolingTemporary"] respondsToSelector:@selector(boolValue)]) {
+      entry->spoolTemporary = [opts[@"spoolingTemporary"] boolValue];
+    } else {
+      entry->spoolTemporary = (spoolPath.length == 0);
+    }
+    if ([opts[@"spoolingThresholdBytes"] respondsToSelector:@selector(longLongValue)]) {
+      entry->spoolThresholdBytes = [opts[@"spoolingThresholdBytes"] longLongValue];
+    }
+    if (entry->spoolingMode == SegLiveEntry::SPOOL_ON) {
+      entry->maybeWriteSnapshotToSpool(entry->snapshotForSpoolLocked(), false);
+    }
+    {
+      std::lock_guard<std::mutex> lock(g_seg_mutex);
+      g_seg_live[entry->bufferId] = entry;
+    }
+    NSMutableDictionary *out = [@{
+      @"bufferId": [NSString stringWithUTF8String:entry->bufferId.c_str()],
+      @"kind": @"liveSegmentBuffer",
+      @"state": @"recording",
+      @"segmentCount": @(0),
+      @"totalSegmentsWritten": @(0),
+      @"spoolMode": [NSString stringWithUTF8String:SegLiveEntry::modeRaw(entry->spoolingMode).c_str()],
+      @"spoolEnabled": @(entry->spoolEnabled()),
+      @"spoolReady": @(entry->spoolReady),
+      @"spoolBytes": @(entry->spoolBytes),
+    } mutableCopy];
+    if (!entry->sourceAudioBufferId.empty()) out[@"sourceAudioBufferId"] = [NSString stringWithUTF8String:entry->sourceAudioBufferId.c_str()];
+    if (!entry->spoolPath.empty()) out[@"spoolPath"] = [NSString stringWithUTF8String:entry->spoolPath.c_str()];
+    resolve(out);
+  } catch (const std::exception &e) {
+    NSString *msg = [NSString stringWithUTF8String:e.what()];
+    NSString *code = @"SEGMENT_INTERNAL_ERROR";
+    NSRange idx = [msg rangeOfString:@":"];
+    if (idx.location != NSNotFound) {
+      code = [msg substringToIndex:idx.location];
+      msg = [[msg substringFromIndex:idx.location + 1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    }
+    reject(code, msg, nil);
+  }
+#else
+  reject(@"SEGMENT_INTERNAL_ERROR", @"SegmentBuffer unavailable", nil);
+#endif
+}
+
+- (void)createEmptyOfflineSegmentBuffer:(NSDictionary *)options
+                                resolve:(RCTPromiseResolveBlock)resolve
+                                 reject:(RCTPromiseRejectBlock)reject
+{
+#ifdef __cplusplus
+  auto entry = std::make_shared<SegOfflineEntry>();
+  entry->bufferId = seg_new_id("seg_off");
+  if ([options[@"sourceAudioBufferId"] isKindOfClass:[NSString class]]) {
+    entry->sourceAudioBufferId = [options[@"sourceAudioBufferId"] UTF8String];
+  }
+  {
+    std::lock_guard<std::mutex> lock(g_seg_mutex);
+    g_seg_offline[entry->bufferId] = entry;
+  }
+  NSMutableDictionary *out = [@{
+    @"bufferId": [NSString stringWithUTF8String:entry->bufferId.c_str()],
+    @"kind": @"offlineSegmentBuffer",
+    @"state": @"immutable",
+    @"segmentCount": @((int)entry->segments.size()),
+  } mutableCopy];
+  if (!entry->sourceAudioBufferId.empty()) {
+    out[@"sourceAudioBufferId"] = [NSString stringWithUTF8String:entry->sourceAudioBufferId.c_str()];
+  }
+  resolve(out);
+#else
+  reject(@"SEGMENT_INTERNAL_ERROR", @"SegmentBuffer unavailable", nil);
+#endif
+}
+
+- (void)appendLiveSegment:(NSString *)liveBufferId
+                     kind:(NSString *)kind
+      sourceAudioBufferId:(NSString *)sourceAudioBufferId
+              startSample:(double)startSample
+                endSample:(double)endSample
+               sampleRate:(double)sampleRate
+               durationMs:(NSNumber *)durationMs
+               confidence:(NSNumber *)confidence
+                  payload:(NSDictionary *)payload
+                  resolve:(RCTPromiseResolveBlock)resolve
+                   reject:(RCTPromiseRejectBlock)reject
+{
+#ifdef __cplusplus
+  std::shared_ptr<SegLiveEntry> entry;
+  {
+    std::lock_guard<std::mutex> lock(g_seg_mutex);
+    auto it = g_seg_live.find(liveBufferId.UTF8String);
+    if (it == g_seg_live.end()) {
+      reject(@"SEGMENT_BUFFER_NOT_FOUND", [NSString stringWithFormat:@"Live segment buffer not found: %@", liveBufferId], nil);
+      return;
+    }
+    entry = it->second;
+  }
+  try {
+    std::lock_guard<std::mutex> lock(entry->lock);
+    if (entry->state == SegLiveEntry::FINISHED) {
+      throw std::runtime_error("SEGMENT_ALREADY_FINALIZED: Live segment buffer is finalized");
+    }
+    SegRecord seg;
+    seg.id = "seg_" + seg_uuid();
+    seg.kind = kind.length > 0 ? kind.UTF8String : "speech";
+    seg.sourceAudioBufferId = sourceAudioBufferId.length > 0 ? sourceAudioBufferId.UTF8String : entry->sourceAudioBufferId;
+    seg.startSample = (int)startSample;
+    seg.endSample = (int)endSample;
+    seg.sampleRate = (int)sampleRate;
+    seg.durationMs = durationMs != nil ? durationMs.intValue : (int)(((seg.endSample - seg.startSample) * 1000.0) / std::max(1, seg.sampleRate));
+    if (confidence != nil) {
+      seg.hasConfidence = true;
+      seg.confidence = confidence.doubleValue;
+    }
+    if ([payload isKindOfClass:[NSDictionary class]]) {
+      NSData *pd = [NSJSONSerialization dataWithJSONObject:payload options:0 error:nil];
+      if (pd) seg.payloadJson = std::string((const char *)pd.bytes, pd.length);
+    }
+    const int segmentIndex = (int)(entry->evictedCount + (int64_t)entry->segments.size());
+    entry->segments.push_back(seg);
+    std::string snapshot = entry->snapshotForSpoolLocked();
+    if ((int)entry->segments.size() > entry->maxSegments) {
+      entry->segments.erase(entry->segments.begin());
+      entry->evictedCount++;
+    }
+    entry->totalSegmentsWritten++;
+    entry->maybeWriteSnapshotToSpool(snapshot, true);
+    resolve(@{ @"segmentId": [NSString stringWithUTF8String:seg.id.c_str()], @"segmentIndex": @(segmentIndex) });
+  } catch (const std::exception &e) {
+    NSString *msg = [NSString stringWithUTF8String:e.what()];
+    NSString *code = @"SEGMENT_INTERNAL_ERROR";
+    NSRange idx = [msg rangeOfString:@":"];
+    if (idx.location != NSNotFound) {
+      code = [msg substringToIndex:idx.location];
+      msg = [[msg substringFromIndex:idx.location + 1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    }
+    reject(code, msg, nil);
+  }
+#else
+  reject(@"SEGMENT_INTERNAL_ERROR", @"SegmentBuffer unavailable", nil);
+#endif
+}
+
+- (void)finalizeLiveSegmentBuffer:(NSString *)liveBufferId
+                          resolve:(RCTPromiseResolveBlock)resolve
+                           reject:(RCTPromiseRejectBlock)reject
+{
+#ifdef __cplusplus
+  std::shared_ptr<SegLiveEntry> entry;
+  {
+    std::lock_guard<std::mutex> lock(g_seg_mutex);
+    auto it = g_seg_live.find(liveBufferId.UTF8String);
+    if (it == g_seg_live.end()) {
+      reject(@"SEGMENT_BUFFER_NOT_FOUND", [NSString stringWithFormat:@"Live segment buffer not found: %@", liveBufferId], nil);
+      return;
+    }
+    entry = it->second;
+  }
+  try {
+    entry->finalize_();
+    resolve(nil);
+  } catch (const std::exception &e) {
+    NSString *msg = [NSString stringWithUTF8String:e.what()];
+    NSString *code = @"SEGMENT_INTERNAL_ERROR";
+    NSRange idx = [msg rangeOfString:@":"];
+    if (idx.location != NSNotFound) {
+      code = [msg substringToIndex:idx.location];
+      msg = [[msg substringFromIndex:idx.location + 1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    }
+    reject(code, msg, nil);
+  }
+#else
+  reject(@"SEGMENT_INTERNAL_ERROR", @"SegmentBuffer unavailable", nil);
+#endif
+}
+
+- (void)createOfflineSegmentBufferFromLive:(NSString *)liveBufferId
+                                      mode:(NSString *)mode
+                                   resolve:(RCTPromiseResolveBlock)resolve
+                                    reject:(RCTPromiseRejectBlock)reject
+{
+#ifdef __cplusplus
+  std::shared_ptr<SegLiveEntry> live;
+  {
+    std::lock_guard<std::mutex> lock(g_seg_mutex);
+    auto it = g_seg_live.find(liveBufferId.UTF8String);
+    if (it == g_seg_live.end()) {
+      reject(@"SEGMENT_BUFFER_NOT_FOUND", [NSString stringWithFormat:@"Live segment buffer not found: %@", liveBufferId], nil);
+      return;
+    }
+    live = it->second;
+  }
+  try {
+    std::vector<SegRecord> records;
+    if ([mode isEqualToString:@"windowSnapshot"]) records = live->snapshotWindow();
+    else if (mode == nil || [mode isEqualToString:@"fullIfSpooled"]) records = live->snapshotFullIfSpooled();
+    else {
+      reject(@"SEGMENT_INVALID_ARGUMENT", [NSString stringWithFormat:@"Unknown mode: %@", mode], nil);
+      return;
+    }
+    auto off = std::make_shared<SegOfflineEntry>();
+    off->bufferId = seg_new_id("seg_off");
+    off->segments = records;
+    off->sourceAudioBufferId = live->sourceAudioBufferId;
+    {
+      std::lock_guard<std::mutex> lock(g_seg_mutex);
+      g_seg_offline[off->bufferId] = off;
+    }
+    NSMutableDictionary *out = [@{
+      @"bufferId": [NSString stringWithUTF8String:off->bufferId.c_str()],
+      @"kind": @"offlineSegmentBuffer",
+      @"state": @"immutable",
+      @"segmentCount": @((int)off->segments.size()),
+    } mutableCopy];
+    if (!off->sourceAudioBufferId.empty()) out[@"sourceAudioBufferId"] = [NSString stringWithUTF8String:off->sourceAudioBufferId.c_str()];
+    resolve(out);
+  } catch (const std::exception &e) {
+    NSString *msg = [NSString stringWithUTF8String:e.what()];
+    NSString *code = @"SEGMENT_INTERNAL_ERROR";
+    NSRange idx = [msg rangeOfString:@":"];
+    if (idx.location != NSNotFound) {
+      code = [msg substringToIndex:idx.location];
+      msg = [[msg substringFromIndex:idx.location + 1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    }
+    reject(code, msg, nil);
+  }
+#else
+  reject(@"SEGMENT_INTERNAL_ERROR", @"SegmentBuffer unavailable", nil);
+#endif
+}
+
+- (void)getPipelineSegmentBufferInfo:(NSString *)bufferId
+                             resolve:(RCTPromiseResolveBlock)resolve
+                              reject:(RCTPromiseRejectBlock)reject
+{
+#ifdef __cplusplus
+  std::lock_guard<std::mutex> lock(g_seg_mutex);
+  auto offIt = g_seg_offline.find(bufferId.UTF8String);
+  if (offIt != g_seg_offline.end()) {
+    auto &off = offIt->second;
+    NSMutableDictionary *out = [@{
+      @"bufferId": [NSString stringWithUTF8String:off->bufferId.c_str()],
+      @"kind": @"offlineSegmentBuffer",
+      @"state": @"immutable",
+      @"segmentCount": @((int)off->segments.size()),
+    } mutableCopy];
+    if (!off->sourceAudioBufferId.empty()) out[@"sourceAudioBufferId"] = [NSString stringWithUTF8String:off->sourceAudioBufferId.c_str()];
+    resolve(out);
+    return;
+  }
+  auto liveIt = g_seg_live.find(bufferId.UTF8String);
+  if (liveIt != g_seg_live.end()) {
+    auto &live = liveIt->second;
+    NSMutableDictionary *out = [@{
+      @"bufferId": [NSString stringWithUTF8String:live->bufferId.c_str()],
+      @"kind": @"liveSegmentBuffer",
+      @"state": live->state == SegLiveEntry::RECORDING ? @"recording" : @"finished",
+      @"segmentCount": @((int)live->segments.size()),
+      @"totalSegmentsWritten": @(live->totalSegmentsWritten),
+      @"spoolMode": [NSString stringWithUTF8String:SegLiveEntry::modeRaw(live->spoolingMode).c_str()],
+      @"spoolEnabled": @(live->spoolEnabled()),
+      @"spoolReady": @(live->spoolReady),
+      @"spoolBytes": @(live->spoolBytes),
+    } mutableCopy];
+    if (!live->sourceAudioBufferId.empty()) out[@"sourceAudioBufferId"] = [NSString stringWithUTF8String:live->sourceAudioBufferId.c_str()];
+    if (!live->spoolPath.empty()) out[@"spoolPath"] = [NSString stringWithUTF8String:live->spoolPath.c_str()];
+    resolve(out);
+    return;
+  }
+  reject(@"SEGMENT_BUFFER_NOT_FOUND", [NSString stringWithFormat:@"Segment buffer not found: %@", bufferId], nil);
+#else
+  reject(@"SEGMENT_INTERNAL_ERROR", @"SegmentBuffer unavailable", nil);
+#endif
+}
+
+- (void)getOfflineSegmentBufferSegments:(NSString *)bufferId
+                                  start:(double)start
+                               maxCount:(double)maxCount
+                                resolve:(RCTPromiseResolveBlock)resolve
+                                 reject:(RCTPromiseRejectBlock)reject
+{
+#ifdef __cplusplus
+  std::shared_ptr<SegOfflineEntry> entry;
+  {
+    std::lock_guard<std::mutex> lock(g_seg_mutex);
+    auto it = g_seg_offline.find(bufferId.UTF8String);
+    if (it == g_seg_offline.end()) {
+      reject(@"SEGMENT_BUFFER_NOT_FOUND", [NSString stringWithFormat:@"Offline segment buffer not found: %@", bufferId], nil);
+      return;
+    }
+    entry = it->second;
+  }
+  int s = (int)start;
+  int c = (int)maxCount;
+  if (s < 0 || c < 0) {
+    reject(@"SEGMENT_SLICE_INVALID", @"Invalid slice range", nil);
+    return;
+  }
+  NSMutableArray *arr = [NSMutableArray array];
+  int end = std::min((int)entry->segments.size(), s + c);
+  for (int i = s; i < end; ++i) [arr addObject:segRecordToDict(entry->segments[i])];
+  resolve(@{@"segments": arr});
+#else
+  reject(@"SEGMENT_INTERNAL_ERROR", @"SegmentBuffer unavailable", nil);
+#endif
+}
+
+- (void)getLiveSegmentBufferSegments:(NSString *)liveBufferId
+                          startIndex:(double)startIndex
+                            maxCount:(double)maxCount
+                             resolve:(RCTPromiseResolveBlock)resolve
+                              reject:(RCTPromiseRejectBlock)reject
+{
+#ifdef __cplusplus
+  std::shared_ptr<SegLiveEntry> entry;
+  {
+    std::lock_guard<std::mutex> lock(g_seg_mutex);
+    auto it = g_seg_live.find(liveBufferId.UTF8String);
+    if (it == g_seg_live.end()) {
+      reject(@"SEGMENT_BUFFER_NOT_FOUND", [NSString stringWithFormat:@"Live segment buffer not found: %@", liveBufferId], nil);
+      return;
+    }
+    entry = it->second;
+  }
+  int s = (int)startIndex;
+  int c = (int)maxCount;
+  if (s < 0 || c < 0) {
+    reject(@"SEGMENT_SLICE_INVALID", @"Invalid slice range", nil);
+    return;
+  }
+  std::vector<SegRecord> snap;
+  {
+    std::lock_guard<std::mutex> guard(entry->lock);
+    int end = std::min((int)entry->segments.size(), s + c);
+    if (s < (int)entry->segments.size() && end > s) {
+      snap.assign(entry->segments.begin() + s, entry->segments.begin() + end);
+    }
+  }
+  NSMutableArray *arr = [NSMutableArray arrayWithCapacity:snap.size()];
+  for (const auto &r : snap) [arr addObject:segRecordToDict(r)];
+  resolve(@{@"segments": arr});
+#else
+  reject(@"SEGMENT_INTERNAL_ERROR", @"SegmentBuffer unavailable", nil);
+#endif
+}
+
+- (void)getLiveSegmentBufferSegmentCount:(NSString *)liveBufferId
+                                 resolve:(RCTPromiseResolveBlock)resolve
+                                  reject:(RCTPromiseRejectBlock)reject
+{
+#ifdef __cplusplus
+  std::lock_guard<std::mutex> lock(g_seg_mutex);
+  auto it = g_seg_live.find(liveBufferId.UTF8String);
+  if (it == g_seg_live.end()) {
+    reject(@"SEGMENT_BUFFER_NOT_FOUND", [NSString stringWithFormat:@"Live segment buffer not found: %@", liveBufferId], nil);
+    return;
+  }
+  resolve(@((int)it->second->segments.size()));
+#else
+  reject(@"SEGMENT_INTERNAL_ERROR", @"SegmentBuffer unavailable", nil);
+#endif
+}
+
+- (void)releasePipelineSegmentBuffer:(NSString *)bufferId
+                             resolve:(RCTPromiseResolveBlock)resolve
+                              reject:(RCTPromiseRejectBlock)reject
+{
+#ifdef __cplusplus
+  std::shared_ptr<SegLiveEntry> live;
+  {
+    std::lock_guard<std::mutex> lock(g_seg_mutex);
+    auto lit = g_seg_live.find(bufferId.UTF8String);
+    if (lit != g_seg_live.end()) {
+      live = lit->second;
+      g_seg_live.erase(lit);
+    }
+    g_seg_offline.erase(bufferId.UTF8String);
+  }
+  if (live) {
+    try { live->release(); } catch (...) {}
+  }
+  resolve(nil);
+#else
+  reject(@"SEGMENT_INTERNAL_ERROR", @"SegmentBuffer unavailable", nil);
+#endif
+}
+
+@end

--- a/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
+++ b/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
@@ -89,6 +89,14 @@ std::vector<SegRecord> segment_records_from_json(const std::string &json) {
 }
 
 struct SegLiveEntry {
+  static constexpr uint32_t kMagic = 0x32474553; // SEG2
+  static constexpr uint16_t kVersion = 2;
+  static constexpr uint16_t kRecordSegmentAppend = 1;
+  static constexpr uint16_t kRecordCheckpointMark = 2;
+  static constexpr uint16_t kRecordFinalizeMark = 3;
+  static constexpr int kHeaderBytes = 16;
+  static constexpr int kCheckpointEveryEvents = 128;
+  static constexpr int64_t kCheckpointEveryBytes = 1048576;
   enum State { RECORDING, FINISHED };
   enum SpoolingMode { SPOOL_OFF, SPOOL_AUTO, SPOOL_ON };
 
@@ -107,9 +115,11 @@ struct SegLiveEntry {
   bool spoolReady = false;
   int64_t spoolBytes = 0;
   int64_t spoolEstimatedBytes = 0;
+  int64_t journalBytesSinceCheckpoint = 0;
+  int journalEventCount = 0;
   std::string spoolFailureCode;
   std::string spoolFailureMessage;
-  FILE *spoolFile = nullptr;
+  FILE *journalFile = nullptr;
 
   std::mutex lock;
   std::mutex spoolLock;
@@ -134,52 +144,98 @@ struct SegLiveEntry {
   }
 
   std::string snapshotForSpoolLocked() { return segment_records_to_json(segments); }
+  std::string journalPath() const { return spoolPath + ".segj"; }
+  std::string checkpointPath() const { return spoolPath + ".segc"; }
 
   void closeSpoolFileLocked(bool flushFirst) {
-    if (!spoolFile) return;
-    if (flushFirst) fflush(spoolFile);
-    fclose(spoolFile);
-    spoolFile = nullptr;
+    if (!journalFile) return;
+    if (flushFirst) fflush(journalFile);
+    fclose(journalFile);
+    journalFile = nullptr;
   }
 
-  void appendSnapshotRecordLocked(const std::string &snapshot) {
-    if (!spoolFile) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Spool file not open for " + bufferId);
-    const uint32_t len = (uint32_t)snapshot.size();
-    unsigned char header[4] = {
+  void appendJournalRecordLocked(uint16_t type, const std::string &payload) {
+    if (!journalFile) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Segment journal not open for " + bufferId);
+    const uint32_t len = (uint32_t)payload.size();
+    uint32_t crc = 0;
+    for (char c : payload) crc = (crc * 33u) ^ (uint8_t)c;
+    unsigned char header[kHeaderBytes] = {
+      (unsigned char)(kMagic & 0xFF),
+      (unsigned char)((kMagic >> 8) & 0xFF),
+      (unsigned char)((kMagic >> 16) & 0xFF),
+      (unsigned char)((kMagic >> 24) & 0xFF),
+      (unsigned char)(kVersion & 0xFF),
+      (unsigned char)((kVersion >> 8) & 0xFF),
+      (unsigned char)(type & 0xFF),
+      (unsigned char)((type >> 8) & 0xFF),
       (unsigned char)(len & 0xFF),
       (unsigned char)((len >> 8) & 0xFF),
       (unsigned char)((len >> 16) & 0xFF),
-      (unsigned char)((len >> 24) & 0xFF)
+      (unsigned char)((len >> 24) & 0xFF),
+      (unsigned char)(crc & 0xFF),
+      (unsigned char)((crc >> 8) & 0xFF),
+      (unsigned char)((crc >> 16) & 0xFF),
+      (unsigned char)((crc >> 24) & 0xFF)
     };
-    const int64_t recordLength = 4 + (int64_t)len;
-    if (fseek(spoolFile, 0, SEEK_SET) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to seek spool for " + bufferId);
-    if (fwrite(header, 1, 4, spoolFile) != 4) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to write spool header for " + bufferId);
-    if (len > 0 && fwrite(snapshot.data(), 1, len, spoolFile) != len) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to write spool payload for " + bufferId);
-    if (fflush(spoolFile) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to flush spool for " + bufferId);
-    if (ftruncate(fileno(spoolFile), recordLength) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to truncate spool for " + bufferId);
-    spoolBytes = recordLength;
+    if (fseek(journalFile, 0, SEEK_END) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to seek segment journal for " + bufferId);
+    if (fwrite(header, 1, kHeaderBytes, journalFile) != kHeaderBytes) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to write segment journal header for " + bufferId);
+    if (len > 0 && fwrite(payload.data(), 1, len, journalFile) != len) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to write segment journal payload for " + bufferId);
+    if (fflush(journalFile) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to flush segment journal for " + bufferId);
+    spoolBytes = ftell(journalFile);
     spoolReady = true;
   }
 
+  void writeCheckpointSnapshotLocked(const std::string &snapshot) {
+    std::string cpPath = checkpointPath();
+    std::string tmpPath = cpPath + ".tmp";
+    FILE *tmp = fopen(tmpPath.c_str(), "wb");
+    if (!tmp) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to create segment checkpoint for " + bufferId);
+    const uint32_t len = (uint32_t)snapshot.size();
+    uint32_t crc = 0;
+    for (char c : snapshot) crc = (crc * 33u) ^ (uint8_t)c;
+    unsigned char header[kHeaderBytes] = {
+      (unsigned char)(kMagic & 0xFF), (unsigned char)((kMagic >> 8) & 0xFF), (unsigned char)((kMagic >> 16) & 0xFF), (unsigned char)((kMagic >> 24) & 0xFF),
+      (unsigned char)(kVersion & 0xFF), (unsigned char)((kVersion >> 8) & 0xFF),
+      (unsigned char)(kRecordCheckpointMark & 0xFF), (unsigned char)((kRecordCheckpointMark >> 8) & 0xFF),
+      (unsigned char)(len & 0xFF), (unsigned char)((len >> 8) & 0xFF), (unsigned char)((len >> 16) & 0xFF), (unsigned char)((len >> 24) & 0xFF),
+      (unsigned char)(crc & 0xFF), (unsigned char)((crc >> 8) & 0xFF), (unsigned char)((crc >> 16) & 0xFF), (unsigned char)((crc >> 24) & 0xFF)
+    };
+    if (fwrite(header, 1, kHeaderBytes, tmp) != kHeaderBytes || (len > 0 && fwrite(snapshot.data(), 1, len, tmp) != len)) {
+      fclose(tmp);
+      remove(tmpPath.c_str());
+      throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to write segment checkpoint payload for " + bufferId);
+    }
+    fflush(tmp);
+    fclose(tmp);
+    remove(cpPath.c_str());
+    if (rename(tmpPath.c_str(), cpPath.c_str()) != 0) {
+      remove(tmpPath.c_str());
+      throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to finalize segment checkpoint for " + bufferId);
+    }
+  }
+
   void ensureSpoolWriterActivatedLocked(const std::string &snapshot) {
-    if (spoolFile) return;
+    if (journalFile) return;
     if (spoolPath.empty()) throwSpoolError("SEGMENT_SPOOL_UNAVAILABLE", "Segment spool path is not configured for " + bufferId);
     NSString *spoolPathNs = [NSString stringWithUTF8String:spoolPath.c_str()];
     NSString *parentPath = [spoolPathNs stringByDeletingLastPathComponent];
     if (parentPath.length > 0) {
       [[NSFileManager defaultManager] createDirectoryAtPath:parentPath withIntermediateDirectories:YES attributes:nil error:nil];
     }
-    spoolFile = fopen(spoolPath.c_str(), "wb");
-    if (!spoolFile) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to create segment spool for " + bufferId);
+    journalFile = fopen(journalPath().c_str(), "ab+");
+    if (!journalFile) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to create segment journal for " + bufferId);
     spoolBytes = 0;
-    appendSnapshotRecordLocked(snapshot);
+    writeCheckpointSnapshotLocked(snapshot);
+    appendJournalRecordLocked(kRecordCheckpointMark, "{}");
+    journalBytesSinceCheckpoint = 0;
+    journalEventCount = 0;
   }
 
   void maybeWriteSnapshotToSpool(const std::string &snapshot, bool mayActivateAuto) {
     if (!spoolEnabled()) return;
     std::lock_guard<std::mutex> lockGuard(spoolLock);
     if (!spoolFailureCode.empty()) throw std::runtime_error(spoolFailureCode + ": " + spoolFailureMessage);
-    if (!spoolFile) {
+    if (!journalFile) {
       switch (spoolingMode) {
         case SPOOL_OFF: return;
         case SPOOL_ON:
@@ -197,7 +253,18 @@ struct SegLiveEntry {
         }
       }
     }
-    appendSnapshotRecordLocked(snapshot);
+    appendJournalRecordLocked(kRecordSegmentAppend, snapshot);
+    journalEventCount += 1;
+    journalBytesSinceCheckpoint += (kHeaderBytes + snapshot.size());
+    if (journalEventCount >= kCheckpointEveryEvents || journalBytesSinceCheckpoint >= kCheckpointEveryBytes) {
+      writeCheckpointSnapshotLocked(snapshotForSpoolLocked());
+      fclose(journalFile);
+      journalFile = fopen(journalPath().c_str(), "wb");
+      if (!journalFile) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to rotate segment journal for " + bufferId);
+      appendJournalRecordLocked(kRecordCheckpointMark, "{}");
+      journalBytesSinceCheckpoint = 0;
+      journalEventCount = 0;
+    }
   }
 
   void finalize_() {
@@ -208,8 +275,9 @@ struct SegLiveEntry {
     }
     if (spoolEnabled()) {
       std::lock_guard<std::mutex> guard(spoolLock);
-      if (spoolFile) {
-        if (fflush(spoolFile) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to finalize segment spool for " + bufferId);
+      if (journalFile) {
+        appendJournalRecordLocked(kRecordFinalizeMark, "{}");
+        if (fflush(journalFile) != 0) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to finalize segment spool for " + bufferId);
         closeSpoolFileLocked(false);
       }
     }
@@ -229,26 +297,50 @@ struct SegLiveEntry {
       if (!spoolReady) throw std::runtime_error("SEGMENT_SPOOL_UNAVAILABLE: Segment spool is not ready for " + bufferId);
       if (spoolPath.empty()) throw std::runtime_error("SEGMENT_SPOOL_UNAVAILABLE: Segment spool path missing for " + bufferId);
       path = spoolPath;
-      if (spoolFile) fflush(spoolFile);
+      if (journalFile) fflush(journalFile);
     }
+    std::string cpPath = path + ".segc";
+    std::vector<SegRecord> result;
+    if ([[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:cpPath.c_str()]]) {
+      FILE *cp = fopen(cpPath.c_str(), "rb");
+      if (!cp) throw std::runtime_error("SEGMENT_SPOOL_READ_FAILED: Failed to open segment checkpoint for " + bufferId);
+      unsigned char header[kHeaderBytes];
+      if (fread(header, 1, kHeaderBytes, cp) != kHeaderBytes) { fclose(cp); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment checkpoint header for " + bufferId); }
+      uint32_t len = (uint32_t)header[8] | ((uint32_t)header[9] << 8) | ((uint32_t)header[10] << 16) | ((uint32_t)header[11] << 24);
+      std::string payload;
+      payload.resize(len);
+      if (len > 0 && fread(payload.data(), 1, len, cp) != len) { fclose(cp); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment checkpoint payload for " + bufferId); }
+      fclose(cp);
+      result = segment_records_from_json(payload);
+      std::string jPath = path + ".segj";
+      FILE *jr = fopen(jPath.c_str(), "rb");
+      if (jr) {
+        while (true) {
+          unsigned char h[kHeaderBytes];
+          size_t n = fread(h, 1, kHeaderBytes, jr);
+          if (n == 0) break;
+          if (n != kHeaderBytes) { fclose(jr); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment journal header for " + bufferId); }
+          uint16_t type = (uint16_t)h[6] | ((uint16_t)h[7] << 8);
+          uint32_t len = (uint32_t)h[8] | ((uint32_t)h[9] << 8) | ((uint32_t)h[10] << 16) | ((uint32_t)h[11] << 24);
+          std::string payload; payload.resize(len);
+          if (len > 0 && fread(payload.data(), 1, len, jr) != len) { fclose(jr); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment journal payload for " + bufferId); }
+          if (type == kRecordSegmentAppend) {
+            auto parsed = segment_records_from_json(payload);
+            if (!parsed.empty()) result.push_back(parsed[0]);
+          }
+        }
+        fclose(jr);
+      }
+      return result;
+    }
+    // Legacy V1 fallback
     FILE *reader = fopen(path.c_str(), "rb");
     if (!reader) throw std::runtime_error("SEGMENT_SPOOL_READ_FAILED: Failed to open segment spool for " + bufferId);
     unsigned char header[4];
-    if (fread(header, 1, 4, reader) != 4) {
-      fclose(reader);
-      throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment spool header for " + bufferId);
-    }
+    if (fread(header, 1, 4, reader) != 4) { fclose(reader); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment spool header for " + bufferId); }
     uint32_t len = (uint32_t)header[0] | ((uint32_t)header[1] << 8) | ((uint32_t)header[2] << 16) | ((uint32_t)header[3] << 24);
-    std::string payload;
-    payload.resize(len);
-    if (len > 0 && fread(payload.data(), 1, len, reader) != len) {
-      fclose(reader);
-      throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment spool payload for " + bufferId);
-    }
-    if (fgetc(reader) != EOF) {
-      fclose(reader);
-      throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Unexpected trailing data in segment spool for " + bufferId);
-    }
+    std::string payload; payload.resize(len);
+    if (len > 0 && fread(payload.data(), 1, len, reader) != len) { fclose(reader); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment spool payload for " + bufferId); }
     fclose(reader);
     return segment_records_from_json(payload);
   }
@@ -264,7 +356,11 @@ struct SegLiveEntry {
         shouldDelete = true;
       }
     }
-    if (shouldDelete) remove(pathToDelete.c_str());
+    if (shouldDelete) {
+      remove(pathToDelete.c_str());
+      remove((pathToDelete + ".segj").c_str());
+      remove((pathToDelete + ".segc").c_str());
+    }
   }
 };
 

--- a/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
+++ b/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
@@ -7,6 +7,7 @@
 #include <random>
 #include <sstream>
 #include <unistd.h>
+#include <zlib.h>
 
 std::unordered_map<std::string, std::shared_ptr<SegOfflineEntry>> g_seg_offline;
 std::unordered_map<std::string, std::shared_ptr<SegLiveEntry>> g_seg_live;
@@ -147,6 +148,62 @@ struct SegLiveEntry {
   std::string journalPath() const { return spoolPath + ".segj"; }
   std::string checkpointPath() const { return spoolPath + ".segc"; }
 
+  uint32_t computeSpoolChecksum(const std::string &payload) const {
+    uLong crc = ::crc32(0L, Z_NULL, 0);
+    if (!payload.empty()) {
+      crc = ::crc32(
+        crc,
+        reinterpret_cast<const Bytef *>(payload.data()),
+        static_cast<uInt>(payload.size())
+      );
+    }
+    return static_cast<uint32_t>(crc);
+  }
+
+  bool isKnownRecordType(uint16_t type) const {
+    return type == kRecordSegmentAppend ||
+      type == kRecordCheckpointMark ||
+      type == kRecordFinalizeMark;
+  }
+
+  void decodeHeaderOrThrow(
+    const unsigned char *header,
+    const std::string &path,
+    uint16_t *recordType,
+    uint32_t *payloadLength,
+    uint32_t *checksum
+  ) const {
+    uint32_t magic =
+      (static_cast<uint32_t>(header[0])) |
+      (static_cast<uint32_t>(header[1]) << 8) |
+      (static_cast<uint32_t>(header[2]) << 16) |
+      (static_cast<uint32_t>(header[3]) << 24);
+    uint16_t version =
+      (static_cast<uint16_t>(header[4])) |
+      (static_cast<uint16_t>(header[5]) << 8);
+    uint16_t type =
+      (static_cast<uint16_t>(header[6])) |
+      (static_cast<uint16_t>(header[7]) << 8);
+    uint32_t len =
+      (static_cast<uint32_t>(header[8])) |
+      (static_cast<uint32_t>(header[9]) << 8) |
+      (static_cast<uint32_t>(header[10]) << 16) |
+      (static_cast<uint32_t>(header[11]) << 24);
+    uint32_t crc =
+      (static_cast<uint32_t>(header[12])) |
+      (static_cast<uint32_t>(header[13]) << 8) |
+      (static_cast<uint32_t>(header[14]) << 16) |
+      (static_cast<uint32_t>(header[15]) << 24);
+
+    if (magic != kMagic || version != kVersion || !isKnownRecordType(type)) {
+      throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Unexpected segment spool record format in " + path);
+    }
+
+    *recordType = type;
+    *payloadLength = len;
+    *checksum = crc;
+  }
+
   void closeSpoolFileLocked(bool flushFirst) {
     if (!journalFile) return;
     if (flushFirst) fflush(journalFile);
@@ -157,8 +214,7 @@ struct SegLiveEntry {
   void appendJournalRecordLocked(uint16_t type, const std::string &payload) {
     if (!journalFile) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Segment journal not open for " + bufferId);
     const uint32_t len = (uint32_t)payload.size();
-    uint32_t crc = 0;
-    for (char c : payload) crc = (crc * 33u) ^ (uint8_t)c;
+    const uint32_t crc = computeSpoolChecksum(payload);
     unsigned char header[kHeaderBytes] = {
       (unsigned char)(kMagic & 0xFF),
       (unsigned char)((kMagic >> 8) & 0xFF),
@@ -191,8 +247,7 @@ struct SegLiveEntry {
     FILE *tmp = fopen(tmpPath.c_str(), "wb");
     if (!tmp) throwSpoolError("SEGMENT_SPOOL_WRITE_FAILED", "Failed to create segment checkpoint for " + bufferId);
     const uint32_t len = (uint32_t)snapshot.size();
-    uint32_t crc = 0;
-    for (char c : snapshot) crc = (crc * 33u) ^ (uint8_t)c;
+    const uint32_t crc = computeSpoolChecksum(snapshot);
     unsigned char header[kHeaderBytes] = {
       (unsigned char)(kMagic & 0xFF), (unsigned char)((kMagic >> 8) & 0xFF), (unsigned char)((kMagic >> 16) & 0xFF), (unsigned char)((kMagic >> 24) & 0xFF),
       (unsigned char)(kVersion & 0xFF), (unsigned char)((kVersion >> 8) & 0xFF),
@@ -243,7 +298,7 @@ struct SegLiveEntry {
           return;
         case SPOOL_AUTO: {
           if (!mayActivateAuto) return;
-          spoolEstimatedBytes += (int64_t)(4 + snapshot.size());
+          spoolEstimatedBytes += (int64_t)(kHeaderBytes + snapshot.size());
           if (spoolEstimatedBytes < std::max<int64_t>(0, spoolThresholdBytes)) {
             spoolReady = false;
             return;
@@ -300,40 +355,119 @@ struct SegLiveEntry {
       if (journalFile) fflush(journalFile);
     }
     std::string cpPath = path + ".segc";
+    std::string jPath = path + ".segj";
+    bool hasCheckpoint = [[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:cpPath.c_str()]];
+    bool hasJournal = [[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:jPath.c_str()]];
+    if (!hasCheckpoint && !hasJournal) {
+      throw std::runtime_error("SEGMENT_SPOOL_UNAVAILABLE: Missing segment spool files for " + bufferId);
+    }
+
     std::vector<SegRecord> result;
-    if ([[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:cpPath.c_str()]]) {
+    if (hasCheckpoint) {
       FILE *cp = fopen(cpPath.c_str(), "rb");
       if (!cp) throw std::runtime_error("SEGMENT_SPOOL_READ_FAILED: Failed to open segment checkpoint for " + bufferId);
+
+      if (fseek(cp, 0, SEEK_END) != 0) {
+        fclose(cp);
+        throw std::runtime_error("SEGMENT_SPOOL_READ_FAILED: Failed to inspect segment checkpoint for " + bufferId);
+      }
+      long checkpointSize = ftell(cp);
+      if (checkpointSize < kHeaderBytes) {
+        fclose(cp);
+        throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment checkpoint header for " + bufferId);
+      }
+      if (fseek(cp, 0, SEEK_SET) != 0) {
+        fclose(cp);
+        throw std::runtime_error("SEGMENT_SPOOL_READ_FAILED: Failed to read segment checkpoint for " + bufferId);
+      }
+
       unsigned char header[kHeaderBytes];
       if (fread(header, 1, kHeaderBytes, cp) != kHeaderBytes) { fclose(cp); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment checkpoint header for " + bufferId); }
-      uint32_t len = (uint32_t)header[8] | ((uint32_t)header[9] << 8) | ((uint32_t)header[10] << 16) | ((uint32_t)header[11] << 24);
+
+      uint16_t type = 0;
+      uint32_t len = 0;
+      uint32_t checksum = 0;
+      decodeHeaderOrThrow(header, cpPath, &type, &len, &checksum);
+      if (type != kRecordCheckpointMark) {
+        fclose(cp);
+        throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Unexpected segment checkpoint record type for " + bufferId);
+      }
+      if (checkpointSize != static_cast<long>(kHeaderBytes + len)) {
+        fclose(cp);
+        throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Unexpected segment checkpoint size for " + bufferId);
+      }
+
       std::string payload;
       payload.resize(len);
       if (len > 0 && fread(payload.data(), 1, len, cp) != len) { fclose(cp); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment checkpoint payload for " + bufferId); }
+
+      uint32_t actualChecksum = computeSpoolChecksum(payload);
+      if (actualChecksum != checksum) {
+        fclose(cp);
+        throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Segment checkpoint checksum mismatch for " + bufferId);
+      }
+
       fclose(cp);
       result = segment_records_from_json(payload);
-      std::string jPath = path + ".segj";
-      FILE *jr = fopen(jPath.c_str(), "rb");
-      if (jr) {
-        while (true) {
-          unsigned char h[kHeaderBytes];
-          size_t n = fread(h, 1, kHeaderBytes, jr);
-          if (n == 0) break;
-          if (n != kHeaderBytes) { fclose(jr); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment journal header for " + bufferId); }
-          uint16_t type = (uint16_t)h[6] | ((uint16_t)h[7] << 8);
-          uint32_t len = (uint32_t)h[8] | ((uint32_t)h[9] << 8) | ((uint32_t)h[10] << 16) | ((uint32_t)h[11] << 24);
-          std::string payload; payload.resize(len);
-          if (len > 0 && fread(payload.data(), 1, len, jr) != len) { fclose(jr); throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment journal payload for " + bufferId); }
-          if (type == kRecordSegmentAppend) {
-            auto parsed = segment_records_from_json(payload);
-            if (!parsed.empty()) result.push_back(parsed[0]);
-          }
-        }
-        fclose(jr);
-      }
-      return result;
     }
-    throw std::runtime_error("SEGMENT_SPOOL_UNAVAILABLE: Missing segment checkpoint for " + bufferId);
+
+    if (hasJournal) {
+      FILE *jr = fopen(jPath.c_str(), "rb");
+      if (!jr) throw std::runtime_error("SEGMENT_SPOOL_READ_FAILED: Failed to open segment journal for " + bufferId);
+
+      if (fseek(jr, 0, SEEK_END) != 0) {
+        fclose(jr);
+        throw std::runtime_error("SEGMENT_SPOOL_READ_FAILED: Failed to inspect segment journal for " + bufferId);
+      }
+      long journalSize = ftell(jr);
+      if (journalSize < 0 || fseek(jr, 0, SEEK_SET) != 0) {
+        fclose(jr);
+        throw std::runtime_error("SEGMENT_SPOOL_READ_FAILED: Failed to read segment journal for " + bufferId);
+      }
+
+      while (true) {
+        unsigned char h[kHeaderBytes];
+        size_t n = fread(h, 1, kHeaderBytes, jr);
+        if (n == 0) break;
+        if (n != kHeaderBytes) {
+          fclose(jr);
+          throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Corrupted segment journal header for " + bufferId);
+        }
+
+        uint16_t type = 0;
+        uint32_t len = 0;
+        uint32_t checksum = 0;
+        decodeHeaderOrThrow(h, jPath, &type, &len, &checksum);
+
+        long payloadStart = ftell(jr);
+        if (payloadStart < 0 || payloadStart + static_cast<long>(len) > journalSize) {
+          fclose(jr);
+          throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment journal payload for " + bufferId);
+        }
+
+        std::string payload;
+        payload.resize(len);
+        if (len > 0 && fread(payload.data(), 1, len, jr) != len) {
+          fclose(jr);
+          throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Truncated segment journal payload for " + bufferId);
+        }
+
+        uint32_t actualChecksum = computeSpoolChecksum(payload);
+        if (actualChecksum != checksum) {
+          fclose(jr);
+          throw std::runtime_error("SEGMENT_SPOOL_CORRUPTED: Segment journal checksum mismatch for " + bufferId);
+        }
+
+        if (type == kRecordSegmentAppend) {
+          auto parsed = segment_records_from_json(payload);
+          if (!parsed.empty()) result.push_back(parsed[0]);
+        }
+      }
+
+      fclose(jr);
+    }
+
+    return result;
   }
 
   void release() {

--- a/ios/segmentbuffer/core/SherpaOnnx+SegmentBufferGlobals.h
+++ b/ios/segmentbuffer/core/SherpaOnnx+SegmentBufferGlobals.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#ifdef __cplusplus
+#ifdef __OBJC__
+#import <Foundation/Foundation.h>
+#endif
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+struct SegRecord {
+  std::string id;
+  std::string kind;
+  std::string sourceAudioBufferId;
+  int startSample = 0;
+  int endSample = 0;
+  int sampleRate = 0;
+  int durationMs = 0;
+  bool hasConfidence = false;
+  double confidence = 0.0;
+  std::string payloadJson;
+};
+
+struct SegOfflineEntry {
+  std::string bufferId;
+  std::vector<SegRecord> segments;
+  std::string sourceAudioBufferId;
+};
+
+struct SegLiveEntry;
+
+extern std::unordered_map<std::string, std::shared_ptr<SegOfflineEntry>> g_seg_offline;
+extern std::unordered_map<std::string, std::shared_ptr<SegLiveEntry>> g_seg_live;
+extern std::mutex g_seg_mutex;
+
+void seg_release_all_entries();
+#endif

--- a/ios/textbuffer/core/SherpaOnnx+TextBufferGlobals.h
+++ b/ios/textbuffer/core/SherpaOnnx+TextBufferGlobals.h
@@ -194,6 +194,9 @@ struct TxtLiveEntry {
 		return committedTextFromSegmentsLocked() + currentText;
 	}
 
+	std::string journalPath() const { return spoolPath + ".txtj"; }
+	std::string checkpointPath() const { return spoolPath + ".txtc"; }
+
 	void closeSpoolFileLocked(bool flushFirst) {
 		if (spoolFile == nullptr) {
 			return;
@@ -218,24 +221,44 @@ struct TxtLiveEntry {
 			(unsigned char)((len >> 24) & 0xFF)
 		};
 
-		const int64_t recordLength = 4 + (int64_t)len;
-		if (fseek(spoolFile, 0, SEEK_SET) != 0) {
-			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to seek text spool for " + bufferId);
+		if (fseek(spoolFile, 0, SEEK_END) != 0) {
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to seek text journal for " + bufferId);
 		}
 		if (fwrite(header, 1, 4, spoolFile) != 4) {
-			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to write spool header for " + bufferId);
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to write text journal header for " + bufferId);
 		}
 		if (len > 0 && fwrite(snapshot.data(), 1, len, spoolFile) != len) {
-			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to write spool payload for " + bufferId);
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to write text journal payload for " + bufferId);
 		}
 		if (fflush(spoolFile) != 0) {
-			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to flush text spool for " + bufferId);
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to flush text journal for " + bufferId);
 		}
-		if (ftruncate(fileno(spoolFile), recordLength) != 0) {
-			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to truncate text spool for " + bufferId);
-		}
-		spoolBytes = recordLength;
+		spoolBytes = ftell(spoolFile);
 		spoolReady = true;
+	}
+
+	void writeCheckpointSnapshotLocked(const std::string &snapshot) {
+		if (spoolPath.empty()) {
+			throwSpoolError("TEXT_SPOOL_UNAVAILABLE", "Text checkpoint path is not configured for " + bufferId);
+		}
+		std::string path = checkpointPath();
+		FILE *cp = fopen(path.c_str(), "wb");
+		if (cp == nullptr) {
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to create text checkpoint for " + bufferId);
+		}
+		const uint32_t len = (uint32_t)snapshot.size();
+		unsigned char header[4] = {
+			(unsigned char)(len & 0xFF),
+			(unsigned char)((len >> 8) & 0xFF),
+			(unsigned char)((len >> 16) & 0xFF),
+			(unsigned char)((len >> 24) & 0xFF)
+		};
+		if (fwrite(header, 1, 4, cp) != 4 || (len > 0 && fwrite(snapshot.data(), 1, len, cp) != len)) {
+			fclose(cp);
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to write text checkpoint for " + bufferId);
+		}
+		fflush(cp);
+		fclose(cp);
 	}
 
 	void ensureSpoolWriterActivatedLocked(const std::string &bootstrapSnapshot) {
@@ -255,11 +278,12 @@ struct TxtLiveEntry {
 													  error:nil];
 		}
 
-		spoolFile = fopen(spoolPath.c_str(), "wb");
+		spoolFile = fopen(journalPath().c_str(), "ab+");
 		if (spoolFile == nullptr) {
-			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to create text spool file for " + bufferId);
+			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to create text journal file for " + bufferId);
 		}
 		spoolBytes = 0;
+		writeCheckpointSnapshotLocked(bootstrapSnapshot);
 		appendSnapshotRecordLocked(bootstrapSnapshot);
 	}
 
@@ -465,37 +489,48 @@ struct TxtLiveEntry {
 			}
 		}
 
-		FILE *reader = fopen(path.c_str(), "rb");
-		if (reader == nullptr) {
-			throw makeCodedError("TEXT_SPOOL_READ_FAILED", "Failed to open text spool for " + bufferId);
+		// Prefer V2-style checkpoint+journal files if present.
+		std::string cpPath = path + ".txtc";
+		std::string jPath = path + ".txtj";
+		bool hasV2 = [[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:cpPath.c_str()]] ||
+			[[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:jPath.c_str()]];
+		if (hasV2) {
+			std::string latest = "";
+			FILE *cp = fopen(cpPath.c_str(), "rb");
+			if (cp != nullptr) {
+				unsigned char h[4];
+				if (fread(h, 1, 4, cp) == 4) {
+					uint32_t len = (uint32_t)h[0] | ((uint32_t)h[1] << 8) | ((uint32_t)h[2] << 16) | ((uint32_t)h[3] << 24);
+					std::string payload; payload.resize(len);
+					if (len == 0 || fread(payload.data(), 1, len, cp) == len) latest = payload;
+				}
+				fclose(cp);
+			}
+			FILE *jr = fopen(jPath.c_str(), "rb");
+			if (jr != nullptr) {
+				while (true) {
+					unsigned char h[4];
+					size_t n = fread(h, 1, 4, jr);
+					if (n == 0) break;
+					if (n != 4) { fclose(jr); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Corrupted text journal header for " + bufferId); }
+					uint32_t len = (uint32_t)h[0] | ((uint32_t)h[1] << 8) | ((uint32_t)h[2] << 16) | ((uint32_t)h[3] << 24);
+					std::string payload; payload.resize(len);
+					if (len > 0 && fread(payload.data(), 1, len, jr) != len) { fclose(jr); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Truncated text journal payload for " + bufferId); }
+					latest = payload;
+				}
+				fclose(jr);
+			}
+			return latest;
 		}
-
+		// Legacy V1 fallback.
+		FILE *reader = fopen(path.c_str(), "rb");
+		if (reader == nullptr) throw makeCodedError("TEXT_SPOOL_READ_FAILED", "Failed to open text spool for " + bufferId);
 		unsigned char header[4];
 		size_t readHeader = fread(header, 1, 4, reader);
-		if (readHeader != 4) {
-			fclose(reader);
-			throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Corrupted text spool header for " + bufferId);
-		}
-		uint32_t len =
-			(uint32_t)header[0] |
-			((uint32_t)header[1] << 8) |
-			((uint32_t)header[2] << 16) |
-			((uint32_t)header[3] << 24);
-
-		std::string payload;
-		payload.resize(len);
-		if (len > 0) {
-			size_t readPayload = fread(payload.data(), 1, len, reader);
-			if (readPayload != len) {
-				fclose(reader);
-				throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Truncated text spool payload for " + bufferId);
-			}
-		}
-
-		if (fgetc(reader) != EOF) {
-			fclose(reader);
-			throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Unexpected trailing data in text spool for " + bufferId);
-		}
+		if (readHeader != 4) { fclose(reader); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Corrupted text spool header for " + bufferId); }
+		uint32_t len = (uint32_t)header[0] | ((uint32_t)header[1] << 8) | ((uint32_t)header[2] << 16) | ((uint32_t)header[3] << 24);
+		std::string payload; payload.resize(len);
+		if (len > 0 && fread(payload.data(), 1, len, reader) != len) { fclose(reader); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Truncated text spool payload for " + bufferId); }
 		fclose(reader);
 		return payload;
 	}
@@ -552,6 +587,8 @@ struct TxtLiveEntry {
 		}
 		if (shouldDelete) {
 			remove(pathToDelete.c_str());
+			remove((pathToDelete + ".txtj").c_str());
+			remove((pathToDelete + ".txtc").c_str());
 		}
 		{
 			std::lock_guard<std::mutex> lock(cursorMutex);

--- a/ios/textbuffer/core/SherpaOnnx+TextBufferGlobals.h
+++ b/ios/textbuffer/core/SherpaOnnx+TextBufferGlobals.h
@@ -489,12 +489,11 @@ struct TxtLiveEntry {
 			}
 		}
 
-		// Prefer V2-style checkpoint+journal files if present.
 		std::string cpPath = path + ".txtc";
 		std::string jPath = path + ".txtj";
-		bool hasV2 = [[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:cpPath.c_str()]] ||
+		bool hasSpool = [[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:cpPath.c_str()]] ||
 			[[NSFileManager defaultManager] fileExistsAtPath:[NSString stringWithUTF8String:jPath.c_str()]];
-		if (hasV2) {
+		if (hasSpool) {
 			std::string latest = "";
 			FILE *cp = fopen(cpPath.c_str(), "rb");
 			if (cp != nullptr) {
@@ -522,17 +521,7 @@ struct TxtLiveEntry {
 			}
 			return latest;
 		}
-		// Legacy V1 fallback.
-		FILE *reader = fopen(path.c_str(), "rb");
-		if (reader == nullptr) throw makeCodedError("TEXT_SPOOL_READ_FAILED", "Failed to open text spool for " + bufferId);
-		unsigned char header[4];
-		size_t readHeader = fread(header, 1, 4, reader);
-		if (readHeader != 4) { fclose(reader); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Corrupted text spool header for " + bufferId); }
-		uint32_t len = (uint32_t)header[0] | ((uint32_t)header[1] << 8) | ((uint32_t)header[2] << 16) | ((uint32_t)header[3] << 24);
-		std::string payload; payload.resize(len);
-		if (len > 0 && fread(payload.data(), 1, len, reader) != len) { fclose(reader); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Truncated text spool payload for " + bufferId); }
-		fclose(reader);
-		return payload;
+		throw makeCodedError("TEXT_SPOOL_UNAVAILABLE", "Text spool files are missing for " + bufferId);
 	}
 
 	NSDictionary *toDict() {
@@ -586,7 +575,6 @@ struct TxtLiveEntry {
 			}
 		}
 		if (shouldDelete) {
-			remove(pathToDelete.c_str());
 			remove((pathToDelete + ".txtj").c_str());
 			remove((pathToDelete + ".txtc").c_str());
 		}

--- a/ios/textbuffer/core/SherpaOnnx+TextBufferGlobals.h
+++ b/ios/textbuffer/core/SherpaOnnx+TextBufferGlobals.h
@@ -17,6 +17,7 @@
 #include <unordered_map>
 #include <unistd.h>
 #include <vector>
+#include <zlib.h>
 
 // Forward declarations of pipeline text entry structs (defined below or in textbuffer/bridge/SherpaOnnx+TextBuffer.mm).
 struct TxtOfflineEntry;
@@ -34,6 +35,14 @@ struct TextSegment {
 struct TxtLiveEntry {
 	enum State { RECORDING, FINISHED };
 	enum SpoolingMode { SPOOL_OFF, SPOOL_AUTO, SPOOL_ON };
+	static constexpr uint32_t kTextSpoolMagic = 0x32545854; // TXT2
+	static constexpr uint16_t kTextSpoolVersion = 2;
+	static constexpr uint16_t kTextSpoolRecordPartialSet = 1;
+	static constexpr uint16_t kTextSpoolRecordPartialAppend = 2;
+	static constexpr uint16_t kTextSpoolRecordSegmentCommit = 3;
+	static constexpr uint16_t kTextSpoolRecordCheckpoint = 4;
+	static constexpr uint16_t kTextSpoolRecordFinalize = 5;
+	static constexpr int kTextSpoolHeaderBytes = 16;
 
 	std::string bufferId;
 	State state = RECORDING;
@@ -197,6 +206,64 @@ struct TxtLiveEntry {
 	std::string journalPath() const { return spoolPath + ".txtj"; }
 	std::string checkpointPath() const { return spoolPath + ".txtc"; }
 
+	uint32_t computeSpoolChecksum(const std::string &payload) const {
+		uLong crc = ::crc32(0L, Z_NULL, 0);
+		if (!payload.empty()) {
+			crc = ::crc32(
+				crc,
+				reinterpret_cast<const Bytef *>(payload.data()),
+				static_cast<uInt>(payload.size())
+			);
+		}
+		return static_cast<uint32_t>(crc);
+	}
+
+	bool isKnownSpoolRecordType(uint16_t type) const {
+		return type == kTextSpoolRecordPartialSet ||
+			type == kTextSpoolRecordPartialAppend ||
+			type == kTextSpoolRecordSegmentCommit ||
+			type == kTextSpoolRecordCheckpoint ||
+			type == kTextSpoolRecordFinalize;
+	}
+
+	void decodeSpoolHeaderOrThrow(
+		const unsigned char *header,
+		const std::string &path,
+		uint16_t *recordType,
+		uint32_t *payloadLength,
+		uint32_t *checksum
+	) {
+		uint32_t magic =
+			(static_cast<uint32_t>(header[0])) |
+			(static_cast<uint32_t>(header[1]) << 8) |
+			(static_cast<uint32_t>(header[2]) << 16) |
+			(static_cast<uint32_t>(header[3]) << 24);
+		uint16_t version =
+			(static_cast<uint16_t>(header[4])) |
+			(static_cast<uint16_t>(header[5]) << 8);
+		uint16_t type =
+			(static_cast<uint16_t>(header[6])) |
+			(static_cast<uint16_t>(header[7]) << 8);
+		uint32_t length =
+			(static_cast<uint32_t>(header[8])) |
+			(static_cast<uint32_t>(header[9]) << 8) |
+			(static_cast<uint32_t>(header[10]) << 16) |
+			(static_cast<uint32_t>(header[11]) << 24);
+		uint32_t crc =
+			(static_cast<uint32_t>(header[12])) |
+			(static_cast<uint32_t>(header[13]) << 8) |
+			(static_cast<uint32_t>(header[14]) << 16) |
+			(static_cast<uint32_t>(header[15]) << 24);
+
+		if (magic != kTextSpoolMagic || version != kTextSpoolVersion || !isKnownSpoolRecordType(type)) {
+			throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Unexpected text spool record format in " + path);
+		}
+
+		*recordType = type;
+		*payloadLength = length;
+		*checksum = crc;
+	}
+
 	void closeSpoolFileLocked(bool flushFirst) {
 		if (spoolFile == nullptr) {
 			return;
@@ -208,23 +275,36 @@ struct TxtLiveEntry {
 		spoolFile = nullptr;
 	}
 
-	void appendSnapshotRecordLocked(const std::string &snapshot) {
+	void appendSnapshotRecordLocked(uint16_t recordType, const std::string &snapshot) {
 		if (spoolFile == nullptr) {
 			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Spool file is not open for " + bufferId);
 		}
 
 		const uint32_t len = (uint32_t)snapshot.size();
-		unsigned char header[4] = {
+		const uint32_t checksum = computeSpoolChecksum(snapshot);
+		unsigned char header[kTextSpoolHeaderBytes] = {
+			(unsigned char)(kTextSpoolMagic & 0xFF),
+			(unsigned char)((kTextSpoolMagic >> 8) & 0xFF),
+			(unsigned char)((kTextSpoolMagic >> 16) & 0xFF),
+			(unsigned char)((kTextSpoolMagic >> 24) & 0xFF),
+			(unsigned char)(kTextSpoolVersion & 0xFF),
+			(unsigned char)((kTextSpoolVersion >> 8) & 0xFF),
+			(unsigned char)(recordType & 0xFF),
+			(unsigned char)((recordType >> 8) & 0xFF),
 			(unsigned char)(len & 0xFF),
 			(unsigned char)((len >> 8) & 0xFF),
 			(unsigned char)((len >> 16) & 0xFF),
-			(unsigned char)((len >> 24) & 0xFF)
+			(unsigned char)((len >> 24) & 0xFF),
+			(unsigned char)(checksum & 0xFF),
+			(unsigned char)((checksum >> 8) & 0xFF),
+			(unsigned char)((checksum >> 16) & 0xFF),
+			(unsigned char)((checksum >> 24) & 0xFF)
 		};
 
 		if (fseek(spoolFile, 0, SEEK_END) != 0) {
 			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to seek text journal for " + bufferId);
 		}
-		if (fwrite(header, 1, 4, spoolFile) != 4) {
+		if (fwrite(header, 1, kTextSpoolHeaderBytes, spoolFile) != kTextSpoolHeaderBytes) {
 			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to write text journal header for " + bufferId);
 		}
 		if (len > 0 && fwrite(snapshot.data(), 1, len, spoolFile) != len) {
@@ -247,13 +327,26 @@ struct TxtLiveEntry {
 			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to create text checkpoint for " + bufferId);
 		}
 		const uint32_t len = (uint32_t)snapshot.size();
-		unsigned char header[4] = {
+		const uint32_t checksum = computeSpoolChecksum(snapshot);
+		unsigned char header[kTextSpoolHeaderBytes] = {
+			(unsigned char)(kTextSpoolMagic & 0xFF),
+			(unsigned char)((kTextSpoolMagic >> 8) & 0xFF),
+			(unsigned char)((kTextSpoolMagic >> 16) & 0xFF),
+			(unsigned char)((kTextSpoolMagic >> 24) & 0xFF),
+			(unsigned char)(kTextSpoolVersion & 0xFF),
+			(unsigned char)((kTextSpoolVersion >> 8) & 0xFF),
+			(unsigned char)(kTextSpoolRecordCheckpoint & 0xFF),
+			(unsigned char)((kTextSpoolRecordCheckpoint >> 8) & 0xFF),
 			(unsigned char)(len & 0xFF),
 			(unsigned char)((len >> 8) & 0xFF),
 			(unsigned char)((len >> 16) & 0xFF),
-			(unsigned char)((len >> 24) & 0xFF)
+			(unsigned char)((len >> 24) & 0xFF),
+			(unsigned char)(checksum & 0xFF),
+			(unsigned char)((checksum >> 8) & 0xFF),
+			(unsigned char)((checksum >> 16) & 0xFF),
+			(unsigned char)((checksum >> 24) & 0xFF)
 		};
-		if (fwrite(header, 1, 4, cp) != 4 || (len > 0 && fwrite(snapshot.data(), 1, len, cp) != len)) {
+		if (fwrite(header, 1, kTextSpoolHeaderBytes, cp) != kTextSpoolHeaderBytes || (len > 0 && fwrite(snapshot.data(), 1, len, cp) != len)) {
 			fclose(cp);
 			throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to write text checkpoint for " + bufferId);
 		}
@@ -284,7 +377,7 @@ struct TxtLiveEntry {
 		}
 		spoolBytes = 0;
 		writeCheckpointSnapshotLocked(bootstrapSnapshot);
-		appendSnapshotRecordLocked(bootstrapSnapshot);
+		appendSnapshotRecordLocked(kTextSpoolRecordCheckpoint, "{}");
 	}
 
 	void maybeWriteSnapshotToSpool(const std::string &snapshot, bool mayActivateAuto) {
@@ -306,7 +399,7 @@ struct TxtLiveEntry {
 					return;
 				case SPOOL_AUTO: {
 					if (!mayActivateAuto) return;
-					spoolEstimatedBytes += (int64_t)(4 + snapshot.size());
+					spoolEstimatedBytes += (int64_t)(kTextSpoolHeaderBytes + snapshot.size());
 					if (spoolEstimatedBytes < std::max<int64_t>(0, spoolThresholdBytes)) {
 						spoolReady = false;
 						return;
@@ -317,7 +410,7 @@ struct TxtLiveEntry {
 			}
 		}
 
-		appendSnapshotRecordLocked(snapshot);
+		appendSnapshotRecordLocked(kTextSpoolRecordPartialSet, snapshot);
 	}
 
 	void configureSpooling(SpoolingMode mode,
@@ -443,6 +536,7 @@ struct TxtLiveEntry {
 		if (spoolEnabled()) {
 			std::lock_guard<std::mutex> lock(spoolMutex);
 			if (spoolFile != nullptr) {
+				appendSnapshotRecordLocked(kTextSpoolRecordFinalize, "{}");
 				if (fflush(spoolFile) != 0) {
 					throwSpoolError("TEXT_SPOOL_WRITE_FAILED", "Failed to finalize text spool for " + bufferId);
 				}
@@ -497,25 +591,107 @@ struct TxtLiveEntry {
 			std::string latest = "";
 			FILE *cp = fopen(cpPath.c_str(), "rb");
 			if (cp != nullptr) {
-				unsigned char h[4];
-				if (fread(h, 1, 4, cp) == 4) {
-					uint32_t len = (uint32_t)h[0] | ((uint32_t)h[1] << 8) | ((uint32_t)h[2] << 16) | ((uint32_t)h[3] << 24);
-					std::string payload; payload.resize(len);
-					if (len == 0 || fread(payload.data(), 1, len, cp) == len) latest = payload;
+				if (fseek(cp, 0, SEEK_END) != 0) {
+					fclose(cp);
+					throw makeCodedError("TEXT_SPOOL_READ_FAILED", "Failed to inspect text checkpoint for " + bufferId);
 				}
+				long cpSize = ftell(cp);
+				if (cpSize < kTextSpoolHeaderBytes) {
+					fclose(cp);
+					throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Corrupted text checkpoint header for " + bufferId);
+				}
+				if (fseek(cp, 0, SEEK_SET) != 0) {
+					fclose(cp);
+					throw makeCodedError("TEXT_SPOOL_READ_FAILED", "Failed to read text checkpoint for " + bufferId);
+				}
+
+				unsigned char h[kTextSpoolHeaderBytes];
+				if (fread(h, 1, kTextSpoolHeaderBytes, cp) != kTextSpoolHeaderBytes) {
+					fclose(cp);
+					throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Corrupted text checkpoint header for " + bufferId);
+				}
+				uint16_t recordType = 0;
+				uint32_t len = 0;
+				uint32_t checksum = 0;
+				decodeSpoolHeaderOrThrow(h, cpPath, &recordType, &len, &checksum);
+				if (recordType != kTextSpoolRecordCheckpoint) {
+					fclose(cp);
+					throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Unexpected text checkpoint record type for " + bufferId);
+				}
+				if (cpSize != static_cast<long>(kTextSpoolHeaderBytes + len)) {
+					fclose(cp);
+					throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Unexpected text checkpoint size for " + bufferId);
+				}
+
+				std::string payload;
+				payload.resize(len);
+				if (len > 0 && fread(payload.data(), 1, len, cp) != len) {
+					fclose(cp);
+					throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Truncated text checkpoint payload for " + bufferId);
+				}
+				uint32_t actualChecksum = computeSpoolChecksum(payload);
+				if (actualChecksum != checksum) {
+					fclose(cp);
+					throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Text checkpoint checksum mismatch for " + bufferId);
+				}
+				latest = payload;
 				fclose(cp);
 			}
 			FILE *jr = fopen(jPath.c_str(), "rb");
 			if (jr != nullptr) {
+				if (fseek(jr, 0, SEEK_END) != 0) {
+					fclose(jr);
+					throw makeCodedError("TEXT_SPOOL_READ_FAILED", "Failed to inspect text journal for " + bufferId);
+				}
+				long journalSize = ftell(jr);
+				if (journalSize < 0 || fseek(jr, 0, SEEK_SET) != 0) {
+					fclose(jr);
+					throw makeCodedError("TEXT_SPOOL_READ_FAILED", "Failed to read text journal for " + bufferId);
+				}
+
 				while (true) {
-					unsigned char h[4];
-					size_t n = fread(h, 1, 4, jr);
+					long recordStart = ftell(jr);
+					if (recordStart < 0) {
+						fclose(jr);
+						throw makeCodedError("TEXT_SPOOL_READ_FAILED", "Failed to inspect text journal position for " + bufferId);
+					}
+					size_t n = 0;
+					unsigned char h[kTextSpoolHeaderBytes];
+					n = fread(h, 1, kTextSpoolHeaderBytes, jr);
 					if (n == 0) break;
-					if (n != 4) { fclose(jr); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Corrupted text journal header for " + bufferId); }
-					uint32_t len = (uint32_t)h[0] | ((uint32_t)h[1] << 8) | ((uint32_t)h[2] << 16) | ((uint32_t)h[3] << 24);
-					std::string payload; payload.resize(len);
-					if (len > 0 && fread(payload.data(), 1, len, jr) != len) { fclose(jr); throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Truncated text journal payload for " + bufferId); }
-					latest = payload;
+					if (n != kTextSpoolHeaderBytes) {
+						fclose(jr);
+						throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Corrupted text journal header for " + bufferId);
+					}
+					uint16_t recordType = 0;
+					uint32_t len = 0;
+					uint32_t checksum = 0;
+					decodeSpoolHeaderOrThrow(h, jPath, &recordType, &len, &checksum);
+
+					long payloadStart = ftell(jr);
+					if (payloadStart < 0 || payloadStart + static_cast<long>(len) > journalSize) {
+						fclose(jr);
+						throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Truncated text journal payload for " + bufferId);
+					}
+
+					std::string payload;
+					payload.resize(len);
+					if (len > 0 && fread(payload.data(), 1, len, jr) != len) {
+						fclose(jr);
+						throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Truncated text journal payload for " + bufferId);
+					}
+
+					uint32_t actualChecksum = computeSpoolChecksum(payload);
+					if (actualChecksum != checksum) {
+						fclose(jr);
+						throw makeCodedError("TEXT_SPOOL_CORRUPTED", "Text journal checksum mismatch for " + bufferId);
+					}
+
+					if (recordType == kTextSpoolRecordPartialSet ||
+						recordType == kTextSpoolRecordPartialAppend ||
+						recordType == kTextSpoolRecordSegmentCommit) {
+						latest = payload;
+					}
 				}
 				fclose(jr);
 			}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,11 @@
       "types": "./lib/typescript/src/textbuffer/index.d.ts",
       "default": "./lib/module/textbuffer/index.js"
     },
+    "./segmentbuffer": {
+      "source": "./src/segmentbuffer/index.ts",
+      "types": "./lib/typescript/src/segmentbuffer/index.d.ts",
+      "default": "./lib/module/segmentbuffer/index.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -603,6 +603,118 @@ export interface Spec extends TurboModule {
   /** Return number of committed segments currently retained in the live segment log. */
   getLiveTextBufferSegmentCount(liveBufferId: string): Promise<number>;
 
+  // ==================== Pipeline Segment Buffers ====================
+
+  createLiveSegmentBuffer(options: {
+    sourceAudioBufferId?: string;
+    maxSegments?: number;
+    spoolingMode?: string;
+    spoolingPath?: string;
+    spoolingTemporary?: boolean;
+    spoolingThresholdBytes?: number;
+  }): Promise<{
+    bufferId: string;
+    kind: string;
+    state: string;
+    segmentCount?: number;
+    totalSegmentsWritten?: number;
+    sourceAudioBufferId?: string;
+    spoolMode?: string;
+    spoolEnabled?: boolean;
+    spoolReady?: boolean;
+    spoolBytes?: number;
+    spoolPath?: string;
+  }>;
+
+  createEmptyOfflineSegmentBuffer(options?: {
+    sourceAudioBufferId?: string;
+  }): Promise<{
+    bufferId: string;
+    kind: string;
+    state: string;
+    segmentCount?: number;
+    sourceAudioBufferId?: string;
+  }>;
+
+  appendLiveSegment(
+    liveBufferId: string,
+    kind: string,
+    sourceAudioBufferId: string,
+    startSample: number,
+    endSample: number,
+    sampleRate: number,
+    durationMs?: number,
+    confidence?: number,
+    payload?: Object
+  ): Promise<{ segmentId: string; segmentIndex: number }>;
+
+  finalizeLiveSegmentBuffer(liveBufferId: string): Promise<void>;
+
+  createOfflineSegmentBufferFromLive(
+    liveBufferId: string,
+    mode?: string
+  ): Promise<{
+    bufferId: string;
+    kind: string;
+    state: string;
+    segmentCount?: number;
+    sourceAudioBufferId?: string;
+  }>;
+
+  getPipelineSegmentBufferInfo(bufferId: string): Promise<{
+    bufferId: string;
+    kind: string;
+    state: string;
+    segmentCount?: number;
+    totalSegmentsWritten?: number;
+    sourceAudioBufferId?: string;
+    spoolMode?: string;
+    spoolEnabled?: boolean;
+    spoolReady?: boolean;
+    spoolBytes?: number;
+    spoolPath?: string;
+  }>;
+
+  getOfflineSegmentBufferSegments(
+    bufferId: string,
+    start?: number,
+    maxCount?: number
+  ): Promise<{
+    segments: Array<{
+      id: string;
+      kind: string;
+      sourceAudioBufferId: string;
+      startSample: number;
+      endSample: number;
+      sampleRate: number;
+      durationMs: number;
+      confidence?: number;
+      payload?: Object;
+    }>;
+  }>;
+
+  getLiveSegmentBufferSegments(
+    liveBufferId: string,
+    startIndex: number,
+    maxCount: number
+  ): Promise<{
+    segments: Array<{
+      id: string;
+      kind: string;
+      sourceAudioBufferId: string;
+      startSample: number;
+      endSample: number;
+      sampleRate: number;
+      durationMs: number;
+      confidence?: number;
+      payload?: Object;
+    }>;
+  }>;
+
+  getLiveSegmentBufferSegmentCount(liveBufferId: string): Promise<number>;
+
+  releasePipelineSegmentBuffer(bufferId: string): Promise<void>;
+
   // ==================== TTS Methods ====================
 
   /**

--- a/src/segmentbuffer/index.ts
+++ b/src/segmentbuffer/index.ts
@@ -1,0 +1,356 @@
+import { TurboModuleRegistry } from 'react-native';
+import type { Spec } from '../NativeSherpaOnnx';
+import { PipelineSegmentErrorCode } from './types';
+import type {
+  CreateEmptyOfflineSegmentBufferOptions,
+  CreateLiveSegmentBufferOptions,
+  LiveSegmentBufferInfo,
+  LiveSegmentBufferRef,
+  LiveSegmentBufferSpoolInfo,
+  LiveSegmentBufferIdSource,
+  LiveSegmentBufferRecordingSource,
+  OfflineSegmentBufferFromLiveMode,
+  OfflineSegmentBufferIdSource,
+  OfflineSegmentBufferInfo,
+  OfflineSegmentBufferRef,
+  PipelineSegmentBufferIdSource,
+  PipelineSegmentBufferInfo,
+  SegmentInput,
+  SegmentMeta,
+  SegmentBufferSpoolingMode,
+} from './types';
+
+const getNative = (): Spec =>
+  TurboModuleRegistry.getEnforcing<Spec>('SherpaOnnx');
+
+const SEGMENT_BUFFER_ID_PATTERN =
+  /^(seg_off|seg_live)_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+function assertValidSegmentBufferId(value: string, sourceName: string): string {
+  const id = value.trim();
+  if (!SEGMENT_BUFFER_ID_PATTERN.test(id)) {
+    throw new Error(
+      `${PipelineSegmentErrorCode.INVALID_ARGUMENT}: ${sourceName} must be a pipeline segment buffer id in the form seg_off_<uuid> or seg_live_<uuid>; received "${value}".`
+    );
+  }
+  return id;
+}
+
+function normalizeSpoolingMode(value: unknown): SegmentBufferSpoolingMode {
+  if (value === 'off' || value === 'auto' || value === 'on') return value;
+  return 'off';
+}
+
+function mapSpoolInfo(raw: {
+  spoolMode?: string;
+  spoolEnabled?: boolean;
+  spoolReady?: boolean;
+  spoolBytes?: number;
+  spoolPath?: string;
+}): LiveSegmentBufferSpoolInfo {
+  const mode = normalizeSpoolingMode(raw.spoolMode);
+  return {
+    mode,
+    enabled: raw.spoolEnabled ?? mode !== 'off',
+    ready: raw.spoolReady ?? false,
+    bytes: raw.spoolBytes ?? 0,
+    ...(typeof raw.spoolPath === 'string' && raw.spoolPath.length > 0
+      ? { path: raw.spoolPath }
+      : {}),
+  };
+}
+
+function mapOfflineInfo(raw: {
+  bufferId: string;
+  kind: string;
+  state: string;
+  segmentCount?: number;
+  sourceAudioBufferId?: string;
+}): OfflineSegmentBufferInfo {
+  return {
+    bufferId: raw.bufferId,
+    kind: 'offlineSegmentBuffer',
+    state: 'immutable',
+    segmentCount: raw.segmentCount ?? 0,
+    ...(typeof raw.sourceAudioBufferId === 'string' &&
+    raw.sourceAudioBufferId.length > 0
+      ? { sourceAudioBufferId: raw.sourceAudioBufferId }
+      : {}),
+  };
+}
+
+function mapLiveInfo(raw: {
+  bufferId: string;
+  kind: string;
+  state: string;
+  segmentCount?: number;
+  totalSegmentsWritten?: number;
+  spoolMode?: string;
+  spoolEnabled?: boolean;
+  spoolReady?: boolean;
+  spoolBytes?: number;
+  spoolPath?: string;
+}): LiveSegmentBufferInfo {
+  return {
+    bufferId: raw.bufferId,
+    kind: 'liveSegmentBuffer',
+    state: raw.state === 'finished' ? 'finished' : 'recording',
+    segmentCount: raw.segmentCount ?? 0,
+    totalSegmentsWritten: raw.totalSegmentsWritten ?? 0,
+    spool: mapSpoolInfo(raw),
+  };
+}
+
+function mapPipelineInfo(raw: {
+  bufferId: string;
+  kind: string;
+  state: string;
+  segmentCount?: number;
+  sourceAudioBufferId?: string;
+  totalSegmentsWritten?: number;
+  spoolMode?: string;
+  spoolEnabled?: boolean;
+  spoolReady?: boolean;
+  spoolBytes?: number;
+  spoolPath?: string;
+}): PipelineSegmentBufferInfo {
+  if (raw.kind === 'liveSegmentBuffer') return mapLiveInfo(raw);
+  return mapOfflineInfo(raw);
+}
+
+export function resolveOfflineSegmentBufferId(
+  source: OfflineSegmentBufferIdSource
+): string {
+  if (typeof source === 'object' && source !== null && 'info' in source) {
+    return assertValidSegmentBufferId(
+      String((source as OfflineSegmentBufferRef).bufferId),
+      'offline segment buffer source'
+    );
+  }
+  return assertValidSegmentBufferId(
+    String(source),
+    'offline segment buffer source'
+  );
+}
+
+export function resolveLiveSegmentBufferId(
+  source: LiveSegmentBufferIdSource
+): string {
+  if (typeof source === 'object' && source !== null && 'info' in source) {
+    return assertValidSegmentBufferId(
+      String((source as LiveSegmentBufferRef).bufferId),
+      'live segment buffer source'
+    );
+  }
+  return assertValidSegmentBufferId(
+    String(source),
+    'live segment buffer source'
+  );
+}
+
+export function resolvePipelineSegmentBufferId(
+  source: PipelineSegmentBufferIdSource
+): string {
+  if (typeof source === 'object' && source !== null) {
+    if ('info' in source) {
+      return assertValidSegmentBufferId(
+        String(
+          (source as LiveSegmentBufferRef | OfflineSegmentBufferRef).bufferId
+        ),
+        'pipeline segment buffer source'
+      );
+    }
+    if ('kind' in source && 'bufferId' in source) {
+      return assertValidSegmentBufferId(
+        String((source as PipelineSegmentBufferInfo).bufferId),
+        'pipeline segment buffer source'
+      );
+    }
+  }
+  return assertValidSegmentBufferId(
+    String(source),
+    'pipeline segment buffer source'
+  );
+}
+
+export async function createLiveSegmentBuffer(
+  options: CreateLiveSegmentBufferOptions = {}
+): Promise<LiveSegmentBufferRef> {
+  const raw = await getNative().createLiveSegmentBuffer({
+    sourceAudioBufferId: options.sourceAudioBufferId,
+    maxSegments: options.maxSegments,
+    spoolingMode: options.spooling?.mode,
+    spoolingPath: options.spooling?.path,
+    spoolingTemporary: options.spooling?.temporary,
+    spoolingThresholdBytes: options.spooling?.thresholdBytes,
+  });
+  return {
+    info: mapLiveInfo(raw),
+    bufferId: raw.bufferId as LiveSegmentBufferRef['bufferId'],
+  };
+}
+
+export async function createEmptyOfflineSegmentBuffer(
+  options: CreateEmptyOfflineSegmentBufferOptions = {}
+): Promise<OfflineSegmentBufferRef> {
+  const raw = await getNative().createEmptyOfflineSegmentBuffer({
+    sourceAudioBufferId: options.sourceAudioBufferId,
+  });
+  return {
+    info: mapOfflineInfo(raw),
+    bufferId: raw.bufferId as OfflineSegmentBufferRef['bufferId'],
+  };
+}
+
+export async function appendLiveSegment(
+  buffer: LiveSegmentBufferRecordingSource,
+  segment: SegmentInput
+): Promise<{ segmentId: string; segmentIndex: number }> {
+  const id =
+    typeof buffer === 'object' && buffer !== null && 'info' in buffer
+      ? resolveLiveSegmentBufferId(buffer as LiveSegmentBufferRef)
+      : assertValidSegmentBufferId(
+          String(buffer),
+          'live segment buffer recording source'
+        );
+  return getNative().appendLiveSegment(
+    id,
+    segment.kind ?? 'speech',
+    segment.sourceAudioBufferId,
+    segment.startSample,
+    segment.endSample,
+    segment.sampleRate,
+    segment.durationMs,
+    segment.confidence,
+    segment.payload
+  );
+}
+
+export async function finalizeLiveSegmentBuffer(
+  buffer: LiveSegmentBufferRecordingSource
+): Promise<void> {
+  const id =
+    typeof buffer === 'object' && buffer !== null && 'info' in buffer
+      ? resolveLiveSegmentBufferId(buffer as LiveSegmentBufferRef)
+      : assertValidSegmentBufferId(
+          String(buffer),
+          'live segment buffer recording source'
+        );
+  await getNative().finalizeLiveSegmentBuffer(id);
+}
+
+export async function createOfflineSegmentBufferFromLive(
+  liveBuffer: LiveSegmentBufferIdSource,
+  mode: OfflineSegmentBufferFromLiveMode = 'fullIfSpooled'
+): Promise<OfflineSegmentBufferRef> {
+  const id = resolveLiveSegmentBufferId(liveBuffer);
+  const raw = await getNative().createOfflineSegmentBufferFromLive(id, mode);
+  return {
+    info: mapOfflineInfo(raw),
+    bufferId: raw.bufferId as OfflineSegmentBufferRef['bufferId'],
+  };
+}
+
+export async function getPipelineSegmentBufferInfo(
+  buffer: PipelineSegmentBufferIdSource
+): Promise<PipelineSegmentBufferInfo> {
+  const id = resolvePipelineSegmentBufferId(buffer);
+  const raw = await getNative().getPipelineSegmentBufferInfo(id);
+  return mapPipelineInfo(raw);
+}
+
+export async function getOfflineSegmentBufferSegments(
+  buffer: OfflineSegmentBufferIdSource,
+  start = 0,
+  maxCount = 1024
+): Promise<SegmentMeta[]> {
+  const id = resolveOfflineSegmentBufferId(buffer);
+  const raw = await getNative().getOfflineSegmentBufferSegments(
+    id,
+    start,
+    maxCount
+  );
+  return raw.segments.map((segment) => ({
+    id: segment.id,
+    kind: 'speech',
+    sourceAudioBufferId: segment.sourceAudioBufferId,
+    startSample: segment.startSample,
+    endSample: segment.endSample,
+    sampleRate: segment.sampleRate,
+    durationMs: segment.durationMs,
+    ...(segment.confidence != null ? { confidence: segment.confidence } : {}),
+    ...(segment.payload != null
+      ? { payload: segment.payload as unknown as Record<string, unknown> }
+      : {}),
+  }));
+}
+
+export async function getLiveSegmentBufferSegments(
+  liveBuffer: LiveSegmentBufferIdSource,
+  startIndex: number,
+  maxCount: number
+): Promise<SegmentMeta[]> {
+  const id = resolveLiveSegmentBufferId(liveBuffer);
+  const raw = await getNative().getLiveSegmentBufferSegments(
+    id,
+    startIndex,
+    maxCount
+  );
+  return raw.segments.map((segment) => ({
+    id: segment.id,
+    kind: 'speech',
+    sourceAudioBufferId: segment.sourceAudioBufferId,
+    startSample: segment.startSample,
+    endSample: segment.endSample,
+    sampleRate: segment.sampleRate,
+    durationMs: segment.durationMs,
+    ...(segment.confidence != null ? { confidence: segment.confidence } : {}),
+    ...(segment.payload != null
+      ? { payload: segment.payload as unknown as Record<string, unknown> }
+      : {}),
+  }));
+}
+
+export async function getLiveSegmentBufferSegmentCount(
+  liveBuffer: LiveSegmentBufferIdSource
+): Promise<number> {
+  const id = resolveLiveSegmentBufferId(liveBuffer);
+  return getNative().getLiveSegmentBufferSegmentCount(id);
+}
+
+export async function releasePipelineSegmentBuffer(
+  buffer: PipelineSegmentBufferIdSource
+): Promise<void> {
+  const id = resolvePipelineSegmentBufferId(buffer);
+  await getNative().releasePipelineSegmentBuffer(id);
+}
+
+export type {
+  PipelineSegmentBufferKind,
+  SegmentKind,
+  SegmentMeta,
+  SegmentInput,
+  SegmentBufferSpoolingMode,
+  SegmentBufferSpoolingOptions,
+  LiveSegmentBufferSpoolInfo,
+  OfflineSegmentBufferState,
+  LiveSegmentBufferState,
+  OfflineSegmentBufferInfo,
+  LiveSegmentBufferInfo,
+  PipelineSegmentBufferInfo,
+  OfflineSegmentBufferHandle,
+  LiveSegmentBufferHandleRecording,
+  LiveSegmentBufferHandleFinished,
+  LiveSegmentBufferHandle,
+  OfflineSegmentBufferRef,
+  LiveSegmentBufferRef,
+  OfflineSegmentBufferIdSource,
+  LiveSegmentBufferIdSource,
+  PipelineSegmentBufferIdSource,
+  LiveSegmentBufferRecordingSource,
+  OfflineSegmentBufferFromLiveMode,
+  CreateLiveSegmentBufferOptions,
+  CreateEmptyOfflineSegmentBufferOptions,
+  PipelineSegmentErrorCodeValue,
+} from './types';
+export { PipelineSegmentErrorCode } from './types';

--- a/src/segmentbuffer/types.ts
+++ b/src/segmentbuffer/types.ts
@@ -1,0 +1,155 @@
+/**
+ * Pipeline segment buffer types for react-native-sherpa-onnx/segmentbuffer.
+ */
+
+export type PipelineSegmentBufferKind =
+  | 'offlineSegmentBuffer'
+  | 'liveSegmentBuffer';
+
+export type OfflineSegmentBufferState = 'immutable';
+export type LiveSegmentBufferState = 'recording' | 'finished';
+
+export type SegmentKind = 'speech';
+
+export type SegmentBufferSpoolingMode = 'off' | 'auto' | 'on';
+
+export interface SegmentBufferSpoolingOptions {
+  mode?: SegmentBufferSpoolingMode;
+  path?: string;
+  temporary?: boolean;
+  thresholdBytes?: number;
+}
+
+export interface LiveSegmentBufferSpoolInfo {
+  mode: SegmentBufferSpoolingMode;
+  enabled: boolean;
+  ready: boolean;
+  bytes: number;
+  path?: string;
+}
+
+export interface SegmentMeta {
+  id: string;
+  kind: SegmentKind;
+  sourceAudioBufferId: string;
+  startSample: number;
+  endSample: number;
+  sampleRate: number;
+  durationMs: number;
+  confidence?: number;
+  payload?: Record<string, unknown>;
+}
+
+export interface SegmentInput {
+  kind?: SegmentKind;
+  sourceAudioBufferId: string;
+  startSample: number;
+  endSample: number;
+  sampleRate: number;
+  durationMs?: number;
+  confidence?: number;
+  payload?: Record<string, unknown>;
+}
+
+export interface OfflineSegmentBufferInfo {
+  bufferId: string;
+  kind: 'offlineSegmentBuffer';
+  state: OfflineSegmentBufferState;
+  segmentCount: number;
+  sourceAudioBufferId?: string;
+}
+
+export interface LiveSegmentBufferInfo {
+  bufferId: string;
+  kind: 'liveSegmentBuffer';
+  state: LiveSegmentBufferState;
+  segmentCount: number;
+  totalSegmentsWritten: number;
+  spool: LiveSegmentBufferSpoolInfo;
+}
+
+export type PipelineSegmentBufferInfo =
+  | OfflineSegmentBufferInfo
+  | LiveSegmentBufferInfo;
+
+export type OfflineSegmentBufferHandle = string & {
+  readonly __brand: 'OfflineSegmentBufferHandle';
+};
+
+export type LiveSegmentBufferHandleRecording = string & {
+  readonly __brand: 'LiveSegmentBufferHandleRecording';
+};
+
+export type LiveSegmentBufferHandleFinished = string & {
+  readonly __brand: 'LiveSegmentBufferHandleFinished';
+};
+
+export type LiveSegmentBufferHandle =
+  | LiveSegmentBufferHandleRecording
+  | LiveSegmentBufferHandleFinished;
+
+export interface OfflineSegmentBufferRef {
+  info: OfflineSegmentBufferInfo;
+  bufferId: OfflineSegmentBufferHandle;
+}
+
+export interface LiveSegmentBufferRef {
+  info: LiveSegmentBufferInfo;
+  bufferId: LiveSegmentBufferHandleRecording;
+}
+
+export type OfflineSegmentBufferIdSource =
+  | OfflineSegmentBufferRef
+  | OfflineSegmentBufferHandle
+  | string;
+
+export type LiveSegmentBufferIdSource =
+  | LiveSegmentBufferRef
+  | LiveSegmentBufferHandleRecording
+  | LiveSegmentBufferHandleFinished
+  | string;
+
+export type PipelineSegmentBufferIdSource =
+  | OfflineSegmentBufferRef
+  | LiveSegmentBufferRef
+  | PipelineSegmentBufferInfo
+  | OfflineSegmentBufferHandle
+  | LiveSegmentBufferHandleRecording
+  | LiveSegmentBufferHandleFinished
+  | string;
+
+export type LiveSegmentBufferRecordingSource =
+  | LiveSegmentBufferRef
+  | LiveSegmentBufferHandleRecording
+  | string;
+
+export type OfflineSegmentBufferFromLiveMode =
+  | 'fullIfSpooled'
+  | 'windowSnapshot';
+
+export interface CreateLiveSegmentBufferOptions {
+  sourceAudioBufferId?: string;
+  maxSegments?: number;
+  spooling?: SegmentBufferSpoolingOptions;
+}
+
+export interface CreateEmptyOfflineSegmentBufferOptions {
+  sourceAudioBufferId?: string;
+}
+
+export const PipelineSegmentErrorCode = {
+  BUFFER_NOT_FOUND: 'SEGMENT_BUFFER_NOT_FOUND',
+  BUFFER_KIND_MISMATCH: 'SEGMENT_BUFFER_KIND_MISMATCH',
+  INVALID_ARGUMENT: 'SEGMENT_INVALID_ARGUMENT',
+  INVALID_STATE: 'SEGMENT_INVALID_STATE',
+  ALREADY_FINALIZED: 'SEGMENT_ALREADY_FINALIZED',
+  SLICE_INVALID: 'SEGMENT_SLICE_INVALID',
+  SPOOL_UNAVAILABLE: 'SEGMENT_SPOOL_UNAVAILABLE',
+  SPOOL_WRITE_FAILED: 'SEGMENT_SPOOL_WRITE_FAILED',
+  SPOOL_READ_FAILED: 'SEGMENT_SPOOL_READ_FAILED',
+  SPOOL_CORRUPTED: 'SEGMENT_SPOOL_CORRUPTED',
+  INTERNAL_ERROR: 'SEGMENT_INTERNAL_ERROR',
+} as const;
+
+export type PipelineSegmentErrorCodeValue =
+  (typeof PipelineSegmentErrorCode)[keyof typeof PipelineSegmentErrorCode];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
       "react-native-sherpa-onnx/pcm": ["./src/pcm/index.ts"],
       "react-native-sherpa-onnx/audiobuffer": ["./src/audiobuffer/index.ts"],
       "react-native-sherpa-onnx/textbuffer": ["./src/textbuffer/index.ts"],
+      "react-native-sherpa-onnx/segmentbuffer": ["./src/segmentbuffer/index.ts"],
       "react-native-sherpa-onnx/fileio": ["./src/fileio/index.ts"],
       "react-native-sherpa-onnx/stt": ["./src/stt/index.ts"],
       "react-native-sherpa-onnx/model-languages": ["./src/model-languages/index.ts"],


### PR DESCRIPTION
This pull request introduces a new "segment buffer" pipeline to the Android module, enabling advanced management of audio segments, including live and offline buffering, segment spooling to disk, and segment retrieval. The changes add a new `LiveSegmentEntry` class, extend the main module with a comprehensive set of segment buffer methods, and ensure proper initialization and cleanup of segment pipeline resources.

**Segment Buffer Pipeline Integration**

* Added initialization and cleanup for the segment pipeline registry in the main module lifecycle, ensuring segment buffers are correctly managed alongside existing text pipelines. [[1]](diffhunk://#diff-879656a663809608669376c509d884bda0e032ec094f58ce4e41a60afbbcf80dR154-R156) [[2]](diffhunk://#diff-879656a663809608669376c509d884bda0e032ec094f58ce4e41a60afbbcf80dR190)

**New Segment Buffer Functionality**

* Introduced a suite of new methods to `SherpaOnnxModule` for segment buffer management, including creation (live and offline), appending segments, finalizing, converting between live and offline, querying buffer info, retrieving segments, counting segments, and releasing resources.

**Core Implementation: LiveSegmentEntry**

* Added the new `LiveSegmentEntry` class, which implements the logic for live segment buffer management, including:
  - In-memory segment storage with eviction,
  - Spooling to disk with support for various modes (ON, OFF, AUTO),
  - Segment append, finalize, and retrieval operations,
  - Safe concurrent access and error handling,
  - Serialization/deserialization for React Native bridge communication.