### PR TITLE
Feat/add segmentation engine stt integration

### DIFF
--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -2208,6 +2208,38 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     }
   }
 
+  override fun populateOfflineTextBufferIfEmpty(
+    bufferId: String,
+    text: String,
+    options: ReadableMap?,
+    promise: Promise,
+  ) {
+    try {
+      val entry = com.sherpaonnx.text.pipeline.TextPipelineRegistry.getOffline(bufferId)
+      if (entry == null) {
+        promise.reject(
+          com.sherpaonnx.text.pipeline.TextErrorCodes.BUFFER_NOT_FOUND,
+          "Offline text buffer not found: $bufferId"
+        )
+        return
+      }
+      entry.populate(
+        text = text,
+        tokens = emptyArray(),
+        timestamps = floatArrayOf(),
+        durations = floatArrayOf(),
+        lang = options?.getString("lang") ?: "",
+        emotion = options?.getString("emotion") ?: "",
+        event = options?.getString("event") ?: "",
+      )
+      promise.resolve(null)
+    } catch (e: IllegalStateException) {
+      promise.reject(com.sherpaonnx.text.pipeline.TextErrorCodes.ALREADY_POPULATED, e.message, e)
+    } catch (e: Exception) {
+      promise.reject(com.sherpaonnx.text.pipeline.TextErrorCodes.INTERNAL_ERROR, e.message, e)
+    }
+  }
+
   override fun createLiveTextBuffer(options: ReadableMap, promise: Promise) {
     try {
       val windowMaxChars = if (options.hasKey("windowMaxChars")) options.getDouble("windowMaxChars").toInt() else 65536
@@ -2850,6 +2882,10 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     policy.putInt("maxSegmentMs", info.policy.maxSegmentMs)
     policy.putInt("hangoverMs", info.policy.hangoverMs)
     policy.putInt("checkpointIntervalMs", info.policy.checkpointIntervalMs)
+    info.policy.vadModelId?.let { policy.putString("vadModelId", it) }
+    info.policy.vadThreshold?.let { policy.putDouble("vadThreshold", it) }
+    info.policy.vadMinSpeechMs?.let { policy.putInt("vadMinSpeechMs", it) }
+    info.policy.vadMinSilenceMs?.let { policy.putInt("vadMinSilenceMs", it) }
     out.putMap("policy", policy)
 
     return out

--- a/android/src/main/java/com/sherpaonnx/segment/engine/SegmentationEngineRegistry.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/engine/SegmentationEngineRegistry.kt
@@ -7,6 +7,12 @@ import com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry
 import com.sherpaonnx.segment.pipeline.SegmentRecord
 import com.sherpaonnx.text.pipeline.TextPipelineRegistry
 import com.sherpaonnx.text.pipeline.LiveTextEntry
+import com.sherpaonnx.vad.core.VadRuntime
+import com.sherpaonnx.vad.core.VadRuntimeOptions
+import com.sherpaonnx.vad.core.createVadRuntime
+import com.sherpaonnx.vad.core.defaultRuntimeOptions
+import com.sherpaonnx.vad.core.withRuntimeOverrides
+import java.io.File
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.log10
@@ -34,6 +40,10 @@ data class SegmentationEnginePolicy(
   val maxSegmentMs: Int = 30000,
   val hangoverMs: Int = 300,
   val checkpointIntervalMs: Int = 0,
+  val vadModelId: String? = null,
+  val vadThreshold: Double? = null,
+  val vadMinSpeechMs: Int? = null,
+  val vadMinSilenceMs: Int? = null,
 )
 
 data class SegmentationEngineInfoSnapshot(
@@ -365,6 +375,296 @@ private class SpeechEnergySilenceEngine(
   }
 }
 
+private fun inferVadModelType(modelPath: String): String {
+  val lower = modelPath.lowercase()
+  return if (lower.contains("ten")) "ten_vad" else "silero_vad"
+}
+
+private fun resolveVadModelPath(modelId: String): String {
+  val raw = modelId.trim()
+  if (raw.isEmpty()) {
+    throw SegmentationEngineException(
+      code = "POLICY_MODEL_UNAVAILABLE",
+      message = "speech_vad_model requires non-empty vadModelId",
+    )
+  }
+
+  val direct = File(raw)
+  if (direct.isFile) return direct.absolutePath
+
+  if (direct.isDirectory) {
+    val candidates = listOf(
+      "silero_vad.onnx",
+      "silero.onnx",
+      "model.onnx",
+      "ten_vad.onnx",
+      "ten-vad.onnx",
+    )
+    for (candidate in candidates) {
+      val file = File(direct, candidate)
+      if (file.isFile) {
+        return file.absolutePath
+      }
+    }
+  }
+
+  throw SegmentationEngineException(
+    code = "POLICY_MODEL_UNAVAILABLE",
+    message = "speech_vad_model model not found for vadModelId: $modelId",
+  )
+}
+
+private fun resolveVadRuntime(
+  policy: SegmentationEnginePolicy,
+  sampleRate: Int,
+): Pair<VadRuntime, VadRuntimeOptions> {
+  val modelId = policy.vadModelId
+    ?: throw SegmentationEngineException(
+      code = "POLICY_MODEL_UNAVAILABLE",
+      message = "speech_vad_model requires policy.vadModelId",
+    )
+
+  val modelPath = resolveVadModelPath(modelId)
+  val modelType = inferVadModelType(modelPath)
+  val baseRuntimeOptions = defaultRuntimeOptions(modelType)
+  val overridden = withRuntimeOverrides(
+    base = baseRuntimeOptions,
+    scoreThreshold = policy.vadThreshold,
+    minSpeechDurationMs =
+      policy.vadMinSpeechMs ?: baseRuntimeOptions.minSpeechDurationMs,
+    minSilenceDurationMs =
+      policy.vadMinSilenceMs ?: baseRuntimeOptions.minSilenceDurationMs,
+    windowSize = null,
+    maxSpeechDurationMs = policy.maxSegmentMs,
+  )
+
+  val runtimeOptions = when (modelType) {
+    "silero_vad" -> overridden as? VadRuntimeOptions.Silero
+    "ten_vad" -> overridden as? VadRuntimeOptions.Ten
+    else -> null
+  } ?: throw SegmentationEngineException(
+    code = "POLICY_MODEL_UNAVAILABLE",
+    message = "speech_vad_model options mismatch for modelType=$modelType",
+  )
+
+  val runtime = try {
+    createVadRuntime(
+      modelType = modelType,
+      modelPath = modelPath,
+      sampleRate = sampleRate,
+      provider = "cpu",
+      numThreads = 1,
+      debug = false,
+      runtimeOptions = runtimeOptions,
+    )
+  } catch (e: Exception) {
+    throw SegmentationEngineException(
+      code = "POLICY_MODEL_UNAVAILABLE",
+      message =
+        "speech_vad_model failed to initialize runtime: ${e.message ?: "unknown error"}",
+    )
+  }
+
+  return Pair(runtime, runtimeOptions)
+}
+
+private class SpeechVadModelEngine(
+  engineId: String,
+  attachedBufferId: String,
+  policy: SegmentationEnginePolicy,
+  override val segmentBufferId: String,
+  private val runtime: VadRuntime,
+  private val runtimeOptions: VadRuntimeOptions,
+) : BaseSegmentationEngine(
+  engineId = engineId,
+  domain = EngineDomain.SPEECH,
+  attachedBufferId = attachedBufferId,
+  policy = policy,
+) {
+  private var processedSamples: Long = 0L
+  private var segmentStartSample: Long = 0L
+  private var speechSamples: Long = 0L
+  private var silenceSamples: Long = 0L
+  private var speechScoreSum: Double = 0.0
+  private var speechScoreCount: Int = 0
+  private var pendingVadSamples: FloatArray = FloatArray(0)
+
+  private fun samplesToMs(samples: Long, sampleRate: Int): Long {
+    if (sampleRate <= 0) return 0L
+    return (samples * 1000L) / sampleRate.toLong()
+  }
+
+  private fun resetSpeechState(nextSegmentStart: Long) {
+    segmentStartSample = nextSegmentStart
+    speechSamples = 0L
+    silenceSamples = 0L
+    speechScoreSum = 0.0
+    speechScoreCount = 0
+  }
+
+  private fun appendSegment(
+    endSampleExclusive: Long,
+    sampleRate: Int,
+    reason: String,
+    score: Double?,
+  ) {
+    if (endSampleExclusive <= segmentStartSample) {
+      resetSpeechState(endSampleExclusive)
+      return
+    }
+
+    val durationMs = samplesToMs(endSampleExclusive - segmentStartSample, sampleRate)
+    if (durationMs < runtimeOptions.minSpeechDurationMs.toLong()) {
+      resetSpeechState(endSampleExclusive)
+      return
+    }
+
+    val segEntry = SegmentPipelineRegistry.getLive(segmentBufferId) ?: return
+    val payload = JSONObject()
+      .put("source", "vad")
+      .put("engine", "vad")
+      .put("decision", "model")
+    if (score != null && score.isFinite()) {
+      payload.put("score", score)
+    }
+
+    val (segmentId, segmentIndex) = segEntry.appendSegment(
+      kind = "speech",
+      sourceAudioBufferId = attachedBufferId,
+      startSample = segmentStartSample.toInt(),
+      endSample = endSampleExclusive.toInt(),
+      sampleRate = sampleRate,
+      durationMs = durationMs.toInt(),
+      confidence = null,
+      payloadJson = payload.toString(),
+    )
+
+    SegmentationEngineRegistry.recordSegmentAnnotation(
+      segmentId = segmentId,
+      annotation = SegmentAnnotationSnapshot(
+        reason = reason,
+        source = "segmentation_engine",
+        createdAtMs = nowMs(),
+        segmentIndex = segmentIndex,
+      )
+    )
+
+    totalSegmentsCommitted += 1
+    lastSegmentId = segmentId
+    resetSpeechState(endSampleExclusive)
+  }
+
+  private fun processVadFrame(
+    frame: FloatArray,
+    effectiveSamples: Int,
+    sampleRate: Int,
+  ) {
+    if (effectiveSamples <= 0) return
+
+    val decision = runtime.infer(frame, sampleRate)
+    if (decision.isSpeech) {
+      if (speechSamples == 0L) {
+        segmentStartSample = processedSamples
+      }
+      speechSamples += effectiveSamples.toLong()
+      silenceSamples = 0L
+      if (decision.score != null) {
+        speechScoreSum += decision.score
+        speechScoreCount += 1
+      }
+    } else if (speechSamples > 0L) {
+      silenceSamples += effectiveSamples.toLong()
+      if (samplesToMs(silenceSamples, sampleRate) >= runtimeOptions.minSilenceDurationMs.toLong()) {
+        val avgScore = if (speechScoreCount > 0) {
+          speechScoreSum / speechScoreCount.toDouble()
+        } else {
+          null
+        }
+        appendSegment(
+          endSampleExclusive = segmentStartSample + speechSamples,
+          sampleRate = sampleRate,
+          reason = "vad_boundary",
+          score = avgScore,
+        )
+      }
+    }
+
+    if (
+      speechSamples > 0L &&
+      samplesToMs(speechSamples, sampleRate) >= policy.maxSegmentMs.toLong()
+    ) {
+      val avgScore = if (speechScoreCount > 0) {
+        speechScoreSum / speechScoreCount.toDouble()
+      } else {
+        null
+      }
+      appendSegment(
+        endSampleExclusive = segmentStartSample + speechSamples,
+        sampleRate = sampleRate,
+        reason = "length_limit",
+        score = avgScore,
+      )
+    }
+
+    processedSamples += effectiveSamples.toLong()
+  }
+
+  override fun evaluateAudioChunk(
+    chunk: FloatArray,
+    sampleRate: Int,
+    totalSamplesWritten: Long,
+  ) {
+    if (currentState != EngineState.ACTIVE) return
+    if (chunk.isEmpty() || sampleRate <= 0) return
+
+    val frameSize = runtimeOptions.windowSize.coerceAtLeast(1)
+    val merged = FloatArray(pendingVadSamples.size + chunk.size)
+    pendingVadSamples.copyInto(merged, 0, 0, pendingVadSamples.size)
+    chunk.copyInto(merged, pendingVadSamples.size, 0, chunk.size)
+
+    var offset = 0
+    while (offset + frameSize <= merged.size) {
+      val frame = merged.copyOfRange(offset, offset + frameSize)
+      processVadFrame(frame, frameSize, sampleRate)
+      offset += frameSize
+    }
+
+    pendingVadSamples = if (offset < merged.size) {
+      merged.copyOfRange(offset, merged.size)
+    } else {
+      FloatArray(0)
+    }
+  }
+
+  override fun flush() {
+    if (currentState != EngineState.ACTIVE) return
+    val live = PipelineAudioRegistry.getLive(attachedBufferId) ?: return
+    val sampleRate = live.sampleRate
+
+    val frameSize = runtimeOptions.windowSize.coerceAtLeast(1)
+    if (pendingVadSamples.isNotEmpty()) {
+      val tail = FloatArray(frameSize)
+      pendingVadSamples.copyInto(tail, 0, 0, pendingVadSamples.size)
+      processVadFrame(tail, pendingVadSamples.size, sampleRate)
+      pendingVadSamples = FloatArray(0)
+    }
+
+    if (speechSamples > 0L) {
+      appendSegment(
+        endSampleExclusive = segmentStartSample + speechSamples,
+        sampleRate = sampleRate,
+        reason = "finalize",
+        score = null,
+      )
+    }
+  }
+
+  override fun release() {
+    super.release()
+    runtime.close()
+  }
+}
+
 private fun normalizeDomain(raw: String): EngineDomain {
   return when (raw.lowercase()) {
     "text" -> EngineDomain.TEXT
@@ -397,6 +697,15 @@ private fun readBoolean(
 ): Boolean {
   val raw = map[key] as? Boolean ?: return defaultValue
   return raw
+}
+
+private fun readString(
+  map: Map<String, Any?>,
+  key: String,
+): String? {
+  val raw = map[key] as? String ?: return null
+  val trimmed = raw.trim()
+  return if (trimmed.isEmpty()) null else trimmed
 }
 
 private fun parsePolicy(
@@ -450,6 +759,10 @@ private fun parsePolicy(
     hangoverMs = readInt(rawPolicy, "hangoverMs", 300).coerceAtLeast(0),
     checkpointIntervalMs =
       readInt(rawPolicy, "checkpointIntervalMs", 0).coerceAtLeast(0),
+    vadModelId = readString(rawPolicy, "vadModelId"),
+    vadThreshold = (rawPolicy["vadThreshold"] as? Number)?.toDouble(),
+    vadMinSpeechMs = (rawPolicy["vadMinSpeechMs"] as? Number)?.toInt(),
+    vadMinSilenceMs = (rawPolicy["vadMinSilenceMs"] as? Number)?.toInt(),
   )
 }
 
@@ -537,21 +850,33 @@ object SegmentationEngineRegistry {
           segmentEventMinIntervalMs = 0L,
         )
 
-        val effectivePolicy =
-          if (policy.evaluator == "speech_vad_model") {
-            policy.copy(evaluator = "speech_vad_model")
-          } else if (policy.evaluator == "continuous_frames") {
-            policy.copy(evaluator = "continuous_frames")
-          } else {
-            policy
-          }
+        val effectivePolicy = if (policy.evaluator == "continuous_frames") {
+          policy.copy(evaluator = "continuous_frames")
+        } else {
+          policy
+        }
 
-        SpeechEnergySilenceEngine(
-          engineId = engineId,
-          attachedBufferId = bufferId,
-          policy = effectivePolicy,
-          segmentBufferId = segmentEntry.bufferId,
-        )
+        if (effectivePolicy.evaluator == "speech_vad_model") {
+          val (runtime, runtimeOptions) = resolveVadRuntime(
+            policy = effectivePolicy,
+            sampleRate = live.sampleRate,
+          )
+          SpeechVadModelEngine(
+            engineId = engineId,
+            attachedBufferId = bufferId,
+            policy = effectivePolicy,
+            segmentBufferId = segmentEntry.bufferId,
+            runtime = runtime,
+            runtimeOptions = runtimeOptions,
+          )
+        } else {
+          SpeechEnergySilenceEngine(
+            engineId = engineId,
+            attachedBufferId = bufferId,
+            policy = effectivePolicy,
+            segmentBufferId = segmentEntry.bufferId,
+          )
+        }
       }
     }
 
@@ -666,7 +991,7 @@ object SegmentationEngineRegistry {
   }
 
   fun peekSegmentAnnotation(segmentId: String): SegmentAnnotationSnapshot? {
-    return segmentAnnotationBySegmentId.remove(segmentId)
+    return segmentAnnotationBySegmentId[segmentId]
   }
 
   fun segmentOfflineBuffer(
@@ -739,54 +1064,238 @@ object SegmentationEngineRegistry {
             message = "Offline audio buffer not found: $bufferId",
           )
 
-        val samples = offline.readAllSamples()
         val sr = offline.sampleRate
-        val minSamples = ((policy.minSegmentMs.toDouble() * sr) / 1000.0).toInt().coerceAtLeast(1)
-        val maxSamples = ((policy.maxSegmentMs.toDouble() * sr) / 1000.0).toInt().coerceAtLeast(minSamples)
-        val silenceSamples =
-          (((policy.silenceThresholdMs + policy.hangoverMs).toDouble() * sr) / 1000.0)
-            .toInt()
-            .coerceAtLeast(1)
-
         val records = ArrayList<SegmentRecord>()
-        var start = 0
-        var cursor = 0
-        var silenceRun = 0
-        val frameSize = (sr / 50).coerceAtLeast(160)
 
-        while (cursor < samples.size) {
-          val end = minOf(samples.size, cursor + frameSize)
-          val frame = samples.copyOfRange(cursor, end)
-          var sum = 0.0
-          for (value in frame) {
-            sum += value * value
-          }
-          val rms = if (frame.isEmpty()) 0.0 else sqrt(sum / frame.size)
-          val db = if (rms <= 1e-9) -120.0 else 20.0 * log10(rms)
-          if (db < policy.energyThresholdDb) {
-            silenceRun += frame.size
-          } else {
-            silenceRun = 0
-          }
+        if (policy.evaluator == "speech_vad_model") {
+          val (runtime, runtimeOptions) = resolveVadRuntime(policy, sr)
+          try {
+            val frameSize = runtimeOptions.windowSize.coerceAtLeast(1)
+            val chunkSize = (frameSize * 8).coerceAtLeast(frameSize)
+            var cursor = 0
+            var processedSamples = 0
+            var segmentStart = 0
+            var speechSamples = 0
+            var silenceSamples = 0
+            var scoreSum = 0.0
+            var scoreCount = 0
+            var pending = FloatArray(0)
 
-          val segmentSize = end - start
-          val shouldCommitSilence =
-            silenceRun >= silenceSamples && segmentSize >= minSamples
-          val shouldCommitLength = segmentSize >= maxSamples
-
-          if (shouldCommitSilence || shouldCommitLength) {
-            val reason = if (policy.evaluator == "speech_vad_model") {
-              "vad_boundary"
-            } else if (shouldCommitSilence) {
-              "energy_silence"
-            } else {
-              "length_limit"
+            fun samplesToMs(samples: Int): Int {
+              if (sr <= 0) return 0
+              return (samples * 1000) / sr
             }
+
+            fun resetState(nextStartSample: Int) {
+              segmentStart = nextStartSample
+              speechSamples = 0
+              silenceSamples = 0
+              scoreSum = 0.0
+              scoreCount = 0
+            }
+
+            fun appendVadRecord(reason: String, score: Double?) {
+              val endExclusive = segmentStart + speechSamples
+              if (endExclusive <= segmentStart) {
+                resetState(processedSamples)
+                return
+              }
+              val durationMs = samplesToMs(endExclusive - segmentStart)
+              if (durationMs < runtimeOptions.minSpeechDurationMs) {
+                resetState(processedSamples)
+                return
+              }
+
+              val payload = JSONObject()
+                .put("source", "vad")
+                .put("engine", "vad")
+                .put("decision", "model")
+              if (score != null && score.isFinite()) {
+                payload.put("score", score)
+              }
+
+              val record = SegmentRecord(
+                id = "seg_${UUID.randomUUID()}",
+                kind = "speech",
+                sourceAudioBufferId = bufferId,
+                startSample = segmentStart,
+                endSample = endExclusive,
+                sampleRate = sr,
+                durationMs = durationMs,
+                confidence = null,
+                payloadJson = payload.toString(),
+              )
+              records.add(record)
+              val segmentIndex = records.lastIndex
+              recordSegmentAnnotation(
+                record.id,
+                SegmentAnnotationSnapshot(
+                  reason = reason,
+                  source = "segmentation_engine",
+                  createdAtMs = nowMs(),
+                  segmentIndex = segmentIndex,
+                )
+              )
+              resetState(endExclusive)
+            }
+
+            fun processFrame(frame: FloatArray, effectiveSamples: Int) {
+              if (effectiveSamples <= 0) return
+              val decision = runtime.infer(frame, sr)
+
+              if (decision.isSpeech) {
+                if (speechSamples == 0) {
+                  segmentStart = processedSamples
+                }
+                speechSamples += effectiveSamples
+                silenceSamples = 0
+                if (decision.score != null) {
+                  scoreSum += decision.score
+                  scoreCount += 1
+                }
+              } else if (speechSamples > 0) {
+                silenceSamples += effectiveSamples
+                if (samplesToMs(silenceSamples) >= runtimeOptions.minSilenceDurationMs) {
+                  val avgScore = if (scoreCount > 0) {
+                    scoreSum / scoreCount.toDouble()
+                  } else {
+                    null
+                  }
+                  appendVadRecord("vad_boundary", avgScore)
+                }
+              }
+
+              if (speechSamples > 0 && samplesToMs(speechSamples) >= policy.maxSegmentMs) {
+                val avgScore = if (scoreCount > 0) {
+                  scoreSum / scoreCount.toDouble()
+                } else {
+                  null
+                }
+                appendVadRecord("length_limit", avgScore)
+              }
+
+              processedSamples += effectiveSamples
+            }
+
+            while (cursor < offline.numSamples) {
+              val count = minOf(chunkSize, offline.numSamples - cursor)
+              val chunk = offline.readSlice(cursor, count)
+              cursor += chunk.size
+              if (chunk.isEmpty()) break
+
+              val merged = FloatArray(pending.size + chunk.size)
+              pending.copyInto(merged, 0, 0, pending.size)
+              chunk.copyInto(merged, pending.size, 0, chunk.size)
+
+              var offset = 0
+              while (offset + frameSize <= merged.size) {
+                val frame = merged.copyOfRange(offset, offset + frameSize)
+                processFrame(frame, frameSize)
+                offset += frameSize
+              }
+
+              pending = if (offset < merged.size) {
+                merged.copyOfRange(offset, merged.size)
+              } else {
+                FloatArray(0)
+              }
+            }
+
+            if (pending.isNotEmpty()) {
+              val tail = FloatArray(frameSize)
+              pending.copyInto(tail, 0, 0, pending.size)
+              processFrame(tail, pending.size)
+              pending = FloatArray(0)
+            }
+
+            if (speechSamples > 0) {
+              appendVadRecord("finalize", null)
+            }
+          } finally {
+            runtime.close()
+          }
+        } else {
+          val samples = offline.readAllSamples()
+          val minSamples = ((policy.minSegmentMs.toDouble() * sr) / 1000.0).toInt().coerceAtLeast(1)
+          val maxSamples = ((policy.maxSegmentMs.toDouble() * sr) / 1000.0).toInt().coerceAtLeast(minSamples)
+          val silenceSamples =
+            (((policy.silenceThresholdMs + policy.hangoverMs).toDouble() * sr) / 1000.0)
+              .toInt()
+              .coerceAtLeast(1)
+
+          var start = 0
+          var cursor = 0
+          var silenceRun = 0
+          val frameSize = (sr / 50).coerceAtLeast(160)
+
+          while (cursor < samples.size) {
+            val end = minOf(samples.size, cursor + frameSize)
+            val frame = samples.copyOfRange(cursor, end)
+            var sum = 0.0
+            for (value in frame) {
+              sum += value * value
+            }
+            val rms = if (frame.isEmpty()) 0.0 else sqrt(sum / frame.size)
+            val db = if (rms <= 1e-9) -120.0 else 20.0 * log10(rms)
+            if (db < policy.energyThresholdDb) {
+              silenceRun += frame.size
+            } else {
+              silenceRun = 0
+            }
+
+            val segmentSize = end - start
+            val shouldCommitSilence =
+              silenceRun >= silenceSamples && segmentSize >= minSamples
+            val shouldCommitLength = segmentSize >= maxSamples
+
+            if (shouldCommitSilence || shouldCommitLength) {
+              val reason = if (shouldCommitSilence) {
+                "energy_silence"
+              } else {
+                "length_limit"
+              }
+              val payload = JSONObject()
+                .put("source", "vad")
+                .put("engine", "vad")
+                .put("decision", "model")
+                .put("score", db)
+                .toString()
+              records.add(
+                SegmentRecord(
+                  id = "seg_${UUID.randomUUID()}",
+                  kind = "speech",
+                  sourceAudioBufferId = bufferId,
+                  startSample = start,
+                  endSample = end,
+                  sampleRate = sr,
+                  durationMs = (((end - start) * 1000.0) / sr).toInt(),
+                  confidence = null,
+                  payloadJson = payload,
+                )
+              )
+              val segmentIndex = records.lastIndex
+              recordSegmentAnnotation(
+                records.last().id,
+                SegmentAnnotationSnapshot(
+                  reason = reason,
+                  source = "segmentation_engine",
+                  createdAtMs = nowMs(),
+                  segmentIndex = segmentIndex,
+                )
+              )
+              start = end
+              silenceRun = 0
+            }
+
+            cursor = end
+          }
+
+          if (start < samples.size) {
+            val end = samples.size
             val payload = JSONObject()
               .put("source", "vad")
               .put("engine", "vad")
               .put("decision", "model")
-              .put("score", db)
               .toString()
             records.add(
               SegmentRecord(
@@ -805,49 +1314,13 @@ object SegmentationEngineRegistry {
             recordSegmentAnnotation(
               records.last().id,
               SegmentAnnotationSnapshot(
-                reason = reason,
+                reason = "finalize",
                 source = "segmentation_engine",
                 createdAtMs = nowMs(),
                 segmentIndex = segmentIndex,
               )
             )
-            start = end
-            silenceRun = 0
           }
-
-          cursor = end
-        }
-
-        if (start < samples.size) {
-          val end = samples.size
-          val payload = JSONObject()
-            .put("source", "vad")
-            .put("engine", "vad")
-            .put("decision", "model")
-            .toString()
-          records.add(
-            SegmentRecord(
-              id = "seg_${UUID.randomUUID()}",
-              kind = "speech",
-              sourceAudioBufferId = bufferId,
-              startSample = start,
-              endSample = end,
-              sampleRate = sr,
-              durationMs = (((end - start) * 1000.0) / sr).toInt(),
-              confidence = null,
-              payloadJson = payload,
-            )
-          )
-          val segmentIndex = records.lastIndex
-          recordSegmentAnnotation(
-            records.last().id,
-            SegmentAnnotationSnapshot(
-              reason = "finalize",
-              source = "segmentation_engine",
-              createdAtMs = nowMs(),
-              segmentIndex = segmentIndex,
-            )
-          )
         }
 
         val offlineSegment = SegmentPipelineRegistry.createEmptyOffline(bufferId)

--- a/android/src/main/java/com/sherpaonnx/stt/pipeline/SttPipelineWorker.kt
+++ b/android/src/main/java/com/sherpaonnx/stt/pipeline/SttPipelineWorker.kt
@@ -100,11 +100,18 @@ class SttPipelineWorker(
 
         if (recognizer.isEndpoint(stream)) {
           if (result.text.isNotBlank()) {
+            val createdAtMs = System.currentTimeMillis()
+            val segmentMeta = mapOf<String, Any>(
+              "__segmentReason" to "endpoint",
+              "__segmentSource" to "segmentation_engine",
+              "__segmentCreatedAtMs" to createdAtMs,
+            )
             val segmentIndex = outputEntry.commitSegment(
               text = result.text,
               tokens = result.tokens,
               timestamps = result.timestamps,
               source = "stt_stream",
+              meta = segmentMeta,
             )
             onSegmentCommitted?.invoke(
               TextSegment(
@@ -113,7 +120,7 @@ class SttPipelineWorker(
                 timestamps = result.timestamps,
                 source = "stt_stream",
                 segmentIndex = segmentIndex,
-                meta = null,
+                meta = segmentMeta,
               ),
               outputEntry.segmentCount,
             )
@@ -142,11 +149,18 @@ class SttPipelineWorker(
     }
     val result = recognizer.getResult(stream)
     if (result.text.isNotBlank()) {
+      val createdAtMs = System.currentTimeMillis()
+      val segmentMeta = mapOf<String, Any>(
+        "__segmentReason" to "endpoint",
+        "__segmentSource" to "segmentation_engine",
+        "__segmentCreatedAtMs" to createdAtMs,
+      )
       val segmentIndex = outputEntry.commitSegment(
         text = result.text,
         tokens = result.tokens,
         timestamps = result.timestamps,
         source = "stt_stream",
+        meta = segmentMeta,
       )
       onSegmentCommitted?.invoke(
         TextSegment(
@@ -155,7 +169,7 @@ class SttPipelineWorker(
           timestamps = result.timestamps,
           source = "stt_stream",
           segmentIndex = segmentIndex,
-          meta = null,
+          meta = segmentMeta,
         ),
         outputEntry.segmentCount,
       )

--- a/docs/migration/segmentationEngine/segmentation-engine-core-snapshot.md
+++ b/docs/migration/segmentationEngine/segmentation-engine-core-snapshot.md
@@ -1,0 +1,190 @@
+# Segmentation Engine — Ist-Stand & TS-API (Snapshot)
+
+High-Level Referenz für die **aktuelle** Kern-Implementierung der Segmentierungs-Engine nach Abschluss von Phase 1d und mit den Phase-2-Erweiterungen (VAD + STT-Verkettung). Gedacht als Einstieg für die Arbeit an den Folgephasen 3–7.
+
+---
+
+## 1. Kern-Implementierung (native-first)
+
+### 1.1 Architektur kurz
+
+- **Single authority:** Die Engine entscheidet über Auto-Segmente; der jeweilige **Buffer** speichert committed Segmente und feuert Events (siehe Sub-Plan 03).
+- **Zwei Plattform-Implementierungen** mit gleichem TurboModule-Contract:
+  - **Android:** `android/src/main/java/com/sherpaonnx/segment/engine/SegmentationEngineRegistry.kt` — Registry (`engineId` ↔ Instanz), Policy-Parsing, konkrete Engine-Klassen für Text und Speech.
+  - **iOS:** `ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm` (C++ Hilfslogik: `SegEngine`, Annotation-Map, Offline-Text/Audio-Pass) — gleiche Semantik wie Android.
+- **Bridge:** `SherpaOnnx` TurboModule (`NativeSherpaOnnx.ts`, Abschnitt „Segmentation Engine Core“): `attachSegmentationEngine`, `detachSegmentationEngine`, `getSegmentationEngineInfo`, `segmentOfflineBuffer`.
+
+### 1.2 Engine-Instanzen (Policy → Verhalten)
+
+| Policy `evaluator` (TS) | Domäne | Implementierung (Kern) | Anmerkung |
+|-------------------------|--------|-------------------------|-----------|
+| `text_synthetic_auto` | Text | Satz-/Zeichengrenzen, `maxLengthChars`, `sentenceBoundary` | P0, kein externes Modell |
+| `text_punctuation_assisted` | Text | Policy ist **zulässig**; Laufzeit nutzt denselben Kernpfad wie synthetic auto | Dediziertes Interpunktions-**Modell** = Folgephase (z. B. Phase 4) |
+| `speech_energy_silence` | Speech | RMS dB vs. `energyThresholdDb`, Stille-Akkumulation, `min`/`maxSegmentMs` | P0 |
+| `speech_vad_model` | Speech | Echte VAD-Runtime (Model-basiert) für Live- und Offline-Segmentierung | Kein stiller Fallback auf Energy-Pfad bei gewählter VAD-Policy |
+| `continuous_frames` | Speech | Zusätzlich grobe **Checkpoints** über `checkpointIntervalMs` → `policy_checkpoint` | Für Enhancement-Drain-Szenarien |
+
+Offline-Pass (`segmentOfflineBuffer`) spiegelt dieselben Parameter (Text: zeichenweise Aufteilung; Speech: Samples scannen, Segmente in `OfflineSegmentBuffer` schreiben).
+
+### 1.3 Registry & Lebenszyklus
+
+- Pro **Live-Buffer** höchstens **eine** aktive Engine (`ENGINE_ALREADY_ATTACHED`).
+- Zustände: **active → detached** (nach `detach` oder Finalize) bzw. **released** bei Buffer-Release.
+- **Flush:** optional bei `detachSegmentationEngine(..., { flushFinal: true })` — schreibt restliches Partial (Text) bzw. offene Samples (Audio) als finales Segment, soweit implementiert.
+
+---
+
+## 2. Zusammenspiel mit Text- und Audio-Buffern
+
+### 2.1 Symmetrisches Zwei-Ebenen-Modell
+
+| Ebene | Text (`LiveTextBuffer`) | Audio (`LiveAudioBuffer`) |
+|-------|-------------------------|---------------------------|
+| **Daten** | `setPartial` / `appendPartial` (TurboModule) | `appendSamplesToLiveAudioBuffer` (JSI append) |
+| **Segmente (manuell)** | `commitSegment` (SDK) | `commitSegment` (SDK) |
+| **Segmente (auto)** | Native Engine an Partial-Write gebunden | Native Engine an Append-Chunk gebunden |
+| **Segment-Lesepfad** | Embedded Segment-Log im Text-Buffer | Zugehöriges `LiveSegmentBuffer` (`segmentBufferId`) |
+
+### 2.2 Live Text — Ablauf
+
+```mermaid
+sequenceDiagram
+  participant JS
+  participant Txt as LiveTextEntry
+  participant Reg as SegmentationEngineRegistry
+  participant Eng as TextSyntheticAutoEngine
+
+  JS->>Txt: setPartial / appendPartial
+  Txt->>Reg: onLiveTextWrite(bufferId)
+  Reg->>Eng: evaluateText()
+  Eng->>Txt: commitSegment (partial → Segment) / writePartial(rest)
+  Txt-->>JS: onPartial / onSegment (native events)
+```
+
+- **Auto-Attach:** `createLiveTextBuffer({ segmentation: { mode: 'auto', policy? } })` ruft nach Buffer-Erzeugung `attachSegmentationEngine` mit Default-Policy (`text_synthetic_auto`), sofern keine Policy übergeben wird (`src/textbuffer/index.ts`).
+- **Manuell attach:** `attachSegmentationEngine(buffer, { policy })` aus `src/segment/index.ts`.
+- **JS-Spiegel:** `registerLiveTextSegmentation`, `registerAttachedSegmentationEngine` in `src/segment/runtime-state.ts` halten Modus/Engine-ID für `commitSegment`/`getSegmentBuffer`-Pfad.
+
+### 2.3 Live Audio — Ablauf
+
+```mermaid
+sequenceDiagram
+  participant JS
+  participant Live as LiveEntry
+  participant Reg as SegmentationEngineRegistry
+  participant Eng as SpeechEnergySilenceEngine
+  participant SegBuf as LiveSegmentBuffer
+
+  JS->>Live: appendSamples (Frames)
+  Live->>Reg: onLiveAudioWrite(bufferId, chunk, sr, totalWritten)
+  Reg->>Eng: evaluateAudioChunk(...)
+  Eng->>SegBuf: appendSegment (Speech)
+  SegBuf-->>JS: pipelineLiveSegmentAppended / onSegment
+```
+
+- **Auto-Attach:** `createEmptyLiveAudioBuffer({ segmentation: { mode: 'auto', policy? } })` analog Text (`src/audiobuffer/index.ts`).
+- Speech-Engine erhält bei Attach eine frisch erzeugte **LiveSegmentBuffer**-ID (`segmentBufferId` in `SegmentationEngineInfo`).
+
+### 2.4 Finalize / Release
+
+- Beim **Finalisieren** des Live-Text- oder Live-Audio-Buffers ruft natives Code **Engine-Flush** und **Detach** auf (siehe `onBufferFinalized` in Registry / iOS-Äquivalent).
+- Bei **Release** des Buffers: Engine wird aus Registry entfernt (`onBufferReleased`).
+
+### 2.5 Offline
+
+- **`segmentOfflineBuffer(offlineBuffer, policy)`** (TS): einmaliger nativer Durchlauf; Ergebnis:
+  - **Text:** Segmentliste wird in JS-Cache (`offlineTextSegmentsByBufferId`) materialisiert; `getSegments`/`getSegmentCount` auf Offline-Text **erfordern** vorher diesen Aufruf (sonst `SEGMENT_NOT_AVAILABLE`).
+  - **Speech:** neues/aktualisiertes **`seg_off_*`**; Zuordnung Parent-Audio → Segmentbuffer wird in JS gecacht.
+
+- **Lazy Default für Offline-Audio:** `getSegmentBuffer(offlineAudio)` kann intern `segmentOfflineBuffer` mit **`DEFAULT_SPEECH_POLICY`** auslösen, wenn noch kein Segmentbuffer verknüpft ist (`ensureOfflineAudioSegmentBuffer` in `src/segment/index.ts`).
+
+---
+
+## 3. TypeScript-API-Referenz (Segmentation Engine)
+
+**Modul:** `react-native-sherpa-onnx/segment` (Quelle: `src/segment/index.ts`, Typen: `src/segment/engine-types.ts`).
+
+### 3.1 Typen (`src/segment/engine-types.ts`)
+
+```typescript
+export type SegmentationEvaluator =
+  | 'text_synthetic_auto'
+  | 'text_punctuation_assisted'
+  | 'speech_energy_silence'
+  | 'speech_vad_model'
+  | 'continuous_frames';
+
+export interface SegmentationPolicy {
+  evaluator: SegmentationEvaluator;
+  maxLengthChars?: number;
+  sentenceBoundary?: boolean;
+  languageHints?: string[];
+  silenceThresholdMs?: number;
+  energyThresholdDb?: number;
+  minSegmentMs?: number;
+  maxSegmentMs?: number;
+  hangoverMs?: number;
+  checkpointIntervalMs?: number;
+  vadModelId?: string;
+  vadThreshold?: number;
+  vadMinSpeechMs?: number;
+  vadMinSilenceMs?: number;
+}
+
+export interface SegmentationConfig {
+  policy: SegmentationPolicy;
+}
+
+export interface SegmentationEngineRef {
+  engineId: string;
+}
+
+export interface SegmentationEngineInfo {
+  engineId: string;
+  attachedBufferId: string;
+  domain: 'text' | 'speech';
+  policy: SegmentationPolicy;
+  state: 'active' | 'detached';
+  totalSegmentsCommitted: number;
+  lastSegmentId?: string;
+  segmentBufferId?: string;
+}
+```
+
+### 3.2 Funktionen (Engine-spezifisch)
+
+| Funktion | Signatur (vereinfacht) | Beschreibung |
+|----------|------------------------|--------------|
+| `attachSegmentationEngine` | `(buffer, config: SegmentationConfig) => Promise<SegmentationEngineRef>` | Nur **Live**-Text oder **Live**-Audio; `config.policy` optional → Defaults (`text_synthetic_auto` / `speech_energy_silence`). Registriert Engine in JS-Runtime-State. |
+| `detachSegmentationEngine` | `(engine \| engineId, options?: { flushFinal?: boolean }) => Promise<void>` | Trennt Engine; optional finales Flush. |
+| `getSegmentationEngineInfo` | `(engine \| engineId) => Promise<SegmentationEngineInfo>` | Liest nativen Snapshot; synchronisiert JS-State (`segmentBufferId` für Audio). |
+| `segmentOfflineBuffer` | `(buffer, policy: SegmentationPolicy) => Promise<SegmentBufferRef>` | **Offline**-Text (`txt_off_*`) oder **Offline**-Audio (`off_*`); Speech-Ergebnis: `SegmentBufferRef` mit `seg_off_*`. |
+
+### 3.3 Verwandte Segment-APIs (gleiches Paket, für Kontext)
+
+| Funktion | Kurzbeschreibung |
+|----------|------------------|
+| `setPartial` / `appendPartial` | Level-1 Text-Schreiben; triggert Engine bei Auto. |
+| `commitSegment` | Level-2 manueller Commit (Text/Audio), nicht die Auto-Engine. |
+| `getSegmentBuffer` | Einheitlicher Zugriff auf Segment-Sicht (Text embedded, Audio `seg_*`). |
+| `getSegments` / `getSegmentCount` | Pull-API; maßgeblich für UI/Orchestrierung. |
+| SegmentLinkMap-Familie | `createSegmentLinkMap`, `addSegmentLink`, … — Cross-Domain Links (Phase 1b), nicht Engine-Core. |
+
+### 3.4 Native TurboModule (Rohcontract)
+
+Siehe `src/NativeSherpaOnnx.ts` — Methoden `attachSegmentationEngine`, `detachSegmentationEngine`, `getSegmentationEngineInfo`, `segmentOfflineBuffer` (Promise-basiert).
+
+### 3.5 Typische Fehler-Codes (native → JS)
+
+- `ENGINE_ALREADY_ATTACHED`, `ENGINE_DETACHED`
+- `POLICY_INVALID` (Evaluator passt nicht zur Domäne)
+- `BUFFER_STATE_INVALID` (Buffer nicht recording / offline nicht gefunden)
+- `SEGMENT_NOT_AVAILABLE` (z. B. Offline-Text ohne vorheriges `segmentOfflineBuffer`)
+
+---
+
+## 4. Siehe auch
+
+- [segmentation_engine_overview.md](segmentation_engine_overview.md) — Phasen 1–7
+- [sub-02-segmentation-engine-core.md](sub-02-segmentation-engine-core.md) — Spezifikation Engine Core
+- [sub-03-buffer-integration.md](sub-03-buffer-integration.md) — Events, `getSegmentBuffer`, Commit-Mechanik

--- a/docs/migration/segmentationEngine/segmentation_engine_overview.md
+++ b/docs/migration/segmentationEngine/segmentation_engine_overview.md
@@ -83,7 +83,7 @@ Da das Fundament (Phase 1) sehr umfangreich ist, wird es in vier machbare Schrit
 | **Phase 1b** | Storage & Write APIs (Sub-Plan 03 + Sub-Plan 01 Runtime-Teil) | Symmetric Write API (`setPartial`, `appendPartial`), `getSegmentBuffer()` Abstraktion, Event-Payloads **sowie SegmentLinkMap Runtime-APIs** (`createSegmentLinkMap`, `addSegmentLink(s)`, `getSpeechSegmentsForText`, `getTextSegmentsForSpeech`, `getAllSegmentLinks`, `getSegmentLinkCount`, `getSegmentLinkMapInfo`, `removeSegmentLink`, `releaseSegmentLinkMap`) inkl. nativer LinkMap-Store/Indizes. **Status: Completed** |
 | **Phase 1c** | Orchestration & Transfer (Sub-Plan 04) | `transferOfflineAudioBufferFromLive`, `OrchestrationSession` State Machine, Error Recovery Strategien (abort, skip, retry, partial). **Status: Completed** *(Benchmark-Teil explizit nicht erforderlich).* |
 | **Phase 1d** | Engine Core (Sub-Plan 02) | Native Evaluatoren (Energy, Punctuation, etc.), Buffer Attachment, Offline-Segmentation Loop. **Status: Completed** |
-| **Phase 2** | VAD + STT (+ `stt_produced` Links) | VAD liefert Grenzen, STT nutzt diese und produziert Text. |
+| **Phase 2** | VAD + STT (+ `stt_produced` Links) | VAD liefert Grenzen, STT nutzt diese und produziert Text. **Status: Completed** (Code + Sub-05/Plan-Parität; Jest-Parity: `segment-api`, `transcribe-segmented`, `offline-orchestrator`). |
 | **Phase 3** | Enhancement (Offline segmentiert) | Verifizierung der Audio-Orchestration & Error Recovery. |
 | **Phase 4** | Punctuation | Verifizierung der Text-Orchestration. |
 | **Phase 5** | TTS (Incremental entfernen, + `tts_produced` Links) | Höchstes Risiko, benötigt Parity. Produziert Links für Playback-Highlighting. |

--- a/docs/migration/segmentationEngine/sub-05-feature-pipeline-migration.md
+++ b/docs/migration/segmentationEngine/sub-05-feature-pipeline-migration.md
@@ -1,7 +1,8 @@
 # Sub-Plan 05: Feature Pipeline Migration
 
 ## Status
-- Draft
+- **Phase 2 (STT + VAD + `stt_produced`):** Completed — Implementierung und Parity-Check (Plan `phase-2-vad-stt`, Jest: `segment-api`, `transcribe-segmented`, `offline-orchestrator`) erfüllt.
+- **Weitere Features in diesem Dokument (TTS, Punctuation, Enhancement, Alignment, …):** weiterhin offen / spätere Phasen.
 - Depends on: Sub-Plan 01, 02, 03, 04
 
 ## Purpose
@@ -43,6 +44,16 @@ Define per-feature migration plans to adopt the shared Segmentation Engine. Each
 7. Merge per-segment transcriptions into final OfflineTextBuffer.
 8. Return `SegmentLinkMap` alongside text output (optional, when segmentation active).
 9. Test: compare full-run vs. segmented-run transcription quality.
+
+### Phase 2 Progress (Current)
+
+- Completed: Streaming STT endpoint commits now carry Segment Contract metadata (`reason: 'endpoint'`, `source: 'segmentation_engine'`, created-at timestamp) on Android and iOS.
+- Completed: `speech_vad_model` now uses a real VAD runtime path for live segmentation (no silent fallback to energy evaluator when selected).
+- Completed: Offline `speech_vad_model` segmentation runs chunked over offline audio slices (no full-buffer preload requirement).
+- Completed: `stt.transcribe(audio, textOut, options)` supports segmented offline mode and returns structured orchestration result (`status`, counts, skips, timing, optional `linkMap`).
+- Completed: Segmented offline STT writes `stt_produced` links for each `(speechSegment, textSegment)` pair.
+- Completed: Native bridge method `populateOfflineTextBufferIfEmpty` added to preserve existing target-buffer semantics in segmented flow.
+- Completed: Parity-Validierung (automatisiert: relevante Jest-Suites inkl. `segmentation-engine-vad.test.ts`; manuell: Abgleich Implementierung vs. Phase-2-Plan und Sub-05).
 
 ### SegmentLink Integration
 

--- a/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
+++ b/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
@@ -2,6 +2,7 @@
 #include "../core/SherpaOnnx+SegmentBufferGlobals.h"
 #include "../../textbuffer/core/SherpaOnnx+TextBufferGlobals.h"
 #include "../../audio/pipeline/SherpaOnnx+PipelineAudioGlobals.h"
+#include "../../vad/core/VadRuntime.h"
 
 #ifdef __cplusplus
 #include <algorithm>
@@ -731,6 +732,10 @@ struct SegEnginePolicy {
   int maxSegmentMs = 30000;
   int hangoverMs = 300;
   int checkpointIntervalMs = 0;
+  std::string vadModelId;
+  double vadThreshold = 0.5;
+  int vadMinSpeechMs = 250;
+  int vadMinSilenceMs = 250;
 };
 
 struct SegEngineAnnotation {
@@ -755,6 +760,9 @@ struct SegEngine {
   int64_t segmentStartSample = 0;
   int64_t checkpointStartSample = 0;
   double silenceAccumulatedMs = 0.0;
+  std::shared_ptr<VadRuntime> vadRuntime;
+  int vadFrameSize = 0;
+  std::vector<float> pendingVadSamples;
 };
 
 std::unordered_map<std::string, std::shared_ptr<SegEngine>> g_seg_engine_by_id;
@@ -770,6 +778,110 @@ static int64_t seg_now_ms() {
 
 static std::string seg_new_engine_id() {
   return "seg_engine_" + seg_uuid();
+}
+
+static bool seg_file_exists(const std::string &path) {
+  if (path.empty()) return false;
+  return [[NSFileManager defaultManager]
+    fileExistsAtPath:[NSString stringWithUTF8String:path.c_str()]];
+}
+
+static bool seg_directory_exists(const std::string &path) {
+  if (path.empty()) return false;
+  BOOL isDir = NO;
+  BOOL exists = [[NSFileManager defaultManager]
+    fileExistsAtPath:[NSString stringWithUTF8String:path.c_str()]
+    isDirectory:&isDir];
+  return exists && isDir;
+}
+
+static std::string seg_join_path(const std::string &dir, const std::string &name) {
+  if (dir.empty()) return name;
+  if (dir.back() == '/') return dir + name;
+  return dir + "/" + name;
+}
+
+static std::string seg_resolve_vad_model_path(const std::string &modelId) {
+  const std::string trimmed = modelId;
+  if (trimmed.empty()) {
+    return "";
+  }
+
+  if (seg_file_exists(trimmed)) {
+    return trimmed;
+  }
+
+  if (seg_directory_exists(trimmed)) {
+    static const std::vector<std::string> kCandidates = {
+      "silero_vad.onnx",
+      "silero.onnx",
+      "model.onnx",
+      "ten_vad.onnx",
+      "ten-vad.onnx",
+    };
+    for (const auto &name : kCandidates) {
+      const std::string candidate = seg_join_path(trimmed, name);
+      if (seg_file_exists(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return "";
+}
+
+static std::string seg_vad_model_type_from_path(const std::string &modelPath) {
+  std::string lower = modelPath;
+  std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+  return lower.find("ten") != std::string::npos ? "ten_vad" : "silero_vad";
+}
+
+static bool seg_init_vad_runtime(
+  const std::shared_ptr<SegEngine> &engine,
+  int sampleRate,
+  std::string *errorOut
+) {
+  if (!engine) {
+    if (errorOut) *errorOut = "Segmentation engine is null";
+    return false;
+  }
+
+  const std::string modelPath = seg_resolve_vad_model_path(engine->policy.vadModelId);
+  if (modelPath.empty()) {
+    if (errorOut) {
+      *errorOut = "speech_vad_model model not found for vadModelId: " + engine->policy.vadModelId;
+    }
+    return false;
+  }
+
+  VadRuntimeConfig cfg;
+  cfg.modelType = seg_vad_model_type_from_path(modelPath);
+  cfg.modelPath = modelPath;
+  cfg.sampleRate = std::max(1, sampleRate);
+  cfg.numThreads = 1;
+  cfg.provider = "cpu";
+  cfg.debug = false;
+  cfg.scoreThreshold = engine->policy.vadThreshold;
+  cfg.minSpeechDurationMs = std::max(1, engine->policy.vadMinSpeechMs);
+  cfg.minSilenceDurationMs = std::max(1, engine->policy.vadMinSilenceMs);
+  cfg.maxSpeechDurationMs = std::max(cfg.minSpeechDurationMs, engine->policy.maxSegmentMs);
+  cfg.windowSize = cfg.modelType == "ten_vad" ? 256 : 512;
+
+  std::string runtimeError;
+  auto runtime = VadRuntime::Create(cfg, &runtimeError);
+  if (!runtime) {
+    if (errorOut) {
+      *errorOut =
+        "speech_vad_model failed to initialize runtime: " +
+        (runtimeError.empty() ? std::string("unknown error") : runtimeError);
+    }
+    return false;
+  }
+
+  engine->vadRuntime = runtime;
+  engine->vadFrameSize = std::max(1, cfg.windowSize);
+  engine->pendingVadSamples.clear();
+  return true;
 }
 
 static std::string seg_reason_from_eval(const std::string &eval, bool silenceCommit) {
@@ -881,6 +993,78 @@ static bool seg_append_speech_segment(
   return true;
 }
 
+static bool seg_append_speech_segment_range(
+  const std::shared_ptr<SegEngine> &engine,
+  int64_t startSample,
+  int64_t endSampleExclusive,
+  const std::string &reason
+) {
+  if (!engine || engine->segmentBufferId.empty()) return false;
+  if (endSampleExclusive <= startSample) return false;
+
+  auto live = pa_get_live_entry(engine->attachedBufferId);
+  if (!live || live->sampleRate <= 0) return false;
+
+  const int durationMs = static_cast<int>(
+    ((endSampleExclusive - startSample) * 1000.0) / live->sampleRate
+  );
+  if (durationMs <= 0) return false;
+
+  NSDictionary *payloadObj = @{
+    @"source": @"vad",
+    @"engine": @"vad",
+    @"decision": @"model",
+  };
+  NSData *payloadData = [NSJSONSerialization dataWithJSONObject:payloadObj options:0 error:nil];
+  std::string payloadJson;
+  if (payloadData) {
+    payloadJson.assign((const char *)payloadData.bytes, payloadData.length);
+  }
+
+  std::string segmentId;
+  int segmentIndex = 0;
+  std::string err;
+  bool ok = seg_live_append_segment(
+    engine->segmentBufferId,
+    "speech",
+    engine->attachedBufferId,
+    static_cast<int>(startSample),
+    static_cast<int>(endSampleExclusive),
+    live->sampleRate,
+    durationMs,
+    false,
+    0.0,
+    payloadJson,
+    &segmentId,
+    &segmentIndex,
+    &err
+  );
+  if (!ok) {
+    return false;
+  }
+
+  seg_record_annotation_for_engine(engine, segmentId, reason, segmentIndex);
+  engine->totalSegmentsCommitted += 1;
+  engine->lastSegmentId = segmentId;
+  return true;
+}
+
+static void seg_append_runtime_vad_segments(
+  const std::shared_ptr<SegEngine> &engine,
+  const std::string &reason
+) {
+  if (!engine || !engine->vadRuntime) return;
+  auto segments = engine->vadRuntime->PopSegments();
+  for (const auto &segment : segments) {
+    seg_append_speech_segment_range(
+      engine,
+      segment.startSample,
+      segment.endSample,
+      reason
+    );
+  }
+}
+
 static void seg_engine_evaluate_text(const std::shared_ptr<SegEngine> &engine) {
   if (!engine || engine->state != SegEngineState::ACTIVE) return;
   auto entry = txt_get_live_entry(engine->attachedBufferId);
@@ -964,6 +1148,27 @@ static void seg_engine_evaluate_audio(
   if (!engine || engine->state != SegEngineState::ACTIVE) return;
   if (!samples || count == 0 || sampleRate <= 0) return;
 
+  if (engine->policy.evaluator == "speech_vad_model") {
+    if (!engine->vadRuntime || engine->vadFrameSize <= 0) {
+      return;
+    }
+    const int frameSize = std::max(1, engine->vadFrameSize);
+    engine->pendingVadSamples.insert(
+      engine->pendingVadSamples.end(),
+      samples,
+      samples + count
+    );
+    while ((int)engine->pendingVadSamples.size() >= frameSize) {
+      engine->vadRuntime->AcceptWaveform(engine->pendingVadSamples.data(), frameSize);
+      seg_append_runtime_vad_segments(engine, "vad_boundary");
+      engine->pendingVadSamples.erase(
+        engine->pendingVadSamples.begin(),
+        engine->pendingVadSamples.begin() + frameSize
+      );
+    }
+    return;
+  }
+
   double chunkDurationMs = ((double)count * 1000.0) / sampleRate;
   double db = seg_rms_db(samples, count);
 
@@ -1000,6 +1205,27 @@ static void seg_engine_evaluate_audio(
 
 static void seg_engine_flush_audio(const std::shared_ptr<SegEngine> &engine) {
   if (!engine || engine->state != SegEngineState::ACTIVE) return;
+  if (engine->policy.evaluator == "speech_vad_model") {
+    if (!engine->vadRuntime || engine->vadFrameSize <= 0) {
+      return;
+    }
+    const int frameSize = std::max(1, engine->vadFrameSize);
+    if (!engine->pendingVadSamples.empty()) {
+      std::vector<float> tail(frameSize, 0.0f);
+      std::copy(
+        engine->pendingVadSamples.begin(),
+        engine->pendingVadSamples.end(),
+        tail.begin()
+      );
+      engine->vadRuntime->AcceptWaveform(tail.data(), frameSize);
+      engine->pendingVadSamples.clear();
+      seg_append_runtime_vad_segments(engine, "vad_boundary");
+    }
+    engine->vadRuntime->Flush();
+    seg_append_runtime_vad_segments(engine, "finalize");
+    return;
+  }
+
   auto live = pa_get_live_entry(engine->attachedBufferId);
   if (!live) return;
   if (live->totalSamplesWritten > engine->segmentStartSample) {
@@ -1022,6 +1248,10 @@ static SegEnginePolicy seg_policy_from_dict(NSDictionary *policy, SegEngineDomai
   if ([p[@"maxSegmentMs"] respondsToSelector:@selector(intValue)]) out.maxSegmentMs = std::max(out.minSegmentMs, [p[@"maxSegmentMs"] intValue]);
   if ([p[@"hangoverMs"] respondsToSelector:@selector(intValue)]) out.hangoverMs = std::max(0, [p[@"hangoverMs"] intValue]);
   if ([p[@"checkpointIntervalMs"] respondsToSelector:@selector(intValue)]) out.checkpointIntervalMs = std::max(0, [p[@"checkpointIntervalMs"] intValue]);
+  if ([p[@"vadModelId"] isKindOfClass:[NSString class]]) out.vadModelId = [p[@"vadModelId"] UTF8String] ?: "";
+  if ([p[@"vadThreshold"] respondsToSelector:@selector(doubleValue)]) out.vadThreshold = [p[@"vadThreshold"] doubleValue];
+  if ([p[@"vadMinSpeechMs"] respondsToSelector:@selector(intValue)]) out.vadMinSpeechMs = std::max(1, [p[@"vadMinSpeechMs"] intValue]);
+  if ([p[@"vadMinSilenceMs"] respondsToSelector:@selector(intValue)]) out.vadMinSilenceMs = std::max(1, [p[@"vadMinSilenceMs"] intValue]);
   return out;
 }
 
@@ -1036,6 +1266,10 @@ static NSDictionary *seg_engine_policy_to_dict(const SegEnginePolicy &p) {
     @"maxSegmentMs": @(p.maxSegmentMs),
     @"hangoverMs": @(p.hangoverMs),
     @"checkpointIntervalMs": @(p.checkpointIntervalMs),
+    @"vadModelId": [NSString stringWithUTF8String:p.vadModelId.c_str()] ?: @"",
+    @"vadThreshold": @(p.vadThreshold),
+    @"vadMinSpeechMs": @(p.vadMinSpeechMs),
+    @"vadMinSilenceMs": @(p.vadMinSilenceMs),
   };
 }
 
@@ -1273,6 +1507,30 @@ bool seg_engine_peek_annotation(
         g_seg_live[entry->bufferId] = entry;
       }
       engine->segmentBufferId = entry->bufferId;
+
+      if (engine->policy.evaluator == "speech_vad_model") {
+        auto live = pa_get_live_entry(bid);
+        if (!live) {
+          {
+            std::lock_guard<std::mutex> lock(g_seg_mutex);
+            g_seg_live.erase(entry->bufferId);
+          }
+          try { entry->release(); } catch (...) {}
+          reject(@"BUFFER_STATE_INVALID", [NSString stringWithFormat:@"Live audio buffer not found: %@", bufferId], nil);
+          return;
+        }
+        std::string vadError;
+        if (!seg_init_vad_runtime(engine, live->sampleRate, &vadError)) {
+          {
+            std::lock_guard<std::mutex> lock(g_seg_mutex);
+            g_seg_live.erase(entry->bufferId);
+          }
+          try { entry->release(); } catch (...) {}
+          NSString *message = [NSString stringWithUTF8String:vadError.c_str()] ?: @"speech_vad_model runtime init failed";
+          reject(@"POLICY_MODEL_UNAVAILABLE", message, nil);
+          return;
+        }
+      }
     }
 
     {
@@ -1408,76 +1666,177 @@ bool seg_engine_peek_annotation(
       return;
     }
 
-    std::vector<float> samples;
     int sampleRate = 0;
-    if (!pa_read_offline_samples(bid, &samples, &sampleRate)) {
+    int totalSamples = 0;
+    std::string metaErrCode;
+    std::string metaErrMessage;
+    if (!pa_get_offline_metadata(
+          bid,
+          &sampleRate,
+          &totalSamples,
+          &metaErrCode,
+          &metaErrMessage
+        )) {
       reject(@"BUFFER_STATE_INVALID", [NSString stringWithFormat:@"Offline audio buffer not found: %@", bufferId], nil);
       return;
     }
 
     SegEnginePolicy p = seg_policy_from_dict(policy, SegEngineDomain::SPEECH);
-    int minSamples = std::max(1, (int)((p.minSegmentMs / 1000.0) * sampleRate));
-    int maxSamples = std::max(minSamples, (int)((p.maxSegmentMs / 1000.0) * sampleRate));
-    int silenceSamples = std::max(1, (int)(((p.silenceThresholdMs + p.hangoverMs) / 1000.0) * sampleRate));
-    int frameSize = std::max(160, sampleRate / 50);
-
     std::vector<SegRecord> records;
-    int start = 0;
-    int cursor = 0;
-    int silenceRun = 0;
-    while (cursor < (int)samples.size()) {
-      int end = std::min((int)samples.size(), cursor + frameSize);
-      double db = seg_rms_db(samples.data() + cursor, (size_t)(end - cursor));
-      if (db < p.energyThresholdDb) silenceRun += (end - cursor);
-      else silenceRun = 0;
+    if (p.evaluator == "speech_vad_model") {
+      auto tempEngine = std::make_shared<SegEngine>();
+      tempEngine->attachedBufferId = bid;
+      tempEngine->policy = p;
+      std::string vadError;
+      if (!seg_init_vad_runtime(tempEngine, sampleRate, &vadError)) {
+        NSString *message = [NSString stringWithUTF8String:vadError.c_str()] ?: @"speech_vad_model runtime init failed";
+        reject(@"POLICY_MODEL_UNAVAILABLE", message, nil);
+        return;
+      }
 
-      int segLen = end - start;
-      bool silenceCommit = silenceRun >= silenceSamples && segLen >= minSamples;
-      bool lengthCommit = segLen >= maxSamples;
-      if (silenceCommit || lengthCommit) {
+      const int frameSize = std::max(1, tempEngine->vadFrameSize);
+      const int chunkSize = std::max(frameSize, frameSize * 8);
+      std::vector<float> pending;
+
+      auto appendRecord = [&](int startSample, int endSample, const std::string &reason) {
+        if (endSample <= startSample) return;
+        SegRecord rec;
+        rec.id = "seg_" + seg_uuid();
+        rec.kind = "speech";
+        rec.sourceAudioBufferId = bid;
+        rec.startSample = startSample;
+        rec.endSample = endSample;
+        rec.sampleRate = sampleRate;
+        rec.durationMs = (int)(((endSample - startSample) * 1000.0) / std::max(1, sampleRate));
+        NSDictionary *payloadObj = @{
+          @"source": @"vad",
+          @"engine": @"vad",
+          @"decision": @"model",
+        };
+        NSData *payloadData = [NSJSONSerialization dataWithJSONObject:payloadObj options:0 error:nil];
+        if (payloadData) rec.payloadJson.assign((const char *)payloadData.bytes, payloadData.length);
+        records.push_back(rec);
+        seg_record_annotation(rec.id, reason, (int)records.size() - 1);
+      };
+
+      int cursor = 0;
+      while (cursor < totalSamples) {
+        std::vector<float> chunk;
+        std::string sliceErrCode;
+        std::string sliceErrMessage;
+        const int readCount = std::min(chunkSize, totalSamples - cursor);
+        if (!pa_get_offline_samples_slice(
+              bid,
+              cursor,
+              readCount,
+              &chunk,
+              &sliceErrCode,
+              &sliceErrMessage
+            )) {
+          NSString *message = [NSString stringWithUTF8String:sliceErrMessage.c_str()] ?: @"Failed to read offline audio slice";
+          reject(@"BUFFER_STATE_INVALID", message, nil);
+          return;
+        }
+        cursor += (int)chunk.size();
+        if (chunk.empty()) break;
+
+        pending.insert(pending.end(), chunk.begin(), chunk.end());
+        while ((int)pending.size() >= frameSize) {
+          tempEngine->vadRuntime->AcceptWaveform(pending.data(), frameSize);
+          auto segments = tempEngine->vadRuntime->PopSegments();
+          for (const auto &segment : segments) {
+            appendRecord(segment.startSample, segment.endSample, "vad_boundary");
+          }
+          pending.erase(pending.begin(), pending.begin() + frameSize);
+        }
+      }
+
+      if (!pending.empty()) {
+        std::vector<float> tail(frameSize, 0.0f);
+        std::copy(pending.begin(), pending.end(), tail.begin());
+        tempEngine->vadRuntime->AcceptWaveform(tail.data(), frameSize);
+        auto segments = tempEngine->vadRuntime->PopSegments();
+        for (const auto &segment : segments) {
+          appendRecord(segment.startSample, segment.endSample, "vad_boundary");
+        }
+      }
+
+      tempEngine->vadRuntime->Flush();
+      {
+        auto segments = tempEngine->vadRuntime->PopSegments();
+        for (const auto &segment : segments) {
+          appendRecord(segment.startSample, segment.endSample, "finalize");
+        }
+      }
+    } else {
+      std::vector<float> samples;
+      if (!pa_read_offline_samples(bid, &samples, &sampleRate)) {
+        reject(@"BUFFER_STATE_INVALID", [NSString stringWithFormat:@"Offline audio buffer not found: %@", bufferId], nil);
+        return;
+      }
+
+      int minSamples = std::max(1, (int)((p.minSegmentMs / 1000.0) * sampleRate));
+      int maxSamples = std::max(minSamples, (int)((p.maxSegmentMs / 1000.0) * sampleRate));
+      int silenceSamples = std::max(1, (int)(((p.silenceThresholdMs + p.hangoverMs) / 1000.0) * sampleRate));
+      int frameSize = std::max(160, sampleRate / 50);
+
+      int start = 0;
+      int cursor = 0;
+      int silenceRun = 0;
+      while (cursor < (int)samples.size()) {
+        int end = std::min((int)samples.size(), cursor + frameSize);
+        double db = seg_rms_db(samples.data() + cursor, (size_t)(end - cursor));
+        if (db < p.energyThresholdDb) silenceRun += (end - cursor);
+        else silenceRun = 0;
+
+        int segLen = end - start;
+        bool silenceCommit = silenceRun >= silenceSamples && segLen >= minSamples;
+        bool lengthCommit = segLen >= maxSamples;
+        if (silenceCommit || lengthCommit) {
+          SegRecord rec;
+          rec.id = "seg_" + seg_uuid();
+          rec.kind = "speech";
+          rec.sourceAudioBufferId = bid;
+          rec.startSample = start;
+          rec.endSample = end;
+          rec.sampleRate = sampleRate;
+          rec.durationMs = (int)(((end - start) * 1000.0) / sampleRate);
+          NSDictionary *payloadObj = @{
+            @"source": @"vad",
+            @"engine": @"vad",
+            @"decision": @"model",
+            @"score": @(db),
+          };
+          NSData *payloadData = [NSJSONSerialization dataWithJSONObject:payloadObj options:0 error:nil];
+          if (payloadData) rec.payloadJson.assign((const char *)payloadData.bytes, payloadData.length);
+          records.push_back(rec);
+          std::string reason = seg_reason_from_eval(p.evaluator, silenceCommit);
+          seg_record_annotation(rec.id, reason, (int)records.size() - 1);
+          start = end;
+          silenceRun = 0;
+        }
+        cursor = end;
+      }
+
+      if (start < (int)samples.size()) {
         SegRecord rec;
         rec.id = "seg_" + seg_uuid();
         rec.kind = "speech";
         rec.sourceAudioBufferId = bid;
         rec.startSample = start;
-        rec.endSample = end;
+        rec.endSample = (int)samples.size();
         rec.sampleRate = sampleRate;
-        rec.durationMs = (int)(((end - start) * 1000.0) / sampleRate);
+        rec.durationMs = (int)(((samples.size() - start) * 1000.0) / sampleRate);
         NSDictionary *payloadObj = @{
           @"source": @"vad",
           @"engine": @"vad",
           @"decision": @"model",
-          @"score": @(db),
         };
         NSData *payloadData = [NSJSONSerialization dataWithJSONObject:payloadObj options:0 error:nil];
         if (payloadData) rec.payloadJson.assign((const char *)payloadData.bytes, payloadData.length);
         records.push_back(rec);
-        std::string reason = seg_reason_from_eval(p.evaluator, silenceCommit);
-        seg_record_annotation(rec.id, reason, (int)records.size() - 1);
-        start = end;
-        silenceRun = 0;
+        seg_record_annotation(rec.id, "finalize", (int)records.size() - 1);
       }
-      cursor = end;
-    }
-
-    if (start < (int)samples.size()) {
-      SegRecord rec;
-      rec.id = "seg_" + seg_uuid();
-      rec.kind = "speech";
-      rec.sourceAudioBufferId = bid;
-      rec.startSample = start;
-      rec.endSample = (int)samples.size();
-      rec.sampleRate = sampleRate;
-      rec.durationMs = (int)(((samples.size() - start) * 1000.0) / sampleRate);
-      NSDictionary *payloadObj = @{
-        @"source": @"vad",
-        @"engine": @"vad",
-        @"decision": @"model",
-      };
-      NSData *payloadData = [NSJSONSerialization dataWithJSONObject:payloadObj options:0 error:nil];
-      if (payloadData) rec.payloadJson.assign((const char *)payloadData.bytes, payloadData.length);
-      records.push_back(rec);
-      seg_record_annotation(rec.id, "finalize", (int)records.size() - 1);
     }
 
     auto off = std::make_shared<SegOfflineEntry>();

--- a/ios/stt/pipeline/SttPipelineWorker.mm
+++ b/ios/stt/pipeline/SttPipelineWorker.mm
@@ -83,6 +83,17 @@ void SttPipelineWorker::runLoop() {
 
       if (wrapper_->isEndpoint(streamId_)) {
         if (!result.text.empty()) {
+          const int64_t createdAtMs =
+            static_cast<int64_t>(
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()
+              ).count()
+            );
+          NSDictionary *segmentMeta = @{
+            @"__segmentReason": @"endpoint",
+            @"__segmentSource": @"segmentation_engine",
+            @"__segmentCreatedAtMs": @(createdAtMs),
+          };
           std::string err;
           if (!txt_live_commit_segment(
                 outputEntry_,
@@ -90,7 +101,7 @@ void SttPipelineWorker::runLoop() {
                 result.tokens,
                 result.timestamps,
                 "stt_stream",
-                nil,
+                segmentMeta,
                 &err
               )) {
             throw std::runtime_error("Failed to commit text segment: " + err);
@@ -140,6 +151,17 @@ void SttPipelineWorker::autoFlushAndCommit() {
 
   auto result = wrapper_->getResult(streamId_);
   if (!result.text.empty()) {
+    const int64_t createdAtMs =
+      static_cast<int64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::system_clock::now().time_since_epoch()
+        ).count()
+      );
+    NSDictionary *segmentMeta = @{
+      @"__segmentReason": @"endpoint",
+      @"__segmentSource": @"segmentation_engine",
+      @"__segmentCreatedAtMs": @(createdAtMs),
+    };
     std::string err;
     if (!txt_live_commit_segment(
           outputEntry_,
@@ -147,7 +169,7 @@ void SttPipelineWorker::autoFlushAndCommit() {
           result.tokens,
           result.timestamps,
           "stt_stream",
-          nil,
+          segmentMeta,
           &err
         )) {
       throw std::runtime_error("Failed to commit flushed text segment: " + err);

--- a/ios/textbuffer/bridge/SherpaOnnx+TextBuffer.mm
+++ b/ios/textbuffer/bridge/SherpaOnnx+TextBuffer.mm
@@ -474,6 +474,66 @@ static std::string txt_generateId(const char *prefix) {
     }
 }
 
+- (void)populateOfflineTextBufferIfEmpty:(NSString *)bufferId
+                                    text:(NSString *)text
+                                 options:(NSDictionary *)options
+                                 resolve:(RCTPromiseResolveBlock)resolve
+                                  reject:(RCTPromiseRejectBlock)reject
+{
+    @try {
+        if (bufferId == nil || [bufferId length] == 0) {
+            reject(kTxtErrInvalidArgument, @"bufferId is required", nil);
+            return;
+        }
+
+        const std::string bid = [bufferId UTF8String] ?: "";
+        const std::string t = text != nil ? ([text UTF8String] ?: "") : "";
+        std::string lang;
+        std::string emotion;
+        std::string event;
+        if (options != nil) {
+            if ([options[@"lang"] isKindOfClass:[NSString class]]) {
+                lang = [options[@"lang"] UTF8String] ?: "";
+            }
+            if ([options[@"emotion"] isKindOfClass:[NSString class]]) {
+                emotion = [options[@"emotion"] UTF8String] ?: "";
+            }
+            if ([options[@"event"] isKindOfClass:[NSString class]]) {
+                event = [options[@"event"] UTF8String] ?: "";
+            }
+        }
+
+        std::string error;
+        if (!txt_populate_offline_if_empty(
+              bid,
+              t,
+              {},
+              {},
+              {},
+              lang,
+              emotion,
+              event,
+              &error
+            )) {
+            NSString *message = [NSString stringWithUTF8String:error.c_str()] ?: @"Failed to populate offline text buffer";
+            if (error.find("not found") != std::string::npos) {
+                reject(kTxtErrBufferNotFound, message, nil);
+                return;
+            }
+            if (error.find("already populated") != std::string::npos) {
+                reject(kTxtErrAlreadyPopulated, message, nil);
+                return;
+            }
+            reject(kTxtErrInternalError, message, nil);
+            return;
+        }
+
+        resolve(nil);
+    } @catch (NSException *exception) {
+        reject(kTxtErrInternalError, exception.reason, nil);
+    }
+}
+
 - (void)createLiveTextBuffer:(NSDictionary *)options
                       resolve:(RCTPromiseResolveBlock)resolve
                        reject:(RCTPromiseRejectBlock)reject

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -451,6 +451,16 @@ export interface Spec extends TurboModule {
   }>;
 
   /**
+   * Populate an existing empty offline text buffer exactly once.
+   * Rejects when the buffer does not exist or was already populated.
+   */
+  populateOfflineTextBufferIfEmpty(
+    bufferId: string,
+    text: string,
+    options?: Object
+  ): Promise<void>;
+
+  /**
    * Create a live text buffer for streaming/incremental text.
    */
   createLiveTextBuffer(options: {

--- a/src/pipeline/__tests__/offline-orchestrator.test.ts
+++ b/src/pipeline/__tests__/offline-orchestrator.test.ts
@@ -32,6 +32,7 @@ jest.mock('../../NativeSherpaOnnx', () => ({
 }));
 
 import {
+  runOfflineAudioToTextPipeline,
   runOfflineAudioPipeline,
   runOfflineTextPipeline,
 } from '../offlineOrchestrator';
@@ -793,5 +794,135 @@ describe('offline orchestrator', () => {
     );
 
     expect(result.linkMap).toBe(linkMap);
+  });
+
+  it('runs offline audio->text orchestration and returns segment mappings', async () => {
+    audio.getPipelineAudioBufferInfo.mockImplementation((id: string) => {
+      if (id === 'off_input') {
+        return Promise.resolve({
+          bufferId: 'off_input',
+          kind: 'offlinePcmBuffer',
+          state: 'immutable',
+          sampleRate: 16000,
+          channelCount: 1,
+          numSamples: 8,
+          durationMs: 0.5,
+        });
+      }
+      return Promise.resolve({
+        bufferId: id,
+        kind: 'offlinePcmBuffer',
+        state: 'immutable',
+        sampleRate: 16000,
+        channelCount: 1,
+        numSamples: 4,
+        durationMs: 0.25,
+      });
+    });
+
+    segment.getSegments.mockResolvedValue([
+      {
+        segmentId: 'seg_1',
+        domain: 'speech',
+        startOffset: 0,
+        endOffset: 4,
+        reason: 'manual_commit',
+        source: 'external',
+        createdAtMs: Date.now(),
+        segmentIndex: 0,
+        sourceAudioBufferId: 'off_input',
+        sampleRate: 16000,
+        durationMs: 0.25,
+      },
+    ]);
+
+    text.getPipelineTextBufferInfo.mockImplementation((id: string) => {
+      if (id === 'txt_empty') {
+        return Promise.resolve({
+          bufferId: id,
+          kind: 'offlineTextBuffer',
+          state: 'immutable',
+          utf16Length: 4,
+          tokenCount: 0,
+          timestampCount: 0,
+          durationCount: 0,
+          hasLang: false,
+          hasEmotion: false,
+          hasEvent: false,
+        });
+      }
+      return Promise.resolve({
+        bufferId: id,
+        kind: 'offlineTextBuffer',
+        state: 'immutable',
+        utf16Length: 4,
+        tokenCount: 0,
+        timestampCount: 0,
+        durationCount: 0,
+        hasLang: false,
+        hasEmotion: false,
+        hasEvent: false,
+      });
+    });
+    text.getOfflineTextBufferTextSlice.mockResolvedValue('test');
+
+    const result = await runOfflineAudioToTextPipeline(
+      'off_input',
+      jest.fn().mockResolvedValue(undefined),
+      {
+        segmentation: { mode: 'auto' },
+      }
+    );
+
+    expect(result.status).toBe('complete');
+    expect(result.outputBuffer?.bufferId).toBe('txt_final');
+    expect(result.segmentMappings).toHaveLength(1);
+    expect(result.segmentMappings[0]).toMatchObject({
+      speechSegmentId: 'seg_1',
+      segmentIndex: 0,
+      text: 'test',
+    });
+  });
+
+  it('audio->text skip recovery inserts placeholder and reports skip', async () => {
+    audio.getPipelineAudioBufferInfo.mockResolvedValue({
+      bufferId: 'off_input',
+      kind: 'offlinePcmBuffer',
+      state: 'immutable',
+      sampleRate: 16000,
+      channelCount: 1,
+      numSamples: 4,
+      durationMs: 0.25,
+    });
+
+    segment.getSegments.mockResolvedValue([
+      {
+        segmentId: 'seg_skip',
+        domain: 'speech',
+        startOffset: 0,
+        endOffset: 4,
+        reason: 'manual_commit',
+        source: 'external',
+        createdAtMs: Date.now(),
+        segmentIndex: 0,
+        sourceAudioBufferId: 'off_input',
+        sampleRate: 16000,
+        durationMs: 0.25,
+      },
+    ]);
+
+    const result = await runOfflineAudioToTextPipeline(
+      'off_input',
+      jest.fn().mockRejectedValue(new Error('stt_fail')),
+      {
+        segmentation: { mode: 'auto' },
+        errorRecovery: 'skip',
+        textSkipPlaceholder: '[skip]',
+      }
+    );
+
+    expect(result.status).toBe('complete');
+    expect(result.skippedSegments).toHaveLength(1);
+    expect(result.segmentMappings).toHaveLength(0);
   });
 });

--- a/src/pipeline/offlineOrchestrator.ts
+++ b/src/pipeline/offlineOrchestrator.ts
@@ -91,6 +91,18 @@ export interface OrchestrationResult<TOutput> {
   linkMap?: SegmentLinkMapRef;
 }
 
+export interface AudioToTextSegmentMapping {
+  speechSegmentId: string;
+  textSegmentId: string;
+  segmentIndex: number;
+  text: string;
+}
+
+export interface AudioToTextOrchestrationResult
+  extends OrchestrationResult<OfflineTextBufferRef> {
+  segmentMappings: AudioToTextSegmentMapping[];
+}
+
 type SessionState =
   | 'created'
   | 'running'
@@ -951,6 +963,256 @@ export async function runOfflineTextPipeline(
       },
       processingTimeMs: Date.now() - session.startedAtMs,
       linkMap: config.linkMap,
+    };
+  }
+}
+
+export async function runOfflineAudioToTextPipeline(
+  input: OfflineAudioBufferIdSource,
+  consumer: (
+    segIn: OfflineAudioBufferRef,
+    segOut: OfflineTextBufferRef
+  ) => Promise<void>,
+  config: OrchestrationConfig = {}
+): Promise<AudioToTextOrchestrationResult> {
+  const strategy = normalizeRecovery(config.errorRecovery);
+  const maxRetries = normalizeRetryCount(config.maxRetriesPerSegment);
+  const retryFallback = normalizeRetryFallback(config.retryExhaustedFallback);
+  const skipPlaceholder = config.textSkipPlaceholder ?? '';
+
+  const session = new OrchestrationSession(nextSessionId('audio_text'));
+  const chunks: string[] = [];
+  const segmentMappings: AudioToTextSegmentMapping[] = [];
+
+  try {
+    const info = await getPipelineAudioBufferInfo(input);
+    if (info.kind !== 'offlinePcmBuffer') {
+      return {
+        status: 'failed',
+        totalSegments: 0,
+        completedSegments: 0,
+        skippedSegments: [],
+        failedSegment: {
+          segmentIndex: -1,
+          segmentId: 'audio_input_kind_mismatch',
+          error:
+            'ORCHESTRATION_INVALID_ARGUMENT: runOfflineAudioToTextPipeline expects an offline audio buffer',
+          retryCount: 0,
+        },
+        processingTimeMs: Date.now() - session.startedAtMs,
+        linkMap: config.linkMap,
+        segmentMappings,
+      };
+    }
+
+    const segments = await collectSpeechSegments(
+      input,
+      info,
+      config,
+      session.sessionId
+    );
+    const totalSegments = segments.length;
+
+    session.start();
+
+    for (const [i, seg] of segments.entries()) {
+      if (isAbortRequested(config.abortSignal)) {
+        session.cancel();
+        break;
+      }
+
+      reportProgress(session, config, i, totalSegments, seg.durationMs ?? 0);
+
+      let attempts = 0;
+      let completed = false;
+      while (!completed) {
+        if (isAbortRequested(config.abortSignal)) {
+          session.cancel();
+          break;
+        }
+
+        let tempIn: OfflineAudioBufferRef | undefined;
+        let tempOut: OfflineTextBufferRef | undefined;
+        try {
+          const segLength = Math.max(0, seg.endOffset - seg.startOffset);
+          const segSamples =
+            segLength > 0
+              ? getOfflineAudioBufferSamplesSlice(
+                  input,
+                  seg.startOffset,
+                  segLength
+                )
+              : new Float32Array(0);
+
+          tempIn = createOfflineAudioBufferFromSamples(
+            segSamples,
+            info.sampleRate,
+            info.channelCount
+          );
+          tempOut = await createEmptyOfflineTextBuffer();
+
+          await consumer(tempIn, tempOut);
+
+          const outInfo = await getPipelineTextBufferInfo(tempOut.bufferId);
+          if (outInfo.kind !== 'offlineTextBuffer') {
+            throw new Error(
+              'ORCHESTRATION_CONSUMER_ERROR: offline audio-to-text consumer must write to an offline text output buffer'
+            );
+          }
+
+          const outText =
+            outInfo.utf16Length > 0
+              ? await getOfflineTextBufferTextSlice(
+                  tempOut.bufferId,
+                  0,
+                  outInfo.utf16Length
+                )
+              : '';
+
+          chunks.push(outText);
+          segmentMappings.push({
+            speechSegmentId: seg.segmentId,
+            textSegmentId: `txtseg_${session.sessionId}_${seg.segmentIndex}`,
+            segmentIndex: seg.segmentIndex,
+            text: outText,
+          });
+          session.addCompletedSegment();
+          completed = true;
+        } catch (err) {
+          const error = formatError(err);
+          session.markRecovering();
+
+          if (strategy === 'retry' && attempts < maxRetries) {
+            attempts += 1;
+            reportProgress(
+              session,
+              config,
+              i,
+              totalSegments,
+              seg.durationMs ?? 0
+            );
+            continue;
+          }
+
+          const exhaustedFallback =
+            strategy === 'retry' ? retryFallback : strategy;
+
+          if (exhaustedFallback === 'skip') {
+            chunks.push(skipPlaceholder);
+            session.addSkippedSegment({
+              segmentIndex: seg.segmentIndex,
+              segmentId: seg.segmentId,
+              error,
+              retryCount: attempts,
+            });
+            completed = true;
+          } else if (exhaustedFallback === 'partial_result') {
+            session.setFailedSegment({
+              segmentIndex: seg.segmentIndex,
+              segmentId: seg.segmentId,
+              error,
+              retryCount: attempts,
+            });
+            session.markCompleting();
+            completed = true;
+          } else {
+            session.fail({
+              segmentIndex: seg.segmentIndex,
+              segmentId: seg.segmentId,
+              error,
+              retryCount: attempts,
+            });
+            completed = true;
+          }
+        } finally {
+          await cleanupAudioTemporaries(tempIn, undefined);
+          await cleanupTextTemporaries(tempOut, undefined);
+        }
+      }
+
+      if (session.state === 'failed') {
+        break;
+      }
+      if (session.state === 'cancelled') {
+        break;
+      }
+      if (session.state === 'completing') {
+        break;
+      }
+    }
+
+    if (session.state === 'failed') {
+      return {
+        status: 'failed',
+        totalSegments: segments.length,
+        completedSegments: session.completedSegments,
+        skippedSegments: session.skippedSegments,
+        ...(session.failedSegment
+          ? { failedSegment: session.failedSegment }
+          : {}),
+        processingTimeMs: Date.now() - session.startedAtMs,
+        linkMap: config.linkMap,
+        segmentMappings,
+      };
+    }
+
+    if (
+      session.state === 'cancelled' &&
+      !shouldReturnPartialOnCancel(strategy)
+    ) {
+      return {
+        status: 'cancelled',
+        totalSegments: segments.length,
+        completedSegments: session.completedSegments,
+        skippedSegments: session.skippedSegments,
+        processingTimeMs: Date.now() - session.startedAtMs,
+        linkMap: config.linkMap,
+        segmentMappings,
+      };
+    }
+
+    const wasCancelled = session.state === 'cancelled';
+    session.markCompleting();
+    const finalText = chunks.join('');
+    const outputBuffer =
+      finalText.length > 0
+        ? await createOfflineTextBufferFromText(finalText)
+        : await createEmptyOfflineTextBuffer();
+    const status: 'complete' | 'partial' | 'cancelled' = wasCancelled
+      ? 'cancelled'
+      : session.failedSegment != null
+      ? 'partial'
+      : 'complete';
+
+    session.markDone();
+    return {
+      outputBuffer,
+      status,
+      totalSegments: segments.length,
+      completedSegments: session.completedSegments,
+      skippedSegments: session.skippedSegments,
+      ...(session.failedSegment
+        ? { failedSegment: session.failedSegment }
+        : {}),
+      processingTimeMs: Date.now() - session.startedAtMs,
+      linkMap: config.linkMap,
+      segmentMappings,
+    };
+  } catch (err) {
+    return {
+      status: 'failed',
+      totalSegments: 0,
+      completedSegments: session.completedSegments,
+      skippedSegments: session.skippedSegments,
+      failedSegment: {
+        segmentIndex: -1,
+        segmentId: `${session.sessionId}_fatal`,
+        error: formatError(err),
+        retryCount: 0,
+      },
+      processingTimeMs: Date.now() - session.startedAtMs,
+      linkMap: config.linkMap,
+      segmentMappings,
     };
   }
 }

--- a/src/segment/__tests__/segment-api.test.ts
+++ b/src/segment/__tests__/segment-api.test.ts
@@ -319,4 +319,35 @@ describe('segment api offline integration', () => {
     expect(textCount).toBe(2);
     expect(audioCount).toBe(1);
   });
+
+  it('maps endpoint/source from native segment meta for live stt commits', async () => {
+    mockTextbuffer.getLiveTextBufferSegmentCount.mockResolvedValue(1);
+    mockTextbuffer.getLiveTextBufferSegments.mockResolvedValue([
+      {
+        text: 'hello world',
+        source: 'stt_stream',
+        segmentIndex: 0,
+        meta: {
+          __segmentReason: 'endpoint',
+          __segmentSource: 'segmentation_engine',
+          __segmentCreatedAtMs: 12345,
+        },
+      },
+    ]);
+
+    const segments = await getSegments(
+      'txt_live_11111111-1111-1111-1111-111111111111',
+      0,
+      10
+    );
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({
+      domain: 'text',
+      reason: 'endpoint',
+      source: 'segmentation_engine',
+      text: 'hello world',
+      createdAtMs: 12345,
+    });
+  });
 });

--- a/src/segment/__tests__/segmentation-engine-vad.test.ts
+++ b/src/segment/__tests__/segmentation-engine-vad.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Phase 2 plan A6: mock native `attachSegmentationEngine` with `speech_vad_model`,
+ * assert engine info shape and live speech segments expose `reason: 'vad_boundary'`.
+ */
+jest.mock('react-native', () => {
+  const mockNative = {
+    setLiveTextBufferPartial: jest.fn(),
+    appendLiveTextBufferPartial: jest.fn(),
+    segmentOfflineBuffer: jest.fn(),
+    attachSegmentationEngine: jest.fn(),
+    detachSegmentationEngine: jest.fn(),
+    getSegmentationEngineInfo: jest.fn(),
+    createSegmentLinkMap: jest.fn(),
+    addSegmentLink: jest.fn(),
+    addSegmentLinks: jest.fn(),
+    removeSegmentLink: jest.fn(),
+    getSpeechSegmentsForText: jest.fn(),
+    getTextSegmentsForSpeech: jest.fn(),
+    getAllSegmentLinks: jest.fn(),
+    getSegmentLinkCount: jest.fn(),
+    getSegmentLinkMapInfo: jest.fn(),
+    releaseSegmentLinkMap: jest.fn(),
+  };
+  return {
+    TurboModuleRegistry: {
+      getEnforcing: () => mockNative,
+    },
+    __mockNative: mockNative,
+  };
+});
+
+jest.mock('../../textbuffer', () => ({
+  appendLiveTextSegment: jest.fn(),
+  getOfflineTextBufferTextSlice: jest.fn(),
+  getLiveTextBufferPartialSlice: jest.fn(),
+  getLiveTextBufferSegmentCount: jest.fn(),
+  getLiveTextBufferSegments: jest.fn(),
+  getPipelineTextBufferInfo: jest.fn(),
+  resolvePipelineTextBufferId: jest.fn((value: unknown) => String(value)),
+}));
+
+jest.mock('../../audiobuffer', () => ({
+  getPipelineAudioBufferInfo: jest.fn(),
+  resolvePipelineAudioBufferId: jest.fn((value: unknown) => String(value)),
+}));
+
+jest.mock('../../segmentbuffer', () => ({
+  appendLiveSegment: jest.fn(),
+  createEmptyOfflineSegmentBuffer: jest.fn(),
+  createLiveSegmentBuffer: jest.fn(),
+  createOfflineSegmentBufferFromLive: jest.fn(),
+  finalizeLiveSegmentBuffer: jest.fn(),
+  getLiveSegmentBufferSegmentCount: jest.fn(),
+  getLiveSegmentBufferSegments: jest.fn(),
+  getOfflineSegmentBufferSegments: jest.fn(),
+  getPipelineSegmentBufferInfo: jest.fn(),
+  releasePipelineSegmentBuffer: jest.fn(),
+}));
+
+import {
+  attachSegmentationEngine,
+  getSegmentationEngineInfo,
+  getSegments,
+} from '../index';
+import { releaseSegmentationStateForBuffer } from '../runtime-state';
+
+describe('segmentation engine VAD (speech_vad_model)', () => {
+  const LIVE_AUDIO_ID = 'live_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  const SEG_LIVE_ID = 'seg_live_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+  const ENGINE_ID = 'eng_vad_mock_01';
+
+  const mockSegmentbuffer = jest.requireMock('../../segmentbuffer') as any;
+  const native = (jest.requireMock('react-native') as any).__mockNative;
+
+  const vadPolicy = {
+    evaluator: 'speech_vad_model' as const,
+    vadModelId: '/models/vad/silero_vad.onnx',
+    vadThreshold: 0.48,
+    vadMinSpeechMs: 120,
+    vadMinSilenceMs: 300,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    releaseSegmentationStateForBuffer(LIVE_AUDIO_ID);
+
+    native.attachSegmentationEngine.mockResolvedValue({
+      engineId: ENGINE_ID,
+      segmentBufferId: SEG_LIVE_ID,
+    });
+
+    native.getSegmentationEngineInfo.mockResolvedValue({
+      engineId: ENGINE_ID,
+      attachedBufferId: LIVE_AUDIO_ID,
+      domain: 'speech',
+      policy: vadPolicy,
+      state: 'active',
+      totalSegmentsCommitted: 2,
+      lastSegmentId: 'speech_seg_vad_2',
+      segmentBufferId: SEG_LIVE_ID,
+    });
+
+    mockSegmentbuffer.getLiveSegmentBufferSegmentCount.mockResolvedValue(1);
+    mockSegmentbuffer.getLiveSegmentBufferSegments.mockResolvedValue([
+      {
+        kind: 'speech',
+        id: 'speech_seg_vad_boundary_0',
+        sourceAudioBufferId: LIVE_AUDIO_ID,
+        startSample: 0,
+        endSample: 8000,
+        sampleRate: 16000,
+        durationMs: 500,
+        reason: 'vad_boundary',
+        source: 'segmentation_engine',
+        createdAtMs: 42_000,
+      },
+    ]);
+  });
+
+  it('forwards speech_vad_model policy to native attachSegmentationEngine', async () => {
+    await attachSegmentationEngine(LIVE_AUDIO_ID, { policy: vadPolicy });
+
+    expect(native.attachSegmentationEngine).toHaveBeenCalledTimes(1);
+    expect(native.attachSegmentationEngine).toHaveBeenCalledWith(
+      LIVE_AUDIO_ID,
+      'speech',
+      expect.objectContaining({
+        evaluator: 'speech_vad_model',
+        vadModelId: '/models/vad/silero_vad.onnx',
+        vadThreshold: 0.48,
+      })
+    );
+  });
+
+  it('exposes SegmentationEngineInfo snapshot for VAD-attached engine', async () => {
+    await attachSegmentationEngine(LIVE_AUDIO_ID, { policy: vadPolicy });
+
+    const info = await getSegmentationEngineInfo({ engineId: ENGINE_ID });
+
+    expect(info).toMatchSnapshot();
+  });
+
+  it('maps live speech segments with reason vad_boundary from native buffer', async () => {
+    await attachSegmentationEngine(LIVE_AUDIO_ID, { policy: vadPolicy });
+
+    const segments = await getSegments(LIVE_AUDIO_ID, 0, 10);
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({
+      domain: 'speech',
+      reason: 'vad_boundary',
+      source: 'segmentation_engine',
+      segmentId: 'speech_seg_vad_boundary_0',
+      sourceAudioBufferId: LIVE_AUDIO_ID,
+      startOffset: 0,
+      endOffset: 8000,
+      sampleRate: 16000,
+      durationMs: 500,
+      createdAtMs: 42_000,
+    });
+  });
+});

--- a/src/segment/engine-types.ts
+++ b/src/segment/engine-types.ts
@@ -16,6 +16,10 @@ export interface SegmentationPolicy {
   maxSegmentMs?: number;
   hangoverMs?: number;
   checkpointIntervalMs?: number;
+  vadModelId?: string;
+  vadThreshold?: number;
+  vadMinSpeechMs?: number;
+  vadMinSilenceMs?: number;
 }
 
 export interface SegmentationConfig {

--- a/src/stt/__tests__/transcribe-segmented.test.ts
+++ b/src/stt/__tests__/transcribe-segmented.test.ts
@@ -1,0 +1,217 @@
+jest.mock('../../NativeSherpaOnnx', () => ({
+  __esModule: true,
+  default: {
+    initializeStt: jest.fn(),
+    unloadStt: jest.fn(),
+    transcribe: jest.fn(),
+    populateOfflineTextBufferIfEmpty: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils', () => ({
+  resolveModelPath: jest.fn(async () => '/models/stt'),
+}));
+
+jest.mock('../../detect', () => ({
+  resolveFileSourceForDetect: jest.fn(async () => ({
+    modelDir: '/models/stt',
+    assetName: 'model.onnx',
+  })),
+}));
+
+jest.mock('../../pipeline/offlineOrchestrator', () => ({
+  runOfflineAudioToTextPipeline: jest.fn(),
+}));
+
+jest.mock('../../segment', () => ({
+  createSegmentLinkMap: jest.fn(),
+  addSegmentLink: jest.fn(),
+}));
+
+jest.mock('../../segment/runtime-state', () => ({
+  setOfflineTextSegments: jest.fn(),
+}));
+
+jest.mock('../../textbuffer', () => ({
+  getPipelineTextBufferInfo: jest.fn(),
+  getOfflineTextBufferTextSlice: jest.fn(),
+  releasePipelineTextBuffer: jest.fn(),
+  resolvePipelineTextBufferId: jest.fn((value: unknown) => String(value)),
+}));
+
+jest.mock('../../audiobuffer', () => ({
+  resolvePipelineAudioBufferId: jest.fn((value: unknown) => String(value)),
+}));
+
+import SherpaOnnx from '../../NativeSherpaOnnx';
+import { createSTT } from '../index';
+import { runOfflineAudioToTextPipeline } from '../../pipeline/offlineOrchestrator';
+import { createSegmentLinkMap, addSegmentLink } from '../../segment';
+import {
+  getOfflineTextBufferTextSlice,
+  getPipelineTextBufferInfo,
+  releasePipelineTextBuffer,
+} from '../../textbuffer';
+import { setOfflineTextSegments } from '../../segment/runtime-state';
+
+describe('stt segmented transcribe', () => {
+  const mockNative = SherpaOnnx as unknown as {
+    initializeStt: jest.Mock;
+    unloadStt: jest.Mock;
+    transcribe: jest.Mock;
+    populateOfflineTextBufferIfEmpty: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNative.initializeStt.mockResolvedValue({
+      success: true,
+      detectedModels: [],
+    });
+    mockNative.unloadStt.mockResolvedValue(null);
+    mockNative.transcribe.mockResolvedValue(null);
+    mockNative.populateOfflineTextBufferIfEmpty.mockResolvedValue(null);
+
+    (createSegmentLinkMap as jest.Mock).mockResolvedValue({
+      linkMapId: 'slm_1',
+    });
+    (addSegmentLink as jest.Mock).mockResolvedValue({
+      linkId: 'link_1',
+      textSegmentId: 'txtseg_1',
+      speechSegmentId: 'sp_1',
+      linkType: 'stt_produced',
+    });
+
+    (getPipelineTextBufferInfo as jest.Mock).mockResolvedValue({
+      bufferId: 'txt_tmp',
+      kind: 'offlineTextBuffer',
+      state: 'immutable',
+      utf16Length: 8,
+    });
+    (getOfflineTextBufferTextSlice as jest.Mock).mockResolvedValue('hi there');
+    (releasePipelineTextBuffer as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('runs segmented orchestration, populates textOut and creates stt_produced links', async () => {
+    (runOfflineAudioToTextPipeline as jest.Mock).mockResolvedValue({
+      status: 'complete',
+      totalSegments: 2,
+      completedSegments: 2,
+      skippedSegments: [],
+      processingTimeMs: 12,
+      outputBuffer: {
+        bufferId: 'txt_tmp',
+        info: {
+          bufferId: 'txt_tmp',
+          kind: 'offlineTextBuffer',
+          state: 'immutable',
+          utf16Length: 8,
+          tokenCount: 0,
+          timestampCount: 0,
+          durationCount: 0,
+          hasLang: false,
+          hasEmotion: false,
+          hasEvent: false,
+        },
+      },
+      segmentMappings: [
+        {
+          speechSegmentId: 'sp_1',
+          textSegmentId: 'tmp_1',
+          segmentIndex: 0,
+          text: 'hi ',
+        },
+        {
+          speechSegmentId: 'sp_2',
+          textSegmentId: 'tmp_2',
+          segmentIndex: 1,
+          text: 'there',
+        },
+      ],
+    });
+
+    const stt = await createSTT({
+      modelPath: { type: 'file', path: '/models/stt' },
+    });
+
+    const result = await stt.transcribe(
+      'off_11111111-1111-1111-1111-111111111111',
+      'txt_off_11111111-1111-1111-1111-111111111111',
+      {
+        segmentation: {
+          mode: 'auto',
+          policy: {
+            evaluator: 'speech_vad_model',
+            vadModelId: '/models/vad/silero_vad.onnx',
+          },
+        },
+      }
+    );
+
+    expect(result.status).toBe('complete');
+    expect(result.completedSegments).toBe(2);
+    expect(result.linkMap?.linkMapId).toBe('slm_1');
+
+    expect(mockNative.populateOfflineTextBufferIfEmpty).toHaveBeenCalledWith(
+      'txt_off_11111111-1111-1111-1111-111111111111',
+      'hi there'
+    );
+    expect(releasePipelineTextBuffer).toHaveBeenCalledWith('txt_tmp');
+    expect(createSegmentLinkMap).toHaveBeenCalled();
+    expect(addSegmentLink).toHaveBeenCalledTimes(2);
+    expect(setOfflineTextSegments).toHaveBeenCalled();
+  });
+
+  it('uses native single-shot path when segmentation mode is off', async () => {
+    const stt = await createSTT({
+      modelPath: { type: 'file', path: '/models/stt' },
+    });
+
+    const result = await stt.transcribe(
+      'off_11111111-1111-1111-1111-111111111111',
+      'txt_off_11111111-1111-1111-1111-111111111111'
+    );
+
+    expect(result.status).toBe('complete');
+    expect(mockNative.transcribe).toHaveBeenCalledWith(
+      expect.stringMatching(/^stt_/),
+      'off_11111111-1111-1111-1111-111111111111',
+      'txt_off_11111111-1111-1111-1111-111111111111'
+    );
+    expect(runOfflineAudioToTextPipeline).not.toHaveBeenCalled();
+  });
+
+  it('throws when segmented orchestration returns failed status', async () => {
+    (runOfflineAudioToTextPipeline as jest.Mock).mockResolvedValue({
+      status: 'failed',
+      totalSegments: 2,
+      completedSegments: 0,
+      skippedSegments: [],
+      failedSegment: {
+        segmentIndex: 0,
+        segmentId: 'sp_1',
+        error: 'boom',
+        retryCount: 0,
+      },
+      processingTimeMs: 3,
+      segmentMappings: [],
+    });
+
+    const stt = await createSTT({
+      modelPath: { type: 'file', path: '/models/stt' },
+    });
+
+    await expect(
+      stt.transcribe(
+        'off_11111111-1111-1111-1111-111111111111',
+        'txt_off_11111111-1111-1111-1111-111111111111',
+        {
+          segmentation: {
+            mode: 'auto',
+            policy: { evaluator: 'speech_energy_silence' },
+          },
+        }
+      )
+    ).rejects.toThrow('boom');
+  });
+});

--- a/src/stt/index.ts
+++ b/src/stt/index.ts
@@ -1,6 +1,11 @@
 import SherpaOnnx from '../NativeSherpaOnnx';
 import { resolvePipelineAudioBufferId } from '../audiobuffer';
-import { resolvePipelineTextBufferId } from '../textbuffer';
+import {
+  getOfflineTextBufferTextSlice,
+  getPipelineTextBufferInfo,
+  releasePipelineTextBuffer,
+  resolvePipelineTextBufferId,
+} from '../textbuffer';
 import type {
   OfflineAudioBufferRef,
   OfflineBufferHandle,
@@ -14,6 +19,8 @@ import type {
   STTModelType,
   SttEngine,
   SttModelOptions,
+  SttTranscribeResult,
+  SttTranscribeOptions,
   SttRuntimeConfig,
 } from './types';
 import type { ModelPathConfig } from '../types';
@@ -28,6 +35,10 @@ import {
   type DetectedModelEntry,
   type SttDetectModelResult,
 } from '../types/modelDetect';
+import { runOfflineAudioToTextPipeline } from '../pipeline/offlineOrchestrator';
+import { addSegmentLink, createSegmentLinkMap } from '../segment';
+import type { TextSegment } from '../segment/segment';
+import { setOfflineTextSegments } from '../segment/runtime-state';
 
 let sttInstanceCounter = 0;
 
@@ -249,14 +260,141 @@ export async function createSTT(
 
     async transcribe(
       buffer: OfflineAudioBufferRef | OfflineBufferHandle | string,
-      textOut: OfflineTextBufferRef | OfflineTextBufferHandle | string
-    ): Promise<void> {
+      textOut: OfflineTextBufferRef | OfflineTextBufferHandle | string,
+      options?: SttTranscribeOptions
+    ): Promise<SttTranscribeResult> {
       guard();
+      const startedAtMs = Date.now();
       const bufferId = normalizeOfflineBufferInput(buffer);
       const textOutBufferId = resolvePipelineTextBufferId(
         typeof textOut === 'string' ? textOut : textOut.bufferId
       );
-      await SherpaOnnx.transcribe(instanceId, bufferId, textOutBufferId);
+
+      const segmentationMode = options?.segmentation?.mode ?? 'off';
+      const segmentationEnabled = segmentationMode !== 'off';
+
+      if (!segmentationEnabled) {
+        await SherpaOnnx.transcribe(instanceId, bufferId, textOutBufferId);
+        return {
+          status: 'complete',
+          totalSegments: 1,
+          completedSegments: 1,
+          skippedSegments: [],
+          processingTimeMs: Date.now() - startedAtMs,
+          linkMap: options?.linkMap,
+        };
+      }
+
+      const orchestrated = await runOfflineAudioToTextPipeline(
+        bufferId,
+        async (segIn, segOut) => {
+          await SherpaOnnx.transcribe(
+            instanceId,
+            segIn.bufferId,
+            segOut.bufferId
+          );
+        },
+        {
+          segmentation: {
+            mode: segmentationMode,
+            policy: options?.segmentation?.policy,
+          },
+          errorRecovery: options?.errorRecovery,
+          maxRetriesPerSegment: options?.maxRetriesPerSegment,
+          retryExhaustedFallback: options?.retryExhaustedFallback,
+          abortSignal: options?.abortSignal,
+          onProgress: options?.onProgress,
+          textSkipPlaceholder: options?.textSkipPlaceholder,
+          linkMap: options?.linkMap,
+        }
+      );
+
+      if (orchestrated.status === 'failed') {
+        const message =
+          orchestrated.failedSegment?.error ??
+          'STT segmented transcription failed';
+        throw new Error(message);
+      }
+
+      let linkMap = options?.linkMap;
+      if (!linkMap) {
+        linkMap = await createSegmentLinkMap({
+          audioBufferId: bufferId,
+          textBufferId: textOutBufferId,
+        });
+      }
+
+      const outputBuffer = orchestrated.outputBuffer;
+      let finalText = '';
+      if (outputBuffer) {
+        try {
+          const outInfo = await getPipelineTextBufferInfo(
+            outputBuffer.bufferId
+          );
+          if (outInfo.kind === 'offlineTextBuffer' && outInfo.utf16Length > 0) {
+            finalText = await getOfflineTextBufferTextSlice(
+              outputBuffer.bufferId,
+              0,
+              outInfo.utf16Length
+            );
+          }
+
+          await SherpaOnnx.populateOfflineTextBufferIfEmpty(
+            textOutBufferId,
+            finalText
+          );
+        } finally {
+          await releasePipelineTextBuffer(outputBuffer.bufferId);
+        }
+      } else {
+        await SherpaOnnx.populateOfflineTextBufferIfEmpty(textOutBufferId, '');
+      }
+
+      let runningOffset = 0;
+      const textSegments: TextSegment[] = orchestrated.segmentMappings.map(
+        (mapping, index) => {
+          const segmentText = mapping.text;
+          const startOffset = runningOffset;
+          const endOffset = startOffset + segmentText.length;
+          runningOffset = endOffset;
+          return {
+            segmentId: `txtseg_${textOutBufferId}_${index}`,
+            domain: 'text',
+            startOffset,
+            endOffset,
+            reason: 'endpoint',
+            source: 'segmentation_engine',
+            createdAtMs: Date.now(),
+            segmentIndex: index,
+            text: segmentText,
+            utf16Length: segmentText.length,
+          };
+        }
+      );
+      setOfflineTextSegments(textOutBufferId, textSegments);
+
+      for (let i = 0; i < textSegments.length; i += 1) {
+        const textSegment = textSegments[i]!;
+        const mapping = orchestrated.segmentMappings[i];
+        if (!mapping) continue;
+        await addSegmentLink(linkMap, {
+          textSegmentId: textSegment.segmentId,
+          speechSegmentId: mapping.speechSegmentId,
+          linkType: 'stt_produced',
+        });
+      }
+
+      return {
+        status: orchestrated.status,
+        totalSegments: orchestrated.totalSegments,
+        completedSegments: orchestrated.completedSegments,
+        skippedSegments: orchestrated.skippedSegments,
+        ...(orchestrated.failedSegment
+          ? { failedSegment: orchestrated.failedSegment }
+          : {}),
+        processingTimeMs: orchestrated.processingTimeMs,
+        linkMap,
+      };
     },
 
     async setConfig(config: SttRuntimeConfig): Promise<void> {
@@ -306,6 +444,9 @@ export type {
   SttQwen3AsrModelOptions,
   SttCohereTranscribeModelOptions,
   SttTranscribeRef,
+  SttTranscribeOptions,
+  SttTranscribeResult,
+  SttSegmentationConfig,
   SttRuntimeConfig,
   SttEngine,
   SttInitResult,

--- a/src/stt/types.ts
+++ b/src/stt/types.ts
@@ -7,6 +7,14 @@ import type {
   OfflineTextBufferRef,
   OfflineTextBufferHandle,
 } from '../textbuffer/types';
+import type {
+  ErrorRecoveryStrategy,
+  FailedSegmentInfo,
+  OrchestrationProgress,
+  SkippedSegmentInfo,
+} from '../pipeline/offlineOrchestrator';
+import type { SegmentationPolicy } from '../segment/engine-types';
+import type { SegmentLinkMapRef } from '../segment/segment-link';
 
 /**
  * Supported STT model types.
@@ -334,6 +342,32 @@ export const SttErrorCode = {
 export type SttErrorCodeValue =
   (typeof SttErrorCode)[keyof typeof SttErrorCode];
 
+export interface SttSegmentationConfig {
+  mode?: 'off' | 'manual' | 'auto';
+  policy?: SegmentationPolicy;
+}
+
+export interface SttTranscribeOptions {
+  segmentation?: SttSegmentationConfig;
+  errorRecovery?: ErrorRecoveryStrategy;
+  maxRetriesPerSegment?: number;
+  retryExhaustedFallback?: 'abort' | 'skip';
+  abortSignal?: AbortSignal;
+  onProgress?: (progress: OrchestrationProgress) => void;
+  linkMap?: SegmentLinkMapRef;
+  textSkipPlaceholder?: string;
+}
+
+export interface SttTranscribeResult {
+  status: 'complete' | 'partial' | 'failed' | 'cancelled';
+  totalSegments: number;
+  completedSegments: number;
+  skippedSegments: SkippedSegmentInfo[];
+  failedSegment?: FailedSegmentInfo;
+  processingTimeMs: number;
+  linkMap?: SegmentLinkMapRef;
+}
+
 // ========== Engine interfaces ==========
 
 /**
@@ -344,8 +378,9 @@ export interface SttEngine {
   readonly instanceId: string;
   transcribe(
     buffer: OfflineAudioBufferRef | OfflineBufferHandle | string,
-    textOut: OfflineTextBufferRef | OfflineTextBufferHandle | string
-  ): Promise<void>;
+    textOut: OfflineTextBufferRef | OfflineTextBufferHandle | string,
+    options?: SttTranscribeOptions
+  ): Promise<SttTranscribeResult>;
   setConfig(options: SttRuntimeConfig): Promise<void>;
   destroy(): Promise<void>;
 }


### PR DESCRIPTION
This pull request implements and documents Phase 2 of the Segmentation Engine project, focusing on full support for VAD (Voice Activity Detection) and STT (Speech-to-Text) integration, including improved metadata handling and expanded segmentation policy support on both Android and iOS. It also updates the documentation to reflect the completion of Phase 2 and provides a comprehensive snapshot of the current segmentation engine core and TypeScript API.

**Key changes:**

### Segmentation Engine: VAD and Policy Support

* Added support for VAD-specific segmentation policy parameters (`vadModelId`, `vadThreshold`, `vadMinSpeechMs`, `vadMinSilenceMs`) to both Android (`SherpaOnnxModule.kt`) and iOS (`SherpaOnnx+SegmentBuffer.mm`) segmentation engine implementations, including model path resolution and VAD runtime initialization on iOS. [[1]](diffhunk://#diff-879656a663809608669376c509d884bda0e032ec094f58ce4e41a60afbbcf80dR2885-R2888) [[2]](diffhunk://#diff-8bb34eff6e73df7f205fcf5e87cb2a0b62130cc8dedb132717c1ad84e3b74c7aR735-R738) [[3]](diffhunk://#diff-8bb34eff6e73df7f205fcf5e87cb2a0b62130cc8dedb132717c1ad84e3b74c7aR763-R765) [[4]](diffhunk://#diff-8bb34eff6e73df7f205fcf5e87cb2a0b62130cc8dedb132717c1ad84e3b74c7aR783-R886)
* The iOS engine now detects and loads VAD models from file or directory, infers model type, and initializes the VAD runtime with appropriate parameters.

### STT Segmentation & Metadata

* Streaming STT endpoint commits now attach detailed segment metadata (`__segmentReason`, `__segmentSource`, `__segmentCreatedAtMs`) to each committed segment, improving traceability and downstream orchestration. [[1]](diffhunk://#diff-cd6a87598f6c1ebbefe2a04515c0bdc392093649d9ff0f99e17958b1c136f747R103-R114) [[2]](diffhunk://#diff-cd6a87598f6c1ebbefe2a04515c0bdc392093649d9ff0f99e17958b1c136f747L116-R123) [[3]](diffhunk://#diff-cd6a87598f6c1ebbefe2a04515c0bdc392093649d9ff0f99e17958b1c136f747R152-R163) [[4]](diffhunk://#diff-cd6a87598f6c1ebbefe2a04515c0bdc392093649d9ff0f99e17958b1c136f747L158-R172)

### Native Bridge & Buffer Management

* Added a new native bridge method `populateOfflineTextBufferIfEmpty` to the Android module to preserve existing buffer semantics in the segmented flow.

### Documentation Updates

* Marked Phase 2 (VAD + STT + `stt_produced` links) as completed in all relevant documentation, including migration plans and overview. [[1]](diffhunk://#diff-3447e3ed5a1ad94dce2466f61e5a367d6a7eb734da0ee109ad98675dfe78fa8fL86-R86) [[2]](diffhunk://#diff-b4f2f40d717ac840e068cef0c07421de46ace4ccad291be1a1c8321b7dfeeaf7L4-R5) [[3]](diffhunk://#diff-b4f2f40d717ac840e068cef0c07421de46ace4ccad291be1a1c8321b7dfeeaf7R48-R57)
* Added a comprehensive snapshot document (`segmentation-engine-core-snapshot.md`) detailing the current architecture, API, and implementation status of the segmentation engine, including TypeScript types, native contracts, and error codes.

---

These changes complete the VAD and STT integration phase, provide rich metadata for segment tracking, and ensure both platforms are aligned in their segmentation capabilities.