### PR TITLE
Feat/add segmentation engine enhancement integration

### DIFF
--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -1419,6 +1419,43 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     }
   }
 
+  override fun populateOfflineAudioBufferIfEmpty(
+    targetBufferId: String,
+    sourceBufferId: String,
+    _options: ReadableMap?,
+    promise: Promise,
+  ) {
+    try {
+      com.sherpaonnx.audio.pipeline.PipelineAudioRegistry.populateOfflineIfEmpty(
+        targetBufferId = targetBufferId,
+        sourceBufferId = sourceBufferId,
+      )
+      promise.resolve(null)
+    } catch (e: IllegalStateException) {
+      promise.reject(
+        com.sherpaonnx.audio.pipeline.PipelineAudioErrorCodes.INVALID_STATE,
+        e.message,
+        e
+      )
+    } catch (e: IllegalArgumentException) {
+      val msg = e.message ?: ""
+      val code = if (
+        msg.contains("not found", ignoreCase = true)
+      ) {
+        com.sherpaonnx.audio.pipeline.PipelineAudioErrorCodes.BUFFER_NOT_FOUND
+      } else {
+        com.sherpaonnx.audio.pipeline.PipelineAudioErrorCodes.INVALID_ARGUMENT
+      }
+      promise.reject(code, e.message, e)
+    } catch (e: Exception) {
+      promise.reject(
+        com.sherpaonnx.audio.pipeline.PipelineAudioErrorCodes.INTERNAL_ERROR,
+        e.message,
+        e
+      )
+    }
+  }
+
   override fun createEmptyLiveAudioBuffer(options: ReadableMap, promise: Promise) {
     try {
       val sampleRate = options.getDouble("sampleRate").toInt()

--- a/android/src/main/java/com/sherpaonnx/audio/pipeline/PipelineAudioRegistry.kt
+++ b/android/src/main/java/com/sherpaonnx/audio/pipeline/PipelineAudioRegistry.kt
@@ -246,6 +246,64 @@ object PipelineAudioRegistry {
     return entry
   }
 
+  /**
+   * Atomically populate an empty offline target by adopting storage from a source offline buffer.
+   *
+   * This is a storage hand-off helper for segmented orchestration outputs where the caller owns
+   * the target buffer handle but the orchestrator produced a temporary source buffer.
+   */
+  @Synchronized
+  fun populateOfflineIfEmpty(
+    targetBufferId: String,
+    sourceBufferId: String,
+  ) {
+    if (targetBufferId == sourceBufferId) return
+
+    val target = offlineEntries[targetBufferId]
+      ?: throw IllegalArgumentException("Offline target buffer not found: $targetBufferId")
+    val source = offlineEntries[sourceBufferId]
+      ?: throw IllegalArgumentException("Offline source buffer not found: $sourceBufferId")
+
+    if (target.numSamples != 0) {
+      throw IllegalStateException("Offline target buffer is not empty: $targetBufferId")
+    }
+
+    if (target.sampleRate != source.sampleRate || target.channelCount != source.channelCount) {
+      throw IllegalArgumentException(
+        "Offline buffer format mismatch: target(${target.sampleRate}Hz/${target.channelCount}ch) != source(${source.sampleRate}Hz/${source.channelCount}ch)"
+      )
+    }
+
+    val replacement = when (source) {
+      is OfflineEntry.InMemory -> {
+        val adopted = source.samples
+        source.samples = FloatArray(0)
+        OfflineEntry.InMemory(
+          bufferId = targetBufferId,
+          sampleRate = source.sampleRate,
+          channelCount = source.channelCount,
+          samples = adopted,
+        )
+      }
+
+      is OfflineEntry.MmapBacked -> {
+        OfflineEntry.createMmapFromFile(
+          bufferId = targetBufferId,
+          sampleRate = source.sampleRate,
+          channelCount = source.channelCount,
+          numSamples = source.numSamples,
+          f32FilePath = source.filePath,
+          dataOffsetBytes = source.dataOffsetBytes,
+        ) ?: throw IllegalStateException(
+          "Failed to adopt mmap-backed source buffer into target: $sourceBufferId"
+        )
+      }
+    }
+
+    offlineEntries[targetBufferId] = replacement
+    offlineEntries.remove(sourceBufferId)
+  }
+
   private fun createFromRingSnapshot(bufferId: String, live: LiveEntry): OfflineEntry {
     val snapshot = live.snapshotRing()
     val entry = createEntryWithThreshold(bufferId, live.sampleRate, live.channelCount, snapshot)

--- a/android/src/main/java/com/sherpaonnx/segment/engine/SegmentationEngineRegistry.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/engine/SegmentationEngineRegistry.kt
@@ -309,6 +309,22 @@ private class SpeechEnergySilenceEngine(
     if (currentState != EngineState.ACTIVE) return
     if (chunk.isEmpty() || sampleRate <= 0) return
 
+    if (policy.evaluator == "continuous_frames") {
+      if (policy.checkpointIntervalMs <= 0) return
+      val checkpointDurationMs =
+        ((totalSamplesWritten - checkpointStartSample).coerceAtLeast(0L) * 1000.0) /
+          sampleRate
+      if (checkpointDurationMs >= policy.checkpointIntervalMs) {
+        appendSegment(
+          endSampleExclusive = totalSamplesWritten,
+          reason = "policy_checkpoint",
+          source = "segmentation_engine",
+          score = rmsDb(chunk),
+        )
+      }
+      return
+    }
+
     val chunkDurationMs = (chunk.size * 1000.0) / sampleRate
     val db = rmsDb(chunk)
     if (db < policy.energyThresholdDb) {
@@ -345,25 +361,25 @@ private class SpeechEnergySilenceEngine(
       return
     }
 
-    if (policy.evaluator == "continuous_frames" && policy.checkpointIntervalMs > 0) {
-      val checkpointDurationMs =
-        ((totalSamplesWritten - checkpointStartSample).coerceAtLeast(0L) * 1000.0) /
-          sampleRate
-      if (checkpointDurationMs >= policy.checkpointIntervalMs) {
-        appendSegment(
-          endSampleExclusive = totalSamplesWritten,
-          reason = "policy_checkpoint",
-          source = "segmentation_engine",
-          score = db,
-        )
-      }
-    }
   }
 
   override fun flush() {
     if (currentState != EngineState.ACTIVE) return
     val live = PipelineAudioRegistry.getLive(attachedBufferId) ?: return
     val endSampleExclusive = live.totalSamplesWritten
+
+    if (policy.evaluator == "continuous_frames") {
+      if (endSampleExclusive > segmentStartSample) {
+        appendSegment(
+          endSampleExclusive = endSampleExclusive,
+          reason = "policy_checkpoint",
+          source = "segmentation_engine",
+          score = null,
+        )
+      }
+      return
+    }
+
     if (endSampleExclusive > segmentStartSample) {
       appendSegment(
         endSampleExclusive = endSampleExclusive,
@@ -1058,6 +1074,14 @@ object SegmentationEngineRegistry {
       }
 
       EngineDomain.SPEECH -> {
+        if (policy.evaluator == "continuous_frames") {
+          throw SegmentationEngineException(
+            code = "POLICY_INVALID_FOR_OFFLINE",
+            message =
+              "Policy evaluator 'continuous_frames' is streaming-only and invalid for offline segmentation",
+          )
+        }
+
         val offline = PipelineAudioRegistry.getOffline(bufferId)
           ?: throw SegmentationEngineException(
             code = "BUFFER_STATE_INVALID",
@@ -1215,7 +1239,6 @@ object SegmentationEngineRegistry {
             runtime.close()
           }
         } else {
-          val samples = offline.readAllSamples()
           val minSamples = ((policy.minSegmentMs.toDouble() * sr) / 1000.0).toInt().coerceAtLeast(1)
           val maxSamples = ((policy.maxSegmentMs.toDouble() * sr) / 1000.0).toInt().coerceAtLeast(minSamples)
           val silenceSamples =
@@ -1228,9 +1251,11 @@ object SegmentationEngineRegistry {
           var silenceRun = 0
           val frameSize = (sr / 50).coerceAtLeast(160)
 
-          while (cursor < samples.size) {
-            val end = minOf(samples.size, cursor + frameSize)
-            val frame = samples.copyOfRange(cursor, end)
+          while (cursor < offline.numSamples) {
+            val readCount = minOf(frameSize, offline.numSamples - cursor)
+            val frame = offline.readSlice(cursor, readCount)
+            if (frame.isEmpty()) break
+            val end = cursor + frame.size
             var sum = 0.0
             for (value in frame) {
               sum += value * value
@@ -1290,8 +1315,8 @@ object SegmentationEngineRegistry {
             cursor = end
           }
 
-          if (start < samples.size) {
-            val end = samples.size
+          if (start < offline.numSamples) {
+            val end = offline.numSamples
             val payload = JSONObject()
               .put("source", "vad")
               .put("engine", "vad")

--- a/docs/migration/segmentationEngine/segmentation_engine_overview.md
+++ b/docs/migration/segmentationEngine/segmentation_engine_overview.md
@@ -84,7 +84,7 @@ Da das Fundament (Phase 1) sehr umfangreich ist, wird es in vier machbare Schrit
 | **Phase 1c** | Orchestration & Transfer (Sub-Plan 04) | `transferOfflineAudioBufferFromLive`, `OrchestrationSession` State Machine, Error Recovery Strategien (abort, skip, retry, partial). **Status: Completed** *(Benchmark-Teil explizit nicht erforderlich).* |
 | **Phase 1d** | Engine Core (Sub-Plan 02) | Native Evaluatoren (Energy, Punctuation, etc.), Buffer Attachment, Offline-Segmentation Loop. **Status: Completed** |
 | **Phase 2** | VAD + STT (+ `stt_produced` Links) | VAD liefert Grenzen, STT nutzt diese und produziert Text. **Status: Completed** (Code + Sub-05/Plan-Parität; Jest-Parity: `segment-api`, `transcribe-segmented`, `offline-orchestrator`). |
-| **Phase 3** | Enhancement (Offline segmentiert) | Verifizierung der Audio-Orchestration & Error Recovery. |
+| **Phase 3** | Enhancement (Offline segmentiert + Streaming `continuous_frames`) | Offline segmentiert über Phase-1c-Orchestrator + `populateOfflineAudioBufferIfEmpty`; Streaming-Enhancement optional mit Checkpoint-only `continuous_frames`-Attach; native Offline-Segmentation bleibt chunked und `continuous_frames` ist streaming-only. **Status: Completed** (Jest: `enhance-segmented`, `enhancement/orchestrate`, `streaming-continuous-frames`, `segmentation-engine-continuous-frames`, erweiterte `offline-orchestrator`). |
 | **Phase 4** | Punctuation | Verifizierung der Text-Orchestration. |
 | **Phase 5** | TTS (Incremental entfernen, + `tts_produced` Links) | Höchstes Risiko, benötigt Parity. Produziert Links für Playback-Highlighting. |
 | **Phase 6** | Alignment (Fake-Live, + `alignment` Links) | Basiert auf `SegmentLinkMap` aus Phase 1a. Komplexe Cross-Domain Strategien. |

--- a/docs/migration/segmentationEngine/sub-05-feature-pipeline-migration.md
+++ b/docs/migration/segmentationEngine/sub-05-feature-pipeline-migration.md
@@ -2,7 +2,8 @@
 
 ## Status
 - **Phase 2 (STT + VAD + `stt_produced`):** Completed — Implementierung und Parity-Check (Plan `phase-2-vad-stt`, Jest: `segment-api`, `transcribe-segmented`, `offline-orchestrator`) erfüllt.
-- **Weitere Features in diesem Dokument (TTS, Punctuation, Enhancement, Alignment, …):** weiterhin offen / spätere Phasen.
+- **Phase 3 (Enhancement offline segmentiert + Streaming `continuous_frames`):** Completed — Offline Enhancement nutzt optional den Phase-1c-Audio-Orchestrator, befüllt das Caller-`audioOut` via `populateOfflineAudioBufferIfEmpty`, Streaming Enhancement kann `continuous_frames` als Checkpoint-only Attach nutzen, und native Offline-Segmentation bleibt chunked.
+- **Weitere Features in diesem Dokument (TTS, Punctuation, Alignment, …):** weiterhin offen / spätere Phasen.
 - Depends on: Sub-Plan 01, 02, 03, 04
 
 ## Purpose
@@ -180,15 +181,20 @@ Enhancement uses the unified segmentation contract at the API level but retains 
 
 ### Migration Steps
 
-1. Add `segmentation` option to offline enhancement API.
-2. Implement offline enhancement orchestration:
-   - Segment audio → per-segment enhance → accumulate via LiveAudioBuffer → transfer.
-3. Update streaming enhancement to use `ContinuousFramesPolicy`:
-   - Attach `ContinuousFramesEvaluator` (mostly no-op).
-   - Frame-drain execution unchanged.
-   - Optional checkpoints emitted.
-4. Update public API: `enhance(audio, { segmentation })`.
-5. Test: verify no boundary artifacts in offline segmented mode.
+1. Completed: `enhance(audioIn, audioOut, options?)` accepts `segmentation`, recovery, progress, and overlap options while preserving the caller-owned `audioOut`.
+2. Completed: segmented offline enhancement uses `runOfflineAudioPipeline` with per-segment `enhanceOfflineAudioBuffers`, LiveAudioBuffer accumulation, final transfer, and `populateOfflineAudioBufferIfEmpty(audioOut, orchestratorOutput)`.
+3. Completed: streaming enhancement optionally attaches `continuous_frames` before native frame-drain startup and detaches on stop/completion. Frame-drain execution is unchanged.
+4. Completed: Android and iOS `continuous_frames` live engines emit checkpoint commits only; `segmentOfflineBuffer(..., { evaluator: 'continuous_frames' })` rejects with `POLICY_INVALID_FOR_OFFLINE`.
+5. Completed: offline energy/VAD segmentation reads audio in slices for the segmented path; no full-file PCM vector is materialized by the segmentation/orchestration path.
+6. Completed: tests cover single-shot vs segmented enhancement, recovery/populate behavior, continuous-frame attach/offline reject, and audio orchestrator behavior.
+
+### Phase 3 Progress (Completed)
+
+- Public API: `EnhancementEngine.enhance(audioIn, audioOut, options?)` returns `EnhancementResult` with status/counts/skips/timing.
+- Native bridge: `populateOfflineAudioBufferIfEmpty(target, source)` atomically adopts source storage into an empty caller target and consumes the source handle.
+- Offline segmented path: default policy is `speech_energy_silence`; `abort`, `skip`, `retry`, and `partial_result` are delegated to `OrchestrationSession`.
+- Streaming path: `segmentation.policy.evaluator = 'continuous_frames'` is supported for checkpoints only; non-continuous streaming policies are rejected by the Enhancement wrapper.
+- Memory audit: one-shot Enhancement may still use native full-buffer model input by design, but segmented offline orchestration and native offline segmentation loops operate on slices/chunks. Streaming remains frame-drain and does not materialize full PCM.
 
 ### Equivalence
 
@@ -196,8 +202,8 @@ Enhancement uses the unified segmentation contract at the API level but retains 
 
 ### Breaking Changes
 
-- `segmentation` parameter added to offline API (additive, not breaking).
-- Streaming: no functional change (continuous frame-drain preserved).
+- `segmentation`/recovery/options parameter added to offline API; existing `(audioIn, audioOut)` call shape remains valid.
+- Streaming: optional `segmentation` parameter added; frame-drain behavior is preserved.
 
 ---
 
@@ -408,17 +414,17 @@ This gives the SDK user full access to:
 
 ## Validation Checklist (per feature)
 
-- [ ] New Segment Contract types used
-- [ ] Old segment model removed
-- [ ] Segmentation config accepted in API
-- [ ] Auto-segmentation works with appropriate policy
-- [ ] Manual commit works
-- [ ] No segmentation (mode='off') works (full run)
-- [ ] onSegment events emitted correctly
-- [ ] Pull API returns correct segments
-- [ ] Spool replay reconstructs segments
-- [ ] Equivalence documented and tested
-- [ ] Old segmentation code removed
-- [ ] **SegmentLinkMap** created when cross-domain processing active (STT, TTS, Alignment)
-- [ ] **SegmentLinks** correctly reference text ↔ speech segment IDs
-- [ ] Bidirectional query returns correct links
+- [x] New Segment Contract types used (Phase 3 Enhancement uses shared `SegmentationPolicy` and segment accessors)
+- [x] Old segment model removed/avoided for Enhancement migration path
+- [x] Segmentation config accepted in Enhancement offline and streaming APIs
+- [x] Auto-segmentation works with appropriate offline policy (`speech_energy_silence`)
+- [x] Manual commit remains a Segment Engine capability; Enhancement Phase 3 uses auto/offline orchestration and continuous streaming checkpoints
+- [x] No segmentation (`mode='off'`) works (full one-shot Enhancement)
+- [x] onSegment events emitted correctly for Streaming `continuous_frames` checkpoints
+- [x] Pull API returns correct checkpoint segments (`reason: 'policy_checkpoint'`)
+- [x] Spool replay/transfer reconstructs segmented Enhancement output via LiveAudioBuffer accumulator
+- [x] Equivalence documented and tested as approximate with overlap support
+- [x] Old segmentation code removed (**N/A for Enhancement**: there was no legacy custom segmentation pipeline to retire; streaming remained frame-drain by design)
+- [x] **SegmentLinkMap** created when cross-domain processing active (**N/A for Enhancement**: single-domain audio->audio flow, no cross-domain linkage)
+- [x] **SegmentLinks** correctly reference text ↔ speech segment IDs (**N/A for Enhancement**)
+- [x] Bidirectional query returns correct links (**N/A for Enhancement**)

--- a/example/src/screens/enhancement-streaming/EnhancementStreamingScreen.tsx
+++ b/example/src/screens/enhancement-streaming/EnhancementStreamingScreen.tsx
@@ -8,6 +8,7 @@ import {
   Alert,
   Platform,
   StyleSheet,
+  Switch,
 } from 'react-native';
 import { styles } from '../stt/STTScreen.styles';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -48,6 +49,7 @@ import {
   type LiveAudioBufferRef,
 } from 'react-native-sherpa-onnx/audiobuffer';
 import { saveAudioAsFile } from 'react-native-sherpa-onnx/audio';
+import { getSegments } from 'react-native-sherpa-onnx/segment';
 import {
   getAssetModelPath,
   getFileModelPath,
@@ -89,6 +91,18 @@ function isEnhancementHint(folder: string, hint: string): boolean {
 }
 
 const localStyles = StyleSheet.create({
+  optionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 12,
+    marginBottom: 12,
+  },
+  optionLabel: {
+    color: '#333',
+    fontSize: 15,
+    fontWeight: '600',
+  },
   playRow: {
     flexDirection: 'row',
     gap: 10,
@@ -147,6 +161,7 @@ export default function EnhancementStreamingScreen() {
     string | null
   >(null);
   const [enhancing, setEnhancing] = useState(false);
+  const [attachContinuousFrames, setAttachContinuousFrames] = useState(false);
   const [enhanceResult, setEnhanceResult] = useState<string | null>(null);
   const [outputWavPath, setOutputWavPath] = useState<string | null>(null);
   const [lastInputPath, setLastInputPath] = useState<string | null>(null);
@@ -861,7 +876,18 @@ export default function EnhancementStreamingScreen() {
       setInputBufferBuildStatus('Starting enhancement pipeline...');
       const pipeline = await engine.enhance(
         inputLive.bufferId,
-        outputLive.bufferId
+        outputLive.bufferId,
+        attachContinuousFrames
+          ? {
+              segmentation: {
+                mode: 'auto',
+                policy: {
+                  evaluator: 'continuous_frames',
+                  checkpointIntervalMs: 1000,
+                },
+              },
+            }
+          : undefined
       );
       pipelineRef.current = pipeline;
       setInputBufferBuildStatus(
@@ -921,6 +947,12 @@ export default function EnhancementStreamingScreen() {
 
       pipelineRef.current = null;
 
+      const checkpointCount = attachContinuousFrames
+        ? (
+            await getSegments(inputLive.bufferId, 0, 100000).catch(() => [])
+          ).filter((segment) => segment.reason === 'policy_checkpoint').length
+        : 0;
+
       setInputBufferBuildProgress(100);
       setInputBufferBuildStatus('Finalizing output...');
       await finalizeLiveAudioBuffer(outputLive.bufferId).catch(() => {});
@@ -954,7 +986,7 @@ export default function EnhancementStreamingScreen() {
       setOutputWavPath(outputPath);
       setLastInputPath(selectedInput.sourcePathForPlayback);
       setEnhanceResult(
-        `Pipeline: streaming enhancement\nFrame shift: ${frameShift} samples\nSamples: ${numSamples}\nSample rate: ${outputSampleRate} Hz\nDuration: ~${durationSeconds} s\nApp copy: ${outputPath}`
+        `Pipeline: streaming enhancement\nContinuous checkpoints: ${checkpointCount}\nFrame shift: ${frameShift} samples\nSamples: ${numSamples}\nSample rate: ${outputSampleRate} Hz\nDuration: ~${durationSeconds} s\nApp copy: ${outputPath}`
       );
       producedOfflineBufferId = null;
       setInputBufferBuildProgress(null);
@@ -1220,6 +1252,19 @@ export default function EnhancementStreamingScreen() {
                 <Text style={styles.warningText}>
                   Initialize a streaming enhancement model first.
                 </Text>
+              </View>
+            )}
+
+            {engineReady && (
+              <View style={localStyles.optionRow}>
+                <Text style={localStyles.optionLabel}>
+                  Continuous checkpoints
+                </Text>
+                <Switch
+                  value={attachContinuousFrames}
+                  onValueChange={setAttachContinuousFrames}
+                  disabled={enhancing || loading || preparingInputBuffer}
+                />
               </View>
             )}
 

--- a/example/src/screens/enhancement/EnhancementScreen.tsx
+++ b/example/src/screens/enhancement/EnhancementScreen.tsx
@@ -8,6 +8,7 @@ import {
   Alert,
   Platform,
   StyleSheet,
+  Switch,
 } from 'react-native';
 import { styles } from '../stt/STTScreen.styles';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -87,6 +88,18 @@ function isEnhancementHint(folder: string, hint: string): boolean {
 }
 
 const localStyles = StyleSheet.create({
+  optionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 12,
+    marginBottom: 12,
+  },
+  optionLabel: {
+    color: '#333',
+    fontSize: 15,
+    fontWeight: '600',
+  },
   playRow: {
     flexDirection: 'row',
     gap: 10,
@@ -155,6 +168,7 @@ export default function EnhancementScreen() {
     string | null
   >(null);
   const [enhancing, setEnhancing] = useState(false);
+  const [useSegmentedEnhancement, setUseSegmentedEnhancement] = useState(false);
   const [enhanceResult, setEnhanceResult] = useState<string | null>(null);
   const [outputWavPath, setOutputWavPath] = useState<string | null>(null);
   /** Path of the input file used for the last successful run (for playback). */
@@ -798,7 +812,17 @@ export default function EnhancementScreen() {
       // Create empty output buffer at model sample rate
       const outputBuf = await createEmptyOfflineAudioBuffer(sr);
       try {
-        await engine.enhance(prepared.bufferId, outputBuf.bufferId);
+        const result = await engine.enhance(
+          prepared.bufferId,
+          outputBuf.bufferId,
+          useSegmentedEnhancement
+            ? {
+                segmentation: { mode: 'auto' },
+                errorRecovery: 'partial_result',
+                overlapSamples: Math.round(sr * 0.02),
+              }
+            : undefined
+        );
         // Get output info for display
         const outInfo = await getPipelineAudioBufferInfo(outputBuf.bufferId);
         const n = outInfo.numSamples ?? 0;
@@ -818,7 +842,13 @@ export default function EnhancementScreen() {
           numSamples: n,
         });
         setEnhanceResult(
-          `Samples: ${n}\nSample rate: ${outSr} Hz\nDuration: ~${sec} s\nApp copy: ${outPath}`
+          `Mode: ${
+            useSegmentedEnhancement ? 'segmented' : 'single-shot'
+          }\nStatus: ${result.status}\nSegments: ${result.completedSegments}/${
+            result.totalSegments
+          }\nSkipped: ${
+            result.skippedSegments.length
+          }\nSamples: ${n}\nSample rate: ${outSr} Hz\nDuration: ~${sec} s\nApp copy: ${outPath}`
         );
       } catch (enhanceErr) {
         // Release output buffer on error (input buffer remains cached for retries)
@@ -1309,21 +1339,33 @@ export default function EnhancementScreen() {
                   ))}
                 </View>
                 {preparedInputBuffer?.sourceType === 'example' && (
-                  <TouchableOpacity
-                    style={[
-                      styles.button,
-                      (enhancing || loading || preparingInputBuffer) &&
-                        styles.buttonDisabled,
-                    ]}
-                    onPress={handleEnhance}
-                    disabled={enhancing || loading || preparingInputBuffer}
-                  >
-                    {enhancing ? (
-                      <ActivityIndicator color="#fff" />
-                    ) : (
-                      <Text style={styles.buttonText}>Run enhancement</Text>
-                    )}
-                  </TouchableOpacity>
+                  <>
+                    <View style={localStyles.optionRow}>
+                      <Text style={localStyles.optionLabel}>
+                        Segmented offline
+                      </Text>
+                      <Switch
+                        value={useSegmentedEnhancement}
+                        onValueChange={setUseSegmentedEnhancement}
+                        disabled={enhancing || loading || preparingInputBuffer}
+                      />
+                    </View>
+                    <TouchableOpacity
+                      style={[
+                        styles.button,
+                        (enhancing || loading || preparingInputBuffer) &&
+                          styles.buttonDisabled,
+                      ]}
+                      onPress={handleEnhance}
+                      disabled={enhancing || loading || preparingInputBuffer}
+                    >
+                      {enhancing ? (
+                        <ActivityIndicator color="#fff" />
+                      ) : (
+                        <Text style={styles.buttonText}>Run enhancement</Text>
+                      )}
+                    </TouchableOpacity>
+                  </>
                 )}
                 {!preparingInputBuffer && !preparedInputBuffer && (
                   <TouchableOpacity

--- a/ios/audio/bridge/SherpaOnnx+PipelineAudio.mm
+++ b/ios/audio/bridge/SherpaOnnx+PipelineAudio.mm
@@ -995,6 +995,68 @@ bool pa_adopt_offline_samples_if_empty(
   return true;
 }
 
+static bool pa_populate_offline_from_source_if_empty(
+  const std::string &targetBufferId,
+  const std::string &sourceBufferId,
+  std::string *errorCode,
+  std::string *errorMessage
+) {
+  if (targetBufferId == sourceBufferId) {
+    return true;
+  }
+
+  std::shared_ptr<PaOfflineEntry> target;
+  std::shared_ptr<PaOfflineEntry> source;
+  {
+    std::lock_guard<std::mutex> lock(g_pa_mutex);
+    auto targetIt = g_pa_offline.find(targetBufferId);
+    if (targetIt == g_pa_offline.end() || !targetIt->second) {
+      if (errorCode) *errorCode = "AUDIO_BUFFER_NOT_FOUND";
+      if (errorMessage) *errorMessage = "Offline target buffer not found";
+      return false;
+    }
+    auto sourceIt = g_pa_offline.find(sourceBufferId);
+    if (sourceIt == g_pa_offline.end() || !sourceIt->second) {
+      if (errorCode) *errorCode = "AUDIO_BUFFER_NOT_FOUND";
+      if (errorMessage) *errorMessage = "Offline source buffer not found";
+      return false;
+    }
+
+    target = targetIt->second;
+    source = sourceIt->second;
+
+    if (target->numSamples() > 0) {
+      if (errorCode) *errorCode = "AUDIO_INVALID_STATE";
+      if (errorMessage) *errorMessage = "Offline target buffer is not empty";
+      return false;
+    }
+
+    if (
+      target->sampleRate != source->sampleRate ||
+      target->channelCount != source->channelCount
+    ) {
+      if (errorCode) *errorCode = "AUDIO_INVALID_ARGUMENT";
+      if (errorMessage) *errorMessage = "Offline target/source format mismatch";
+      return false;
+    }
+
+    auto replacement = std::make_shared<PaOfflineEntry>();
+    replacement->bufferId = targetBufferId;
+    replacement->sampleRate = source->sampleRate;
+    replacement->channelCount = source->channelCount;
+    if (source->isMmapBacked()) {
+      replacement->mmapRegion = std::move(source->mmapRegion);
+    } else {
+      replacement->samples = std::move(source->samples);
+    }
+
+    g_pa_offline[targetBufferId] = replacement;
+    g_pa_offline.erase(sourceBufferId);
+  }
+
+  return true;
+}
+
 @implementation SherpaOnnx (PipelineAudio)
 
 #if __has_include(<SherpaOnnxSpec/SherpaOnnxSpec.h>)
@@ -1150,6 +1212,51 @@ bool pa_adopt_offline_samples_if_empty(
     }
 
     resolve(entry->toDict());
+  } @catch (NSException *e) {
+    reject(kPAErrInternalError, e.reason, nil);
+  }
+}
+
+- (void)populateOfflineAudioBufferIfEmpty:(NSString *)targetBufferId
+                             sourceBufferId:(NSString *)sourceBufferId
+                                    options:(NSDictionary *)options
+                                    resolve:(RCTPromiseResolveBlock)resolve
+                                     reject:(RCTPromiseRejectBlock)reject
+{
+  (void)options;
+  @try {
+    if (targetBufferId == nil || [targetBufferId length] == 0) {
+      reject(kPAErrInvalidArgument, @"targetBufferId is required", nil);
+      return;
+    }
+    if (sourceBufferId == nil || [sourceBufferId length] == 0) {
+      reject(kPAErrInvalidArgument, @"sourceBufferId is required", nil);
+      return;
+    }
+
+    std::string targetId = [targetBufferId UTF8String] ?: "";
+    std::string sourceId = [sourceBufferId UTF8String] ?: "";
+    std::string errCode;
+    std::string errMsg;
+    if (!pa_populate_offline_from_source_if_empty(targetId, sourceId, &errCode, &errMsg)) {
+      NSString *message = [NSString stringWithUTF8String:errMsg.c_str()] ?: @"Failed to populate offline audio buffer";
+      if (errCode == "AUDIO_BUFFER_NOT_FOUND") {
+        reject(kPAErrBufferNotFound, message, nil);
+        return;
+      }
+      if (errCode == "AUDIO_INVALID_STATE") {
+        reject(kPAErrInvalidState, message, nil);
+        return;
+      }
+      if (errCode == "AUDIO_INVALID_ARGUMENT") {
+        reject(kPAErrInvalidArgument, message, nil);
+        return;
+      }
+      reject(kPAErrInternalError, message, nil);
+      return;
+    }
+
+    resolve(nil);
   } @catch (NSException *e) {
     reject(kPAErrInternalError, e.reason, nil);
   }

--- a/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
+++ b/ios/segmentbuffer/bridge/SherpaOnnx+SegmentBuffer.mm
@@ -2,6 +2,7 @@
 #include "../core/SherpaOnnx+SegmentBufferGlobals.h"
 #include "../../textbuffer/core/SherpaOnnx+TextBufferGlobals.h"
 #include "../../audio/pipeline/SherpaOnnx+PipelineAudioGlobals.h"
+#include "../../audio/pipeline/PaLiveEntry.h"
 #include "../../vad/core/VadRuntime.h"
 
 #ifdef __cplusplus
@@ -603,26 +604,6 @@ static void seg_notify_segment_appended(
 }
 } // namespace
 
-void seg_release_all_entries() {
-  std::unordered_map<std::string, std::shared_ptr<SegLiveEntry>> liveEntries;
-  {
-    std::lock_guard<std::mutex> lock(g_seg_mutex);
-    liveEntries.swap(g_seg_live);
-    g_seg_offline.clear();
-  }
-  for (auto &pair : liveEntries) {
-    try { pair.second->release(); } catch (...) {}
-  }
-
-  {
-    std::lock_guard<std::mutex> lock(g_seg_engine_mutex);
-    g_seg_engine_by_id.clear();
-    g_seg_engine_id_by_buffer.clear();
-    g_seg_engine_annotation_by_segment.clear();
-    g_seg_engine_eval_guard.clear();
-  }
-}
-
 std::shared_ptr<SegLiveEntry> seg_get_live_entry(const std::string &bufferId) {
   std::lock_guard<std::mutex> lock(g_seg_mutex);
   auto it = g_seg_live.find(bufferId);
@@ -772,6 +753,33 @@ std::unordered_set<std::string> g_seg_engine_eval_guard;
 std::mutex g_seg_engine_mutex;
 std::condition_variable g_seg_engine_eval_cv;
 
+} // namespace
+
+void seg_release_all_entries() {
+  std::unordered_map<std::string, std::shared_ptr<SegLiveEntry>> liveEntries;
+  {
+    std::lock_guard<std::mutex> lock(g_seg_mutex);
+    liveEntries.swap(g_seg_live);
+    g_seg_offline.clear();
+  }
+  for (auto &pair : liveEntries) {
+    try {
+      pair.second->release();
+    } catch (...) {
+    }
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(g_seg_engine_mutex);
+    g_seg_engine_by_id.clear();
+    g_seg_engine_id_by_buffer.clear();
+    g_seg_engine_annotation_by_segment.clear();
+    g_seg_engine_eval_guard.clear();
+  }
+}
+
+namespace {
+
 static int64_t seg_now_ms() {
   return (int64_t)([[NSDate date] timeIntervalSince1970] * 1000.0);
 }
@@ -886,7 +894,6 @@ static bool seg_init_vad_runtime(
 
 static std::string seg_reason_from_eval(const std::string &eval, bool silenceCommit) {
   if (eval == "speech_vad_model") return "vad_boundary";
-  if (eval == "continuous_frames") return "policy_checkpoint";
   return silenceCommit ? "energy_silence" : "length_limit";
 }
 
@@ -1148,6 +1155,18 @@ static void seg_engine_evaluate_audio(
   if (!engine || engine->state != SegEngineState::ACTIVE) return;
   if (!samples || count == 0 || sampleRate <= 0) return;
 
+  if (engine->policy.evaluator == "continuous_frames") {
+    if (engine->policy.checkpointIntervalMs <= 0) return;
+    double checkpointMs =
+      ((double)std::max<int64_t>(0, totalSamplesWritten - engine->checkpointStartSample) * 1000.0) /
+      sampleRate;
+    if (checkpointMs >= engine->policy.checkpointIntervalMs) {
+      double db = seg_rms_db(samples, count);
+      seg_append_speech_segment(engine, totalSamplesWritten, "policy_checkpoint", db);
+    }
+    return;
+  }
+
   if (engine->policy.evaluator == "speech_vad_model") {
     if (!engine->vadRuntime || engine->vadFrameSize <= 0) {
       return;
@@ -1192,15 +1211,6 @@ static void seg_engine_evaluate_audio(
     seg_append_speech_segment(engine, totalSamplesWritten, reason, db);
     return;
   }
-
-  if (engine->policy.evaluator == "continuous_frames" && engine->policy.checkpointIntervalMs > 0) {
-    double checkpointMs =
-      ((double)std::max<int64_t>(0, totalSamplesWritten - engine->checkpointStartSample) * 1000.0) /
-      sampleRate;
-    if (checkpointMs >= engine->policy.checkpointIntervalMs) {
-      seg_append_speech_segment(engine, totalSamplesWritten, "policy_checkpoint", db);
-    }
-  }
 }
 
 static void seg_engine_flush_audio(const std::shared_ptr<SegEngine> &engine) {
@@ -1229,7 +1239,9 @@ static void seg_engine_flush_audio(const std::shared_ptr<SegEngine> &engine) {
   auto live = pa_get_live_entry(engine->attachedBufferId);
   if (!live) return;
   if (live->totalSamplesWritten > engine->segmentStartSample) {
-    seg_append_speech_segment(engine, live->totalSamplesWritten, "finalize", 0.0);
+    const char *reason =
+      engine->policy.evaluator == "continuous_frames" ? "policy_checkpoint" : "finalize";
+    seg_append_speech_segment(engine, live->totalSamplesWritten, reason, 0.0);
   }
 }
 
@@ -1682,6 +1694,11 @@ bool seg_engine_peek_annotation(
     }
 
     SegEnginePolicy p = seg_policy_from_dict(policy, SegEngineDomain::SPEECH);
+    if (p.evaluator == "continuous_frames") {
+      reject(@"POLICY_INVALID_FOR_OFFLINE", @"Policy evaluator 'continuous_frames' is streaming-only and invalid for offline segmentation", nil);
+      return;
+    }
+
     std::vector<SegRecord> records;
     if (p.evaluator == "speech_vad_model") {
       auto tempEngine = std::make_shared<SegEngine>();
@@ -1769,12 +1786,6 @@ bool seg_engine_peek_annotation(
         }
       }
     } else {
-      std::vector<float> samples;
-      if (!pa_read_offline_samples(bid, &samples, &sampleRate)) {
-        reject(@"BUFFER_STATE_INVALID", [NSString stringWithFormat:@"Offline audio buffer not found: %@", bufferId], nil);
-        return;
-      }
-
       int minSamples = std::max(1, (int)((p.minSegmentMs / 1000.0) * sampleRate));
       int maxSamples = std::max(minSamples, (int)((p.maxSegmentMs / 1000.0) * sampleRate));
       int silenceSamples = std::max(1, (int)(((p.silenceThresholdMs + p.hangoverMs) / 1000.0) * sampleRate));
@@ -1783,10 +1794,28 @@ bool seg_engine_peek_annotation(
       int start = 0;
       int cursor = 0;
       int silenceRun = 0;
-      while (cursor < (int)samples.size()) {
-        int end = std::min((int)samples.size(), cursor + frameSize);
-        double db = seg_rms_db(samples.data() + cursor, (size_t)(end - cursor));
-        if (db < p.energyThresholdDb) silenceRun += (end - cursor);
+      while (cursor < totalSamples) {
+        int readCount = std::min(frameSize, totalSamples - cursor);
+        std::vector<float> frame;
+        std::string sliceErrCode;
+        std::string sliceErrMessage;
+        if (!pa_get_offline_samples_slice(
+              bid,
+              cursor,
+              readCount,
+              &frame,
+              &sliceErrCode,
+              &sliceErrMessage
+            )) {
+          NSString *message = [NSString stringWithUTF8String:sliceErrMessage.c_str()] ?: @"Failed to read offline audio slice";
+          reject(@"BUFFER_STATE_INVALID", message, nil);
+          return;
+        }
+        if (frame.empty()) break;
+
+        int end = cursor + (int)frame.size();
+        double db = seg_rms_db(frame.data(), frame.size());
+        if (db < p.energyThresholdDb) silenceRun += (int)frame.size();
         else silenceRun = 0;
 
         int segLen = end - start;
@@ -1818,15 +1847,15 @@ bool seg_engine_peek_annotation(
         cursor = end;
       }
 
-      if (start < (int)samples.size()) {
+      if (start < totalSamples) {
         SegRecord rec;
         rec.id = "seg_" + seg_uuid();
         rec.kind = "speech";
         rec.sourceAudioBufferId = bid;
         rec.startSample = start;
-        rec.endSample = (int)samples.size();
+        rec.endSample = totalSamples;
         rec.sampleRate = sampleRate;
-        rec.durationMs = (int)(((samples.size() - start) * 1000.0) / sampleRate);
+        rec.durationMs = (int)(((totalSamples - start) * 1000.0) / sampleRate);
         NSDictionary *payloadObj = @{
           @"source": @"vad",
           @"engine": @"vad",

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -268,6 +268,18 @@ export interface Spec extends TurboModule {
   }>;
 
   /**
+   * Populate an existing empty offline audio buffer exactly once by adopting
+   * storage from another offline audio buffer.
+   *
+   * The source buffer is invalidated/consumed after successful adoption.
+   */
+  populateOfflineAudioBufferIfEmpty(
+    targetBufferId: string,
+    sourceBufferId: string,
+    options?: Object
+  ): Promise<void>;
+
+  /**
    * Create an empty live audio buffer with a rolling-window ring buffer.
    * @param options.sampleRate - Sample rate in Hz.
    * @param options.ringSeconds - Ring buffer window size in seconds (default: 60).

--- a/src/enhancement/__tests__/enhance-segmented.test.ts
+++ b/src/enhancement/__tests__/enhance-segmented.test.ts
@@ -1,0 +1,174 @@
+jest.mock('../../NativeSherpaOnnx', () => ({
+  __esModule: true,
+  default: {
+    initializeEnhancement: jest.fn(),
+    unloadEnhancement: jest.fn(),
+    enhanceOfflineAudioBuffers: jest.fn(),
+    populateOfflineAudioBufferIfEmpty: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils', () => ({
+  resolveModelPath: jest.fn(async () => '/models/enhancement'),
+}));
+
+jest.mock('../../detect', () => ({
+  resolveFileSourceForDetect: jest.fn(async () => ({
+    modelDir: '/models/enhancement',
+    assetName: 'model.onnx',
+  })),
+}));
+
+jest.mock('../../model-languages', () => ({
+  resolvePublicLanguageHints: jest.fn(() => []),
+}));
+
+jest.mock('../../audiobuffer', () => ({
+  releasePipelineAudioBuffer: jest.fn(),
+  resolvePipelineAudioBufferId: jest.fn((value: unknown) => String(value)),
+}));
+
+jest.mock('../orchestrate', () => ({
+  runOfflineEnhancementPipeline: jest.fn(),
+}));
+
+import SherpaOnnx from '../../NativeSherpaOnnx';
+import { releasePipelineAudioBuffer } from '../../audiobuffer';
+import { createEnhancement } from '../index';
+import { runOfflineEnhancementPipeline } from '../orchestrate';
+
+describe('enhancement segmented offline API', () => {
+  const native = SherpaOnnx as unknown as {
+    initializeEnhancement: jest.Mock;
+    unloadEnhancement: jest.Mock;
+    enhanceOfflineAudioBuffers: jest.Mock;
+    populateOfflineAudioBufferIfEmpty: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    native.initializeEnhancement.mockResolvedValue({
+      success: true,
+      detectedModels: [],
+    });
+    native.unloadEnhancement.mockResolvedValue(null);
+    native.enhanceOfflineAudioBuffers.mockResolvedValue(null);
+    native.populateOfflineAudioBufferIfEmpty.mockResolvedValue(null);
+    (releasePipelineAudioBuffer as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('uses native single-shot path when segmentation is off', async () => {
+    const enhancement = await createEnhancement({
+      modelPath: { type: 'file', path: '/models/enhancement' },
+    });
+
+    const result = await enhancement.enhance('off_input', 'off_output');
+
+    expect(result).toMatchObject({
+      status: 'complete',
+      totalSegments: 1,
+      completedSegments: 1,
+      skippedSegments: [],
+    });
+    expect(native.enhanceOfflineAudioBuffers).toHaveBeenCalledWith(
+      expect.stringMatching(/^enhancement_/),
+      'off_input',
+      'off_output'
+    );
+    expect(runOfflineEnhancementPipeline).not.toHaveBeenCalled();
+    expect(native.populateOfflineAudioBufferIfEmpty).not.toHaveBeenCalled();
+  });
+
+  it('runs segmented orchestration and populates caller-owned audioOut', async () => {
+    (runOfflineEnhancementPipeline as jest.Mock).mockResolvedValue({
+      status: 'complete',
+      totalSegments: 2,
+      completedSegments: 2,
+      skippedSegments: [],
+      processingTimeMs: 12,
+      outputBuffer: { bufferId: 'off_orchestrated' },
+    });
+
+    const enhancement = await createEnhancement({
+      modelPath: { type: 'file', path: '/models/enhancement' },
+    });
+
+    const result = await enhancement.enhance('off_input', 'off_output', {
+      segmentation: { mode: 'auto' },
+    });
+
+    expect(result.status).toBe('complete');
+    expect(runOfflineEnhancementPipeline).toHaveBeenCalledWith(
+      'off_input',
+      expect.stringMatching(/^enhancement_/),
+      { segmentation: { mode: 'auto' } }
+    );
+    expect(native.populateOfflineAudioBufferIfEmpty).toHaveBeenCalledWith(
+      'off_output',
+      'off_orchestrated'
+    );
+    expect(releasePipelineAudioBuffer).toHaveBeenCalledWith('off_orchestrated');
+  });
+
+  it('populates partial_result output when orchestration returns a partial buffer', async () => {
+    (runOfflineEnhancementPipeline as jest.Mock).mockResolvedValue({
+      status: 'partial',
+      totalSegments: 3,
+      completedSegments: 1,
+      skippedSegments: [],
+      failedSegment: {
+        segmentIndex: 1,
+        segmentId: 'speech_1',
+        error: 'boom',
+        retryCount: 0,
+      },
+      processingTimeMs: 20,
+      outputBuffer: { bufferId: 'off_partial' },
+    });
+
+    const enhancement = await createEnhancement({
+      modelPath: { type: 'file', path: '/models/enhancement' },
+    });
+
+    const result = await enhancement.enhance('off_input', 'off_output', {
+      segmentation: { mode: 'auto' },
+      errorRecovery: 'partial_result',
+    });
+
+    expect(result.status).toBe('partial');
+    expect(result.failedSegment?.segmentId).toBe('speech_1');
+    expect(native.populateOfflineAudioBufferIfEmpty).toHaveBeenCalledWith(
+      'off_output',
+      'off_partial'
+    );
+  });
+
+  it('does not populate audioOut when abort recovery fails without output', async () => {
+    (runOfflineEnhancementPipeline as jest.Mock).mockResolvedValue({
+      status: 'failed',
+      totalSegments: 2,
+      completedSegments: 0,
+      skippedSegments: [],
+      failedSegment: {
+        segmentIndex: 0,
+        segmentId: 'speech_0',
+        error: 'boom',
+        retryCount: 0,
+      },
+      processingTimeMs: 4,
+    });
+
+    const enhancement = await createEnhancement({
+      modelPath: { type: 'file', path: '/models/enhancement' },
+    });
+
+    const result = await enhancement.enhance('off_input', 'off_output', {
+      segmentation: { mode: 'auto' },
+      errorRecovery: 'abort',
+    });
+
+    expect(result.status).toBe('failed');
+    expect(native.populateOfflineAudioBufferIfEmpty).not.toHaveBeenCalled();
+    expect(releasePipelineAudioBuffer).not.toHaveBeenCalled();
+  });
+});

--- a/src/enhancement/__tests__/orchestrate.test.ts
+++ b/src/enhancement/__tests__/orchestrate.test.ts
@@ -1,0 +1,95 @@
+jest.mock('../../NativeSherpaOnnx', () => ({
+  __esModule: true,
+  default: {
+    enhanceOfflineAudioBuffers: jest.fn(),
+  },
+}));
+
+jest.mock('../../pipeline/offlineOrchestrator', () => ({
+  runOfflineAudioPipeline: jest.fn(),
+}));
+
+import SherpaOnnx from '../../NativeSherpaOnnx';
+import { runOfflineAudioPipeline } from '../../pipeline/offlineOrchestrator';
+import { runOfflineEnhancementPipeline } from '../orchestrate';
+
+describe('runOfflineEnhancementPipeline', () => {
+  const native = SherpaOnnx as unknown as {
+    enhanceOfflineAudioBuffers: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    native.enhanceOfflineAudioBuffers.mockResolvedValue(null);
+    (runOfflineAudioPipeline as jest.Mock).mockImplementation(
+      async (_input, consumer, _config) => {
+        await consumer({ bufferId: 'off_seg_in' }, { bufferId: 'off_seg_out' });
+        return {
+          status: 'complete',
+          totalSegments: 1,
+          completedSegments: 1,
+          skippedSegments: [],
+          processingTimeMs: 5,
+          outputBuffer: { bufferId: 'off_final' },
+        };
+      }
+    );
+  });
+
+  it('uses offline audio orchestrator with default speech energy policy', async () => {
+    await runOfflineEnhancementPipeline('off_input', 'enh_1', {
+      segmentation: { mode: 'auto' },
+    });
+
+    expect(runOfflineAudioPipeline).toHaveBeenCalledWith(
+      'off_input',
+      expect.any(Function),
+      expect.objectContaining({
+        segmentation: {
+          mode: 'auto',
+          policy: expect.objectContaining({
+            evaluator: 'speech_energy_silence',
+          }),
+        },
+      })
+    );
+    expect(native.enhanceOfflineAudioBuffers).toHaveBeenCalledWith(
+      'enh_1',
+      'off_seg_in',
+      'off_seg_out'
+    );
+  });
+
+  it('passes recovery and overlap options through to orchestration', async () => {
+    const abortController = new AbortController();
+
+    await runOfflineEnhancementPipeline('off_input', 'enh_1', {
+      segmentation: {
+        mode: 'auto',
+        policy: {
+          evaluator: 'speech_energy_silence',
+          maxSegmentMs: 2000,
+        },
+      },
+      errorRecovery: 'retry',
+      maxRetriesPerSegment: 2,
+      retryExhaustedFallback: 'skip',
+      abortSignal: abortController.signal,
+      onProgress: jest.fn(),
+      overlapSamples: 160,
+    });
+
+    expect(runOfflineAudioPipeline).toHaveBeenCalledWith(
+      'off_input',
+      expect.any(Function),
+      expect.objectContaining({
+        errorRecovery: 'retry',
+        maxRetriesPerSegment: 2,
+        retryExhaustedFallback: 'skip',
+        abortSignal: abortController.signal,
+        onProgress: expect.any(Function),
+        overlapSamples: 160,
+      })
+    );
+  });
+});

--- a/src/enhancement/__tests__/streaming-continuous-frames.test.ts
+++ b/src/enhancement/__tests__/streaming-continuous-frames.test.ts
@@ -1,0 +1,135 @@
+jest.mock('../../NativeSherpaOnnx', () => ({
+  __esModule: true,
+  default: {
+    initializeOnlineEnhancement: jest.fn(),
+    unloadOnlineEnhancement: jest.fn(),
+    getEnhancementSampleRate: jest.fn(),
+    startEnhancementPipeline: jest.fn(),
+    stopStreamingPipeline: jest.fn(),
+    flushStreamingPipeline: jest.fn(),
+    resetStreamingPipeline: jest.fn(),
+    getStreamingPipelineStatus: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils', () => ({
+  resolveModelPath: jest.fn(async () => '/models/enhancement'),
+}));
+
+jest.mock('../../audiobuffer', () => ({
+  resolvePipelineAudioBufferId: jest.fn((value: unknown) => String(value)),
+}));
+
+jest.mock('../../audiobuffer/streamingPipelineCompletion', () => ({
+  createStreamingPipelineCompletionPromise: jest.fn(
+    () => new Promise(() => {})
+  ),
+}));
+
+jest.mock('../../segment', () => ({
+  attachSegmentationEngine: jest.fn(),
+  detachSegmentationEngine: jest.fn(),
+}));
+
+import SherpaOnnx from '../../NativeSherpaOnnx';
+import {
+  attachSegmentationEngine,
+  detachSegmentationEngine,
+} from '../../segment';
+import { createStreamingEnhancement } from '../streaming';
+
+describe('streaming enhancement continuous_frames attach', () => {
+  const native = SherpaOnnx as unknown as {
+    initializeOnlineEnhancement: jest.Mock;
+    unloadOnlineEnhancement: jest.Mock;
+    startEnhancementPipeline: jest.Mock;
+    stopStreamingPipeline: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    native.initializeOnlineEnhancement.mockResolvedValue({
+      success: true,
+      frameShiftInSamples: 256,
+    });
+    native.unloadOnlineEnhancement.mockResolvedValue(null);
+    native.startEnhancementPipeline.mockResolvedValue({
+      pipelineId: 'enh_pipe_1',
+    });
+    native.stopStreamingPipeline.mockResolvedValue(null);
+    (attachSegmentationEngine as jest.Mock).mockResolvedValue({
+      engineId: 'eng_continuous_1',
+    });
+    (detachSegmentationEngine as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('attaches continuous_frames policy before starting enhancement pipeline', async () => {
+    const enhancement = await createStreamingEnhancement({
+      modelPath: { type: 'file', path: '/models/enhancement' },
+    });
+
+    const handle = await enhancement.enhance('live_input', 'live_output', {
+      segmentation: {
+        mode: 'auto',
+        policy: {
+          evaluator: 'continuous_frames',
+          checkpointIntervalMs: 250,
+        },
+      },
+    });
+
+    expect(attachSegmentationEngine).toHaveBeenCalledWith('live_input', {
+      policy: {
+        evaluator: 'continuous_frames',
+        checkpointIntervalMs: 250,
+      },
+    });
+    expect(native.startEnhancementPipeline).toHaveBeenCalledWith(
+      expect.stringMatching(/^streaming_enhancement_/),
+      'live_input',
+      'live_output'
+    );
+
+    await handle.stop();
+
+    expect(native.stopStreamingPipeline).toHaveBeenCalledWith('enh_pipe_1');
+    expect(detachSegmentationEngine).toHaveBeenCalledWith('eng_continuous_1', {
+      flushFinal: true,
+    });
+  });
+
+  it('uses continuous_frames default policy when segmentation mode is enabled without policy', async () => {
+    const enhancement = await createStreamingEnhancement({
+      modelPath: { type: 'file', path: '/models/enhancement' },
+    });
+
+    await enhancement.enhance('live_input', 'live_output', {
+      segmentation: { mode: 'auto' },
+    });
+
+    expect(attachSegmentationEngine).toHaveBeenCalledWith('live_input', {
+      policy: {
+        evaluator: 'continuous_frames',
+        checkpointIntervalMs: 1000,
+      },
+    });
+  });
+
+  it('rejects non-continuous streaming segmentation policies without starting native pipeline', async () => {
+    const enhancement = await createStreamingEnhancement({
+      modelPath: { type: 'file', path: '/models/enhancement' },
+    });
+
+    await expect(
+      enhancement.enhance('live_input', 'live_output', {
+        segmentation: {
+          mode: 'auto',
+          policy: { evaluator: 'speech_energy_silence' },
+        },
+      })
+    ).rejects.toThrow('supports only continuous_frames');
+
+    expect(attachSegmentationEngine).not.toHaveBeenCalled();
+    expect(native.startEnhancementPipeline).not.toHaveBeenCalled();
+  });
+});

--- a/src/enhancement/index.ts
+++ b/src/enhancement/index.ts
@@ -5,15 +5,21 @@ import { resolveFileSourceForDetect } from '../detect';
 import { resolvePublicLanguageHints } from '../model-languages';
 import { ModelCategory } from '../download/types';
 import { isDetectionSource } from './types';
-import { resolvePipelineAudioBufferId } from '../audiobuffer';
+import {
+  releasePipelineAudioBuffer,
+  resolvePipelineAudioBufferId,
+} from '../audiobuffer';
 import type {
   DetectedModelEntry,
   DetectionSource,
   EnhancementDetectResult,
   EnhancementEngine,
   EnhancementInitializeOptions,
+  EnhanceOptions,
+  EnhancementResult,
 } from './types';
 import type { OfflineAudioBufferIdSource } from '../audiobuffer/types';
+import { runOfflineEnhancementPipeline } from './orchestrate';
 
 let enhancementInstanceCounter = 0;
 
@@ -117,12 +123,57 @@ export async function createEnhancement(
     },
     async enhance(
       audioIn: OfflineAudioBufferIdSource,
-      audioOut: OfflineAudioBufferIdSource
-    ): Promise<void> {
+      audioOut: OfflineAudioBufferIdSource,
+      enhanceOptions?: EnhanceOptions
+    ): Promise<EnhancementResult> {
       guard();
+      const startedAtMs = Date.now();
       const inId = resolvePipelineAudioBufferId(audioIn);
       const outId = resolvePipelineAudioBufferId(audioOut);
-      await SherpaOnnx.enhanceOfflineAudioBuffers(instanceId, inId, outId);
+
+      const segmentationMode = enhanceOptions?.segmentation?.mode ?? 'off';
+      if (segmentationMode === 'off') {
+        await SherpaOnnx.enhanceOfflineAudioBuffers(instanceId, inId, outId);
+        return {
+          status: 'complete',
+          totalSegments: 1,
+          completedSegments: 1,
+          skippedSegments: [],
+          processingTimeMs: Date.now() - startedAtMs,
+        };
+      }
+
+      const orchestrated = await runOfflineEnhancementPipeline(
+        inId,
+        instanceId,
+        enhanceOptions ?? {}
+      );
+
+      const outputBuffer = orchestrated.outputBuffer;
+      if (outputBuffer) {
+        try {
+          await SherpaOnnx.populateOfflineAudioBufferIfEmpty(
+            outId,
+            outputBuffer.bufferId
+          );
+        } finally {
+          // Source may already be consumed by populate; release is best-effort cleanup.
+          await releasePipelineAudioBuffer(outputBuffer.bufferId).catch(
+            () => undefined
+          );
+        }
+      }
+
+      return {
+        status: orchestrated.status,
+        totalSegments: orchestrated.totalSegments,
+        completedSegments: orchestrated.completedSegments,
+        skippedSegments: orchestrated.skippedSegments,
+        ...(orchestrated.failedSegment
+          ? { failedSegment: orchestrated.failedSegment }
+          : {}),
+        processingTimeMs: orchestrated.processingTimeMs,
+      };
     },
     async getSampleRate(): Promise<number> {
       guard();
@@ -140,6 +191,7 @@ export { createStreamingEnhancement } from './streaming';
 export type {
   StreamingEnhancementEngine,
   StreamingEnhancementInitializeOptions,
+  StreamingEnhancementEnhanceOptions,
   EnhancementPipelineHandle,
 } from './streamingTypes';
 
@@ -148,5 +200,8 @@ export type {
   EnhancementInitializeOptions,
   EnhancementDetectResult,
   EnhancementEngine,
+  EnhanceOptions,
+  EnhancementResult,
+  EnhanceSegmentationConfig,
 } from './types';
 export { ENHANCEMENT_MODEL_TYPES } from './types';

--- a/src/enhancement/orchestrate.ts
+++ b/src/enhancement/orchestrate.ts
@@ -1,0 +1,55 @@
+import SherpaOnnx from '../NativeSherpaOnnx';
+import { runOfflineAudioPipeline } from '../pipeline/offlineOrchestrator';
+import type { OrchestrationResult } from '../pipeline/offlineOrchestrator';
+import type {
+  OfflineAudioBufferIdSource,
+  OfflineAudioBufferRef,
+} from '../audiobuffer/types';
+import type { SegmentationPolicy } from '../segment/engine-types';
+import type { EnhanceOptions } from './types';
+
+const DEFAULT_ENHANCEMENT_SEGMENTATION_POLICY: SegmentationPolicy = {
+  evaluator: 'speech_energy_silence',
+  silenceThresholdMs: 500,
+  energyThresholdDb: -40,
+  minSegmentMs: 1000,
+  maxSegmentMs: 30000,
+  hangoverMs: 300,
+};
+
+export async function runOfflineEnhancementPipeline(
+  input: OfflineAudioBufferIdSource,
+  instanceId: string,
+  options: EnhanceOptions = {}
+): Promise<OrchestrationResult<OfflineAudioBufferRef>> {
+  const mode = options.segmentation?.mode ?? 'off';
+  const segmentation =
+    mode === 'off'
+      ? { mode: 'off' as const }
+      : {
+          mode,
+          policy:
+            options.segmentation?.policy ??
+            DEFAULT_ENHANCEMENT_SEGMENTATION_POLICY,
+        };
+
+  return runOfflineAudioPipeline(
+    input,
+    async (segIn, segOut) => {
+      await SherpaOnnx.enhanceOfflineAudioBuffers(
+        instanceId,
+        segIn.bufferId,
+        segOut.bufferId
+      );
+    },
+    {
+      segmentation,
+      errorRecovery: options.errorRecovery,
+      maxRetriesPerSegment: options.maxRetriesPerSegment,
+      retryExhaustedFallback: options.retryExhaustedFallback,
+      abortSignal: options.abortSignal,
+      onProgress: options.onProgress,
+      overlapSamples: options.overlapSamples,
+    }
+  );
+}

--- a/src/enhancement/streaming.ts
+++ b/src/enhancement/streaming.ts
@@ -1,11 +1,14 @@
 import SherpaOnnx from '../NativeSherpaOnnx';
+import { resolvePipelineAudioBufferId } from '../audiobuffer';
 import type { StreamingPipelineStatus } from '../audiobuffer/streamingPipelineTypes';
 import { createStreamingPipelineCompletionPromise } from '../audiobuffer/streamingPipelineCompletion';
+import { attachSegmentationEngine, detachSegmentationEngine } from '../segment';
 import { resolveModelPath } from '../utils';
 import type { EnhancementModelType } from './types';
 import type {
   EnhancementPipelineHandle,
   StreamingEnhancementEngine,
+  StreamingEnhancementEnhanceOptions,
   StreamingEnhancementInitializeOptions,
 } from './streamingTypes';
 
@@ -13,9 +16,26 @@ let streamingEnhancementInstanceCounter = 0;
 
 function createEnhancementPipelineHandle(
   instanceId: string,
-  pipelineId: string
+  pipelineId: string,
+  attachedSegmentationEngineId?: string
 ): EnhancementPipelineHandle {
-  const completed = createStreamingPipelineCompletionPromise(pipelineId);
+  let detached = false;
+  const detachIfNeeded = async () => {
+    if (!attachedSegmentationEngineId || detached) return;
+    detached = true;
+    try {
+      await detachSegmentationEngine(attachedSegmentationEngineId, {
+        flushFinal: true,
+      });
+    } catch {
+      // Best effort: segmentation detach must not mask pipeline shutdown.
+    }
+  };
+
+  const completed =
+    createStreamingPipelineCompletionPromise(pipelineId).finally(
+      detachIfNeeded
+    );
 
   return {
     instanceId,
@@ -24,7 +44,11 @@ function createEnhancementPipelineHandle(
     },
     completed,
     async stop(): Promise<void> {
-      await SherpaOnnx.stopStreamingPipeline(pipelineId);
+      try {
+        await SherpaOnnx.stopStreamingPipeline(pipelineId);
+      } finally {
+        await detachIfNeeded();
+      }
     },
     async flush(): Promise<void> {
       await SherpaOnnx.flushStreamingPipeline(pipelineId);
@@ -94,15 +118,63 @@ export async function createStreamingEnhancement(
 
     async enhance(
       inputBufferId: string,
-      outputBufferId: string
+      outputBufferId: string,
+      enhanceOptions?: StreamingEnhancementEnhanceOptions
     ): Promise<EnhancementPipelineHandle> {
       guard();
-      const raw = await SherpaOnnx.startEnhancementPipeline(
-        instanceId,
-        inputBufferId,
-        outputBufferId
-      );
-      return createEnhancementPipelineHandle(instanceId, raw.pipelineId);
+
+      const normalizedInputId = resolvePipelineAudioBufferId(inputBufferId);
+      if (!normalizedInputId.startsWith('live_')) {
+        throw new Error(
+          'ENHANCEMENT_INVALID_ARGUMENT: streaming enhancement input buffer must be live_*'
+        );
+      }
+
+      const normalizedOutputId = resolvePipelineAudioBufferId(outputBufferId);
+      if (!normalizedOutputId.startsWith('live_')) {
+        throw new Error(
+          'ENHANCEMENT_INVALID_ARGUMENT: streaming enhancement output buffer must be live_*'
+        );
+      }
+
+      const mode = enhanceOptions?.segmentation?.mode ?? 'off';
+      let attachedSegmentationEngineId: string | undefined;
+      if (mode !== 'off') {
+        const policy = enhanceOptions?.segmentation?.policy ?? {
+          evaluator: 'continuous_frames' as const,
+          checkpointIntervalMs: 1000,
+        };
+        if (policy.evaluator !== 'continuous_frames') {
+          throw new Error(
+            'ENHANCEMENT_INVALID_SEGMENTATION: streaming enhancement supports only continuous_frames policy'
+          );
+        }
+
+        const attached = await attachSegmentationEngine(normalizedInputId, {
+          policy,
+        });
+        attachedSegmentationEngineId = attached.engineId;
+      }
+
+      try {
+        const raw = await SherpaOnnx.startEnhancementPipeline(
+          instanceId,
+          normalizedInputId,
+          normalizedOutputId
+        );
+        return createEnhancementPipelineHandle(
+          instanceId,
+          raw.pipelineId,
+          attachedSegmentationEngineId
+        );
+      } catch (err) {
+        if (attachedSegmentationEngineId) {
+          await detachSegmentationEngine(attachedSegmentationEngineId, {
+            flushFinal: true,
+          }).catch(() => undefined);
+        }
+        throw err;
+      }
     },
   };
 }

--- a/src/enhancement/streamingTypes.ts
+++ b/src/enhancement/streamingTypes.ts
@@ -1,8 +1,15 @@
-import type { EnhancementInitializeOptions } from './types';
+import type {
+  EnhanceSegmentationConfig,
+  EnhancementInitializeOptions,
+} from './types';
 import type { StreamingPipelineHandle } from '../audiobuffer/streamingPipelineTypes';
 
 export type StreamingEnhancementInitializeOptions =
   EnhancementInitializeOptions;
+
+export interface StreamingEnhancementEnhanceOptions {
+  segmentation?: EnhanceSegmentationConfig;
+}
 
 /**
  * Online denoiser from `createStreamingEnhancement`. Audio is produced only via
@@ -15,7 +22,8 @@ export interface StreamingEnhancementEngine {
   destroy(): Promise<void>;
   enhance(
     inputBufferId: string,
-    outputBufferId: string
+    outputBufferId: string,
+    options?: StreamingEnhancementEnhanceOptions
   ): Promise<EnhancementPipelineHandle>;
 }
 

--- a/src/enhancement/types.ts
+++ b/src/enhancement/types.ts
@@ -1,6 +1,13 @@
 import type { ModelPathConfig } from '../types';
 import type { EnhancementDetectModelResult } from '../types/modelDetect';
 import type { OfflineAudioBufferIdSource } from '../audiobuffer/types';
+import type {
+  ErrorRecoveryStrategy,
+  FailedSegmentInfo,
+  OrchestrationProgress,
+  SkippedSegmentInfo,
+} from '../pipeline/offlineOrchestrator';
+import type { SegmentationPolicy } from '../segment/engine-types';
 
 export {
   DETECTION_SOURCES,
@@ -28,6 +35,30 @@ export interface EnhancementInitializeOptions {
 
 export type EnhancementDetectResult = EnhancementDetectModelResult;
 
+export interface EnhanceSegmentationConfig {
+  mode?: 'off' | 'manual' | 'auto';
+  policy?: SegmentationPolicy;
+}
+
+export interface EnhanceOptions {
+  segmentation?: EnhanceSegmentationConfig;
+  errorRecovery?: ErrorRecoveryStrategy;
+  maxRetriesPerSegment?: number;
+  retryExhaustedFallback?: 'abort' | 'skip';
+  abortSignal?: AbortSignal;
+  onProgress?: (progress: OrchestrationProgress) => void;
+  overlapSamples?: number;
+}
+
+export interface EnhancementResult {
+  status: 'complete' | 'partial' | 'failed' | 'cancelled';
+  totalSegments: number;
+  completedSegments: number;
+  skippedSegments: SkippedSegmentInfo[];
+  failedSegment?: FailedSegmentInfo;
+  processingTimeMs: number;
+}
+
 export interface EnhancementEngine {
   readonly instanceId: string;
   /**
@@ -37,8 +68,9 @@ export interface EnhancementEngine {
    */
   enhance(
     audioIn: OfflineAudioBufferIdSource,
-    audioOut: OfflineAudioBufferIdSource
-  ): Promise<void>;
+    audioOut: OfflineAudioBufferIdSource,
+    options?: EnhanceOptions
+  ): Promise<EnhancementResult>;
   getSampleRate(): Promise<number>;
   destroy(): Promise<void>;
 }

--- a/src/pipeline/__tests__/offline-orchestrator.test.ts
+++ b/src/pipeline/__tests__/offline-orchestrator.test.ts
@@ -236,8 +236,8 @@ describe('offline orchestrator', () => {
     });
 
     const customPolicy = {
-      evaluator: 'continuous_frames' as const,
-      checkpointIntervalMs: 250,
+      evaluator: 'speech_energy_silence' as const,
+      energyThresholdDb: -36,
       minSegmentMs: 500,
       maxSegmentMs: 5000,
     };

--- a/src/segment/__tests__/segmentation-engine-continuous-frames.test.ts
+++ b/src/segment/__tests__/segmentation-engine-continuous-frames.test.ts
@@ -1,0 +1,165 @@
+jest.mock('react-native', () => {
+  const mockNative = {
+    setLiveTextBufferPartial: jest.fn(),
+    appendLiveTextBufferPartial: jest.fn(),
+    segmentOfflineBuffer: jest.fn(),
+    attachSegmentationEngine: jest.fn(),
+    detachSegmentationEngine: jest.fn(),
+    getSegmentationEngineInfo: jest.fn(),
+    createSegmentLinkMap: jest.fn(),
+    addSegmentLink: jest.fn(),
+    addSegmentLinks: jest.fn(),
+    removeSegmentLink: jest.fn(),
+    getSpeechSegmentsForText: jest.fn(),
+    getTextSegmentsForSpeech: jest.fn(),
+    getAllSegmentLinks: jest.fn(),
+    getSegmentLinkCount: jest.fn(),
+    getSegmentLinkMapInfo: jest.fn(),
+    releaseSegmentLinkMap: jest.fn(),
+  };
+  return {
+    TurboModuleRegistry: {
+      getEnforcing: () => mockNative,
+    },
+    __mockNative: mockNative,
+  };
+});
+
+jest.mock('../../textbuffer', () => ({
+  appendLiveTextSegment: jest.fn(),
+  getOfflineTextBufferTextSlice: jest.fn(),
+  getLiveTextBufferPartialSlice: jest.fn(),
+  getLiveTextBufferSegmentCount: jest.fn(),
+  getLiveTextBufferSegments: jest.fn(),
+  getPipelineTextBufferInfo: jest.fn(),
+  resolvePipelineTextBufferId: jest.fn((value: unknown) => String(value)),
+}));
+
+jest.mock('../../audiobuffer', () => ({
+  getPipelineAudioBufferInfo: jest.fn(),
+  resolvePipelineAudioBufferId: jest.fn((value: unknown) => String(value)),
+}));
+
+jest.mock('../../segmentbuffer', () => ({
+  appendLiveSegment: jest.fn(),
+  createEmptyOfflineSegmentBuffer: jest.fn(),
+  createLiveSegmentBuffer: jest.fn(),
+  createOfflineSegmentBufferFromLive: jest.fn(),
+  finalizeLiveSegmentBuffer: jest.fn(),
+  getLiveSegmentBufferSegmentCount: jest.fn(),
+  getLiveSegmentBufferSegments: jest.fn(),
+  getOfflineSegmentBufferSegments: jest.fn(),
+  getPipelineSegmentBufferInfo: jest.fn(),
+  releasePipelineSegmentBuffer: jest.fn(),
+}));
+
+import {
+  attachSegmentationEngine,
+  getSegments,
+  segmentOfflineBuffer,
+} from '../index';
+import { releaseSegmentationStateForBuffer } from '../runtime-state';
+
+describe('segmentation engine continuous_frames', () => {
+  const LIVE_AUDIO_ID = 'live_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  const OFFLINE_AUDIO_ID = 'off_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  const SEG_LIVE_ID = 'seg_live_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+  const ENGINE_ID = 'eng_continuous_mock_01';
+
+  const segmentbuffer = jest.requireMock('../../segmentbuffer') as any;
+  const native = (jest.requireMock('react-native') as any).__mockNative;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    releaseSegmentationStateForBuffer(LIVE_AUDIO_ID);
+
+    native.attachSegmentationEngine.mockResolvedValue({
+      engineId: ENGINE_ID,
+      segmentBufferId: SEG_LIVE_ID,
+    });
+    segmentbuffer.getLiveSegmentBufferSegmentCount.mockResolvedValue(2);
+    segmentbuffer.getLiveSegmentBufferSegments.mockResolvedValue([
+      {
+        kind: 'speech',
+        id: 'speech_checkpoint_0',
+        sourceAudioBufferId: LIVE_AUDIO_ID,
+        startSample: 0,
+        endSample: 4000,
+        sampleRate: 16000,
+        durationMs: 250,
+        reason: 'policy_checkpoint',
+        source: 'segmentation_engine',
+        createdAtMs: 10_000,
+      },
+      {
+        kind: 'speech',
+        id: 'speech_checkpoint_1',
+        sourceAudioBufferId: LIVE_AUDIO_ID,
+        startSample: 4000,
+        endSample: 8000,
+        sampleRate: 16000,
+        durationMs: 250,
+        reason: 'policy_checkpoint',
+        source: 'segmentation_engine',
+        createdAtMs: 10_250,
+      },
+    ]);
+  });
+
+  it('attaches continuous_frames and exposes only policy_checkpoint live segments', async () => {
+    await attachSegmentationEngine(LIVE_AUDIO_ID, {
+      policy: {
+        evaluator: 'continuous_frames',
+        checkpointIntervalMs: 250,
+      },
+    });
+
+    expect(native.attachSegmentationEngine).toHaveBeenCalledWith(
+      LIVE_AUDIO_ID,
+      'speech',
+      {
+        evaluator: 'continuous_frames',
+        checkpointIntervalMs: 250,
+      }
+    );
+
+    const segments = await getSegments(LIVE_AUDIO_ID, 0, 10);
+
+    expect(segments).toHaveLength(2);
+    expect(
+      segments.every((segment) => segment.reason === 'policy_checkpoint')
+    ).toBe(true);
+    expect(
+      segments.some(
+        (segment) =>
+          segment.reason === 'energy_silence' ||
+          segment.reason === 'length_limit' ||
+          segment.reason === 'vad_boundary'
+      )
+    ).toBe(false);
+  });
+
+  it('rejects continuous_frames for offline segmentation', async () => {
+    native.segmentOfflineBuffer.mockRejectedValue(
+      new Error(
+        "POLICY_INVALID_FOR_OFFLINE: Policy evaluator 'continuous_frames' is streaming-only"
+      )
+    );
+
+    await expect(
+      segmentOfflineBuffer(OFFLINE_AUDIO_ID, {
+        evaluator: 'continuous_frames',
+        checkpointIntervalMs: 250,
+      })
+    ).rejects.toThrow('POLICY_INVALID_FOR_OFFLINE');
+
+    expect(native.segmentOfflineBuffer).toHaveBeenCalledWith(
+      OFFLINE_AUDIO_ID,
+      'speech',
+      {
+        evaluator: 'continuous_frames',
+        checkpointIntervalMs: 250,
+      }
+    );
+  });
+});


### PR DESCRIPTION
This pull request delivers the Phase 3 "Enhancement" migration for the segmentation engine, implementing segmented offline enhancement, streaming support for the `continuous_frames` policy, and improved orchestration and buffer management. The changes span native Android code, documentation, and the example app, ensuring both the core and API layers support the new segmented and streaming enhancement flows.

**Core segmentation and enhancement improvements:**

* Added `populateOfflineAudioBufferIfEmpty` to `SherpaOnnxModule` and `PipelineAudioRegistry`, enabling atomic hand-off of audio buffer storage between orchestrator-produced and caller-owned buffers for segmented offline enhancement. [[1]](diffhunk://#diff-879656a663809608669376c509d884bda0e032ec094f58ce4e41a60afbbcf80dR1422-R1458) [[2]](diffhunk://#diff-6e22647333673288a3d05d535a64fa12e4803e7ab31dca3f6a6e7d38cbb5837fR249-R306)
* Updated the segmentation engine to support streaming with `continuous_frames` policy (checkpoint-only segments) and to explicitly reject this policy in offline segmentation, enforcing correct usage. [[1]](diffhunk://#diff-e1625d9346a412d48d4fb207750706d13f99e41bb71355d7307537c1f01384daR312-R327) [[2]](diffhunk://#diff-e1625d9346a412d48d4fb207750706d13f99e41bb71355d7307537c1f01384daL348-L366) [[3]](diffhunk://#diff-e1625d9346a412d48d4fb207750706d13f99e41bb71355d7307537c1f01384daR1077-R1084)
* Refactored offline segmentation to read audio in slices/chunks instead of materializing the entire PCM vector, improving memory efficiency for segmented enhancement. [[1]](diffhunk://#diff-e1625d9346a412d48d4fb207750706d13f99e41bb71355d7307537c1f01384daL1218) [[2]](diffhunk://#diff-e1625d9346a412d48d4fb207750706d13f99e41bb71355d7307537c1f01384daL1231-R1258) [[3]](diffhunk://#diff-e1625d9346a412d48d4fb207750706d13f99e41bb71355d7307537c1f01384daL1293-R1319)

**Documentation updates:**

* Marked Phase 3 as completed in migration docs, detailing the new segmented and streaming enhancement flows, buffer transfer, and API changes. Added a comprehensive validation checklist, migration steps, and clarified breaking changes. [[1]](diffhunk://#diff-3447e3ed5a1ad94dce2466f61e5a367d6a7eb734da0ee109ad98675dfe78fa8fL87-R87) [[2]](diffhunk://#diff-b4f2f40d717ac840e068cef0c07421de46ace4ccad291be1a1c8321b7dfeeaf7L5-R6) [[3]](diffhunk://#diff-b4f2f40d717ac840e068cef0c07421de46ace4ccad291be1a1c8321b7dfeeaf7L183-R206) [[4]](diffhunk://#diff-b4f2f40d717ac840e068cef0c07421de46ace4ccad291be1a1c8321b7dfeeaf7L411-R430)

**Example app improvements:**

* Enhanced the streaming enhancement screen to allow toggling `continuous_frames` segmentation, passing the correct options to the engine, and reporting checkpoint segment counts for validation. [[1]](diffhunk://#diff-543297d681d8616283b2c3f831c17980bb0ba0d50391bc41e9ca81ccff559768R11) [[2]](diffhunk://#diff-543297d681d8616283b2c3f831c17980bb0ba0d50391bc41e9ca81ccff559768R52) [[3]](diffhunk://#diff-543297d681d8616283b2c3f831c17980bb0ba0d50391bc41e9ca81ccff559768R94-R105) [[4]](diffhunk://#diff-543297d681d8616283b2c3f831c17980bb0ba0d50391bc41e9ca81ccff559768R164) [[5]](diffhunk://#diff-543297d681d8616283b2c3f831c17980bb0ba0d50391bc41e9ca81ccff559768L864-R890) [[6]](diffhunk://#diff-543297d681d8616283b2c3f831c17980bb0ba0d50391bc41e9ca81ccff559768R950-R955)

These changes collectively enable robust, memory-efficient segmented enhancement in offline and streaming modes, with clear API and orchestration boundaries and improved developer and user feedback.