### PR TITLE
Feat/add custom model type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ React Native SDK for sherpa-onnx – offline and streaming speech processing
 
 A React Native TurboModule that provides offline and streaming speech processing capabilities using [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx). The SDK aims to support all functionalities that sherpa-onnx offers, including offline and **online (streaming)** speech-to-text, text-to-speech (batch and streaming), speaker diarization, speech enhancement, source separation, and VAD (Voice Activity Detection).
 
+## Installation
+
+```sh
+npm install react-native-sherpa-onnx
+```
+
 ## Feature Support
 
 ### Speech & media features
@@ -47,13 +53,36 @@ A React Native TurboModule that provides offline and streaming speech processing
 - ✅ Playback: [PCM Player](./docs/pcm-player.md)
 - ✅ Audio visualization: [Spectrum profiles (`levels` + timeline `frames`)](./docs/audio-visualization.md)
 - ✅ Runtime acceleration: [Execution providers](./docs/execution-providers.md)
-- ✅ Model configuration and detection: [Model setup](./docs/model-setup.md) · [Model languages](./docs/model-languages.md)
+- ✅ Model configuration and detection: [Model setup](./docs/model-setup.md) · [Model detection & init](./docs/model-detect.md) · [Model languages](./docs/model-languages.md)
 - ✅ Runtime model delivery: [Download manager](./docs/download-manager.md) · [Extraction API](./docs/extraction.md) · [PAD (Android) & ODR (iOS)](./docs/model-delivery-pad-odr.md) — install-time, fast-follow, on-demand
 
 ### Planned / not yet
 
 - ⏳ Speaker diarization: [Diarization](./docs/diarization.md)
 - ⏳ Source separation: [Separation](./docs/separation.md)
+
+## How to start
+
+Every feature needs **model files on disk** and a way to point the SDK at them. Read these guides **in order** before diving into STT, TTS, VAD, or any other feature doc:
+
+| Step | Doc | You learn |
+| --- | --- | --- |
+| **1** | [Model setup](./docs/model-setup.md) | Where models live (bundled app assets, downloads, PAD/ODR), how **`FileSource`** works, expected folder layouts |
+| **2** | [Model detection & init](./docs/model-detect.md) | Cheap preflight with `detect*Model`, **`auto` vs `custom`** init, required-file validation |
+| **3** | [Feature pipelines](./docs/feature-pipelines.md) | End-to-end recipes and how features chain (buffers, segmentation, live overload) |
+| **4** | Your **feature doc** | Quick start + API for the engine you need — see below |
+
+**Optional, depending on your app:**
+
+| Need | Read |
+| --- | --- |
+| Large models shipped outside the main APK/IPA | [PAD & ODR delivery](./docs/model-delivery-pad-odr.md) (after step 1) |
+| Download models at runtime | [Download manager](./docs/download-manager.md) |
+| Long audio or offline-only models on low-end devices (OOM risk) | [Segmentation engine](./docs/segmentation-engine.md) — process bounded chunks instead of one monolithic pass; essential on modest RAM when a full-file load would exhaust memory |
+| RAM planning for large files or chained engines | [Memory and models](./docs/memory-and-models.md) |
+
+Full doc index: [docs/README.md](./docs/README.md).
+
 
 ## Built for on-device memory
 
@@ -77,27 +106,10 @@ A React Native TurboModule that provides offline and streaming speech processing
 
 **Default mindset:** use buffers, segmentation, and pipeline APIs for large or chained work—treat “load everything into memory, run once” as the exception.
 
-## Segmentation
-
-Deep dive on policies, offline orchestration, and live overload hooks: [Segmentation engine](./docs/segmentation-engine.md). For how segmentation fits OOM planning, see [Memory and models — Segmentation & OOM](./docs/memory-and-models.md#segmentation-engine-offline-only-models-and-oom-mitigation).
-
 ## Installation
 
 ```sh
 npm install react-native-sherpa-onnx
-```
-
-If your project uses Yarn (v3+) or Plug'n'Play, configure Yarn to use the Node Modules linker to avoid postinstall issues:
-
-```yaml
-# .yarnrc.yml
-nodeLinker: node-modules
-```
-
-Alternatively, set the environment variable during install:
-
-```sh
-YARN_NODE_LINKER=node-modules yarn install
 ```
 
 ### Android
@@ -334,32 +346,61 @@ Full guide: [Audio visualization](./docs/audio-visualization.md).
 
 ## Documentation
 
-- [Known issues](./docs/KNOWN_ISSUES.md) – SDK-facing notes (e.g. Pocket TTS cloning / cross-platform behavior)
-- [Memory and models](./docs/memory-and-models.md) – OOM awareness, model sizing, concurrent engines, buffer planning, **offline-only models vs segmentation / chunking**
-- [Segmentation engine](./docs/segmentation-engine.md) – segment boundaries, links, modes; **OOM mitigation** when using offline models on constrained devices
-- **Speech-to-Text (STT):** [Offline](./docs/stt-offline.md) · [Streaming](./docs/stt-streaming.md)
-- **Text-to-Speech (TTS):** [Offline](./docs/tts-offline.md)
-- **Speech Enhancement:** [Offline](./docs/enhancement-offline.md) · [Streaming](./docs/enhancement-streaming.md)
-- **Punctuation:** [Offline](./docs/punctuation-offline.md)
-- [Voice Activity Detection (VAD)](./docs/vad-streaming.md)
-- [Alignment / subtitles (offline)](./docs/alignment-offline.md) – `createAlignment`, `proportional` / `estimated` / `accurate`, `generateSpeechWithTimestamps()`
-- **Pipeline audio buffers:** [Offline](./docs/audiobuffer-offline.md) · [Live / streaming](./docs/audiobuffer-streaming.md)
-- **Pipeline text buffers:** [Offline](./docs/textbuffer-offline.md) · [Live / streaming](./docs/textbuffer-streaming.md)
-- **Pipeline segment buffers:** [Offline](./docs/segmentbuffer-offline.md) · [Live / streaming](./docs/segmentbuffer-streaming.md)
-- [Pipeline Audio Session](./docs/audio-session.md) – Global audio session policy and route preference for mic + PCM
-- [PCM Player](./docs/pcm-player.md) – Play audio from pipeline buffers
-- [Audio visualization](./docs/audio-visualization.md) – `computeAudioVisualizationProfile` — static `levels` and timeline `frames` for spectrum UI
-- [Execution provider support (QNN, NNAPI, XNNPACK, Core ML)](./docs/execution-providers.md)
-- [Speaker Diarization](./docs/diarization.md)
-- [Source Separation](./docs/separation.md)
-- [Model Setup](./docs/model-setup.md) – Bundled assets, model discovery APIs, and troubleshooting
-- [Ship Model Delivery (PAD & ODR)](./docs/model-delivery-pad-odr.md) – install-time, fast-follow, on-demand; `fetchAssetPack`, progress, extraction
-- [Model Download Manager](./docs/download-manager.md)
-- [Extraction API](./docs/extraction.md)
-- [Disable FFMPEG](./docs/disable-ffmpeg.md)
-- [Disable LIBARCHIVE](./docs/disable-libarchive.md)
+Full index: [docs/README.md](./docs/README.md). New to models? See [How to start](#how-to-start).
 
-Note: For when to use `listAssetModels()` vs `listModelsAtPath()` and how to combine bundled and PAD/file-based models, see [Model Setup](./docs/model-setup.md).
+### Getting started & planning
+
+- [How to start](#how-to-start) – model setup → detection → feature pipelines → feature doc
+- [Feature pipelines](./docs/feature-pipelines.md) – end-to-end recipes, chaining features
+- [Memory and models](./docs/memory-and-models.md) – OOM awareness, model sizing, concurrent engines, buffer planning
+- [Streaming pipelines overview](./docs/streaming-pipelines-overview.md) – shared live pipeline lifecycle (`stop` / `flush` / `completed`)
+- [Native diagnostics](./docs/native-diagnostics.md) – crash ring buffer, `SherpaNativeDiag`
+
+### Models & delivery
+
+- [Model setup](./docs/model-setup.md) – `FileSource`, bundled/PAD/downloaded paths, discovery APIs
+- [Model detection & init](./docs/model-detect.md) – preflight, `auto` vs `custom` init, validation
+- [Model languages](./docs/model-languages.md) – language pickers and `modelOptions` hints
+- [Ship model delivery (PAD & ODR)](./docs/model-delivery-pad-odr.md) – install-time, fast-follow, on-demand
+- [Download manager](./docs/download-manager.md) – runtime model downloads
+- [Extraction API](./docs/extraction.md) – `.tar.zst` / `.tar.bz2` ship archives
+- [File I/O](./docs/fileio.md) – `copyFile`, `saveText`, `shareFile`
+- [Hotwords](./docs/hotwords.md) – boosted phrases for supported STT models
+
+> For `listAssetModels()` vs `listModelsAtPath()` and combining bundled with PAD/file-based models, see [Model setup](./docs/model-setup.md).
+
+### Speech & media features
+
+- **Speech-to-Text (STT):** [Offline](./docs/stt-offline.md) · [Streaming](./docs/stt-streaming.md)
+- **Text-to-Speech (TTS):** [Offline](./docs/tts-offline.md) · [Streaming](./docs/tts-streaming.md)
+- **Speech Enhancement:** [Offline](./docs/enhancement-offline.md) · [Streaming](./docs/enhancement-streaming.md)
+- **Punctuation:** [Offline](./docs/punctuation-offline.md) · [Streaming](./docs/punctuation-streaming.md)
+- **VAD:** [Streaming](./docs/vad-streaming.md)
+- **Alignment / timestamps:** [Offline](./docs/alignment-offline.md) – `createAlignment`, `proportional` / `estimated` / `accurate`
+
+### Segmentation
+
+- [Segmentation engine](./docs/segmentation-engine.md) – policies, `SegmentLink`, live overload; **OOM mitigation** on low-end devices when offline models cannot load full audio at once
+
+### Pipeline buffers
+
+- **Audio:** [Offline](./docs/audiobuffer-offline.md) · [Live / streaming](./docs/audiobuffer-streaming.md)
+- **Text:** [Offline](./docs/textbuffer-offline.md) · [Live / streaming](./docs/textbuffer-streaming.md)
+- **Segment:** [Offline](./docs/segmentbuffer-offline.md) · [Live / streaming](./docs/segmentbuffer-streaming.md)
+
+### Audio I/O & playback
+
+- [Pipeline audio session](./docs/audio-session.md) – mic + PCM route policy
+- [PCM player](./docs/pcm-player.md) – play pipeline buffer output
+- [Audio conversion](./docs/audio-conversion.md) – save / encode, duration probe
+- [Audio visualization](./docs/audio-visualization.md) – spectrum `levels` and timeline `frames`
+
+### Platform & build
+
+- [Execution providers](./docs/execution-providers.md) – CPU, NNAPI, XNNPACK, Core ML, QNN
+- [Disable FFmpeg](./docs/disable-ffmpeg.md) · [Disable libarchive](./docs/disable-libarchive.md)
+- [Known issues](./docs/KNOWN_ISSUES.md) – SDK-facing notes (e.g. Pocket TTS cross-platform drift)
+- **Planned:** [Speaker diarization](./docs/diarization.md) · [Source separation](./docs/separation.md)
 
 ## Requirements
 

--- a/SherpaOnnx.podspec
+++ b/SherpaOnnx.podspec
@@ -137,6 +137,7 @@ Pod::Spec.new do |s|
     "\"#{pod_root}/android/src/main/cpp/jni/model_detect/tts\"",
     "\"#{pod_root}/android/src/main/cpp/jni/model_detect/enhancement\"",
     "\"#{pod_root}/android/src/main/cpp/jni/model_detect/punctuation\"",
+    "\"#{pod_root}/android/src/main/cpp/jni/model_detect/vad\"",
     "\"#{pod_root}/android/src/main/cpp/jni/model_detect/alignment\"",
     "\"#{pod_root}/android/src/main/cpp/alignment\"",
     "\"#{pod_root}/android/src/main/cpp/jni/audio\"",

--- a/SherpaOnnx.podspec
+++ b/SherpaOnnx.podspec
@@ -131,6 +131,7 @@ Pod::Spec.new do |s|
 
   header_search_paths = [
     "$(inherited)",
+    "\"#{pod_root}/ios/stt/native\"",
     "\"#{pod_root}/android/src/main/cpp/jni/model_detect/common\"",
     "\"#{pod_root}/android/src/main/cpp/jni/model_detect/stt\"",
     "\"#{pod_root}/android/src/main/cpp/jni/model_detect/tts\"",

--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -96,6 +96,7 @@ set(SOURCES
     jni/model_detect/stt/sherpa-onnx-stt-catalog-metadata.cpp
     jni/model_detect/stt/sherpa-onnx-model-detect-stt.cpp
     jni/model_detect/stt/sherpa-onnx-validate-stt.cpp
+    jni/model_detect/stt/sherpa-onnx-validate-online-stt.cpp
     jni/model_detect/stt/sherpa-onnx-stt-wrapper.cpp
     jni/model_detect/stt/sherpa-onnx-stt-online-guard.cpp
     jni/model_detect/stt/sherpa-onnx-stt-online-guard-transducer.cpp

--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -88,6 +88,8 @@ set(SOURCES
     jni/model_detect/common/sherpa-onnx-model-detect-helper.cpp
     jni/model_detect/common/sherpa-onnx-detect-jni-common.cpp
     jni/model_detect/common/sherpa-onnx-model-detect-unified.cpp
+    jni/model_detect/common/sherpa-onnx-model-path-fill.cpp
+    jni/model_detect/common/sherpa-onnx-validate-custom.cpp
     jni/model_detect/common/sherpa-onnx-unified-detect-wrapper.cpp
     jni/model_detect/common/sherpa-onnx-catalog-metadata.cpp
     jni/model_detect/common/sherpa-onnx-ort-guard-utils.cpp

--- a/android/src/main/cpp/jni/model_detect/alignment/sherpa-onnx-validate-alignment.cpp
+++ b/android/src/main/cpp/jni/model_detect/alignment/sherpa-onnx-validate-alignment.cpp
@@ -63,4 +63,16 @@ AlignmentValidationResult ValidateAlignmentPaths(
     return result;
 }
 
+std::vector<CustomPathFieldSpec> GetAlignmentPathRequirements(AlignmentModelKind kind) {
+    std::vector<CustomPathFieldSpec> specs;
+    size_t count = 0;
+    const auto* reqs = GetRequirements(kind, count);
+    if (!reqs) return specs;
+    specs.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        specs.push_back({reqs[i].fieldName, reqs[i].required});
+    }
+    return specs;
+}
+
 } // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/alignment/sherpa-onnx-validate-alignment.h
+++ b/android/src/main/cpp/jni/model_detect/alignment/sherpa-onnx-validate-alignment.h
@@ -2,6 +2,7 @@
 #define SHERPA_ONNX_VALIDATE_ALIGNMENT_H
 
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-validate-custom-types.h"
 #include <string>
 #include <vector>
 
@@ -24,6 +25,8 @@ AlignmentValidationResult ValidateAlignmentPaths(
     const AlignmentModelPaths& paths,
     const std::string& modelDir
 );
+
+std::vector<CustomPathFieldSpec> GetAlignmentPathRequirements(AlignmentModelKind kind);
 
 } // namespace sherpaonnx
 

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-detect-jni-common.cpp
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-detect-jni-common.cpp
@@ -106,6 +106,37 @@ jobject BuildStringList(JNIEnv* env, const std::vector<std::string>& strings) {
   return list;
 }
 
+jobject BuildStringStringMap(
+    JNIEnv* env,
+    const std::map<std::string, std::string>& strings
+) {
+  if (strings.empty()) {
+    return nullptr;
+  }
+  jclass mapClass = env->FindClass("java/util/HashMap");
+  if (!mapClass) return nullptr;
+  jmethodID mapInit = env->GetMethodID(mapClass, "<init>", "()V");
+  jmethodID mapPut = env->GetMethodID(
+      mapClass,
+      "put",
+      "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+  if (!mapInit || !mapPut) {
+    env->DeleteLocalRef(mapClass);
+    return nullptr;
+  }
+  jobject map = env->NewObject(mapClass, mapInit);
+  env->DeleteLocalRef(mapClass);
+  if (!map) return nullptr;
+
+  for (const auto& entry : strings) {
+    if (entry.second.empty()) {
+      continue;
+    }
+    PutString(env, map, mapPut, entry.first.c_str(), entry.second);
+  }
+  return map;
+}
+
 jobject BuildLexiconLanguagesList(
     JNIEnv* env,
     const std::vector<model_detect::LexiconCandidate>& languages) {

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-detect-jni-common.cpp
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-detect-jni-common.cpp
@@ -146,4 +146,157 @@ jobject BuildLexiconLanguagesList(
   return list;
 }
 
+std::map<std::string, std::string> JavaHashMapToStringMap(JNIEnv* env, jobject map) {
+  std::map<std::string, std::string> out;
+  if (!map) return out;
+
+  jclass mapClass = env->FindClass("java/util/Map");
+  jclass entryClass = env->FindClass("java/util/Map$Entry");
+  jclass setClass = env->FindClass("java/util/Set");
+  if (!mapClass || !entryClass || !setClass) return out;
+
+  jmethodID entrySet = env->GetMethodID(mapClass, "entrySet", "()Ljava/util/Set;");
+  jmethodID setIterator = env->GetMethodID(setClass, "iterator", "()Ljava/util/Iterator;");
+  jclass iteratorClass = env->FindClass("java/util/Iterator");
+  jmethodID iteratorHasNext = env->GetMethodID(iteratorClass, "hasNext", "()Z");
+  jmethodID iteratorNext = env->GetMethodID(iteratorClass, "next", "()Ljava/lang/Object;");
+  jmethodID entryGetKey = env->GetMethodID(entryClass, "getKey", "()Ljava/lang/Object;");
+  jmethodID entryGetValue = env->GetMethodID(entryClass, "getValue", "()Ljava/lang/Object;");
+
+  if (!entrySet || !setIterator || !iteratorHasNext || !iteratorNext ||
+      !entryGetKey || !entryGetValue) {
+    env->DeleteLocalRef(mapClass);
+    env->DeleteLocalRef(entryClass);
+    env->DeleteLocalRef(setClass);
+    env->DeleteLocalRef(iteratorClass);
+    return out;
+  }
+
+  jobject entries = env->CallObjectMethod(map, entrySet);
+  if (!entries) {
+    env->DeleteLocalRef(mapClass);
+    env->DeleteLocalRef(entryClass);
+    env->DeleteLocalRef(setClass);
+    env->DeleteLocalRef(iteratorClass);
+    return out;
+  }
+
+  jobject it = env->CallObjectMethod(entries, setIterator);
+  env->DeleteLocalRef(entries);
+  if (!it) {
+    env->DeleteLocalRef(mapClass);
+    env->DeleteLocalRef(entryClass);
+    env->DeleteLocalRef(setClass);
+    env->DeleteLocalRef(iteratorClass);
+    return out;
+  }
+
+  while (env->CallBooleanMethod(it, iteratorHasNext)) {
+    jobject entry = env->CallObjectMethod(it, iteratorNext);
+    if (!entry) continue;
+    jstring jkey = static_cast<jstring>(env->CallObjectMethod(entry, entryGetKey));
+    jstring jval = static_cast<jstring>(env->CallObjectMethod(entry, entryGetValue));
+    if (jkey && jval) {
+      const char* keyChars = env->GetStringUTFChars(jkey, nullptr);
+      const char* valChars = env->GetStringUTFChars(jval, nullptr);
+      if (keyChars && valChars && valChars[0] != '\0') {
+        out.emplace(keyChars, valChars);
+      }
+      if (keyChars) env->ReleaseStringUTFChars(jkey, keyChars);
+      if (valChars) env->ReleaseStringUTFChars(jval, valChars);
+    }
+    if (jkey) env->DeleteLocalRef(jkey);
+    if (jval) env->DeleteLocalRef(jval);
+    env->DeleteLocalRef(entry);
+  }
+
+  env->DeleteLocalRef(it);
+  env->DeleteLocalRef(mapClass);
+  env->DeleteLocalRef(entryClass);
+  env->DeleteLocalRef(setClass);
+  env->DeleteLocalRef(iteratorClass);
+  return out;
+}
+
+jobject BuildCustomValidationResultMap(
+    JNIEnv* env,
+    const CustomModelValidationResult& result
+) {
+  jclass mapClass = env->FindClass("java/util/HashMap");
+  if (!mapClass) return nullptr;
+  jmethodID mapInit = env->GetMethodID(mapClass, "<init>", "()V");
+  jmethodID mapPut = env->GetMethodID(
+      mapClass,
+      "put",
+      "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+  if (!mapInit || !mapPut) {
+    env->DeleteLocalRef(mapClass);
+    return nullptr;
+  }
+
+  jobject map = env->NewObject(mapClass, mapInit);
+  env->DeleteLocalRef(mapClass);
+  if (!map) return nullptr;
+
+  PutBoolean(env, map, mapPut, "ok", result.ok);
+  if (!result.error.empty()) {
+    PutString(env, map, mapPut, "error", result.error);
+  }
+  if (!result.missingRequired.empty()) {
+    jobject missing = BuildStringList(env, result.missingRequired);
+    if (missing) {
+      jstring jkey = env->NewStringUTF("missingRequired");
+      if (jkey) {
+        env->CallObjectMethod(map, mapPut, jkey, missing);
+        env->DeleteLocalRef(jkey);
+      }
+      env->DeleteLocalRef(missing);
+    }
+  }
+  return map;
+}
+
+jobject BuildCustomPathRequirementsMap(
+    JNIEnv* env,
+    const CustomModelPathRequirements& requirements
+) {
+  jclass mapClass = env->FindClass("java/util/HashMap");
+  if (!mapClass) return nullptr;
+  jmethodID mapInit = env->GetMethodID(mapClass, "<init>", "()V");
+  jmethodID mapPut = env->GetMethodID(
+      mapClass,
+      "put",
+      "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+  if (!mapInit || !mapPut) {
+    env->DeleteLocalRef(mapClass);
+    return nullptr;
+  }
+
+  jobject map = env->NewObject(mapClass, mapInit);
+  env->DeleteLocalRef(mapClass);
+  if (!map) return nullptr;
+
+  jobject required = BuildStringList(env, requirements.required);
+  if (required) {
+    jstring jkey = env->NewStringUTF("required");
+    if (jkey) {
+      env->CallObjectMethod(map, mapPut, jkey, required);
+      env->DeleteLocalRef(jkey);
+    }
+    env->DeleteLocalRef(required);
+  }
+
+  jobject optional = BuildStringList(env, requirements.optional);
+  if (optional) {
+    jstring jkey = env->NewStringUTF("optional");
+    if (jkey) {
+      env->CallObjectMethod(map, mapPut, jkey, optional);
+      env->DeleteLocalRef(jkey);
+    }
+    env->DeleteLocalRef(optional);
+  }
+
+  return map;
+}
+
 }  // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-detect-jni-common.cpp
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-detect-jni-common.cpp
@@ -256,6 +256,32 @@ jobject BuildCustomValidationResultMap(
   return map;
 }
 
+jobject BuildCustomPathFieldMap(
+    JNIEnv* env,
+    const CustomPathFieldSpec& field
+) {
+  jclass mapClass = env->FindClass("java/util/HashMap");
+  if (!mapClass) return nullptr;
+  jmethodID mapInit = env->GetMethodID(mapClass, "<init>", "()V");
+  jmethodID mapPut = env->GetMethodID(
+      mapClass,
+      "put",
+      "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+  if (!mapInit || !mapPut) {
+    env->DeleteLocalRef(mapClass);
+    return nullptr;
+  }
+
+  jobject map = env->NewObject(mapClass, mapInit);
+  env->DeleteLocalRef(mapClass);
+  if (!map) return nullptr;
+
+  PutString(env, map, mapPut, "key", field.key);
+  PutBoolean(env, map, mapPut, "required", field.required);
+  PutString(env, map, mapPut, "kind", field.isDirectory ? "dir" : "file");
+  return map;
+}
+
 jobject BuildCustomPathRequirementsMap(
     JNIEnv* env,
     const CustomModelPathRequirements& requirements
@@ -276,24 +302,31 @@ jobject BuildCustomPathRequirementsMap(
   env->DeleteLocalRef(mapClass);
   if (!map) return nullptr;
 
-  jobject required = BuildStringList(env, requirements.required);
-  if (required) {
-    jstring jkey = env->NewStringUTF("required");
-    if (jkey) {
-      env->CallObjectMethod(map, mapPut, jkey, required);
-      env->DeleteLocalRef(jkey);
+  if (!requirements.fields.empty()) {
+    jclass listClass = env->FindClass("java/util/ArrayList");
+    if (listClass) {
+      jmethodID listInit = env->GetMethodID(listClass, "<init>", "()V");
+      jmethodID listAdd = env->GetMethodID(listClass, "add", "(Ljava/lang/Object;)Z");
+      if (listInit && listAdd) {
+        jobject fields = env->NewObject(listClass, listInit);
+        if (fields) {
+          for (const auto& field : requirements.fields) {
+            jobject fieldMap = BuildCustomPathFieldMap(env, field);
+            if (fieldMap) {
+              env->CallBooleanMethod(fields, listAdd, fieldMap);
+              env->DeleteLocalRef(fieldMap);
+            }
+          }
+          jstring jkey = env->NewStringUTF("fields");
+          if (jkey) {
+            env->CallObjectMethod(map, mapPut, jkey, fields);
+            env->DeleteLocalRef(jkey);
+          }
+          env->DeleteLocalRef(fields);
+        }
+      }
+      env->DeleteLocalRef(listClass);
     }
-    env->DeleteLocalRef(required);
-  }
-
-  jobject optional = BuildStringList(env, requirements.optional);
-  if (optional) {
-    jstring jkey = env->NewStringUTF("optional");
-    if (jkey) {
-      env->CallObjectMethod(map, mapPut, jkey, optional);
-      env->DeleteLocalRef(jkey);
-    }
-    env->DeleteLocalRef(optional);
   }
 
   return map;

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-detect-jni-common.h
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-detect-jni-common.h
@@ -20,6 +20,10 @@ bool PutBoolean(JNIEnv* env, jobject map, jmethodID putId, const char* key, bool
 jobject BuildDetectedModelsList(JNIEnv* env, const std::vector<DetectedModel>& models);
 /** Build a Java ArrayList<String> from a vector of strings. Returns null on failure. */
 jobject BuildStringList(JNIEnv* env, const std::vector<std::string>& strings);
+/** Build a Java HashMap<String,String> from a C++ string map (skips empty values). */
+jobject BuildStringStringMap(
+    JNIEnv* env,
+    const std::map<std::string, std::string>& strings);
 /** Build ArrayList<HashMap> with {id, path} for lexicon languages. Returns null on failure. */
 jobject BuildLexiconLanguagesList(
     JNIEnv* env,

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-detect-jni-common.h
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-detect-jni-common.h
@@ -7,6 +7,9 @@
 
 #include "sherpa-onnx-common.h"
 #include "sherpa-onnx-model-detect-helper.h"
+#include "sherpa-onnx-validate-custom-types.h"
+
+#include <map>
 
 namespace sherpaonnx {
 
@@ -21,6 +24,19 @@ jobject BuildStringList(JNIEnv* env, const std::vector<std::string>& strings);
 jobject BuildLexiconLanguagesList(
     JNIEnv* env,
     const std::vector<model_detect::LexiconCandidate>& languages);
+
+/** Read a Java HashMap<String,String> into a C++ string map (skips null/empty values). */
+std::map<std::string, std::string> JavaHashMapToStringMap(JNIEnv* env, jobject map);
+
+jobject BuildCustomValidationResultMap(
+    JNIEnv* env,
+    const CustomModelValidationResult& result
+);
+
+jobject BuildCustomPathRequirementsMap(
+    JNIEnv* env,
+    const CustomModelPathRequirements& requirements
+);
 
 }  // namespace sherpaonnx
 

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-detect-unified.cpp
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-detect-unified.cpp
@@ -6,6 +6,7 @@
 #include "sherpa-onnx-model-detect-unified.h"
 
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-model-path-fill.h"
 
 #include <algorithm>
 
@@ -135,6 +136,7 @@ UnifiedModelDetectResult MakeHit(
     bool isHardwareSpecificUnsupported,
     const std::vector<DetectedModel>& detectedModels,
     const std::vector<DetectionSource>& detectionSources,
+    const std::map<std::string, std::string>& paths,
     const std::string& error) {
     UnifiedModelDetectResult out;
     out.matched = true;
@@ -148,6 +150,7 @@ UnifiedModelDetectResult MakeHit(
     out.isHardwareSpecificUnsupported = isHardwareSpecificUnsupported;
     out.detectedModels = detectedModels;
     CopyDetectionSources(out, detectionSources);
+    out.paths = paths;
     out.error = error;
     return out;
 }
@@ -175,6 +178,7 @@ UnifiedModelDetectResult DetectModelInternal(
             false,
             tts.detectedModels,
             tts.detectionSources,
+            TtsModelPathsToStringMap(tts.paths),
             tts.error);
     }
 
@@ -192,6 +196,7 @@ UnifiedModelDetectResult DetectModelInternal(
             stt.isHardwareSpecificUnsupported,
             stt.detectedModels,
             stt.detectionSources,
+            SttModelPathsToStringMap(stt.paths),
             stt.error);
     }
 
@@ -208,6 +213,7 @@ UnifiedModelDetectResult DetectModelInternal(
             false,
             vad.detectedModels,
             vad.detectionSources,
+            VadModelPathsToStringMap(vad.paths),
             vad.error);
     }
 
@@ -227,6 +233,7 @@ UnifiedModelDetectResult DetectModelInternal(
             false,
             punctuation.detectedModels,
             punctuation.detectionSources,
+            PunctuationModelPathsToStringMap(punctuation.paths),
             punctuation.error);
     }
 
@@ -246,6 +253,7 @@ UnifiedModelDetectResult DetectModelInternal(
             false,
             enhancement.detectedModels,
             enhancement.detectionSources,
+            EnhancementModelPathsToStringMap(enhancement.paths),
             enhancement.error);
     }
 
@@ -272,6 +280,7 @@ UnifiedModelDetectResult DetectModelInternal(
                 false,
                 alignment.detectedModels,
                 alignment.detectionSources,
+                AlignmentModelPathsToStringMap(alignment.paths),
                 alignment.error);
         }
     }

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-detect-unified.h
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-detect-unified.h
@@ -2,6 +2,7 @@
 #define SHERPA_ONNX_MODEL_DETECT_UNIFIED_H
 
 #include "sherpa-onnx-common.h"
+#include <map>
 #include <optional>
 #include <string>
 #include <vector>
@@ -25,6 +26,7 @@ struct UnifiedModelDetectResult {
     bool isHardwareSpecificUnsupported = false;
     std::vector<DetectedModel> detectedModels;
     std::vector<std::string> detectionSources;
+    std::map<std::string, std::string> paths;
     std::string error;
 };
 

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-detect.h
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-detect.h
@@ -33,6 +33,9 @@ enum class SttModelKind {
     kToneCtc
 };
 
+/** Parse public model type string to {@link SttModelKind}. Returns kUnknown when unrecognized. */
+SttModelKind ParseSttModelType(const std::string& modelType);
+
 enum class TtsModelKind {
     kUnknown,
     kVits,

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-path-fill.cpp
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-path-fill.cpp
@@ -1,0 +1,113 @@
+#include "sherpa-onnx-model-path-fill.h"
+
+namespace sherpaonnx {
+namespace {
+
+void SetPathFromMap(
+    const std::map<std::string, std::string>& m,
+    const char* key,
+    std::string& out
+) {
+    const auto it = m.find(key);
+    if (it != m.end() && !it->second.empty()) {
+        out = it->second;
+    }
+}
+
+}  // namespace
+
+void FillSttModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    SttModelPaths& out
+) {
+    SetPathFromMap(paths, "encoder", out.encoder);
+    SetPathFromMap(paths, "decoder", out.decoder);
+    SetPathFromMap(paths, "joiner", out.joiner);
+    SetPathFromMap(paths, "tokens", out.tokens);
+    SetPathFromMap(paths, "bpeVocab", out.bpeVocab);
+    SetPathFromMap(paths, "paraformerModel", out.paraformerModel);
+    SetPathFromMap(paths, "ctcModel", out.ctcModel);
+    SetPathFromMap(paths, "whisperEncoder", out.whisperEncoder);
+    SetPathFromMap(paths, "whisperDecoder", out.whisperDecoder);
+    SetPathFromMap(paths, "funasrEncoderAdaptor", out.funasrEncoderAdaptor);
+    SetPathFromMap(paths, "funasrLLM", out.funasrLLM);
+    SetPathFromMap(paths, "funasrEmbedding", out.funasrEmbedding);
+    SetPathFromMap(paths, "funasrTokenizer", out.funasrTokenizer);
+    SetPathFromMap(paths, "qwen3ConvFrontend", out.qwen3ConvFrontend);
+    SetPathFromMap(paths, "qwen3Encoder", out.qwen3Encoder);
+    SetPathFromMap(paths, "qwen3Decoder", out.qwen3Decoder);
+    SetPathFromMap(paths, "qwen3Tokenizer", out.qwen3Tokenizer);
+    SetPathFromMap(paths, "cohereEncoder", out.cohereEncoder);
+    SetPathFromMap(paths, "cohereDecoder", out.cohereDecoder);
+    SetPathFromMap(paths, "moonshinePreprocessor", out.moonshinePreprocessor);
+    SetPathFromMap(paths, "moonshineEncoder", out.moonshineEncoder);
+    SetPathFromMap(paths, "moonshineUncachedDecoder", out.moonshineUncachedDecoder);
+    SetPathFromMap(paths, "moonshineCachedDecoder", out.moonshineCachedDecoder);
+    SetPathFromMap(paths, "moonshineMergedDecoder", out.moonshineMergedDecoder);
+    SetPathFromMap(paths, "fireRedEncoder", out.fireRedEncoder);
+    SetPathFromMap(paths, "fireRedDecoder", out.fireRedDecoder);
+    SetPathFromMap(paths, "canaryEncoder", out.canaryEncoder);
+    SetPathFromMap(paths, "canaryDecoder", out.canaryDecoder);
+    SetPathFromMap(paths, "dolphinModel", out.dolphinModel);
+    SetPathFromMap(paths, "omnilingualModel", out.omnilingualModel);
+    SetPathFromMap(paths, "medasrModel", out.medasrModel);
+    SetPathFromMap(paths, "telespeechCtcModel", out.telespeechCtcModel);
+}
+
+void FillTtsModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    TtsModelPaths& out
+) {
+    SetPathFromMap(paths, "ttsModel", out.ttsModel);
+    SetPathFromMap(paths, "tokens", out.tokens);
+    SetPathFromMap(paths, "lexicon", out.lexicon);
+    SetPathFromMap(paths, "dataDir", out.dataDir);
+    SetPathFromMap(paths, "voices", out.voices);
+    SetPathFromMap(paths, "acousticModel", out.acousticModel);
+    SetPathFromMap(paths, "vocoder", out.vocoder);
+    SetPathFromMap(paths, "encoder", out.encoder);
+    SetPathFromMap(paths, "decoder", out.decoder);
+    SetPathFromMap(paths, "lmFlow", out.lmFlow);
+    SetPathFromMap(paths, "lmMain", out.lmMain);
+    SetPathFromMap(paths, "textConditioner", out.textConditioner);
+    SetPathFromMap(paths, "vocabJson", out.vocabJson);
+    SetPathFromMap(paths, "tokenScoresJson", out.tokenScoresJson);
+    SetPathFromMap(paths, "durationPredictor", out.durationPredictor);
+    SetPathFromMap(paths, "textEncoder", out.textEncoder);
+    SetPathFromMap(paths, "vectorEstimator", out.vectorEstimator);
+    SetPathFromMap(paths, "ttsJson", out.ttsJson);
+    SetPathFromMap(paths, "unicodeIndexer", out.unicodeIndexer);
+    SetPathFromMap(paths, "voiceStyle", out.voiceStyle);
+}
+
+void FillVadModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    VadModelPaths& out
+) {
+    SetPathFromMap(paths, "model", out.model);
+}
+
+void FillEnhancementModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    EnhancementModelPaths& out
+) {
+    SetPathFromMap(paths, "model", out.model);
+}
+
+void FillPunctuationModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    PunctuationModelPaths& out
+) {
+    SetPathFromMap(paths, "ct_transformer", out.ct_transformer);
+    SetPathFromMap(paths, "cnn_bilstm", out.cnn_bilstm);
+    SetPathFromMap(paths, "bpe_vocab", out.bpe_vocab);
+}
+
+void FillAlignmentModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    AlignmentModelPaths& out
+) {
+    SetPathFromMap(paths, "model", out.model);
+}
+
+}  // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-path-fill.cpp
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-path-fill.cpp
@@ -121,4 +121,105 @@ void FillOnlineSttModelPathsFromStringMap(
     SetPathFromMap(paths, "model", out.model);
 }
 
+void PutPathIfNonEmpty(
+    std::map<std::string, std::string>& out,
+    const char* key,
+    const std::string& path
+) {
+    if (!path.empty()) {
+        out.emplace(key, path);
+    }
+}
+
+std::map<std::string, std::string> SttModelPathsToStringMap(const SttModelPaths& paths) {
+    std::map<std::string, std::string> out;
+    PutPathIfNonEmpty(out, "encoder", paths.encoder);
+    PutPathIfNonEmpty(out, "decoder", paths.decoder);
+    PutPathIfNonEmpty(out, "joiner", paths.joiner);
+    PutPathIfNonEmpty(out, "tokens", paths.tokens);
+    PutPathIfNonEmpty(out, "bpeVocab", paths.bpeVocab);
+    PutPathIfNonEmpty(out, "paraformerModel", paths.paraformerModel);
+    PutPathIfNonEmpty(out, "ctcModel", paths.ctcModel);
+    PutPathIfNonEmpty(out, "whisperEncoder", paths.whisperEncoder);
+    PutPathIfNonEmpty(out, "whisperDecoder", paths.whisperDecoder);
+    PutPathIfNonEmpty(out, "funasrEncoderAdaptor", paths.funasrEncoderAdaptor);
+    PutPathIfNonEmpty(out, "funasrLLM", paths.funasrLLM);
+    PutPathIfNonEmpty(out, "funasrEmbedding", paths.funasrEmbedding);
+    PutPathIfNonEmpty(out, "funasrTokenizer", paths.funasrTokenizer);
+    PutPathIfNonEmpty(out, "qwen3ConvFrontend", paths.qwen3ConvFrontend);
+    PutPathIfNonEmpty(out, "qwen3Encoder", paths.qwen3Encoder);
+    PutPathIfNonEmpty(out, "qwen3Decoder", paths.qwen3Decoder);
+    PutPathIfNonEmpty(out, "qwen3Tokenizer", paths.qwen3Tokenizer);
+    PutPathIfNonEmpty(out, "cohereEncoder", paths.cohereEncoder);
+    PutPathIfNonEmpty(out, "cohereDecoder", paths.cohereDecoder);
+    PutPathIfNonEmpty(out, "moonshinePreprocessor", paths.moonshinePreprocessor);
+    PutPathIfNonEmpty(out, "moonshineEncoder", paths.moonshineEncoder);
+    PutPathIfNonEmpty(out, "moonshineUncachedDecoder", paths.moonshineUncachedDecoder);
+    PutPathIfNonEmpty(out, "moonshineCachedDecoder", paths.moonshineCachedDecoder);
+    PutPathIfNonEmpty(out, "moonshineMergedDecoder", paths.moonshineMergedDecoder);
+    PutPathIfNonEmpty(out, "fireRedEncoder", paths.fireRedEncoder);
+    PutPathIfNonEmpty(out, "fireRedDecoder", paths.fireRedDecoder);
+    PutPathIfNonEmpty(out, "canaryEncoder", paths.canaryEncoder);
+    PutPathIfNonEmpty(out, "canaryDecoder", paths.canaryDecoder);
+    PutPathIfNonEmpty(out, "dolphinModel", paths.dolphinModel);
+    PutPathIfNonEmpty(out, "omnilingualModel", paths.omnilingualModel);
+    PutPathIfNonEmpty(out, "medasrModel", paths.medasrModel);
+    PutPathIfNonEmpty(out, "telespeechCtcModel", paths.telespeechCtcModel);
+    return out;
+}
+
+std::map<std::string, std::string> TtsModelPathsToStringMap(const TtsModelPaths& paths) {
+    std::map<std::string, std::string> out;
+    PutPathIfNonEmpty(out, "ttsModel", paths.ttsModel);
+    PutPathIfNonEmpty(out, "tokens", paths.tokens);
+    PutPathIfNonEmpty(out, "lexicon", paths.lexicon);
+    PutPathIfNonEmpty(out, "dataDir", paths.dataDir);
+    PutPathIfNonEmpty(out, "voices", paths.voices);
+    PutPathIfNonEmpty(out, "acousticModel", paths.acousticModel);
+    PutPathIfNonEmpty(out, "vocoder", paths.vocoder);
+    PutPathIfNonEmpty(out, "encoder", paths.encoder);
+    PutPathIfNonEmpty(out, "decoder", paths.decoder);
+    PutPathIfNonEmpty(out, "lmFlow", paths.lmFlow);
+    PutPathIfNonEmpty(out, "lmMain", paths.lmMain);
+    PutPathIfNonEmpty(out, "textConditioner", paths.textConditioner);
+    PutPathIfNonEmpty(out, "vocabJson", paths.vocabJson);
+    PutPathIfNonEmpty(out, "tokenScoresJson", paths.tokenScoresJson);
+    PutPathIfNonEmpty(out, "durationPredictor", paths.durationPredictor);
+    PutPathIfNonEmpty(out, "textEncoder", paths.textEncoder);
+    PutPathIfNonEmpty(out, "vectorEstimator", paths.vectorEstimator);
+    PutPathIfNonEmpty(out, "ttsJson", paths.ttsJson);
+    PutPathIfNonEmpty(out, "unicodeIndexer", paths.unicodeIndexer);
+    PutPathIfNonEmpty(out, "voiceStyle", paths.voiceStyle);
+    return out;
+}
+
+std::map<std::string, std::string> VadModelPathsToStringMap(const VadModelPaths& paths) {
+    std::map<std::string, std::string> out;
+    PutPathIfNonEmpty(out, "model", paths.model);
+    return out;
+}
+
+std::map<std::string, std::string> EnhancementModelPathsToStringMap(
+    const EnhancementModelPaths& paths) {
+    std::map<std::string, std::string> out;
+    PutPathIfNonEmpty(out, "model", paths.model);
+    return out;
+}
+
+std::map<std::string, std::string> PunctuationModelPathsToStringMap(
+    const PunctuationModelPaths& paths) {
+    std::map<std::string, std::string> out;
+    PutPathIfNonEmpty(out, "ct_transformer", paths.ct_transformer);
+    PutPathIfNonEmpty(out, "cnn_bilstm", paths.cnn_bilstm);
+    PutPathIfNonEmpty(out, "bpe_vocab", paths.bpe_vocab);
+    return out;
+}
+
+std::map<std::string, std::string> AlignmentModelPathsToStringMap(
+    const AlignmentModelPaths& paths) {
+    std::map<std::string, std::string> out;
+    PutPathIfNonEmpty(out, "model", paths.model);
+    return out;
+}
+
 }  // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-path-fill.cpp
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-path-fill.cpp
@@ -110,4 +110,15 @@ void FillAlignmentModelPathsFromStringMap(
     SetPathFromMap(paths, "model", out.model);
 }
 
+void FillOnlineSttModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    OnlineSttModelPaths& out
+) {
+    SetPathFromMap(paths, "encoder", out.encoder);
+    SetPathFromMap(paths, "decoder", out.decoder);
+    SetPathFromMap(paths, "joiner", out.joiner);
+    SetPathFromMap(paths, "tokens", out.tokens);
+    SetPathFromMap(paths, "model", out.model);
+}
+
 }  // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-path-fill.h
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-path-fill.h
@@ -43,6 +43,16 @@ void FillOnlineSttModelPathsFromStringMap(
     OnlineSttModelPaths& out
 );
 
+std::map<std::string, std::string> SttModelPathsToStringMap(const SttModelPaths& paths);
+std::map<std::string, std::string> TtsModelPathsToStringMap(const TtsModelPaths& paths);
+std::map<std::string, std::string> VadModelPathsToStringMap(const VadModelPaths& paths);
+std::map<std::string, std::string> EnhancementModelPathsToStringMap(
+    const EnhancementModelPaths& paths);
+std::map<std::string, std::string> PunctuationModelPathsToStringMap(
+    const PunctuationModelPaths& paths);
+std::map<std::string, std::string> AlignmentModelPathsToStringMap(
+    const AlignmentModelPaths& paths);
+
 }  // namespace sherpaonnx
 
 #endif  // SHERPA_ONNX_MODEL_PATH_FILL_H

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-path-fill.h
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-path-fill.h
@@ -1,0 +1,42 @@
+#ifndef SHERPA_ONNX_MODEL_PATH_FILL_H
+#define SHERPA_ONNX_MODEL_PATH_FILL_H
+
+#include "sherpa-onnx-model-detect.h"
+#include <map>
+#include <string>
+
+namespace sherpaonnx {
+
+void FillSttModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    SttModelPaths& out
+);
+
+void FillTtsModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    TtsModelPaths& out
+);
+
+void FillVadModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    VadModelPaths& out
+);
+
+void FillEnhancementModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    EnhancementModelPaths& out
+);
+
+void FillPunctuationModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    PunctuationModelPaths& out
+);
+
+void FillAlignmentModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    AlignmentModelPaths& out
+);
+
+}  // namespace sherpaonnx
+
+#endif  // SHERPA_ONNX_MODEL_PATH_FILL_H

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-path-fill.h
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-model-path-fill.h
@@ -2,6 +2,7 @@
 #define SHERPA_ONNX_MODEL_PATH_FILL_H
 
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-validate-online-stt.h"
 #include <map>
 #include <string>
 
@@ -35,6 +36,11 @@ void FillPunctuationModelPathsFromStringMap(
 void FillAlignmentModelPathsFromStringMap(
     const std::map<std::string, std::string>& paths,
     AlignmentModelPaths& out
+);
+
+void FillOnlineSttModelPathsFromStringMap(
+    const std::map<std::string, std::string>& paths,
+    OnlineSttModelPaths& out
 );
 
 }  // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-unified-detect-wrapper.cpp
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-unified-detect-wrapper.cpp
@@ -75,6 +75,14 @@ jobject UnifiedDetectResultToJava(JNIEnv* env, const UnifiedModelDetectResult& r
         env->DeleteLocalRef(detectionSourcesList);
     }
 
+    jobject pathsMap = BuildStringStringMap(env, result.paths);
+    if (pathsMap) {
+        jstring keyPaths = env->NewStringUTF("paths");
+        env->CallObjectMethod(map, mapPut, keyPaths, pathsMap);
+        env->DeleteLocalRef(keyPaths);
+        env->DeleteLocalRef(pathsMap);
+    }
+
     return map;
 }
 

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-validate-custom-types.h
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-validate-custom-types.h
@@ -1,0 +1,27 @@
+#ifndef SHERPA_ONNX_VALIDATE_CUSTOM_TYPES_H
+#define SHERPA_ONNX_VALIDATE_CUSTOM_TYPES_H
+
+#include <string>
+#include <vector>
+
+namespace sherpaonnx {
+
+struct CustomPathFieldSpec {
+    std::string key;
+    bool required = false;
+};
+
+struct CustomModelValidationResult {
+    bool ok = true;
+    std::vector<std::string> missingRequired;
+    std::string error;
+};
+
+struct CustomModelPathRequirements {
+    std::vector<std::string> required;
+    std::vector<std::string> optional;
+};
+
+}  // namespace sherpaonnx
+
+#endif  // SHERPA_ONNX_VALIDATE_CUSTOM_TYPES_H

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-validate-custom-types.h
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-validate-custom-types.h
@@ -9,6 +9,7 @@ namespace sherpaonnx {
 struct CustomPathFieldSpec {
     std::string key;
     bool required = false;
+    bool isDirectory = false;
 };
 
 struct CustomModelValidationResult {
@@ -18,8 +19,7 @@ struct CustomModelValidationResult {
 };
 
 struct CustomModelPathRequirements {
-    std::vector<std::string> required;
-    std::vector<std::string> optional;
+    std::vector<CustomPathFieldSpec> fields;
 };
 
 }  // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-validate-custom.cpp
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-validate-custom.cpp
@@ -29,13 +29,7 @@ CustomModelValidationResult FromValidation(
 
 CustomModelPathRequirements FromSpecs(const std::vector<CustomPathFieldSpec>& specs) {
     CustomModelPathRequirements out;
-    for (const auto& spec : specs) {
-        if (spec.required) {
-            out.required.push_back(spec.key);
-        } else {
-            out.optional.push_back(spec.key);
-        }
-    }
+    out.fields = specs;
     return out;
 }
 

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-validate-custom.cpp
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-validate-custom.cpp
@@ -6,6 +6,7 @@
 #include "sherpa-onnx-validate-enhancement.h"
 #include "sherpa-onnx-validate-punctuation.h"
 #include "sherpa-onnx-validate-stt.h"
+#include "sherpa-onnx-validate-online-stt.h"
 #include "sherpa-onnx-validate-tts.h"
 #include "sherpa-onnx-validate-vad.h"
 
@@ -102,6 +103,21 @@ CustomModelValidationResult ValidateCustomModelPaths(
         return FromValidation(vr.ok, vr.missingRequired, vr.error);
     }
 
+    if (cat == "stt_streaming") {
+        const OnlineSttModelKind kind = ParseOnlineSttModelType(modelType);
+        if (kind == OnlineSttModelKind::kUnknown) {
+            return FromValidation(
+                false,
+                {},
+                "Unsupported custom streaming STT model type: " + modelType
+            );
+        }
+        OnlineSttModelPaths onlinePaths;
+        FillOnlineSttModelPathsFromStringMap(paths, onlinePaths);
+        const auto vr = ValidateOnlineSttPaths(kind, onlinePaths, contextLabel);
+        return FromValidation(vr.ok, vr.missingRequired, vr.error);
+    }
+
     if (cat == "tts") {
         const TtsModelKind kind = ParseTtsModelTypeLocal(modelType);
         if (kind == TtsModelKind::kUnknown) {
@@ -194,6 +210,11 @@ CustomModelPathRequirements GetCustomModelPathRequirements(
         const SttModelKind kind = ParseSttModelType(modelType);
         if (kind == SttModelKind::kUnknown) return {};
         return FromSpecs(GetSttPathRequirements(kind));
+    }
+    if (cat == "stt_streaming") {
+        const OnlineSttModelKind kind = ParseOnlineSttModelType(modelType);
+        if (kind == OnlineSttModelKind::kUnknown) return {};
+        return FromSpecs(GetOnlineSttPathRequirements(kind));
     }
     if (cat == "tts") {
         const TtsModelKind kind = ParseTtsModelTypeLocal(modelType);

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-validate-custom.cpp
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-validate-custom.cpp
@@ -1,0 +1,227 @@
+#include "sherpa-onnx-validate-custom.h"
+
+#include "sherpa-onnx-model-detect-helper.h"
+#include "sherpa-onnx-model-path-fill.h"
+#include "sherpa-onnx-validate-alignment.h"
+#include "sherpa-onnx-validate-enhancement.h"
+#include "sherpa-onnx-validate-punctuation.h"
+#include "sherpa-onnx-validate-stt.h"
+#include "sherpa-onnx-validate-tts.h"
+#include "sherpa-onnx-validate-vad.h"
+
+namespace sherpaonnx {
+namespace {
+
+using model_detect::ToLower;
+
+CustomModelValidationResult FromValidation(
+    bool ok,
+    const std::vector<std::string>& missingRequired,
+    const std::string& error
+) {
+    CustomModelValidationResult out;
+    out.ok = ok;
+    out.missingRequired = missingRequired;
+    out.error = error;
+    return out;
+}
+
+CustomModelPathRequirements FromSpecs(const std::vector<CustomPathFieldSpec>& specs) {
+    CustomModelPathRequirements out;
+    for (const auto& spec : specs) {
+        if (spec.required) {
+            out.required.push_back(spec.key);
+        } else {
+            out.optional.push_back(spec.key);
+        }
+    }
+    return out;
+}
+
+TtsModelKind ParseTtsModelTypeLocal(const std::string& modelType) {
+    if (modelType == "vits") return TtsModelKind::kVits;
+    if (modelType == "matcha") return TtsModelKind::kMatcha;
+    if (modelType == "kokoro") return TtsModelKind::kKokoro;
+    if (modelType == "kitten") return TtsModelKind::kKitten;
+    if (modelType == "pocket") return TtsModelKind::kPocket;
+    if (modelType == "zipvoice") return TtsModelKind::kZipvoice;
+    if (modelType == "supertonic") return TtsModelKind::kSupertonic;
+    return TtsModelKind::kUnknown;
+}
+
+VadModelKind ParseVadModelTypeLocal(const std::string& modelType) {
+    if (modelType == "silero_vad") return VadModelKind::kSileroVad;
+    if (modelType == "ten_vad") return VadModelKind::kTenVad;
+    return VadModelKind::kUnknown;
+}
+
+EnhancementModelKind ParseEnhancementModelTypeLocal(const std::string& modelType) {
+    if (modelType == "gtcrn") return EnhancementModelKind::kGtcrn;
+    if (modelType == "dpdfnet") return EnhancementModelKind::kDpdfNet;
+    return EnhancementModelKind::kUnknown;
+}
+
+PunctuationModelKind ParsePunctuationModelTypeLocal(const std::string& modelType) {
+    const std::string t = ToLower(modelType);
+    if (t == "ct_transformer" || t == "offline") {
+        return PunctuationModelKind::kCtTransformer;
+    }
+    if (t == "cnn_bilstm" || t == "online") {
+        return PunctuationModelKind::kCnnBilstm;
+    }
+    return PunctuationModelKind::kUnknown;
+}
+
+AlignmentModelKind ParseAlignmentModelTypeLocal(const std::string& modelType) {
+    if (modelType == "wav2vec2") return AlignmentModelKind::kWav2Vec2;
+    return AlignmentModelKind::kUnknown;
+}
+
+}  // namespace
+
+CustomModelValidationResult ValidateCustomModelPaths(
+    const std::string& category,
+    const std::string& modelType,
+    const std::map<std::string, std::string>& paths,
+    const std::string& contextLabel
+) {
+    const std::string cat = ToLower(category);
+
+    if (cat == "stt") {
+        const SttModelKind kind = ParseSttModelType(modelType);
+        if (kind == SttModelKind::kUnknown) {
+            return FromValidation(
+                false,
+                {},
+                "Unsupported custom STT model type: " + modelType
+            );
+        }
+        SttModelPaths sttPaths;
+        FillSttModelPathsFromStringMap(paths, sttPaths);
+        const auto vr = ValidateSttPaths(kind, sttPaths, contextLabel);
+        return FromValidation(vr.ok, vr.missingRequired, vr.error);
+    }
+
+    if (cat == "tts") {
+        const TtsModelKind kind = ParseTtsModelTypeLocal(modelType);
+        if (kind == TtsModelKind::kUnknown) {
+            return FromValidation(
+                false,
+                {},
+                "Unsupported custom TTS model type: " + modelType
+            );
+        }
+        TtsModelPaths ttsPaths;
+        FillTtsModelPathsFromStringMap(paths, ttsPaths);
+        const auto vr = ValidateTtsPaths(kind, ttsPaths, contextLabel);
+        return FromValidation(vr.ok, vr.missingRequired, vr.error);
+    }
+
+    if (cat == "vad") {
+        const VadModelKind kind = ParseVadModelTypeLocal(modelType);
+        if (kind == VadModelKind::kUnknown) {
+            return FromValidation(
+                false,
+                {},
+                "Unsupported custom VAD model type: " + modelType
+            );
+        }
+        VadModelPaths vadPaths;
+        FillVadModelPathsFromStringMap(paths, vadPaths);
+        const auto vr = ValidateVadPaths(kind, vadPaths, contextLabel);
+        return FromValidation(vr.ok, vr.missingRequired, vr.error);
+    }
+
+    if (cat == "enhancement") {
+        const EnhancementModelKind kind = ParseEnhancementModelTypeLocal(modelType);
+        if (kind == EnhancementModelKind::kUnknown) {
+            return FromValidation(
+                false,
+                {},
+                "Unsupported custom enhancement model type: " + modelType
+            );
+        }
+        EnhancementModelPaths enhancementPaths;
+        FillEnhancementModelPathsFromStringMap(paths, enhancementPaths);
+        const auto vr = ValidateEnhancementPaths(kind, enhancementPaths, contextLabel);
+        return FromValidation(vr.ok, vr.missingRequired, vr.error);
+    }
+
+    if (cat == "punctuation") {
+        const PunctuationModelKind kind = ParsePunctuationModelTypeLocal(modelType);
+        if (kind == PunctuationModelKind::kUnknown) {
+            return FromValidation(
+                false,
+                {},
+                "Unsupported custom punctuation model type: " + modelType
+            );
+        }
+        PunctuationModelPaths punctuationPaths;
+        FillPunctuationModelPathsFromStringMap(paths, punctuationPaths);
+        const auto vr = ValidatePunctuationPaths(kind, punctuationPaths, contextLabel);
+        return FromValidation(vr.ok, vr.missingRequired, vr.error);
+    }
+
+    if (cat == "alignment") {
+        const AlignmentModelKind kind = ParseAlignmentModelTypeLocal(modelType);
+        if (kind == AlignmentModelKind::kUnknown) {
+            return FromValidation(
+                false,
+                {},
+                "Unsupported custom alignment model type: " + modelType
+            );
+        }
+        AlignmentModelPaths alignmentPaths;
+        FillAlignmentModelPathsFromStringMap(paths, alignmentPaths);
+        const auto vr = ValidateAlignmentPaths(kind, alignmentPaths, contextLabel);
+        return FromValidation(vr.ok, vr.missingRequired, vr.error);
+    }
+
+    return FromValidation(
+        false,
+        {},
+        "Unsupported custom model category: " + category
+    );
+}
+
+CustomModelPathRequirements GetCustomModelPathRequirements(
+    const std::string& category,
+    const std::string& modelType
+) {
+    const std::string cat = ToLower(category);
+
+    if (cat == "stt") {
+        const SttModelKind kind = ParseSttModelType(modelType);
+        if (kind == SttModelKind::kUnknown) return {};
+        return FromSpecs(GetSttPathRequirements(kind));
+    }
+    if (cat == "tts") {
+        const TtsModelKind kind = ParseTtsModelTypeLocal(modelType);
+        if (kind == TtsModelKind::kUnknown) return {};
+        return FromSpecs(GetTtsPathRequirements(kind));
+    }
+    if (cat == "vad") {
+        const VadModelKind kind = ParseVadModelTypeLocal(modelType);
+        if (kind == VadModelKind::kUnknown) return {};
+        return FromSpecs(GetVadPathRequirements(kind));
+    }
+    if (cat == "enhancement") {
+        const EnhancementModelKind kind = ParseEnhancementModelTypeLocal(modelType);
+        if (kind == EnhancementModelKind::kUnknown) return {};
+        return FromSpecs(GetEnhancementPathRequirements(kind));
+    }
+    if (cat == "punctuation") {
+        const PunctuationModelKind kind = ParsePunctuationModelTypeLocal(modelType);
+        if (kind == PunctuationModelKind::kUnknown) return {};
+        return FromSpecs(GetPunctuationPathRequirements(kind));
+    }
+    if (cat == "alignment") {
+        const AlignmentModelKind kind = ParseAlignmentModelTypeLocal(modelType);
+        if (kind == AlignmentModelKind::kUnknown) return {};
+        return FromSpecs(GetAlignmentPathRequirements(kind));
+    }
+
+    return {};
+}
+
+}  // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-validate-custom.h
+++ b/android/src/main/cpp/jni/model_detect/common/sherpa-onnx-validate-custom.h
@@ -1,0 +1,24 @@
+#ifndef SHERPA_ONNX_VALIDATE_CUSTOM_H
+#define SHERPA_ONNX_VALIDATE_CUSTOM_H
+
+#include "sherpa-onnx-validate-custom-types.h"
+#include <map>
+#include <string>
+
+namespace sherpaonnx {
+
+CustomModelValidationResult ValidateCustomModelPaths(
+    const std::string& category,
+    const std::string& modelType,
+    const std::map<std::string, std::string>& paths,
+    const std::string& contextLabel = "custom"
+);
+
+CustomModelPathRequirements GetCustomModelPathRequirements(
+    const std::string& category,
+    const std::string& modelType
+);
+
+}  // namespace sherpaonnx
+
+#endif  // SHERPA_ONNX_VALIDATE_CUSTOM_H

--- a/android/src/main/cpp/jni/model_detect/enhancement/sherpa-onnx-validate-enhancement.cpp
+++ b/android/src/main/cpp/jni/model_detect/enhancement/sherpa-onnx-validate-enhancement.cpp
@@ -65,4 +65,18 @@ EnhancementValidationResult ValidateEnhancementPaths(
     return result;
 }
 
+std::vector<CustomPathFieldSpec> GetEnhancementPathRequirements(
+    EnhancementModelKind kind
+) {
+    std::vector<CustomPathFieldSpec> specs;
+    size_t count = 0;
+    const auto* reqs = GetRequirements(kind, count);
+    if (!reqs) return specs;
+    specs.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        specs.push_back({reqs[i].fieldName, reqs[i].required});
+    }
+    return specs;
+}
+
 } // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/enhancement/sherpa-onnx-validate-enhancement.h
+++ b/android/src/main/cpp/jni/model_detect/enhancement/sherpa-onnx-validate-enhancement.h
@@ -2,6 +2,7 @@
 #define SHERPA_ONNX_VALIDATE_ENHANCEMENT_H
 
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-validate-custom-types.h"
 #include <string>
 #include <vector>
 
@@ -23,6 +24,10 @@ EnhancementValidationResult ValidateEnhancementPaths(
     EnhancementModelKind kind,
     const EnhancementModelPaths& paths,
     const std::string& modelDir
+);
+
+std::vector<CustomPathFieldSpec> GetEnhancementPathRequirements(
+    EnhancementModelKind kind
 );
 
 } // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/punctuation/sherpa-onnx-validate-punctuation.cpp
+++ b/android/src/main/cpp/jni/model_detect/punctuation/sherpa-onnx-validate-punctuation.cpp
@@ -59,4 +59,17 @@ PunctuationValidationResult ValidatePunctuationPaths(
     return result;
 }
 
+std::vector<CustomPathFieldSpec> GetPunctuationPathRequirements(
+    PunctuationModelKind kind
+) {
+    switch (kind) {
+        case PunctuationModelKind::kCtTransformer:
+            return {{"ct_transformer", true}};
+        case PunctuationModelKind::kCnnBilstm:
+            return {{"cnn_bilstm", true}, {"bpe_vocab", true}};
+        default:
+            return {};
+    }
+}
+
 }  // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/punctuation/sherpa-onnx-validate-punctuation.h
+++ b/android/src/main/cpp/jni/model_detect/punctuation/sherpa-onnx-validate-punctuation.h
@@ -2,6 +2,7 @@
 #define SHERPA_ONNX_VALIDATE_PUNCTUATION_H
 
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-validate-custom-types.h"
 #include <string>
 #include <vector>
 
@@ -17,6 +18,10 @@ PunctuationValidationResult ValidatePunctuationPaths(
     PunctuationModelKind kind,
     const PunctuationModelPaths& paths,
     const std::string& modelDir
+);
+
+std::vector<CustomPathFieldSpec> GetPunctuationPathRequirements(
+    PunctuationModelKind kind
 );
 
 }  // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-model-detect-stt.cpp
+++ b/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-model-detect-stt.cpp
@@ -99,30 +99,6 @@ static const char* EmptyOrPath(const std::string& s) {
     return s.empty() ? "(empty)" : s.c_str();
 }
 
-SttModelKind ParseSttModelType(const std::string& modelType) {
-    if (modelType == "transducer") return SttModelKind::kTransducer;
-    if (modelType == "nemo_transducer") return SttModelKind::kNemoTransducer;
-    if (modelType == "paraformer") return SttModelKind::kParaformer;
-    if (modelType == "nemo_ctc") return SttModelKind::kNemoCtc;
-    if (modelType == "wenet_ctc") return SttModelKind::kWenetCtc;
-    if (modelType == "sense_voice") return SttModelKind::kSenseVoice;
-    if (modelType == "zipformer_ctc" || modelType == "ctc") return SttModelKind::kZipformerCtc;
-    if (modelType == "whisper") return SttModelKind::kWhisper;
-    if (modelType == "funasr_nano") return SttModelKind::kFunAsrNano;
-    if (modelType == "qwen3_asr") return SttModelKind::kQwen3Asr;
-    if (modelType == "cohere_transcribe") return SttModelKind::kCohereTranscribe;
-    if (modelType == "fire_red_asr") return SttModelKind::kFireRedAsr;
-    if (modelType == "moonshine") return SttModelKind::kMoonshine;
-    if (modelType == "moonshine_v2") return SttModelKind::kMoonshineV2;
-    if (modelType == "dolphin") return SttModelKind::kDolphin;
-    if (modelType == "canary") return SttModelKind::kCanary;
-    if (modelType == "omnilingual") return SttModelKind::kOmnilingual;
-    if (modelType == "medasr") return SttModelKind::kMedAsr;
-    if (modelType == "telespeech_ctc") return SttModelKind::kTeleSpeechCtc;
-    if (modelType == "tone_ctc") return SttModelKind::kToneCtc;
-    return SttModelKind::kUnknown;
-}
-
 /** Returns true if \p cap and hints/paths support the given \p kind (required files present). */
 static bool CapabilitySupportsKind(
     SttModelKind kind,
@@ -989,6 +965,30 @@ static SttDetectResult DetectSttModelFromFiles(
 }
 
 } // namespace
+
+SttModelKind ParseSttModelType(const std::string& modelType) {
+    if (modelType == "transducer") return SttModelKind::kTransducer;
+    if (modelType == "nemo_transducer") return SttModelKind::kNemoTransducer;
+    if (modelType == "paraformer") return SttModelKind::kParaformer;
+    if (modelType == "nemo_ctc") return SttModelKind::kNemoCtc;
+    if (modelType == "wenet_ctc") return SttModelKind::kWenetCtc;
+    if (modelType == "sense_voice") return SttModelKind::kSenseVoice;
+    if (modelType == "zipformer_ctc" || modelType == "ctc") return SttModelKind::kZipformerCtc;
+    if (modelType == "whisper") return SttModelKind::kWhisper;
+    if (modelType == "funasr_nano") return SttModelKind::kFunAsrNano;
+    if (modelType == "qwen3_asr") return SttModelKind::kQwen3Asr;
+    if (modelType == "cohere_transcribe") return SttModelKind::kCohereTranscribe;
+    if (modelType == "fire_red_asr") return SttModelKind::kFireRedAsr;
+    if (modelType == "moonshine") return SttModelKind::kMoonshine;
+    if (modelType == "moonshine_v2") return SttModelKind::kMoonshineV2;
+    if (modelType == "dolphin") return SttModelKind::kDolphin;
+    if (modelType == "canary") return SttModelKind::kCanary;
+    if (modelType == "omnilingual") return SttModelKind::kOmnilingual;
+    if (modelType == "medasr") return SttModelKind::kMedAsr;
+    if (modelType == "telespeech_ctc") return SttModelKind::kTeleSpeechCtc;
+    if (modelType == "tone_ctc") return SttModelKind::kToneCtc;
+    return SttModelKind::kUnknown;
+}
 
 SttDetectResult DetectSttModel(
     const std::optional<std::string>& model_dir_opt,

--- a/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-stt-wrapper.h
+++ b/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-stt-wrapper.h
@@ -1,5 +1,5 @@
-#ifndef SHERPA_ONNX_STT_WRAPPER_H
-#define SHERPA_ONNX_STT_WRAPPER_H
+#ifndef SHERPA_ONNX_STT_JNI_BRIDGE_H
+#define SHERPA_ONNX_STT_JNI_BRIDGE_H
 
 #include <jni.h>
 
@@ -13,4 +13,4 @@ jobject SttDetectResultToJava(JNIEnv* env, const SttDetectResult& result);
 
 }  // namespace sherpaonnx
 
-#endif  // SHERPA_ONNX_STT_WRAPPER_H
+#endif  // SHERPA_ONNX_STT_JNI_BRIDGE_H

--- a/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-validate-online-stt.cpp
+++ b/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-validate-online-stt.cpp
@@ -1,0 +1,138 @@
+#include "sherpa-onnx-validate-online-stt.h"
+
+#include "sherpa-onnx-model-detect-helper.h"
+
+#include <cstddef>
+#include <cstring>
+
+namespace sherpaonnx {
+namespace {
+
+using model_detect::ToLower;
+
+struct OnlineSttFieldRequirement {
+  const char* fieldName;
+  std::string OnlineSttModelPaths::*field;
+  bool required;
+};
+
+static const OnlineSttFieldRequirement kTransducerReqs[] = {
+    {"encoder", &OnlineSttModelPaths::encoder, true},
+    {"decoder", &OnlineSttModelPaths::decoder, true},
+    {"joiner", &OnlineSttModelPaths::joiner, true},
+    {"tokens", &OnlineSttModelPaths::tokens, true},
+};
+
+static const OnlineSttFieldRequirement kParaformerReqs[] = {
+    {"encoder", &OnlineSttModelPaths::encoder, true},
+    {"decoder", &OnlineSttModelPaths::decoder, true},
+    {"tokens", &OnlineSttModelPaths::tokens, true},
+};
+
+static const OnlineSttFieldRequirement kSingleModelReqs[] = {
+    {"model", &OnlineSttModelPaths::model, true},
+    {"tokens", &OnlineSttModelPaths::tokens, true},
+};
+
+static const OnlineSttFieldRequirement* GetRequirements(
+    OnlineSttModelKind kind,
+    size_t& count
+) {
+  switch (kind) {
+    case OnlineSttModelKind::kTransducer:
+    case OnlineSttModelKind::kNemoTransducer:
+      count = std::size(kTransducerReqs);
+      return kTransducerReqs;
+    case OnlineSttModelKind::kParaformer:
+      count = std::size(kParaformerReqs);
+      return kParaformerReqs;
+    case OnlineSttModelKind::kZipformer2Ctc:
+    case OnlineSttModelKind::kNemoCtc:
+    case OnlineSttModelKind::kToneCtc:
+      count = std::size(kSingleModelReqs);
+      return kSingleModelReqs;
+    default:
+      count = 0;
+      return nullptr;
+  }
+}
+
+static const char* KindToName(OnlineSttModelKind kind) {
+  switch (kind) {
+    case OnlineSttModelKind::kTransducer:
+      return "Transducer";
+    case OnlineSttModelKind::kNemoTransducer:
+      return "NeMo Transducer";
+    case OnlineSttModelKind::kParaformer:
+      return "Paraformer";
+    case OnlineSttModelKind::kZipformer2Ctc:
+      return "Zipformer2 CTC";
+    case OnlineSttModelKind::kNemoCtc:
+      return "NeMo CTC";
+    case OnlineSttModelKind::kToneCtc:
+      return "Tone CTC";
+    default:
+      return "Unknown";
+  }
+}
+
+}  // namespace
+
+OnlineSttModelKind ParseOnlineSttModelType(const std::string& modelType) {
+  const std::string t = ToLower(modelType);
+  if (t == "transducer") return OnlineSttModelKind::kTransducer;
+  if (t == "nemo_transducer") return OnlineSttModelKind::kNemoTransducer;
+  if (t == "paraformer") return OnlineSttModelKind::kParaformer;
+  if (t == "zipformer2_ctc" || t == "zipformer_ctc" || t == "ctc") {
+    return OnlineSttModelKind::kZipformer2Ctc;
+  }
+  if (t == "nemo_ctc") return OnlineSttModelKind::kNemoCtc;
+  if (t == "tone_ctc") return OnlineSttModelKind::kToneCtc;
+  return OnlineSttModelKind::kUnknown;
+}
+
+OnlineSttValidationResult ValidateOnlineSttPaths(
+    OnlineSttModelKind kind,
+    const OnlineSttModelPaths& paths,
+    const std::string& contextLabel
+) {
+  OnlineSttValidationResult result;
+  size_t count = 0;
+  const auto* reqs = GetRequirements(kind, count);
+  if (!reqs) {
+    result.ok = false;
+    result.error = "Unsupported streaming STT model type";
+    return result;
+  }
+
+  for (size_t i = 0; i < count; ++i) {
+    if (reqs[i].required && (paths.*(reqs[i].field)).empty()) {
+      result.missingRequired.push_back(reqs[i].fieldName);
+    }
+  }
+
+  if (!result.missingRequired.empty()) {
+    result.ok = false;
+    result.error = std::string("Streaming STT ") + KindToName(kind)
+                 + ": missing required files in " + contextLabel + ": ";
+    for (size_t i = 0; i < result.missingRequired.size(); ++i) {
+      if (i > 0) result.error += ", ";
+      result.error += result.missingRequired[i];
+    }
+  }
+  return result;
+}
+
+std::vector<CustomPathFieldSpec> GetOnlineSttPathRequirements(OnlineSttModelKind kind) {
+  std::vector<CustomPathFieldSpec> specs;
+  size_t count = 0;
+  const auto* reqs = GetRequirements(kind, count);
+  if (!reqs) return specs;
+  specs.reserve(count);
+  for (size_t i = 0; i < count; ++i) {
+    specs.push_back({reqs[i].fieldName, reqs[i].required});
+  }
+  return specs;
+}
+
+}  // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-validate-online-stt.h
+++ b/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-validate-online-stt.h
@@ -1,0 +1,47 @@
+#ifndef SHERPA_ONNX_VALIDATE_ONLINE_STT_H
+#define SHERPA_ONNX_VALIDATE_ONLINE_STT_H
+
+#include "sherpa-onnx-validate-custom-types.h"
+#include <string>
+#include <vector>
+
+namespace sherpaonnx {
+
+enum class OnlineSttModelKind {
+  kUnknown = 0,
+  kTransducer,
+  kNemoTransducer,
+  kParaformer,
+  kZipformer2Ctc,
+  kNemoCtc,
+  kToneCtc,
+};
+
+struct OnlineSttModelPaths {
+  std::string encoder;
+  std::string decoder;
+  std::string joiner;
+  std::string tokens;
+  /** Single ONNX for zipformer2_ctc / nemo_ctc / tone_ctc streaming models. */
+  std::string model;
+};
+
+struct OnlineSttValidationResult {
+  bool ok = true;
+  std::vector<std::string> missingRequired;
+  std::string error;
+};
+
+OnlineSttModelKind ParseOnlineSttModelType(const std::string& modelType);
+
+OnlineSttValidationResult ValidateOnlineSttPaths(
+    OnlineSttModelKind kind,
+    const OnlineSttModelPaths& paths,
+    const std::string& contextLabel
+);
+
+std::vector<CustomPathFieldSpec> GetOnlineSttPathRequirements(OnlineSttModelKind kind);
+
+}  // namespace sherpaonnx
+
+#endif  // SHERPA_ONNX_VALIDATE_ONLINE_STT_H

--- a/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-validate-stt.cpp
+++ b/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-validate-stt.cpp
@@ -247,4 +247,16 @@ SttValidationResult ValidateSttPaths(
     return result;
 }
 
+std::vector<CustomPathFieldSpec> GetSttPathRequirements(SttModelKind kind) {
+    std::vector<CustomPathFieldSpec> specs;
+    size_t count = 0;
+    const auto* reqs = GetRequirements(kind, count);
+    if (!reqs) return specs;
+    specs.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        specs.push_back({reqs[i].fieldName, reqs[i].required});
+    }
+    return specs;
+}
+
 } // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-validate-stt.cpp
+++ b/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-validate-stt.cpp
@@ -25,12 +25,10 @@ static const SttFieldRequirement kTransducerReqs[] = {
     {"bpeVocab", &SttModelPaths::bpeVocab, false},
 };
 
-// Offline paraformer uses paraformerModel; streaming paraformer uses encoder+decoder.
-// Both are valid — validated via custom logic in ValidateSttPaths, not via this table.
+// Offline paraformer: single model.onnx via paraformerModel (+ tokens).
+// Streaming encoder+decoder layout lives under stt_streaming (GetOnlineSttPathRequirements).
 static const SttFieldRequirement kParaformerReqs[] = {
-    {"paraformerModel", &SttModelPaths::paraformerModel, false},
-    {"encoder",         &SttModelPaths::encoder,         false},
-    {"decoder",         &SttModelPaths::decoder,         false},
+    {"paraformerModel", &SttModelPaths::paraformerModel, true},
     {"tokens",          &SttModelPaths::tokens,          true},
 };
 
@@ -70,11 +68,13 @@ static const SttFieldRequirement kMoonshineReqs[] = {
     {"moonshineEncoder",         &SttModelPaths::moonshineEncoder,         true},
     {"moonshineUncachedDecoder", &SttModelPaths::moonshineUncachedDecoder, true},
     {"moonshineCachedDecoder",   &SttModelPaths::moonshineCachedDecoder,   true},
+    {"tokens",                   &SttModelPaths::tokens,                   true},
 };
 
 static const SttFieldRequirement kMoonshineV2Reqs[] = {
     {"moonshineEncoder",       &SttModelPaths::moonshineEncoder,       true},
     {"moonshineMergedDecoder", &SttModelPaths::moonshineMergedDecoder, true},
+    {"tokens",                 &SttModelPaths::tokens,                 true},
 };
 
 static const SttFieldRequirement kFireRedReqs[] = {
@@ -216,16 +216,6 @@ SttValidationResult ValidateSttPaths(
     for (size_t i = 0; i < count; ++i) {
         if (reqs[i].required && (paths.*(reqs[i].field)).empty()) {
             result.missingRequired.push_back(reqs[i].fieldName);
-        }
-    }
-
-    // Paraformer: offline uses paraformerModel, streaming uses encoder+decoder.
-    // At least one variant must be present.
-    if (kind == SttModelKind::kParaformer) {
-        bool hasOffline = !paths.paraformerModel.empty();
-        bool hasStreaming = !paths.encoder.empty() && !paths.decoder.empty();
-        if (!hasOffline && !hasStreaming) {
-            result.missingRequired.push_back("paraformerModel (or encoder+decoder for streaming)");
         }
     }
 

--- a/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-validate-stt.h
+++ b/android/src/main/cpp/jni/model_detect/stt/sherpa-onnx-validate-stt.h
@@ -10,6 +10,7 @@
 #define SHERPA_ONNX_VALIDATE_STT_H
 
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-validate-custom-types.h"
 #include <string>
 #include <vector>
 
@@ -32,6 +33,8 @@ SttValidationResult ValidateSttPaths(
     const SttModelPaths& paths,
     const std::string& modelDir
 );
+
+std::vector<CustomPathFieldSpec> GetSttPathRequirements(SttModelKind kind);
 
 } // namespace sherpaonnx
 

--- a/android/src/main/cpp/jni/model_detect/tts/sherpa-onnx-validate-tts.cpp
+++ b/android/src/main/cpp/jni/model_detect/tts/sherpa-onnx-validate-tts.cpp
@@ -18,55 +18,55 @@ namespace {
 // ============================================================
 
 static const TtsFieldRequirement kVitsReqs[] = {
-    {"ttsModel", &TtsModelPaths::ttsModel, true},
-    {"tokens",   &TtsModelPaths::tokens,   true},
-    {"dataDir",  &TtsModelPaths::dataDir,  false},
-    {"lexicon",  &TtsModelPaths::lexicon,  false},
+    {"ttsModel", &TtsModelPaths::ttsModel, true, false},
+    {"tokens",   &TtsModelPaths::tokens,   true, false},
+    {"dataDir",  &TtsModelPaths::dataDir,  false, true},
+    {"lexicon",  &TtsModelPaths::lexicon,  false, false},
 };
 
 static const TtsFieldRequirement kMatchaReqs[] = {
-    {"acousticModel", &TtsModelPaths::acousticModel, true},
-    {"vocoder",       &TtsModelPaths::vocoder,       true},
-    {"tokens",        &TtsModelPaths::tokens,        true},
-    {"dataDir",       &TtsModelPaths::dataDir,       false},
-    {"lexicon",       &TtsModelPaths::lexicon,       false},
+    {"acousticModel", &TtsModelPaths::acousticModel, true, false},
+    {"vocoder",       &TtsModelPaths::vocoder,       true, false},
+    {"tokens",        &TtsModelPaths::tokens,        true, false},
+    {"dataDir",       &TtsModelPaths::dataDir,       false, true},
+    {"lexicon",       &TtsModelPaths::lexicon,       false, false},
 };
 
 static const TtsFieldRequirement kKokoroReqs[] = {
-    {"ttsModel", &TtsModelPaths::ttsModel, true},
-    {"tokens",   &TtsModelPaths::tokens,   true},
-    {"voices",   &TtsModelPaths::voices,   true},
-    {"dataDir",  &TtsModelPaths::dataDir,  true},
-    {"lexicon",  &TtsModelPaths::lexicon,  false},
+    {"ttsModel", &TtsModelPaths::ttsModel, true, false},
+    {"tokens",   &TtsModelPaths::tokens,   true, false},
+    {"voices",   &TtsModelPaths::voices,   true, false},
+    {"dataDir",  &TtsModelPaths::dataDir,  true, true},
+    {"lexicon",  &TtsModelPaths::lexicon,  false, false},
 };
 
 static const TtsFieldRequirement kPocketReqs[] = {
-    {"lmFlow",          &TtsModelPaths::lmFlow,          true},
-    {"lmMain",          &TtsModelPaths::lmMain,          true},
-    {"encoder",         &TtsModelPaths::encoder,         true},
-    {"decoder",         &TtsModelPaths::decoder,         true},
-    {"textConditioner", &TtsModelPaths::textConditioner, true},
-    {"vocabJson",       &TtsModelPaths::vocabJson,       true},
-    {"tokenScoresJson", &TtsModelPaths::tokenScoresJson, true},
+    {"lmFlow",          &TtsModelPaths::lmFlow,          true, false},
+    {"lmMain",          &TtsModelPaths::lmMain,          true, false},
+    {"encoder",         &TtsModelPaths::encoder,         true, false},
+    {"decoder",         &TtsModelPaths::decoder,         true, false},
+    {"textConditioner", &TtsModelPaths::textConditioner, true, false},
+    {"vocabJson",       &TtsModelPaths::vocabJson,       true, false},
+    {"tokenScoresJson", &TtsModelPaths::tokenScoresJson, true, false},
 };
 
 static const TtsFieldRequirement kZipvoiceReqs[] = {
-    {"encoder",  &TtsModelPaths::encoder,  true},
-    {"decoder",  &TtsModelPaths::decoder,  true},
-    {"vocoder",  &TtsModelPaths::vocoder,  true},
-    {"tokens",   &TtsModelPaths::tokens,   true},
-    {"dataDir",  &TtsModelPaths::dataDir,  true},
-    {"lexicon",  &TtsModelPaths::lexicon,  true},
+    {"encoder",  &TtsModelPaths::encoder,  true, false},
+    {"decoder",  &TtsModelPaths::decoder,  true, false},
+    {"vocoder",  &TtsModelPaths::vocoder,  true, false},
+    {"tokens",   &TtsModelPaths::tokens,   true, false},
+    {"dataDir",  &TtsModelPaths::dataDir,  true, true},
+    {"lexicon",  &TtsModelPaths::lexicon,  true, false},
 };
 
 static const TtsFieldRequirement kSupertonicReqs[] = {
-    {"durationPredictor", &TtsModelPaths::durationPredictor, true},
-    {"textEncoder",       &TtsModelPaths::textEncoder,       true},
-    {"vectorEstimator",   &TtsModelPaths::vectorEstimator,   true},
-    {"vocoder",           &TtsModelPaths::vocoder,           true},
-    {"ttsJson",           &TtsModelPaths::ttsJson,           true},
-    {"unicodeIndexer",    &TtsModelPaths::unicodeIndexer,    true},
-    {"voiceStyle",        &TtsModelPaths::voiceStyle,        true},
+    {"durationPredictor", &TtsModelPaths::durationPredictor, true, false},
+    {"textEncoder",       &TtsModelPaths::textEncoder,       true, false},
+    {"vectorEstimator",   &TtsModelPaths::vectorEstimator,   true, false},
+    {"vocoder",           &TtsModelPaths::vocoder,           true, false},
+    {"ttsJson",           &TtsModelPaths::ttsJson,           true, false},
+    {"unicodeIndexer",    &TtsModelPaths::unicodeIndexer,    true, false},
+    {"voiceStyle",        &TtsModelPaths::voiceStyle,        true, false},
 };
 
 // ============================================================
@@ -164,7 +164,7 @@ std::vector<CustomPathFieldSpec> GetTtsPathRequirements(TtsModelKind kind) {
     if (!reqs) return specs;
     specs.reserve(count);
     for (size_t i = 0; i < count; ++i) {
-        specs.push_back({reqs[i].fieldName, reqs[i].required});
+        specs.push_back({reqs[i].fieldName, reqs[i].required, reqs[i].isDirectory});
     }
     return specs;
 }

--- a/android/src/main/cpp/jni/model_detect/tts/sherpa-onnx-validate-tts.cpp
+++ b/android/src/main/cpp/jni/model_detect/tts/sherpa-onnx-validate-tts.cpp
@@ -157,4 +157,16 @@ TtsValidationResult ValidateTtsPaths(
     return result;
 }
 
+std::vector<CustomPathFieldSpec> GetTtsPathRequirements(TtsModelKind kind) {
+    std::vector<CustomPathFieldSpec> specs;
+    size_t count = 0;
+    const auto* reqs = GetRequirements(kind, count);
+    if (!reqs) return specs;
+    specs.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        specs.push_back({reqs[i].fieldName, reqs[i].required});
+    }
+    return specs;
+}
+
 } // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/tts/sherpa-onnx-validate-tts.h
+++ b/android/src/main/cpp/jni/model_detect/tts/sherpa-onnx-validate-tts.h
@@ -20,6 +20,7 @@ struct TtsFieldRequirement {
     const char* fieldName;
     std::string TtsModelPaths::* field;
     bool required;
+    bool isDirectory = false;
 };
 
 struct TtsValidationResult {

--- a/android/src/main/cpp/jni/model_detect/tts/sherpa-onnx-validate-tts.h
+++ b/android/src/main/cpp/jni/model_detect/tts/sherpa-onnx-validate-tts.h
@@ -10,6 +10,7 @@
 #define SHERPA_ONNX_VALIDATE_TTS_H
 
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-validate-custom-types.h"
 #include <string>
 #include <vector>
 
@@ -32,6 +33,8 @@ TtsValidationResult ValidateTtsPaths(
     const TtsModelPaths& paths,
     const std::string& modelDir
 );
+
+std::vector<CustomPathFieldSpec> GetTtsPathRequirements(TtsModelKind kind);
 
 } // namespace sherpaonnx
 

--- a/android/src/main/cpp/jni/model_detect/vad/sherpa-onnx-validate-vad.cpp
+++ b/android/src/main/cpp/jni/model_detect/vad/sherpa-onnx-validate-vad.cpp
@@ -65,4 +65,16 @@ VadValidationResult ValidateVadPaths(
     return result;
 }
 
+std::vector<CustomPathFieldSpec> GetVadPathRequirements(VadModelKind kind) {
+    std::vector<CustomPathFieldSpec> specs;
+    size_t count = 0;
+    const auto* reqs = GetRequirements(kind, count);
+    if (!reqs) return specs;
+    specs.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        specs.push_back({reqs[i].fieldName, reqs[i].required});
+    }
+    return specs;
+}
+
 } // namespace sherpaonnx

--- a/android/src/main/cpp/jni/model_detect/vad/sherpa-onnx-validate-vad.h
+++ b/android/src/main/cpp/jni/model_detect/vad/sherpa-onnx-validate-vad.h
@@ -2,6 +2,7 @@
 #define SHERPA_ONNX_VALIDATE_VAD_H
 
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-validate-custom-types.h"
 #include <string>
 #include <vector>
 
@@ -24,6 +25,8 @@ VadValidationResult ValidateVadPaths(
     const VadModelPaths& paths,
     const std::string& modelDir
 );
+
+std::vector<CustomPathFieldSpec> GetVadPathRequirements(VadModelKind kind);
 
 } // namespace sherpaonnx
 

--- a/android/src/main/cpp/jni/module/sherpa-onnx-module-jni.cpp
+++ b/android/src/main/cpp/jni/module/sherpa-onnx-module-jni.cpp
@@ -27,6 +27,8 @@
 #include "sherpa-onnx-alignment-wrapper.h"
 #include "sherpa-onnx-model-detect-unified.h"
 #include "sherpa-onnx-unified-detect-wrapper.h"
+#include "sherpa-onnx-detect-jni-common.h"
+#include "sherpa-onnx-validate-custom.h"
 #include "../diagnostic/NativeDiagnostic.h"
 
 extern "C" {
@@ -441,6 +443,49 @@ Java_com_sherpaonnx_SherpaOnnxModule_nativeDetectModelsBatch(
     }
   }
   return outList;
+}
+
+JNIEXPORT jobject JNICALL
+Java_com_sherpaonnx_SherpaOnnxModule_nativeValidateCustomModelPaths(
+    JNIEnv* env,
+    jobject /* this */,
+    jstring j_category,
+    jstring j_model_type,
+    jobject j_paths) {
+  auto category = OptionalJstring(env, j_category);
+  auto modelType = OptionalJstring(env, j_model_type);
+  if (!category || !modelType) {
+    sherpaonnx::CustomModelValidationResult invalid;
+    invalid.ok = false;
+    invalid.error = "category and modelType are required";
+    return sherpaonnx::BuildCustomValidationResultMap(env, invalid);
+  }
+
+  const auto paths = sherpaonnx::JavaHashMapToStringMap(env, j_paths);
+  const auto result = sherpaonnx::ValidateCustomModelPaths(
+      *category,
+      *modelType,
+      paths,
+      "custom");
+  return sherpaonnx::BuildCustomValidationResultMap(env, result);
+}
+
+JNIEXPORT jobject JNICALL
+Java_com_sherpaonnx_SherpaOnnxModule_nativeGetCustomModelPathRequirements(
+    JNIEnv* env,
+    jobject /* this */,
+    jstring j_category,
+    jstring j_model_type) {
+  auto category = OptionalJstring(env, j_category);
+  auto modelType = OptionalJstring(env, j_model_type);
+  if (!category || !modelType) {
+    return sherpaonnx::BuildCustomPathRequirementsMap(env, {});
+  }
+
+  const auto requirements = sherpaonnx::GetCustomModelPathRequirements(
+      *category,
+      *modelType);
+  return sherpaonnx::BuildCustomPathRequirementsMap(env, requirements);
 }
 
 }  // extern "C"

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -4711,20 +4711,12 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
 
   override fun initializeEnhancement(
     instanceId: String,
-    modelDir: String,
-    modelType: String?,
-    numThreads: Double?,
-    provider: String?,
-    debug: Boolean?,
+    options: ReadableMap,
     promise: Promise
   ) {
     enhancementHelper.initializeEnhancement(
       instanceId,
-      modelDir,
-      modelType,
-      numThreads,
-      provider,
-      debug,
+      options,
       promise
     )
   }
@@ -4748,20 +4740,12 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
 
   override fun initializeOnlineEnhancement(
     instanceId: String,
-    modelDir: String,
-    modelType: String?,
-    numThreads: Double?,
-    provider: String?,
-    debug: Boolean?,
+    options: ReadableMap,
     promise: Promise
   ) {
     enhancementHelper.initializeOnlineEnhancement(
       instanceId,
-      modelDir,
-      modelType,
-      numThreads,
-      provider,
-      debug,
+      options,
       promise
     )
   }

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -1035,60 +1035,7 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
   // ==================== Online (streaming) STT Methods ====================
 
   override fun initializeOnlineStt(instanceId: String, options: ReadableMap, promise: Promise) {
-    val modelDir = options.getString("modelDir")
-    if (modelDir.isNullOrEmpty()) {
-      promise.reject("INIT_ERROR", "modelDir is required")
-      return
-    }
-    val modelType = options.getString("modelType") ?: "transducer"
-    val enableEndpoint = if (options.hasKey("enableEndpoint")) options.getBoolean("enableEndpoint") else true
-    val decodingMethod = options.getString("decodingMethod") ?: "greedy_search"
-    val maxActivePaths = if (options.hasKey("maxActivePaths")) options.getDouble("maxActivePaths").toInt() else 4
-    val hotwordsFile = if (options.hasKey("hotwordsFile")) options.getString("hotwordsFile") else null
-    val hotwordsScore = if (options.hasKey("hotwordsScore")) options.getDouble("hotwordsScore") else null
-    val numThreads = if (options.hasKey("numThreads")) options.getDouble("numThreads") else null
-    val provider = if (options.hasKey("provider")) options.getString("provider") else null
-    val ruleFsts = if (options.hasKey("ruleFsts")) options.getString("ruleFsts") else null
-    val ruleFars = if (options.hasKey("ruleFars")) options.getString("ruleFars") else null
-    val dither = if (options.hasKey("dither")) options.getDouble("dither") else null
-    val blankPenalty = if (options.hasKey("blankPenalty")) options.getDouble("blankPenalty") else null
-    val debug = if (options.hasKey("debug")) options.getBoolean("debug") else null
-    val rule1MustContainNonSilence = if (options.hasKey("rule1MustContainNonSilence")) options.getBoolean("rule1MustContainNonSilence") else null
-    val rule1MinTrailingSilence = if (options.hasKey("rule1MinTrailingSilence")) options.getDouble("rule1MinTrailingSilence") else null
-    val rule1MinUtteranceLength = if (options.hasKey("rule1MinUtteranceLength")) options.getDouble("rule1MinUtteranceLength") else null
-    val rule2MustContainNonSilence = if (options.hasKey("rule2MustContainNonSilence")) options.getBoolean("rule2MustContainNonSilence") else null
-    val rule2MinTrailingSilence = if (options.hasKey("rule2MinTrailingSilence")) options.getDouble("rule2MinTrailingSilence") else null
-    val rule2MinUtteranceLength = if (options.hasKey("rule2MinUtteranceLength")) options.getDouble("rule2MinUtteranceLength") else null
-    val rule3MustContainNonSilence = if (options.hasKey("rule3MustContainNonSilence")) options.getBoolean("rule3MustContainNonSilence") else null
-    val rule3MinTrailingSilence = if (options.hasKey("rule3MinTrailingSilence")) options.getDouble("rule3MinTrailingSilence") else null
-    val rule3MinUtteranceLength = if (options.hasKey("rule3MinUtteranceLength")) options.getDouble("rule3MinUtteranceLength") else null
-    onlineSttHelper.initializeOnlineStt(
-      instanceId,
-      modelDir,
-      modelType,
-      enableEndpoint,
-      decodingMethod,
-      maxActivePaths,
-      hotwordsFile,
-      hotwordsScore,
-      numThreads,
-      provider,
-      ruleFsts,
-      ruleFars,
-      dither,
-      blankPenalty,
-      debug,
-      rule1MustContainNonSilence,
-      rule1MinTrailingSilence,
-      rule1MinUtteranceLength,
-      rule2MustContainNonSilence,
-      rule2MinTrailingSilence,
-      rule2MinUtteranceLength,
-      rule3MustContainNonSilence,
-      rule3MinTrailingSilence,
-      rule3MinUtteranceLength,
-      promise
-    )
+    onlineSttHelper.initializeOnlineStt(instanceId, options, promise)
   }
 
   override fun unloadOnlineStt(instanceId: String, promise: Promise) {

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -4903,20 +4903,12 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
 
   override fun initializeOfflinePunctuation(
     instanceId: String,
-    modelDir: String,
-    modelType: String?,
-    numThreads: Double?,
-    provider: String?,
-    debug: Boolean?,
+    options: ReadableMap,
     promise: Promise
   ) {
     punctuationHelper.initializeOfflinePunctuation(
       instanceId,
-      modelDir,
-      modelType,
-      numThreads,
-      provider,
-      debug,
+      options,
       promise
     )
   }
@@ -4962,20 +4954,12 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
 
   override fun initializeOnlinePunctuation(
     instanceId: String,
-    modelDir: String,
-    modelType: String?,
-    numThreads: Double?,
-    provider: String?,
-    debug: Boolean?,
+    options: ReadableMap,
     promise: Promise
   ) {
     onlinePunctuationHelper.initializeOnlinePunctuation(
       instanceId,
-      modelDir,
-      modelType,
-      numThreads,
-      provider,
-      debug,
+      options,
       promise
     )
   }

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -5450,22 +5450,19 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     ): com.facebook.react.bridge.WritableMap {
       val map = Arguments.createMap()
       @Suppress("UNCHECKED_CAST")
-      val required = result["required"] as? ArrayList<String>
-      if (!required.isNullOrEmpty()) {
+      val fields = result["fields"] as? ArrayList<HashMap<String, Any?>>
+      if (!fields.isNullOrEmpty()) {
         val arr = Arguments.createArray()
-        for (entry in required) {
-          arr.pushString(entry)
+        for (entry in fields) {
+          val key = entry["key"] as? String ?: continue
+          val fieldMap = Arguments.createMap()
+          fieldMap.putString("key", key)
+          fieldMap.putBoolean("required", entry["required"] as? Boolean ?: false)
+          val kind = entry["kind"] as? String
+          fieldMap.putString("kind", if (kind == "dir") "dir" else "file")
+          arr.pushMap(fieldMap)
         }
-        map.putArray("required", arr)
-      }
-      @Suppress("UNCHECKED_CAST")
-      val optional = result["optional"] as? ArrayList<String>
-      if (!optional.isNullOrEmpty()) {
-        val arr = Arguments.createArray()
-        for (entry in optional) {
-          arr.pushString(entry)
-        }
-        map.putArray("optional", arr)
+        map.putArray("fields", arr)
       }
       return map
     }

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -4895,6 +4895,57 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     }
   }
 
+  override fun validateCustomModelPaths(
+    category: String,
+    modelType: String,
+    paths: ReadableMap,
+    promise: Promise
+  ) {
+    try {
+      val pathMap = HashMap<String, String>()
+      val iterator = paths.keySetIterator()
+      while (iterator.hasNextKey()) {
+        val key = iterator.nextKey()
+        if (!paths.isNull(key)) {
+          paths.getString(key)?.let { pathMap[key] = it }
+        }
+      }
+      val result = Companion.validateCustomModelPathsNative(category, modelType, pathMap)
+        ?: run {
+          promise.reject("VALIDATE_ERROR", "Custom model path validation returned null")
+          return
+        }
+      promise.resolve(Companion.customValidationHashMapToWritableMap(result))
+    } catch (e: Exception) {
+      promise.reject(
+        "VALIDATE_ERROR",
+        "Custom model path validation failed: ${e.message}",
+        e
+      )
+    }
+  }
+
+  override fun getCustomModelPathRequirements(
+    category: String,
+    modelType: String,
+    promise: Promise
+  ) {
+    try {
+      val result = Companion.getCustomModelPathRequirementsNative(category, modelType)
+        ?: run {
+          promise.reject("VALIDATE_ERROR", "Custom model path requirements returned null")
+          return
+        }
+      promise.resolve(Companion.customPathRequirementsHashMapToWritableMap(result))
+    } catch (e: Exception) {
+      promise.reject(
+        "VALIDATE_ERROR",
+        "Custom model path requirements failed: ${e.message}",
+        e
+      )
+    }
+  }
+
   // ==================== VAD Methods ====================
 
   override fun initializeVad(instanceId: String, options: ReadableMap, promise: Promise) {
@@ -5374,6 +5425,34 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     ): ArrayList<HashMap<String, Any?>>
 
     @JvmStatic
+    internal fun validateCustomModelPathsNative(
+      category: String,
+      modelType: String,
+      paths: HashMap<String, String>
+    ): HashMap<String, Any?>? =
+      nativeValidateCustomModelPaths(category, modelType, paths)
+
+    @JvmStatic
+    internal fun getCustomModelPathRequirementsNative(
+      category: String,
+      modelType: String
+    ): HashMap<String, Any?>? =
+      nativeGetCustomModelPathRequirements(category, modelType)
+
+    @JvmStatic
+    private external fun nativeValidateCustomModelPaths(
+      category: String,
+      modelType: String,
+      paths: HashMap<String, String>
+    ): HashMap<String, Any?>?
+
+    @JvmStatic
+    private external fun nativeGetCustomModelPathRequirements(
+      category: String,
+      modelType: String
+    ): HashMap<String, Any?>?
+
+    @JvmStatic
     internal fun unifiedDetectHashMapToWritableMap(
       result: HashMap<String, Any?>
     ): com.facebook.react.bridge.WritableMap {
@@ -5427,6 +5506,52 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
         map.putArray("detectionSources", arr)
       }
 
+      return map
+    }
+
+    @JvmStatic
+    internal fun customValidationHashMapToWritableMap(
+      result: HashMap<String, Any?>
+    ): com.facebook.react.bridge.WritableMap {
+      val map = Arguments.createMap()
+      map.putBoolean("ok", result["ok"] as? Boolean ?: false)
+      val error = result["error"] as? String
+      if (!error.isNullOrBlank()) map.putString("error", error)
+      @Suppress("UNCHECKED_CAST")
+      val missing = result["missingRequired"] as? ArrayList<String>
+      if (!missing.isNullOrEmpty()) {
+        val arr = Arguments.createArray()
+        for (entry in missing) {
+          arr.pushString(entry)
+        }
+        map.putArray("missingRequired", arr)
+      }
+      return map
+    }
+
+    @JvmStatic
+    internal fun customPathRequirementsHashMapToWritableMap(
+      result: HashMap<String, Any?>
+    ): com.facebook.react.bridge.WritableMap {
+      val map = Arguments.createMap()
+      @Suppress("UNCHECKED_CAST")
+      val required = result["required"] as? ArrayList<String>
+      if (!required.isNullOrEmpty()) {
+        val arr = Arguments.createArray()
+        for (entry in required) {
+          arr.pushString(entry)
+        }
+        map.putArray("required", arr)
+      }
+      @Suppress("UNCHECKED_CAST")
+      val optional = result["optional"] as? ArrayList<String>
+      if (!optional.isNullOrEmpty()) {
+        val arr = Arguments.createArray()
+        for (entry in optional) {
+          arr.pushString(entry)
+        }
+        map.putArray("optional", arr)
+      }
       return map
     }
 

--- a/android/src/main/java/com/sherpaonnx/bridge/InitModeModelPathsParser.kt
+++ b/android/src/main/java/com/sherpaonnx/bridge/InitModeModelPathsParser.kt
@@ -1,0 +1,72 @@
+package com.sherpaonnx.bridge
+
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
+
+/** Shared initMode / modelDir / modelPaths parsing for TurboModule init bridges. */
+internal object InitModeModelPathsParser {
+  data class Core(
+    val initMode: String,
+    val modelDir: String?,
+    val modelPaths: Map<String, String>?,
+    val modelType: String?,
+  )
+
+  fun parseCore(
+    options: ReadableMap,
+    requireModelTypeForCustom: Boolean = true,
+  ): Core? {
+    val initMode = if (options.hasKey("initMode")) {
+      options.getString("initMode")?.trim().orEmpty().ifEmpty { "auto" }
+    } else {
+      "auto"
+    }
+
+    val modelDir = if (options.hasKey("modelDir")) {
+      options.getString("modelDir")?.trim()?.takeIf { it.isNotEmpty() }
+    } else {
+      null
+    }
+
+    val modelPaths = if (options.hasKey("modelPaths") && !options.isNull("modelPaths")) {
+      readStringMap(options.getMap("modelPaths"))
+    } else {
+      null
+    }
+
+    val modelType = if (options.hasKey("modelType") && !options.isNull("modelType")) {
+      options.getString("modelType")?.trim()?.takeIf { it.isNotEmpty() }
+    } else {
+      null
+    }
+
+    if (initMode == "custom") {
+      if (modelPaths.isNullOrEmpty()) return null
+      if (requireModelTypeForCustom && modelType.isNullOrEmpty()) return null
+    } else if (modelDir.isNullOrEmpty()) {
+      return null
+    }
+
+    return Core(
+      initMode = initMode,
+      modelDir = modelDir,
+      modelPaths = modelPaths,
+      modelType = modelType,
+    )
+  }
+
+  fun readStringMap(map: ReadableMap?): Map<String, String>? {
+    if (map == null) return null
+    val out = linkedMapOf<String, String>()
+    val iterator = map.keySetIterator()
+    while (iterator.hasNextKey()) {
+      val key = iterator.nextKey()
+      if (map.getType(key) != ReadableType.String) continue
+      val value = map.getString(key)?.trim().orEmpty()
+      if (value.isNotEmpty()) {
+        out[key] = value
+      }
+    }
+    return out
+  }
+}

--- a/android/src/main/java/com/sherpaonnx/detect/ModelPathValidationNative.kt
+++ b/android/src/main/java/com/sherpaonnx/detect/ModelPathValidationNative.kt
@@ -1,0 +1,33 @@
+package com.sherpaonnx.detect
+
+import com.sherpaonnx.SherpaOnnxModule
+
+internal object ModelPathValidationNative {
+
+  fun validate(
+    category: String,
+    modelType: String,
+    paths: Map<String, String>
+  ): String? {
+    @Suppress("UNCHECKED_CAST")
+    val result =
+      SherpaOnnxModule.validateCustomModelPathsNative(
+        category,
+        modelType,
+        HashMap(paths)
+      ) as? HashMap<String, Any?> ?: return "Custom model path validation returned null"
+
+    val ok = result["ok"] as? Boolean ?: false
+    if (ok) return null
+
+    val error = result["error"] as? String
+    if (!error.isNullOrBlank()) return error
+
+    @Suppress("UNCHECKED_CAST")
+    val missing = result["missingRequired"] as? ArrayList<String>
+    if (!missing.isNullOrEmpty()) {
+      return "Missing required paths: ${missing.joinToString(", ")}"
+    }
+    return "Invalid custom model paths"
+  }
+}

--- a/android/src/main/java/com/sherpaonnx/enhancement/config/EnhancementInitOptionsParser.kt
+++ b/android/src/main/java/com/sherpaonnx/enhancement/config/EnhancementInitOptionsParser.kt
@@ -1,0 +1,39 @@
+package com.sherpaonnx.enhancement.config
+
+import com.facebook.react.bridge.ReadableMap
+import com.sherpaonnx.bridge.InitModeModelPathsParser
+
+/** Parse `initializeEnhancement` / `initializeOnlineEnhancement` TurboModule maps. */
+internal object EnhancementInitOptionsParser {
+  data class Parsed(
+    val initMode: String,
+    val modelDir: String?,
+    val modelPaths: Map<String, String>?,
+    val modelType: String,
+    val numThreads: Double,
+    val provider: String?,
+    val debug: Boolean,
+  )
+
+  fun parse(options: ReadableMap?): Parsed? {
+    if (options == null) return null
+    val core = InitModeModelPathsParser.parseCore(options) ?: return null
+
+    return Parsed(
+      initMode = core.initMode,
+      modelDir = core.modelDir,
+      modelPaths = core.modelPaths,
+      modelType = core.modelType?.trim()?.takeIf { it.isNotEmpty() } ?: "auto",
+      numThreads = if (options.hasKey("numThreads")) options.getDouble("numThreads") else 1.0,
+      provider = optionalString(options, "provider"),
+      debug = if (options.hasKey("debug")) options.getBoolean("debug") else false,
+    )
+  }
+
+  private fun optionalString(options: ReadableMap, key: String): String? =
+    if (options.hasKey(key) && !options.isNull(key)) {
+      options.getString(key)?.trim()?.takeIf { it.isNotEmpty() }
+    } else {
+      null
+    }
+}

--- a/android/src/main/java/com/sherpaonnx/enhancement/facade/SherpaOnnxEnhancementHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/enhancement/facade/SherpaOnnxEnhancementHelper.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.k2fsa.sherpa.onnx.OfflineSpeechDenoiser
 import com.k2fsa.sherpa.onnx.OfflineSpeechDenoiserConfig
@@ -14,6 +15,8 @@ import com.sherpaonnx.audio.pipeline.OfflineEntry
 import com.sherpaonnx.audio.pipeline.PipelineAudioRegistry
 import com.sherpaonnx.audio.pipeline.StreamingPipelineCompletion
 import com.sherpaonnx.audio.pipeline.StreamingPipelineRegistry
+import com.sherpaonnx.detect.ModelPathValidationNative
+import com.sherpaonnx.enhancement.config.EnhancementInitOptionsParser
 import com.sherpaonnx.errors.OfflineOomError
 import com.sherpaonnx.enhancement.core.EnhancementErrorCodes
 import com.sherpaonnx.enhancement.core.EnhancementInstance
@@ -26,7 +29,6 @@ import com.sherpaonnx.segment.engine.SegmentationEngineRegistry
 import com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry
 import com.sherpaonnx.livePipeline.OfflineLivePipelineWorker
 import com.facebook.react.bridge.WritableNativeMap
-import com.facebook.react.bridge.ReadableMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.UUID
 
@@ -73,46 +75,31 @@ internal class SherpaOnnxEnhancementHelper(
 
   fun initializeEnhancement(
     instanceId: String,
-    modelDir: String,
-    modelType: String?,
-    numThreads: Double?,
-    provider: String?,
-    debug: Boolean?,
+    options: ReadableMap,
     promise: Promise,
   ) {
+    if (instanceId.isBlank()) {
+      promise.reject(EnhancementErrorCodes.ENHANCEMENT_INIT_ERROR, "instanceId is required")
+      return
+    }
+    val parsed = EnhancementInitOptionsParser.parse(options)
+    if (parsed == null) {
+      promise.reject(
+        EnhancementErrorCodes.ENHANCEMENT_INIT_ERROR,
+        if (options.hasKey("initMode") && options.getString("initMode") == "custom") {
+          "custom init requires initMode, modelType, and modelPaths"
+        } else {
+          "auto init requires modelDir"
+        }
+      )
+      return
+    }
     try {
-      val result = nativeDetectEnhancementModel(modelDir, null, modelType ?: "auto")
-      if (result == null || result["success"] as? Boolean != true) {
-        val reason = result?.get("error") as? String ?: "Failed to detect enhancement model"
-        promise.reject(EnhancementErrorCodes.ENHANCEMENT_INIT_ERROR, reason)
-        return
+      if (parsed.initMode == "custom") {
+        initializeEnhancementCustom(instanceId, parsed, promise)
+      } else {
+        initializeEnhancementAuto(instanceId, parsed, promise)
       }
-
-      val modelTypeStr = EnhancementModelConfigFactory.extractModelType(result)
-      val paths = EnhancementModelConfigFactory.extractPaths(result)
-      val modelConfig = try {
-        EnhancementModelConfigFactory.build(modelTypeStr, paths, numThreads, provider, debug)
-      } catch (e: IllegalArgumentException) {
-        promise.reject(EnhancementErrorCodes.ENHANCEMENT_INIT_ERROR, e.message)
-        return
-      }
-
-      val inst = instances.getOrPut(instanceId) { EnhancementInstance() }
-      inst.release()
-      val denoiser = OfflineSpeechDenoiser(
-        config = OfflineSpeechDenoiserConfig(model = modelConfig),
-      )
-      inst.denoiser = denoiser
-
-      val out = Arguments.createMap()
-      out.putBoolean("success", true)
-      out.putArray(
-        "detectedModels",
-        EnhancementResultMapper.detectedModelsToWritableArray(result["detectedModels"] as? ArrayList<*>),
-      )
-      out.putString("modelType", modelTypeStr)
-      out.putInt("sampleRate", denoiser.sampleRate)
-      promise.resolve(out)
     } catch (e: Exception) {
       Log.e(EnhancementErrorCodes.TAG, "Failed to initialize enhancement", e)
       promise.reject(
@@ -121,6 +108,113 @@ internal class SherpaOnnxEnhancementHelper(
         e,
       )
     }
+  }
+
+  private fun initializeEnhancementCustom(
+    instanceId: String,
+    parsed: EnhancementInitOptionsParser.Parsed,
+    promise: Promise,
+  ) {
+    val modelTypeStr = parsed.modelType.trim()
+    if (modelTypeStr.isEmpty() || modelTypeStr == "auto") {
+      promise.reject(
+        EnhancementErrorCodes.ENHANCEMENT_INIT_ERROR,
+        "custom init requires a concrete modelType",
+      )
+      return
+    }
+    if (modelTypeStr != "gtcrn" && modelTypeStr != "dpdfnet") {
+      promise.reject(
+        EnhancementErrorCodes.ENHANCEMENT_INIT_ERROR,
+        "Unsupported enhancement model type: $modelTypeStr",
+      )
+      return
+    }
+
+    val pathStrings = parsed.modelPaths.orEmpty()
+    ModelPathValidationNative.validate("enhancement", modelTypeStr, pathStrings)?.let { errorMsg ->
+      promise.reject(EnhancementErrorCodes.ENHANCEMENT_INIT_ERROR, errorMsg)
+      return
+    }
+
+    finishInitializeOfflineWithModelPath(
+      instanceId = instanceId,
+      modelTypeStr = modelTypeStr,
+      paths = pathStrings,
+      parsed = parsed,
+      promise = promise,
+    )
+  }
+
+  private fun initializeEnhancementAuto(
+    instanceId: String,
+    parsed: EnhancementInitOptionsParser.Parsed,
+    promise: Promise,
+  ) {
+    val modelDir = parsed.modelDir.orEmpty()
+    val result = nativeDetectEnhancementModel(modelDir, null, parsed.modelType)
+    if (result == null || result["success"] as? Boolean != true) {
+      val reason = result?.get("error") as? String ?: "Failed to detect enhancement model"
+      promise.reject(EnhancementErrorCodes.ENHANCEMENT_INIT_ERROR, reason)
+      return
+    }
+
+    val modelTypeStr = EnhancementModelConfigFactory.extractModelType(result)
+    val paths = EnhancementModelConfigFactory.extractPaths(result)
+    finishInitializeOfflineWithModelPath(
+      instanceId = instanceId,
+      modelTypeStr = modelTypeStr,
+      paths = paths,
+      parsed = parsed,
+      promise = promise,
+      detectedModels = result["detectedModels"] as? ArrayList<*>,
+    )
+  }
+
+  private fun finishInitializeOfflineWithModelPath(
+    instanceId: String,
+    modelTypeStr: String,
+    paths: Map<String, String>,
+    parsed: EnhancementInitOptionsParser.Parsed,
+    promise: Promise,
+    detectedModels: ArrayList<*>? = null,
+  ) {
+    val modelConfig = try {
+      EnhancementModelConfigFactory.build(
+        modelTypeStr,
+        paths,
+        parsed.numThreads,
+        parsed.provider,
+        parsed.debug,
+      )
+    } catch (e: IllegalArgumentException) {
+      promise.reject(EnhancementErrorCodes.ENHANCEMENT_INIT_ERROR, e.message)
+      return
+    }
+
+    val inst = instances.getOrPut(instanceId) { EnhancementInstance() }
+    inst.release()
+    val denoiser = OfflineSpeechDenoiser(
+      config = OfflineSpeechDenoiserConfig(model = modelConfig),
+    )
+    inst.denoiser = denoiser
+
+    val out = Arguments.createMap()
+    out.putBoolean("success", true)
+    out.putArray(
+      "detectedModels",
+      EnhancementResultMapper.detectedModelsToWritableArray(
+        detectedModels ?: arrayListOf(
+          hashMapOf(
+            "type" to modelTypeStr,
+            "modelDir" to (parsed.modelDir ?: "custom"),
+          )
+        )
+      ),
+    )
+    out.putString("modelType", modelTypeStr)
+    out.putInt("sampleRate", denoiser.sampleRate)
+    promise.resolve(out)
   }
 
   fun enhanceOfflineAudioBuffers(
@@ -138,7 +232,7 @@ internal class SherpaOnnxEnhancementHelper(
       return
     }
 
-    
+
     if (!audioInBufferId.startsWith("off_")) {
       promise.reject(
         EnhancementErrorCodes.ENHANCEMENT_BUFFER_KIND_MISMATCH,
@@ -203,7 +297,6 @@ internal class SherpaOnnxEnhancementHelper(
         )
         return
       }
-      // Upgrade output to mmap if it exceeds the threshold
       PipelineAudioRegistry.upgradeToMmapIfNeeded(audioOutBufferId)
       promise.resolve(null)
     } catch (e: OutOfMemoryError) {
@@ -243,42 +336,31 @@ internal class SherpaOnnxEnhancementHelper(
 
   fun initializeOnlineEnhancement(
     instanceId: String,
-    modelDir: String,
-    modelType: String?,
-    numThreads: Double?,
-    provider: String?,
-    debug: Boolean?,
+    options: ReadableMap,
     promise: Promise,
   ) {
-    try {
-      val result = nativeDetectEnhancementModel(modelDir, null, modelType ?: "auto")
-      if (result == null || result["success"] as? Boolean != true) {
-        val reason = result?.get("error") as? String ?: "Failed to detect enhancement model"
-        promise.reject(EnhancementErrorCodes.ONLINE_ENHANCEMENT_INIT_ERROR, reason)
-        return
-      }
-
-      val modelTypeStr = EnhancementModelConfigFactory.extractModelType(result)
-      val paths = EnhancementModelConfigFactory.extractPaths(result)
-      val modelConfig = try {
-        EnhancementModelConfigFactory.build(modelTypeStr, paths, numThreads, provider, debug)
-      } catch (e: IllegalArgumentException) {
-        promise.reject(EnhancementErrorCodes.ONLINE_ENHANCEMENT_INIT_ERROR, e.message)
-        return
-      }
-
-      val inst = onlineInstances.getOrPut(instanceId) { OnlineEnhancementInstance() }
-      inst.release()
-      val denoiser = OnlineSpeechDenoiser(
-        config = OnlineSpeechDenoiserConfig(model = modelConfig),
+    if (instanceId.isBlank()) {
+      promise.reject(EnhancementErrorCodes.ONLINE_ENHANCEMENT_INIT_ERROR, "instanceId is required")
+      return
+    }
+    val parsed = EnhancementInitOptionsParser.parse(options)
+    if (parsed == null) {
+      promise.reject(
+        EnhancementErrorCodes.ONLINE_ENHANCEMENT_INIT_ERROR,
+        if (options.hasKey("initMode") && options.getString("initMode") == "custom") {
+          "custom init requires initMode, modelType, and modelPaths"
+        } else {
+          "auto init requires modelDir"
+        }
       )
-      inst.denoiser = denoiser
-
-      val out = Arguments.createMap()
-      out.putBoolean("success", true)
-      out.putInt("sampleRate", denoiser.sampleRate)
-      out.putInt("frameShiftInSamples", denoiser.frameShiftInSamples)
-      promise.resolve(out)
+      return
+    }
+    try {
+      if (parsed.initMode == "custom") {
+        initializeOnlineEnhancementCustom(instanceId, parsed, promise)
+      } else {
+        initializeOnlineEnhancementAuto(instanceId, parsed, promise)
+      }
     } catch (e: Exception) {
       promise.reject(
         EnhancementErrorCodes.ONLINE_ENHANCEMENT_INIT_ERROR,
@@ -286,6 +368,100 @@ internal class SherpaOnnxEnhancementHelper(
         e,
       )
     }
+  }
+
+  private fun initializeOnlineEnhancementCustom(
+    instanceId: String,
+    parsed: EnhancementInitOptionsParser.Parsed,
+    promise: Promise,
+  ) {
+    val modelTypeStr = parsed.modelType.trim()
+    if (modelTypeStr.isEmpty() || modelTypeStr == "auto") {
+      promise.reject(
+        EnhancementErrorCodes.ONLINE_ENHANCEMENT_INIT_ERROR,
+        "custom init requires a concrete modelType",
+      )
+      return
+    }
+    if (modelTypeStr != "gtcrn" && modelTypeStr != "dpdfnet") {
+      promise.reject(
+        EnhancementErrorCodes.ONLINE_ENHANCEMENT_INIT_ERROR,
+        "Unsupported enhancement model type: $modelTypeStr",
+      )
+      return
+    }
+
+    val pathStrings = parsed.modelPaths.orEmpty()
+    ModelPathValidationNative.validate("enhancement", modelTypeStr, pathStrings)?.let { errorMsg ->
+      promise.reject(EnhancementErrorCodes.ONLINE_ENHANCEMENT_INIT_ERROR, errorMsg)
+      return
+    }
+
+    finishInitializeOnlineWithModelPath(
+      instanceId = instanceId,
+      modelTypeStr = modelTypeStr,
+      paths = pathStrings,
+      parsed = parsed,
+      promise = promise,
+    )
+  }
+
+  private fun initializeOnlineEnhancementAuto(
+    instanceId: String,
+    parsed: EnhancementInitOptionsParser.Parsed,
+    promise: Promise,
+  ) {
+    val modelDir = parsed.modelDir.orEmpty()
+    val result = nativeDetectEnhancementModel(modelDir, null, parsed.modelType)
+    if (result == null || result["success"] as? Boolean != true) {
+      val reason = result?.get("error") as? String ?: "Failed to detect enhancement model"
+      promise.reject(EnhancementErrorCodes.ONLINE_ENHANCEMENT_INIT_ERROR, reason)
+      return
+    }
+
+    val modelTypeStr = EnhancementModelConfigFactory.extractModelType(result)
+    val paths = EnhancementModelConfigFactory.extractPaths(result)
+    finishInitializeOnlineWithModelPath(
+      instanceId = instanceId,
+      modelTypeStr = modelTypeStr,
+      paths = paths,
+      parsed = parsed,
+      promise = promise,
+    )
+  }
+
+  private fun finishInitializeOnlineWithModelPath(
+    instanceId: String,
+    modelTypeStr: String,
+    paths: Map<String, String>,
+    parsed: EnhancementInitOptionsParser.Parsed,
+    promise: Promise,
+  ) {
+    val modelConfig = try {
+      EnhancementModelConfigFactory.build(
+        modelTypeStr,
+        paths,
+        parsed.numThreads,
+        parsed.provider,
+        parsed.debug,
+      )
+    } catch (e: IllegalArgumentException) {
+      promise.reject(EnhancementErrorCodes.ONLINE_ENHANCEMENT_INIT_ERROR, e.message)
+      return
+    }
+
+    val inst = onlineInstances.getOrPut(instanceId) { OnlineEnhancementInstance() }
+    inst.release()
+    val denoiser = OnlineSpeechDenoiser(
+      config = OnlineSpeechDenoiserConfig(model = modelConfig),
+    )
+    inst.denoiser = denoiser
+
+    val out = Arguments.createMap()
+    out.putBoolean("success", true)
+    out.putInt("sampleRate", denoiser.sampleRate)
+    out.putInt("frameShiftInSamples", denoiser.frameShiftInSamples)
+    promise.resolve(out)
   }
 
   fun startEnhancementPipeline(

--- a/android/src/main/java/com/sherpaonnx/punctuation/config/PunctuationInitOptionsParser.kt
+++ b/android/src/main/java/com/sherpaonnx/punctuation/config/PunctuationInitOptionsParser.kt
@@ -1,0 +1,39 @@
+package com.sherpaonnx.punctuation.config
+
+import com.facebook.react.bridge.ReadableMap
+import com.sherpaonnx.bridge.InitModeModelPathsParser
+
+/** Parse `initializeOfflinePunctuation` / `initializeOnlinePunctuation` TurboModule maps. */
+internal object PunctuationInitOptionsParser {
+  data class Parsed(
+    val initMode: String,
+    val modelDir: String?,
+    val modelPaths: Map<String, String>?,
+    val modelType: String,
+    val numThreads: Double,
+    val provider: String?,
+    val debug: Boolean,
+  )
+
+  fun parse(options: ReadableMap?): Parsed? {
+    if (options == null) return null
+    val core = InitModeModelPathsParser.parseCore(options) ?: return null
+
+    return Parsed(
+      initMode = core.initMode,
+      modelDir = core.modelDir,
+      modelPaths = core.modelPaths,
+      modelType = core.modelType?.trim()?.takeIf { it.isNotEmpty() } ?: "auto",
+      numThreads = if (options.hasKey("numThreads")) options.getDouble("numThreads") else 1.0,
+      provider = optionalString(options, "provider"),
+      debug = if (options.hasKey("debug")) options.getBoolean("debug") else false,
+    )
+  }
+
+  private fun optionalString(options: ReadableMap, key: String): String? =
+    if (options.hasKey(key) && !options.isNull(key)) {
+      options.getString(key)?.trim()?.takeIf { it.isNotEmpty() }
+    } else {
+      null
+    }
+}

--- a/android/src/main/java/com/sherpaonnx/punctuation/facade/SherpaOnnxOnlinePunctuationHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/punctuation/facade/SherpaOnnxOnlinePunctuationHelper.kt
@@ -4,6 +4,7 @@ import android.os.SystemClock
 import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.k2fsa.sherpa.onnx.OnlinePunctuation
@@ -11,6 +12,8 @@ import com.k2fsa.sherpa.onnx.OnlinePunctuationConfig
 import com.k2fsa.sherpa.onnx.OnlinePunctuationModelConfig
 import com.sherpaonnx.audio.pipeline.StreamingPipelineCompletion
 import com.sherpaonnx.audio.pipeline.StreamingPipelineRegistry
+import com.sherpaonnx.detect.ModelPathValidationNative
+import com.sherpaonnx.punctuation.config.PunctuationInitOptionsParser
 import com.sherpaonnx.punctuation.core.PunctuationErrorCodes
 import com.sherpaonnx.punctuation.core.PunctuationTextInputNormalization
 import com.sherpaonnx.punctuation.pipeline.PunctuationPipelineWorker
@@ -55,96 +58,179 @@ class SherpaOnnxOnlinePunctuationHelper(
 
   fun initializeOnlinePunctuation(
     instanceId: String,
-    modelDir: String,
-    modelType: String?,
-    numThreads: Double?,
-    provider: String?,
-    debug: Boolean?,
+    options: ReadableMap,
     promise: Promise
   ) {
     if (instanceId.isBlank()) {
       promise.reject(PunctuationErrorCodes.INIT_ERROR, "instanceId is required", null)
       return
     }
-    if (modelDir.isBlank()) {
-      promise.reject(PunctuationErrorCodes.INIT_ERROR, "modelDir is required", null)
+    val parsed = PunctuationInitOptionsParser.parse(options)
+    if (parsed == null) {
+      promise.reject(
+        PunctuationErrorCodes.INIT_ERROR,
+        if (options.hasKey("initMode") && options.getString("initMode") == "custom") {
+          "custom init requires initMode, modelType, and modelPaths"
+        } else {
+          "auto init requires modelDir"
+        },
+        null
+      )
       return
     }
     try {
-      val req = (modelType ?: "auto").lowercase()
-      if (req != "auto" && req != "cnn_bilstm") {
-        promise.reject(
-          PunctuationErrorCodes.INIT_ERROR,
-          "Streaming punctuation requires cnn_bilstm or auto; received $modelType",
-          null
-        )
-        return
+      if (parsed.initMode == "custom") {
+        initializeOnlinePunctuationCustom(instanceId, parsed, promise)
+      } else {
+        initializeOnlinePunctuationAuto(instanceId, parsed, promise)
       }
-      val detect = nativeDetectPunctuationModel(modelDir, null, "cnn_bilstm")
-      if (detect == null) {
-        promise.reject(PunctuationErrorCodes.INIT_ERROR, "Punctuation model detection returned null", null)
-        return
-      }
-      val success = detect["success"] as? Boolean ?: false
-      if (!success) {
-        val reason = (detect["error"] as? String)?.trim()
-        promise.reject(
-          PunctuationErrorCodes.INIT_ERROR,
-          if (reason.isNullOrEmpty()) "Punctuation: model is not a valid online CNN-BiLSTM layout" else reason,
-          null
-        )
-        return
-      }
-      val resolvedType = (detect["modelType"] as? String)?.trim() ?: ""
-      val isStreaming = detect["isStreaming"] as? Boolean ?: false
-      if (resolvedType != "cnn_bilstm" || !isStreaming) {
-        promise.reject(
-          PunctuationErrorCodes.INIT_ERROR,
-          "Streaming punctuation requires online cnn_bilstm; native detect reported modelType=$resolvedType isStreaming=$isStreaming",
-          null
-        )
-        return
-      }
-      @Suppress("UNCHECKED_CAST")
-      val paths = detect["paths"] as? HashMap<*, *>
-      val cnn = (paths?.get("cnn_bilstm") as? String)?.trim() ?: ""
-      val vocab = (paths?.get("bpe_vocab") as? String)?.trim() ?: ""
-      if (cnn.isEmpty() || vocab.isEmpty()) {
-        promise.reject(PunctuationErrorCodes.INIT_ERROR, "Punctuation: missing cnn_bilstm or bpe.vocab path", null)
-        return
-      }
-
-      val config = OnlinePunctuationConfig(
-        model = OnlinePunctuationModelConfig(
-          cnnBilstm = cnn,
-          bpeVocab = vocab,
-          numThreads = (numThreads ?: 1.0).toInt().coerceAtLeast(1),
-          debug = debug ?: false,
-          provider = provider?.trim().takeIf { !it.isNullOrEmpty() } ?: "cpu",
-        )
-      )
-      val eng = OnlinePunctuation(assetManager = null, config = config)
-      onlineEngines[instanceId]?.release()
-      onlineEngines[instanceId] = eng
-
-      val out = Arguments.createMap()
-      out.putBoolean("success", true)
-      out.putString("modelType", "cnn_bilstm")
-      @Suppress("UNCHECKED_CAST")
-      val dms = detect["detectedModels"] as? ArrayList<HashMap<String, String>> ?: arrayListOf()
-      val arr = Arguments.createArray()
-      for (m in dms) {
-        val w = Arguments.createMap()
-        w.putString("type", m["type"] ?: "")
-        w.putString("modelDir", m["modelDir"] ?: "")
-        arr.pushMap(w)
-      }
-      out.putArray("detectedModels", arr)
-      promise.resolve(out)
     } catch (e: Exception) {
       Log.e("SherpaOnnxPunct", "initializeOnlinePunctuation", e)
       promise.reject(PunctuationErrorCodes.INIT_ERROR, "Failed to initialize online punctuation: ${e.message}", e)
     }
+  }
+
+  private fun initializeOnlinePunctuationCustom(
+    instanceId: String,
+    parsed: PunctuationInitOptionsParser.Parsed,
+    promise: Promise
+  ) {
+    val modelTypeStr = parsed.modelType.trim()
+    if (modelTypeStr.isEmpty() || modelTypeStr == "auto") {
+      promise.reject(
+        PunctuationErrorCodes.INIT_ERROR,
+        "custom init requires a concrete modelType",
+        null
+      )
+      return
+    }
+    if (modelTypeStr != "cnn_bilstm") {
+      promise.reject(
+        PunctuationErrorCodes.INIT_ERROR,
+        "Streaming punctuation requires cnn_bilstm; received $modelTypeStr",
+        null
+      )
+      return
+    }
+
+    val pathStrings = parsed.modelPaths.orEmpty()
+    ModelPathValidationNative.validate("punctuation", modelTypeStr, pathStrings)?.let { errorMsg ->
+      promise.reject(PunctuationErrorCodes.INIT_ERROR, errorMsg, null)
+      return
+    }
+
+    finishInitializeOnlineWithPaths(
+      instanceId = instanceId,
+      cnn = pathStrings["cnn_bilstm"]?.trim().orEmpty(),
+      vocab = pathStrings["bpe_vocab"]?.trim().orEmpty(),
+      parsed = parsed,
+      detectedModels = arrayListOf(
+        hashMapOf("type" to "cnn_bilstm", "modelDir" to "custom")
+      ),
+      promise = promise
+    )
+  }
+
+  private fun initializeOnlinePunctuationAuto(
+    instanceId: String,
+    parsed: PunctuationInitOptionsParser.Parsed,
+    promise: Promise
+  ) {
+    val modelDir = parsed.modelDir?.trim().orEmpty()
+    if (modelDir.isEmpty()) {
+      promise.reject(PunctuationErrorCodes.INIT_ERROR, "modelDir is required", null)
+      return
+    }
+
+    val req = parsed.modelType.lowercase()
+    if (req != "auto" && req != "cnn_bilstm") {
+      promise.reject(
+        PunctuationErrorCodes.INIT_ERROR,
+        "Streaming punctuation requires cnn_bilstm or auto; received ${parsed.modelType}",
+        null
+      )
+      return
+    }
+    val detect = nativeDetectPunctuationModel(modelDir, null, "cnn_bilstm")
+    if (detect == null) {
+      promise.reject(PunctuationErrorCodes.INIT_ERROR, "Punctuation model detection returned null", null)
+      return
+    }
+    val success = detect["success"] as? Boolean ?: false
+    if (!success) {
+      val reason = (detect["error"] as? String)?.trim()
+      promise.reject(
+        PunctuationErrorCodes.INIT_ERROR,
+        if (reason.isNullOrEmpty()) "Punctuation: model is not a valid online CNN-BiLSTM layout" else reason,
+        null
+      )
+      return
+    }
+    val resolvedType = (detect["modelType"] as? String)?.trim() ?: ""
+    val isStreaming = detect["isStreaming"] as? Boolean ?: false
+    if (resolvedType != "cnn_bilstm" || !isStreaming) {
+      promise.reject(
+        PunctuationErrorCodes.INIT_ERROR,
+        "Streaming punctuation requires online cnn_bilstm; native detect reported modelType=$resolvedType isStreaming=$isStreaming",
+        null
+      )
+      return
+    }
+    @Suppress("UNCHECKED_CAST")
+    val paths = detect["paths"] as? HashMap<*, *>
+    val cnn = (paths?.get("cnn_bilstm") as? String)?.trim() ?: ""
+    val vocab = (paths?.get("bpe_vocab") as? String)?.trim() ?: ""
+
+    @Suppress("UNCHECKED_CAST")
+    val dms = detect["detectedModels"] as? ArrayList<HashMap<String, String>> ?: arrayListOf()
+    finishInitializeOnlineWithPaths(
+      instanceId = instanceId,
+      cnn = cnn,
+      vocab = vocab,
+      parsed = parsed,
+      detectedModels = dms,
+      promise = promise
+    )
+  }
+
+  private fun finishInitializeOnlineWithPaths(
+    instanceId: String,
+    cnn: String,
+    vocab: String,
+    parsed: PunctuationInitOptionsParser.Parsed,
+    detectedModels: ArrayList<HashMap<String, String>>,
+    promise: Promise
+  ) {
+    if (cnn.isEmpty() || vocab.isEmpty()) {
+      promise.reject(PunctuationErrorCodes.INIT_ERROR, "Punctuation: missing cnn_bilstm or bpe.vocab path", null)
+      return
+    }
+
+    val config = OnlinePunctuationConfig(
+      model = OnlinePunctuationModelConfig(
+        cnnBilstm = cnn,
+        bpeVocab = vocab,
+        numThreads = parsed.numThreads.toInt().coerceAtLeast(1),
+        debug = parsed.debug,
+        provider = parsed.provider?.trim().takeIf { !it.isNullOrEmpty() } ?: "cpu",
+      )
+    )
+    val eng = OnlinePunctuation(assetManager = null, config = config)
+    onlineEngines[instanceId]?.release()
+    onlineEngines[instanceId] = eng
+
+    val out = Arguments.createMap()
+    out.putBoolean("success", true)
+    out.putString("modelType", "cnn_bilstm")
+    val arr = Arguments.createArray()
+    for (m in detectedModels) {
+      val w = Arguments.createMap()
+      w.putString("type", m["type"] ?: "")
+      w.putString("modelDir", m["modelDir"] ?: "")
+      arr.pushMap(w)
+    }
+    out.putArray("detectedModels", arr)
+    promise.resolve(out)
   }
 
   fun processOnlinePunctuationChunk(

--- a/android/src/main/java/com/sherpaonnx/punctuation/facade/SherpaOnnxPunctuationHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/punctuation/facade/SherpaOnnxPunctuationHelper.kt
@@ -4,9 +4,12 @@ import android.os.SystemClock
 import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReadableMap
 import com.k2fsa.sherpa.onnx.OfflinePunctuation
 import com.k2fsa.sherpa.onnx.OfflinePunctuationConfig
 import com.k2fsa.sherpa.onnx.OfflinePunctuationModelConfig
+import com.sherpaonnx.detect.ModelPathValidationNative
+import com.sherpaonnx.punctuation.config.PunctuationInitOptionsParser
 import com.sherpaonnx.punctuation.core.PunctuationErrorCodes
 import com.sherpaonnx.punctuation.core.PunctuationTextInputNormalization
 import com.sherpaonnx.text.pipeline.TextErrorCodes
@@ -129,87 +132,32 @@ class SherpaOnnxPunctuationHelper(
 
   fun initializeOfflinePunctuation(
     instanceId: String,
-    modelDir: String,
-    modelType: String?,
-    numThreads: Double?,
-    provider: String?,
-    debug: Boolean?,
+    options: ReadableMap,
     promise: Promise
   ) {
     if (instanceId.isBlank()) {
       promise.reject(PunctuationErrorCodes.INIT_ERROR, "instanceId is required", null)
       return
     }
-    if (modelDir.isBlank()) {
-      promise.reject(PunctuationErrorCodes.INIT_ERROR, "modelDir is required", null)
+    val parsed = PunctuationInitOptionsParser.parse(options)
+    if (parsed == null) {
+      promise.reject(
+        PunctuationErrorCodes.INIT_ERROR,
+        if (options.hasKey("initMode") && options.getString("initMode") == "custom") {
+          "custom init requires initMode, modelType, and modelPaths"
+        } else {
+          "auto init requires modelDir"
+        },
+        null
+      )
       return
     }
     try {
-      // Always resolve **offline CT** for this API (no native `auto` that prefers CNN).
-      val detect = nativeDetectPunctuationModel(modelDir, null, "ct_transformer")
-      if (detect == null) {
-        promise.reject(PunctuationErrorCodes.INIT_ERROR, "Punctuation model detection returned null", null)
-        return
+      if (parsed.initMode == "custom") {
+        initializeOfflinePunctuationCustom(instanceId, parsed, promise)
+      } else {
+        initializeOfflinePunctuationAuto(instanceId, parsed, promise)
       }
-      val success = detect["success"] as? Boolean ?: false
-      if (!success) {
-        val reason = (detect["error"] as? String)?.trim()
-        promise.reject(
-          PunctuationErrorCodes.INIT_ERROR,
-          if (reason.isNullOrEmpty()) "Punctuation: model is not a valid offline CT-Transformer layout for this directory" else reason
-        )
-        return
-      }
-      val resolvedType = (detect["modelType"] as? String)?.trim() ?: ""
-      if (resolvedType != "ct_transformer") {
-        promise.reject(
-          PunctuationErrorCodes.INIT_ERROR,
-          "Offline punctuation requires ct_transformer; native detect reported: $resolvedType"
-        )
-        return
-      }
-      @Suppress("UNCHECKED_CAST")
-      val paths = detect["paths"] as? HashMap<*, *>
-      val ctPath = (paths?.get("ct_transformer") as? String)?.trim() ?: ""
-      if (ctPath.isEmpty()) {
-        promise.reject(PunctuationErrorCodes.INIT_ERROR, "Punctuation: missing ct_transformer onnx path in detect result", null)
-        return
-      }
-      // Optional: ensure requested modelType in options is compatible (v1: only auto / ct)
-      val req = (modelType ?: "auto").lowercase()
-      if (req != "auto" && req != "ct_transformer") {
-        promise.reject(PunctuationErrorCodes.INIT_ERROR, "Unsupported modelType for offline engine: $modelType", null)
-        return
-      }
-
-      val threads = (numThreads ?: 1.0).toInt().coerceAtLeast(1)
-      val prov = provider?.trim().takeIf { !it.isNullOrEmpty() } ?: "cpu"
-      val debugVal = debug ?: false
-      val modelConfig = OfflinePunctuationModelConfig(
-        ctTransformer = ctPath,
-        numThreads = threads,
-        debug = debugVal,
-        provider = prov
-      )
-      val config = OfflinePunctuationConfig(model = modelConfig)
-      val eng = OfflinePunctuation(assetManager = null, config = config)
-      offlineEngines[instanceId]?.release()
-      offlineEngines[instanceId] = eng
-
-      val out = Arguments.createMap()
-      out.putBoolean("success", true)
-      out.putString("modelType", "ct_transformer")
-      @Suppress("UNCHECKED_CAST")
-      val dms = detect["detectedModels"] as? ArrayList<HashMap<String, String>> ?: arrayListOf()
-      val arr = Arguments.createArray()
-      for (m in dms) {
-        val w = Arguments.createMap()
-        w.putString("type", m["type"] ?: "")
-        w.putString("modelDir", m["modelDir"] ?: "")
-        arr.pushMap(w)
-      }
-      out.putArray("detectedModels", arr)
-      promise.resolve(out)
     } catch (e: Exception) {
       Log.e("SherpaOnnxPunct", "initializeOfflinePunctuation", e)
       promise.reject(
@@ -218,6 +166,143 @@ class SherpaOnnxPunctuationHelper(
         e
       )
     }
+  }
+
+  private fun initializeOfflinePunctuationCustom(
+    instanceId: String,
+    parsed: PunctuationInitOptionsParser.Parsed,
+    promise: Promise
+  ) {
+    val modelTypeStr = parsed.modelType.trim()
+    if (modelTypeStr.isEmpty() || modelTypeStr == "auto") {
+      promise.reject(
+        PunctuationErrorCodes.INIT_ERROR,
+        "custom init requires a concrete modelType",
+        null
+      )
+      return
+    }
+    if (modelTypeStr != "ct_transformer") {
+      promise.reject(
+        PunctuationErrorCodes.INIT_ERROR,
+        "Unsupported modelType for offline engine: $modelTypeStr",
+        null
+      )
+      return
+    }
+
+    val pathStrings = parsed.modelPaths.orEmpty()
+    ModelPathValidationNative.validate("punctuation", modelTypeStr, pathStrings)?.let { errorMsg ->
+      promise.reject(PunctuationErrorCodes.INIT_ERROR, errorMsg, null)
+      return
+    }
+
+    finishInitializeOfflineWithPaths(
+      instanceId = instanceId,
+      ctPath = pathStrings["ct_transformer"]?.trim().orEmpty(),
+      parsed = parsed,
+      detectedModels = arrayListOf(
+        hashMapOf("type" to "ct_transformer", "modelDir" to "custom")
+      ),
+      promise = promise
+    )
+  }
+
+  private fun initializeOfflinePunctuationAuto(
+    instanceId: String,
+    parsed: PunctuationInitOptionsParser.Parsed,
+    promise: Promise
+  ) {
+    val modelDir = parsed.modelDir?.trim().orEmpty()
+    if (modelDir.isEmpty()) {
+      promise.reject(PunctuationErrorCodes.INIT_ERROR, "modelDir is required", null)
+      return
+    }
+
+    // Always resolve **offline CT** for this API (no native `auto` that prefers CNN).
+    val detect = nativeDetectPunctuationModel(modelDir, null, "ct_transformer")
+    if (detect == null) {
+      promise.reject(PunctuationErrorCodes.INIT_ERROR, "Punctuation model detection returned null", null)
+      return
+    }
+    val success = detect["success"] as? Boolean ?: false
+    if (!success) {
+      val reason = (detect["error"] as? String)?.trim()
+      promise.reject(
+        PunctuationErrorCodes.INIT_ERROR,
+        if (reason.isNullOrEmpty()) "Punctuation: model is not a valid offline CT-Transformer layout for this directory" else reason
+      )
+      return
+    }
+    val resolvedType = (detect["modelType"] as? String)?.trim() ?: ""
+    if (resolvedType != "ct_transformer") {
+      promise.reject(
+        PunctuationErrorCodes.INIT_ERROR,
+        "Offline punctuation requires ct_transformer; native detect reported: $resolvedType"
+      )
+      return
+    }
+    @Suppress("UNCHECKED_CAST")
+    val paths = detect["paths"] as? HashMap<*, *>
+    val ctPath = (paths?.get("ct_transformer") as? String)?.trim() ?: ""
+    if (ctPath.isEmpty()) {
+      promise.reject(PunctuationErrorCodes.INIT_ERROR, "Punctuation: missing ct_transformer onnx path in detect result", null)
+      return
+    }
+    val req = parsed.modelType.lowercase()
+    if (req != "auto" && req != "ct_transformer") {
+      promise.reject(PunctuationErrorCodes.INIT_ERROR, "Unsupported modelType for offline engine: ${parsed.modelType}", null)
+      return
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    val dms = detect["detectedModels"] as? ArrayList<HashMap<String, String>> ?: arrayListOf()
+    finishInitializeOfflineWithPaths(
+      instanceId = instanceId,
+      ctPath = ctPath,
+      parsed = parsed,
+      detectedModels = dms,
+      promise = promise
+    )
+  }
+
+  private fun finishInitializeOfflineWithPaths(
+    instanceId: String,
+    ctPath: String,
+    parsed: PunctuationInitOptionsParser.Parsed,
+    detectedModels: ArrayList<HashMap<String, String>>,
+    promise: Promise
+  ) {
+    if (ctPath.isEmpty()) {
+      promise.reject(PunctuationErrorCodes.INIT_ERROR, "Punctuation: missing ct_transformer onnx path", null)
+      return
+    }
+
+    val threads = parsed.numThreads.toInt().coerceAtLeast(1)
+    val prov = parsed.provider?.trim().takeIf { !it.isNullOrEmpty() } ?: "cpu"
+    val modelConfig = OfflinePunctuationModelConfig(
+      ctTransformer = ctPath,
+      numThreads = threads,
+      debug = parsed.debug,
+      provider = prov
+    )
+    val config = OfflinePunctuationConfig(model = modelConfig)
+    val eng = OfflinePunctuation(assetManager = null, config = config)
+    offlineEngines[instanceId]?.release()
+    offlineEngines[instanceId] = eng
+
+    val out = Arguments.createMap()
+    out.putBoolean("success", true)
+    out.putString("modelType", "ct_transformer")
+    val arr = Arguments.createArray()
+    for (m in detectedModels) {
+      val w = Arguments.createMap()
+      w.putString("type", m["type"] ?: "")
+      w.putString("modelDir", m["modelDir"] ?: "")
+      arr.pushMap(w)
+    }
+    out.putArray("detectedModels", arr)
+    promise.resolve(out)
   }
 
   private fun getEngine(instanceId: String): OfflinePunctuation? = offlineEngines[instanceId]

--- a/android/src/main/java/com/sherpaonnx/stt/config/OnlineSttInitOptionsParser.kt
+++ b/android/src/main/java/com/sherpaonnx/stt/config/OnlineSttInitOptionsParser.kt
@@ -1,7 +1,7 @@
 package com.sherpaonnx.stt.config
 
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.ReadableType
+import com.sherpaonnx.bridge.InitModeModelPathsParser
 
 /** Parse `initializeOnlineStt(instanceId, options)` TurboModule map. */
 internal object OnlineSttInitOptionsParser {
@@ -34,36 +34,13 @@ internal object OnlineSttInitOptionsParser {
   )
 
   fun parse(options: ReadableMap): Parsed? {
-    val initMode = if (options.hasKey("initMode")) {
-      options.getString("initMode")?.trim().orEmpty().ifEmpty { "auto" }
-    } else {
-      "auto"
-    }
-
-    val modelDir = if (options.hasKey("modelDir")) {
-      options.getString("modelDir")?.trim()?.takeIf { it.isNotEmpty() }
-    } else {
-      null
-    }
-
-    val modelPaths = if (options.hasKey("modelPaths") && !options.isNull("modelPaths")) {
-      readStringMap(options.getMap("modelPaths"))
-    } else {
-      null
-    }
-
-    if (initMode == "custom") {
-      if (modelPaths.isNullOrEmpty()) return null
-      if (!options.hasKey("modelType") || options.isNull("modelType")) return null
-    } else if (modelDir.isNullOrEmpty()) {
-      return null
-    }
+    val core = InitModeModelPathsParser.parseCore(options) ?: return null
 
     return Parsed(
-      initMode = initMode,
-      modelDir = modelDir,
-      modelPaths = modelPaths,
-      modelType = if (options.hasKey("modelType")) options.getString("modelType") else null,
+      initMode = core.initMode,
+      modelDir = core.modelDir,
+      modelPaths = core.modelPaths,
+      modelType = core.modelType ?: if (options.hasKey("modelType")) options.getString("modelType") else null,
       enableEndpoint = if (options.hasKey("enableEndpoint")) options.getBoolean("enableEndpoint") else null,
       decodingMethod = if (options.hasKey("decodingMethod")) options.getString("decodingMethod") else null,
       maxActivePaths = if (options.hasKey("maxActivePaths")) options.getDouble("maxActivePaths").toInt() else null,
@@ -86,20 +63,5 @@ internal object OnlineSttInitOptionsParser {
       rule3MinTrailingSilence = if (options.hasKey("rule3MinTrailingSilence")) options.getDouble("rule3MinTrailingSilence") else null,
       rule3MinUtteranceLength = if (options.hasKey("rule3MinUtteranceLength")) options.getDouble("rule3MinUtteranceLength") else null,
     )
-  }
-
-  private fun readStringMap(map: ReadableMap?): Map<String, String>? {
-    if (map == null) return null
-    val out = linkedMapOf<String, String>()
-    val iterator = map.keySetIterator()
-    while (iterator.hasNextKey()) {
-      val key = iterator.nextKey()
-      if (map.getType(key) != ReadableType.String) continue
-      val value = map.getString(key)?.trim().orEmpty()
-      if (value.isNotEmpty()) {
-        out[key] = value
-      }
-    }
-    return out
   }
 }

--- a/android/src/main/java/com/sherpaonnx/stt/config/OnlineSttInitOptionsParser.kt
+++ b/android/src/main/java/com/sherpaonnx/stt/config/OnlineSttInitOptionsParser.kt
@@ -1,0 +1,105 @@
+package com.sherpaonnx.stt.config
+
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
+
+/** Parse `initializeOnlineStt(instanceId, options)` TurboModule map. */
+internal object OnlineSttInitOptionsParser {
+  data class Parsed(
+    val initMode: String,
+    val modelDir: String?,
+    val modelPaths: Map<String, String>?,
+    val modelType: String?,
+    val enableEndpoint: Boolean?,
+    val decodingMethod: String?,
+    val maxActivePaths: Int?,
+    val hotwordsFile: String?,
+    val hotwordsScore: Double?,
+    val numThreads: Double?,
+    val provider: String?,
+    val ruleFsts: String?,
+    val ruleFars: String?,
+    val dither: Double?,
+    val blankPenalty: Double?,
+    val debug: Boolean?,
+    val rule1MustContainNonSilence: Boolean?,
+    val rule1MinTrailingSilence: Double?,
+    val rule1MinUtteranceLength: Double?,
+    val rule2MustContainNonSilence: Boolean?,
+    val rule2MinTrailingSilence: Double?,
+    val rule2MinUtteranceLength: Double?,
+    val rule3MustContainNonSilence: Boolean?,
+    val rule3MinTrailingSilence: Double?,
+    val rule3MinUtteranceLength: Double?,
+  )
+
+  fun parse(options: ReadableMap): Parsed? {
+    val initMode = if (options.hasKey("initMode")) {
+      options.getString("initMode")?.trim().orEmpty().ifEmpty { "auto" }
+    } else {
+      "auto"
+    }
+
+    val modelDir = if (options.hasKey("modelDir")) {
+      options.getString("modelDir")?.trim()?.takeIf { it.isNotEmpty() }
+    } else {
+      null
+    }
+
+    val modelPaths = if (options.hasKey("modelPaths") && !options.isNull("modelPaths")) {
+      readStringMap(options.getMap("modelPaths"))
+    } else {
+      null
+    }
+
+    if (initMode == "custom") {
+      if (modelPaths.isNullOrEmpty()) return null
+      if (!options.hasKey("modelType") || options.isNull("modelType")) return null
+    } else if (modelDir.isNullOrEmpty()) {
+      return null
+    }
+
+    return Parsed(
+      initMode = initMode,
+      modelDir = modelDir,
+      modelPaths = modelPaths,
+      modelType = if (options.hasKey("modelType")) options.getString("modelType") else null,
+      enableEndpoint = if (options.hasKey("enableEndpoint")) options.getBoolean("enableEndpoint") else null,
+      decodingMethod = if (options.hasKey("decodingMethod")) options.getString("decodingMethod") else null,
+      maxActivePaths = if (options.hasKey("maxActivePaths")) options.getDouble("maxActivePaths").toInt() else null,
+      hotwordsFile = if (options.hasKey("hotwordsFile")) options.getString("hotwordsFile") else null,
+      hotwordsScore = if (options.hasKey("hotwordsScore")) options.getDouble("hotwordsScore") else null,
+      numThreads = if (options.hasKey("numThreads")) options.getDouble("numThreads") else null,
+      provider = if (options.hasKey("provider")) options.getString("provider") else null,
+      ruleFsts = if (options.hasKey("ruleFsts")) options.getString("ruleFsts") else null,
+      ruleFars = if (options.hasKey("ruleFars")) options.getString("ruleFars") else null,
+      dither = if (options.hasKey("dither")) options.getDouble("dither") else null,
+      blankPenalty = if (options.hasKey("blankPenalty")) options.getDouble("blankPenalty") else null,
+      debug = if (options.hasKey("debug")) options.getBoolean("debug") else null,
+      rule1MustContainNonSilence = if (options.hasKey("rule1MustContainNonSilence")) options.getBoolean("rule1MustContainNonSilence") else null,
+      rule1MinTrailingSilence = if (options.hasKey("rule1MinTrailingSilence")) options.getDouble("rule1MinTrailingSilence") else null,
+      rule1MinUtteranceLength = if (options.hasKey("rule1MinUtteranceLength")) options.getDouble("rule1MinUtteranceLength") else null,
+      rule2MustContainNonSilence = if (options.hasKey("rule2MustContainNonSilence")) options.getBoolean("rule2MustContainNonSilence") else null,
+      rule2MinTrailingSilence = if (options.hasKey("rule2MinTrailingSilence")) options.getDouble("rule2MinTrailingSilence") else null,
+      rule2MinUtteranceLength = if (options.hasKey("rule2MinUtteranceLength")) options.getDouble("rule2MinUtteranceLength") else null,
+      rule3MustContainNonSilence = if (options.hasKey("rule3MustContainNonSilence")) options.getBoolean("rule3MustContainNonSilence") else null,
+      rule3MinTrailingSilence = if (options.hasKey("rule3MinTrailingSilence")) options.getDouble("rule3MinTrailingSilence") else null,
+      rule3MinUtteranceLength = if (options.hasKey("rule3MinUtteranceLength")) options.getDouble("rule3MinUtteranceLength") else null,
+    )
+  }
+
+  private fun readStringMap(map: ReadableMap?): Map<String, String>? {
+    if (map == null) return null
+    val out = linkedMapOf<String, String>()
+    val iterator = map.keySetIterator()
+    while (iterator.hasNextKey()) {
+      val key = iterator.nextKey()
+      if (map.getType(key) != ReadableType.String) continue
+      val value = map.getString(key)?.trim().orEmpty()
+      if (value.isNotEmpty()) {
+        out[key] = value
+      }
+    }
+    return out
+  }
+}

--- a/android/src/main/java/com/sherpaonnx/stt/config/SttInitOptionsParser.kt
+++ b/android/src/main/java/com/sherpaonnx/stt/config/SttInitOptionsParser.kt
@@ -1,7 +1,7 @@
 package com.sherpaonnx.stt.config
 
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.ReadableType
+import com.sherpaonnx.bridge.InitModeModelPathsParser
 
 /** Parse `initializeStt(instanceId, options)` TurboModule map. */
 internal object SttInitOptionsParser {
@@ -25,41 +25,14 @@ internal object SttInitOptionsParser {
   )
 
   fun parse(options: ReadableMap): Parsed? {
-    val initMode = if (options.hasKey("initMode")) {
-      options.getString("initMode")?.trim().orEmpty().ifEmpty { "auto" }
-    } else {
-      "auto"
-    }
-
-    val modelDir = if (options.hasKey("modelDir")) {
-      options.getString("modelDir")?.trim()?.takeIf { it.isNotEmpty() }
-    } else {
-      null
-    }
-
-    val modelPaths = if (options.hasKey("modelPaths") && !options.isNull("modelPaths")) {
-      readStringMap(options.getMap("modelPaths"))
-    } else {
-      null
-    }
-
-    if (initMode == "custom") {
-      if (modelPaths.isNullOrEmpty()) {
-        return null
-      }
-      if (!options.hasKey("modelType") || options.isNull("modelType")) {
-        return null
-      }
-    } else if (modelDir.isNullOrEmpty()) {
-      return null
-    }
+    val core = InitModeModelPathsParser.parseCore(options) ?: return null
 
     return Parsed(
-      initMode = initMode,
-      modelDir = modelDir,
-      modelPaths = modelPaths,
+      initMode = core.initMode,
+      modelDir = core.modelDir,
+      modelPaths = core.modelPaths,
       preferInt8 = if (options.hasKey("preferInt8")) options.getBoolean("preferInt8") else null,
-      modelType = if (options.hasKey("modelType")) options.getString("modelType") else null,
+      modelType = core.modelType ?: if (options.hasKey("modelType")) options.getString("modelType") else null,
       debug = if (options.hasKey("debug")) options.getBoolean("debug") else null,
       hotwordsFile = if (options.hasKey("hotwordsFile")) options.getString("hotwordsFile") else null,
       hotwordsScore = if (options.hasKey("hotwordsScore")) options.getDouble("hotwordsScore") else null,
@@ -77,20 +50,5 @@ internal object SttInitOptionsParser {
       modelingUnit = if (options.hasKey("modelingUnit")) options.getString("modelingUnit") else null,
       bpeVocab = if (options.hasKey("bpeVocab")) options.getString("bpeVocab") else null,
     )
-  }
-
-  private fun readStringMap(map: ReadableMap?): Map<String, String>? {
-    if (map == null) return null
-    val out = linkedMapOf<String, String>()
-    val iterator = map.keySetIterator()
-    while (iterator.hasNextKey()) {
-      val key = iterator.nextKey()
-      if (map.getType(key) != ReadableType.String) continue
-      val value = map.getString(key)?.trim().orEmpty()
-      if (value.isNotEmpty()) {
-        out[key] = value
-      }
-    }
-    return out
   }
 }

--- a/android/src/main/java/com/sherpaonnx/stt/config/SttInitOptionsParser.kt
+++ b/android/src/main/java/com/sherpaonnx/stt/config/SttInitOptionsParser.kt
@@ -1,11 +1,14 @@
 package com.sherpaonnx.stt.config
 
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
 
 /** Parse `initializeStt(instanceId, options)` TurboModule map. */
 internal object SttInitOptionsParser {
   data class Parsed(
-    val modelDir: String,
+    val initMode: String,
+    val modelDir: String?,
+    val modelPaths: Map<String, String>?,
     val preferInt8: Boolean?,
     val modelType: String?,
     val debug: Boolean?,
@@ -22,10 +25,39 @@ internal object SttInitOptionsParser {
   )
 
   fun parse(options: ReadableMap): Parsed? {
-    val modelDir = options.getString("modelDir")?.trim().orEmpty()
-    if (modelDir.isEmpty()) return null
+    val initMode = if (options.hasKey("initMode")) {
+      options.getString("initMode")?.trim().orEmpty().ifEmpty { "auto" }
+    } else {
+      "auto"
+    }
+
+    val modelDir = if (options.hasKey("modelDir")) {
+      options.getString("modelDir")?.trim()?.takeIf { it.isNotEmpty() }
+    } else {
+      null
+    }
+
+    val modelPaths = if (options.hasKey("modelPaths") && !options.isNull("modelPaths")) {
+      readStringMap(options.getMap("modelPaths"))
+    } else {
+      null
+    }
+
+    if (initMode == "custom") {
+      if (modelPaths.isNullOrEmpty()) {
+        return null
+      }
+      if (!options.hasKey("modelType") || options.isNull("modelType")) {
+        return null
+      }
+    } else if (modelDir.isNullOrEmpty()) {
+      return null
+    }
+
     return Parsed(
+      initMode = initMode,
       modelDir = modelDir,
+      modelPaths = modelPaths,
       preferInt8 = if (options.hasKey("preferInt8")) options.getBoolean("preferInt8") else null,
       modelType = if (options.hasKey("modelType")) options.getString("modelType") else null,
       debug = if (options.hasKey("debug")) options.getBoolean("debug") else null,
@@ -45,5 +77,20 @@ internal object SttInitOptionsParser {
       modelingUnit = if (options.hasKey("modelingUnit")) options.getString("modelingUnit") else null,
       bpeVocab = if (options.hasKey("bpeVocab")) options.getString("bpeVocab") else null,
     )
+  }
+
+  private fun readStringMap(map: ReadableMap?): Map<String, String>? {
+    if (map == null) return null
+    val out = linkedMapOf<String, String>()
+    val iterator = map.keySetIterator()
+    while (iterator.hasNextKey()) {
+      val key = iterator.nextKey()
+      if (map.getType(key) != ReadableType.String) continue
+      val value = map.getString(key)?.trim().orEmpty()
+      if (value.isNotEmpty()) {
+        out[key] = value
+      }
+    }
+    return out
   }
 }

--- a/android/src/main/java/com/sherpaonnx/stt/core/OnlineSttRecognizerConfigFactory.kt
+++ b/android/src/main/java/com/sherpaonnx/stt/core/OnlineSttRecognizerConfigFactory.kt
@@ -42,6 +42,59 @@ internal class OnlineSttRecognizerConfigFactory(
     rule3MinUtteranceLength: Float?
   ): OnlineRecognizerConfig {
     val paths = scanOnlineModelPaths(modelDir, modelType)
+    return buildOnlineRecognizerConfigFromPaths(
+      paths,
+      modelType,
+      enableEndpoint,
+      decodingMethod,
+      maxActivePaths,
+      hotwordsFile,
+      hotwordsScore,
+      numThreads,
+      provider,
+      ruleFsts,
+      ruleFars,
+      dither,
+      blankPenalty,
+      debug,
+      rule1MustContainNonSilence,
+      rule1MinTrailingSilence,
+      rule1MinUtteranceLength,
+      rule2MustContainNonSilence,
+      rule2MinTrailingSilence,
+      rule2MinUtteranceLength,
+      rule3MustContainNonSilence,
+      rule3MinTrailingSilence,
+      rule3MinUtteranceLength
+    )
+  }
+
+  fun buildOnlineRecognizerConfigFromPaths(
+    paths: Map<String, String>,
+    modelType: String,
+    enableEndpoint: Boolean,
+    decodingMethod: String,
+    maxActivePaths: Int,
+    hotwordsFile: String?,
+    hotwordsScore: Float?,
+    numThreads: Int?,
+    provider: String?,
+    ruleFsts: String?,
+    ruleFars: String?,
+    dither: Float?,
+    blankPenalty: Float?,
+    debug: Boolean?,
+    rule1MustContainNonSilence: Boolean?,
+    rule1MinTrailingSilence: Float?,
+    rule1MinUtteranceLength: Float?,
+    rule2MustContainNonSilence: Boolean?,
+    rule2MinTrailingSilence: Float?,
+    rule2MinUtteranceLength: Float?,
+    rule3MustContainNonSilence: Boolean?,
+    rule3MinTrailingSilence: Float?,
+    rule3MinUtteranceLength: Float?
+  ): OnlineRecognizerConfig {
+    validateOnlinePaths(paths, modelType)
 
     val endpointConfig = EndpointConfig(
       rule1 = EndpointRule(
@@ -188,21 +241,35 @@ internal class OnlineSttRecognizerConfigFactory(
       )
       else -> throw IllegalArgumentException("Unsupported online STT model type: $modelType. Use: transducer, nemo_transducer, paraformer, zipformer2_ctc, nemo_ctc, tone_ctc")
     }.also { paths ->
-      when (modelType) {
-        "transducer", "nemo_transducer" -> {
-          if ((paths["encoder"]?.isEmpty() != false) || (paths["decoder"]?.isEmpty() != false) || (paths["joiner"]?.isEmpty() != false)) {
-            throw IllegalArgumentException("Transducer model requires encoder, decoder, and joiner .onnx files in $modelDir")
-          }
+      validateOnlinePaths(paths, modelType)
+    }
+  }
+
+  private fun validateOnlinePaths(paths: Map<String, String>, modelType: String) {
+    when (modelType) {
+      "transducer", "nemo_transducer" -> {
+        if (
+          paths["encoder"].isNullOrEmpty() ||
+          paths["decoder"].isNullOrEmpty() ||
+          paths["joiner"].isNullOrEmpty()
+        ) {
+          throw IllegalArgumentException(
+            "Transducer model requires encoder, decoder, and joiner .onnx files"
+          )
         }
-        "paraformer" -> {
-          if ((paths["encoder"]?.isEmpty() != false) || (paths["decoder"]?.isEmpty() != false)) {
-            throw IllegalArgumentException("Paraformer model requires encoder and decoder .onnx files in $modelDir")
-          }
+      }
+      "paraformer" -> {
+        if (paths["encoder"].isNullOrEmpty() || paths["decoder"].isNullOrEmpty()) {
+          throw IllegalArgumentException(
+            "Paraformer model requires encoder and decoder .onnx files"
+          )
         }
-        "zipformer2_ctc", "nemo_ctc", "tone_ctc" -> {
-          if (paths["model"]?.isEmpty() != false) {
-            throw IllegalArgumentException("$modelType model requires model.onnx (or model*.onnx) in $modelDir")
-          }
+      }
+      "zipformer2_ctc", "nemo_ctc", "tone_ctc" -> {
+        if (paths["model"].isNullOrEmpty()) {
+          throw IllegalArgumentException(
+            "$modelType model requires model.onnx (or model*.onnx)"
+          )
         }
       }
     }

--- a/android/src/main/java/com/sherpaonnx/stt/facade/SherpaOnnxOnlineSttHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/stt/facade/SherpaOnnxOnlineSttHelper.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.k2fsa.sherpa.onnx.OnlineRecognizer
 import com.k2fsa.sherpa.onnx.OnlineRecognizerConfig
@@ -11,6 +12,8 @@ import com.sherpaonnx.audio.pipeline.LiveEntry
 import com.sherpaonnx.audio.pipeline.PipelineAudioRegistry
 import com.sherpaonnx.audio.pipeline.StreamingPipelineCompletion
 import com.sherpaonnx.audio.pipeline.StreamingPipelineRegistry
+import com.sherpaonnx.detect.ModelPathValidationNative
+import com.sherpaonnx.stt.config.OnlineSttInitOptionsParser
 import com.sherpaonnx.stt.pipeline.SttPipelineWorker
 import com.sherpaonnx.stt.core.OnlineSttRecognizerConfigFactory
 import com.sherpaonnx.stt.core.SttErrorCodes
@@ -22,7 +25,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Helper for streaming (online) STT using sherpa-onnx OnlineRecognizer + OnlineStream.
- * Manages recognizer instances and streams; resolves model paths by scanning the model directory.
+ * Manages recognizer instances and streams; auto mode scans the model directory.
  */
 internal class SherpaOnnxOnlineSttHelper(
   private val context: ReactApplicationContext,
@@ -98,57 +101,88 @@ internal class SherpaOnnxOnlineSttHelper(
 
   fun initializeOnlineStt(
     instanceId: String,
-    modelDir: String,
-    modelType: String,
-    enableEndpoint: Boolean,
-    decodingMethod: String,
-    maxActivePaths: Int,
-    hotwordsFile: String?,
-    hotwordsScore: Double?,
-    numThreads: Double?,
-    provider: String?,
-    ruleFsts: String?,
-    ruleFars: String?,
-    dither: Double?,
-    blankPenalty: Double?,
-    debug: Boolean?,
-    rule1MustContainNonSilence: Boolean?,
-    rule1MinTrailingSilence: Double?,
-    rule1MinUtteranceLength: Double?,
-    rule2MustContainNonSilence: Boolean?,
-    rule2MinTrailingSilence: Double?,
-    rule2MinUtteranceLength: Double?,
-    rule3MustContainNonSilence: Boolean?,
-    rule3MinTrailingSilence: Double?,
-    rule3MinUtteranceLength: Double?,
+    options: ReadableMap,
     promise: Promise
   ) {
-    try {
-      val config = configFactory.buildOnlineRecognizerConfig(
-        modelDir = modelDir,
-        modelType = modelType,
-        enableEndpoint = enableEndpoint,
-        decodingMethod = decodingMethod,
-        maxActivePaths = maxActivePaths,
-        hotwordsFile = hotwordsFile,
-        hotwordsScore = hotwordsScore?.toFloat(),
-        numThreads = numThreads?.toInt(),
-        provider = provider,
-        ruleFsts = ruleFsts,
-        ruleFars = ruleFars,
-        dither = dither?.toFloat(),
-        blankPenalty = blankPenalty?.toFloat(),
-        debug = debug,
-        rule1MustContainNonSilence = rule1MustContainNonSilence,
-        rule1MinTrailingSilence = rule1MinTrailingSilence?.toFloat(),
-        rule1MinUtteranceLength = rule1MinUtteranceLength?.toFloat(),
-        rule2MustContainNonSilence = rule2MustContainNonSilence,
-        rule2MinTrailingSilence = rule2MinTrailingSilence?.toFloat(),
-        rule2MinUtteranceLength = rule2MinUtteranceLength?.toFloat(),
-        rule3MustContainNonSilence = rule3MustContainNonSilence,
-        rule3MinTrailingSilence = rule3MinTrailingSilence?.toFloat(),
-        rule3MinUtteranceLength = rule3MinUtteranceLength?.toFloat()
+    val parsed = OnlineSttInitOptionsParser.parse(options)
+    if (parsed == null) {
+      promise.reject(
+        SttErrorCodes.INIT_FAILED,
+        if (options.hasKey("initMode") && options.getString("initMode") == "custom") {
+          "custom init requires initMode, modelType, and modelPaths"
+        } else {
+          "auto init requires modelDir"
+        }
       )
+      return
+    }
+
+    val modelType = parsed.modelType?.trim().orEmpty().ifEmpty { "transducer" }
+    val enableEndpoint = parsed.enableEndpoint ?: true
+    val decodingMethod = parsed.decodingMethod?.trim().orEmpty().ifEmpty { "greedy_search" }
+    val maxActivePaths = parsed.maxActivePaths ?: 4
+
+    try {
+      val config = if (parsed.initMode == "custom") {
+        val pathStrings = parsed.modelPaths.orEmpty()
+        ModelPathValidationNative.validate("stt_streaming", modelType, pathStrings)?.let { errorMsg ->
+          Log.e(logTag, errorMsg)
+          promise.reject(SttErrorCodes.INIT_FAILED, errorMsg)
+          return
+        }
+        configFactory.buildOnlineRecognizerConfigFromPaths(
+          paths = pathStrings,
+          modelType = modelType,
+          enableEndpoint = enableEndpoint,
+          decodingMethod = decodingMethod,
+          maxActivePaths = maxActivePaths,
+          hotwordsFile = parsed.hotwordsFile,
+          hotwordsScore = parsed.hotwordsScore?.toFloat(),
+          numThreads = parsed.numThreads?.toInt(),
+          provider = parsed.provider,
+          ruleFsts = parsed.ruleFsts,
+          ruleFars = parsed.ruleFars,
+          dither = parsed.dither?.toFloat(),
+          blankPenalty = parsed.blankPenalty?.toFloat(),
+          debug = parsed.debug,
+          rule1MustContainNonSilence = parsed.rule1MustContainNonSilence,
+          rule1MinTrailingSilence = parsed.rule1MinTrailingSilence?.toFloat(),
+          rule1MinUtteranceLength = parsed.rule1MinUtteranceLength?.toFloat(),
+          rule2MustContainNonSilence = parsed.rule2MustContainNonSilence,
+          rule2MinTrailingSilence = parsed.rule2MinTrailingSilence?.toFloat(),
+          rule2MinUtteranceLength = parsed.rule2MinUtteranceLength?.toFloat(),
+          rule3MustContainNonSilence = parsed.rule3MustContainNonSilence,
+          rule3MinTrailingSilence = parsed.rule3MinTrailingSilence?.toFloat(),
+          rule3MinUtteranceLength = parsed.rule3MinUtteranceLength?.toFloat()
+        )
+      } else {
+        configFactory.buildOnlineRecognizerConfig(
+          modelDir = parsed.modelDir.orEmpty(),
+          modelType = modelType,
+          enableEndpoint = enableEndpoint,
+          decodingMethod = decodingMethod,
+          maxActivePaths = maxActivePaths,
+          hotwordsFile = parsed.hotwordsFile,
+          hotwordsScore = parsed.hotwordsScore?.toFloat(),
+          numThreads = parsed.numThreads?.toInt(),
+          provider = parsed.provider,
+          ruleFsts = parsed.ruleFsts,
+          ruleFars = parsed.ruleFars,
+          dither = parsed.dither?.toFloat(),
+          blankPenalty = parsed.blankPenalty?.toFloat(),
+          debug = parsed.debug,
+          rule1MustContainNonSilence = parsed.rule1MustContainNonSilence,
+          rule1MinTrailingSilence = parsed.rule1MinTrailingSilence?.toFloat(),
+          rule1MinUtteranceLength = parsed.rule1MinUtteranceLength?.toFloat(),
+          rule2MustContainNonSilence = parsed.rule2MustContainNonSilence,
+          rule2MinTrailingSilence = parsed.rule2MinTrailingSilence?.toFloat(),
+          rule2MinUtteranceLength = parsed.rule2MinUtteranceLength?.toFloat(),
+          rule3MustContainNonSilence = parsed.rule3MustContainNonSilence,
+          rule3MinTrailingSilence = parsed.rule3MinTrailingSilence?.toFloat(),
+          rule3MinUtteranceLength = parsed.rule3MinUtteranceLength?.toFloat()
+        )
+      }
+
       val recognizer = OnlineRecognizer(assetManager = null, config = config)
       instances[instanceId] = OnlineSttInstance(recognizer = recognizer, config = config)
       promise.resolve(Arguments.createMap().apply { putBoolean("success", true) })
@@ -157,7 +191,6 @@ internal class SherpaOnnxOnlineSttHelper(
       promise.reject(SttErrorCodes.INIT_FAILED, "Online STT init failed: ${e.message}", e)
     }
   }
-
 
   fun unloadOnlineStt(instanceId: String, promise: Promise) {
     try {

--- a/android/src/main/java/com/sherpaonnx/stt/facade/SherpaOnnxSttHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/stt/facade/SherpaOnnxSttHelper.kt
@@ -13,6 +13,7 @@ import com.sherpaonnx.audio.pipeline.PipelineAudioRegistry
 import com.sherpaonnx.errors.OfflineOomError
 import com.sherpaonnx.stt.config.SttInitOptionsParser
 import com.sherpaonnx.stt.core.OfflineSttRecognizerConfigFactory
+import com.sherpaonnx.detect.ModelPathValidationNative
 import com.sherpaonnx.stt.core.SttErrorCodes
 import com.sherpaonnx.stt.core.SttPathResolver
 import com.sherpaonnx.stt.core.normalizeQwen3HotwordsCsv
@@ -61,47 +62,31 @@ internal class SherpaOnnxSttHelper(
   ) {
     val parsed = SttInitOptionsParser.parse(options)
     if (parsed == null) {
-      promise.reject(SttErrorCodes.INIT_FAILED, "modelDir is required")
+      promise.reject(
+        SttErrorCodes.INIT_FAILED,
+        if (options.hasKey("initMode") && options.getString("initMode") == "custom") {
+          "custom init requires initMode, modelType, and modelPaths"
+        } else {
+          "auto init requires modelDir"
+        }
+      )
       return
     }
-    initializeSttInternal(
-      instanceId,
-      parsed.modelDir,
-      parsed.preferInt8,
-      parsed.modelType,
-      parsed.debug,
-      parsed.hotwordsFile,
-      parsed.hotwordsScore,
-      parsed.numThreads,
-      parsed.provider,
-      parsed.ruleFsts,
-      parsed.ruleFars,
-      parsed.dither,
-      parsed.modelOptions,
-      parsed.modelingUnit,
-      parsed.bpeVocab,
-      promise
-    )
+
+    if (parsed.initMode == "custom") {
+      initializeSttCustom(instanceId, parsed, promise)
+      return
+    }
+
+    initializeSttAuto(instanceId, parsed, promise)
   }
 
-  private fun initializeSttInternal(
+  private fun initializeSttAuto(
     instanceId: String,
-    modelDir: String,
-    preferInt8: Boolean?,
-    modelType: String?,
-    debug: Boolean?,
-    hotwordsFile: String?,
-    hotwordsScore: Double?,
-    numThreads: Double?,
-    provider: String?,
-    ruleFsts: String?,
-    ruleFars: String?,
-    dither: Double?,
-    modelOptions: ReadableMap?,
-    modelingUnit: String?,
-    bpeVocab: String?,
+    parsed: SttInitOptionsParser.Parsed,
     promise: Promise
   ) {
+    val modelDir = parsed.modelDir.orEmpty()
     try {
       val modelDirFile = File(modelDir)
       if (!modelDirFile.exists()) {
@@ -121,10 +106,10 @@ internal class SherpaOnnxSttHelper(
       val result = detectSttModel(
         modelDir,
         null,
-        modelType ?: "auto",
-        preferInt8 ?: false,
-        preferInt8 != null,
-        debug ?: false
+        parsed.modelType ?: "auto",
+        parsed.preferInt8 ?: false,
+        parsed.preferInt8 != null,
+        parsed.debug ?: false
       )
 
       if (result == null) {
@@ -154,101 +139,154 @@ internal class SherpaOnnxSttHelper(
       val pathStrings = paths.mapValues { (_, v) -> (v as? String).orEmpty() }.mapKeys { it.key.toString() }
       val modelTypeStr = result["modelType"] as? String ?: "unknown"
 
-      val hotwordsFileTrimmed = hotwordsFile?.trim().orEmpty()
-      if (hotwordsFileTrimmed.isNotEmpty() && !supportsHotwords(modelTypeStr)) {
-        val errorMsg = "Hotwords are only supported for transducer models (transducer, nemo_transducer). Current model type: $modelTypeStr"
-        Log.e(logTag, errorMsg)
-        promise.reject(SttErrorCodes.CONFIG_FAILED, errorMsg)
-        return
-      }
-      val resolvedHotwordsPath = if (hotwordsFileTrimmed.isNotEmpty()) {
-        try {
-          pathResolver.resolveHotwordsPath(hotwordsFileTrimmed)
-        } catch (e: Exception) {
-          val errorMsg = e.message ?: "Hotwords file could not be resolved"
-          Log.e(logTag, errorMsg, e)
-          promise.reject(SttErrorCodes.CONFIG_FAILED, errorMsg, e)
-          return
-        }
-      } else ""
-      if (resolvedHotwordsPath.isNotEmpty()) {
-        pathResolver.validateHotwordsFile(resolvedHotwordsPath)?.let { errorMsg ->
-          Log.e(logTag, errorMsg)
-          promise.reject(SttErrorCodes.CONFIG_FAILED, errorMsg)
-          return
-        }
-      }
-
-      val resolvedRuleFsts = try {
-        pathResolver.resolveFilePaths(ruleFsts.orEmpty().trim(), "stt_rule_fst")
-      } catch (e: Exception) {
-        val errorMsg = e.message ?: "Rule FST path(s) could not be resolved"
-        Log.e(logTag, errorMsg, e)
-        promise.reject(SttErrorCodes.INIT_FAILED, errorMsg, e)
-        return
-      }
-      val resolvedRuleFars = try {
-        pathResolver.resolveFilePaths(ruleFars.orEmpty().trim(), "stt_rule_far")
-      } catch (e: Exception) {
-        val errorMsg = e.message ?: "Rule FAR path(s) could not be resolved"
-        Log.e(logTag, errorMsg, e)
-        promise.reject(SttErrorCodes.INIT_FAILED, errorMsg, e)
-        return
-      }
-
-      val inst = instances.getOrPut(instanceId) { SttEngineInstance() }
-      inst.recognizer?.release()
-      inst.recognizer = null
-      val config = configFactory.buildRecognizerConfig(
-        pathStrings,
-        modelTypeStr,
-        hotwordsFile = resolvedHotwordsPath,
-        hotwordsScore = hotwordsScore?.toFloat() ?: 1.5f,
-        numThreads = numThreads?.toInt(),
-        provider = provider,
-        ruleFsts = resolvedRuleFsts,
-        ruleFars = resolvedRuleFars,
-        dither = dither?.toFloat() ?: 0f,
-        modelOptions = modelOptions,
-        modelingUnit = modelingUnit?.trim().orEmpty(),
-        bpeVocab = bpeVocab?.trim().orEmpty()
+      finishInitializeWithPaths(
+        instanceId = instanceId,
+        pathStrings = pathStrings,
+        modelTypeStr = modelTypeStr,
+        detectedModels = detectedModels,
+        parsed = parsed,
+        promise = promise
       )
-      inst.lastRecognizerConfig = config
-      inst.currentSttModelType = modelTypeStr
-      inst.qwen3HotwordsForStream = if (modelTypeStr == "qwen3_asr") {
-        normalizeQwen3HotwordsCsv(modelOptions?.getMap("qwen3Asr")?.getString("hotwords")?.trim().orEmpty())
-      } else ""
-      // Defer recognizer creation to the dedicated background thread so release() of the previous
-      // recognizer can complete off the UI thread (avoids "destroyed mutex" / SIGSEGV when switching models).
-      initHandler.post {
-        try {
-          inst.recognizer = OfflineRecognizer(config = config)
-          val resultMap = Arguments.createMap()
-          resultMap.putBoolean("success", true)
-          resultMap.putString("modelType", modelTypeStr)
-          resultMap.putString("decodingMethod", config.decodingMethod)
-          val detectedModelsArray = Arguments.createArray()
-          for (model in detectedModels) {
-            val modelMap = model as? HashMap<*, *>
-            if (modelMap != null) {
-              val modelResultMap = Arguments.createMap()
-              modelResultMap.putString("type", modelMap["type"] as? String ?: "")
-              modelResultMap.putString("modelDir", modelMap["modelDir"] as? String ?: "")
-              detectedModelsArray.pushMap(modelResultMap)
-            }
-          }
-          resultMap.putArray("detectedModels", detectedModelsArray)
-          promise.resolve(resultMap)
-        } catch (e: Exception) {
-          val errorMsg = "Exception creating recognizer: ${e.message ?: e.javaClass.simpleName}"
-          Log.e(logTag, errorMsg, e)
-          promise.reject(SttErrorCodes.INIT_FAILED, errorMsg, e)
-        }
-      }
     } catch (e: Exception) {
       val errorMsg = "Exception during initialization: ${e.message ?: e.javaClass.simpleName}"
       Log.e(logTag, errorMsg, e)
       promise.reject(SttErrorCodes.INIT_FAILED, errorMsg, e)
+    }
+  }
+
+  private fun initializeSttCustom(
+    instanceId: String,
+    parsed: SttInitOptionsParser.Parsed,
+    promise: Promise
+  ) {
+    try {
+      val modelTypeStr = parsed.modelType?.trim().orEmpty()
+      if (modelTypeStr.isEmpty() || modelTypeStr == "auto") {
+        promise.reject(SttErrorCodes.INIT_FAILED, "custom init requires a concrete modelType")
+        return
+      }
+
+      val pathStrings = parsed.modelPaths.orEmpty()
+      ModelPathValidationNative.validate("stt", modelTypeStr, pathStrings)?.let { errorMsg ->
+        Log.e(logTag, errorMsg)
+        promise.reject(SttErrorCodes.INIT_FAILED, errorMsg)
+        return
+      }
+
+      finishInitializeWithPaths(
+        instanceId = instanceId,
+        pathStrings = pathStrings,
+        modelTypeStr = modelTypeStr,
+        detectedModels = arrayListOf(
+          hashMapOf("type" to modelTypeStr, "modelDir" to "custom")
+        ),
+        parsed = parsed,
+        promise = promise
+      )
+    } catch (e: Exception) {
+      val errorMsg = "Exception during custom initialization: ${e.message ?: e.javaClass.simpleName}"
+      Log.e(logTag, errorMsg, e)
+      promise.reject(SttErrorCodes.INIT_FAILED, errorMsg, e)
+    }
+  }
+
+  private fun finishInitializeWithPaths(
+    instanceId: String,
+    pathStrings: Map<String, String>,
+    modelTypeStr: String,
+    detectedModels: ArrayList<*>,
+    parsed: SttInitOptionsParser.Parsed,
+    promise: Promise
+  ) {
+    val hotwordsFileTrimmed = parsed.hotwordsFile?.trim().orEmpty()
+    if (hotwordsFileTrimmed.isNotEmpty() && !supportsHotwords(modelTypeStr)) {
+      val errorMsg =
+        "Hotwords are only supported for transducer models (transducer, nemo_transducer). Current model type: $modelTypeStr"
+      Log.e(logTag, errorMsg)
+      promise.reject(SttErrorCodes.CONFIG_FAILED, errorMsg)
+      return
+    }
+    val resolvedHotwordsPath = if (hotwordsFileTrimmed.isNotEmpty()) {
+      try {
+        pathResolver.resolveHotwordsPath(hotwordsFileTrimmed)
+      } catch (e: Exception) {
+        val errorMsg = e.message ?: "Hotwords file could not be resolved"
+        Log.e(logTag, errorMsg, e)
+        promise.reject(SttErrorCodes.CONFIG_FAILED, errorMsg, e)
+        return
+      }
+    } else ""
+    if (resolvedHotwordsPath.isNotEmpty()) {
+      pathResolver.validateHotwordsFile(resolvedHotwordsPath)?.let { errorMsg ->
+        Log.e(logTag, errorMsg)
+        promise.reject(SttErrorCodes.CONFIG_FAILED, errorMsg)
+        return
+      }
+    }
+
+    val resolvedRuleFsts = try {
+      pathResolver.resolveFilePaths(parsed.ruleFsts.orEmpty().trim(), "stt_rule_fst")
+    } catch (e: Exception) {
+      val errorMsg = e.message ?: "Rule FST path(s) could not be resolved"
+      Log.e(logTag, errorMsg, e)
+      promise.reject(SttErrorCodes.INIT_FAILED, errorMsg, e)
+      return
+    }
+    val resolvedRuleFars = try {
+      pathResolver.resolveFilePaths(parsed.ruleFars.orEmpty().trim(), "stt_rule_far")
+    } catch (e: Exception) {
+      val errorMsg = e.message ?: "Rule FAR path(s) could not be resolved"
+      Log.e(logTag, errorMsg, e)
+      promise.reject(SttErrorCodes.INIT_FAILED, errorMsg, e)
+      return
+    }
+
+    val inst = instances.getOrPut(instanceId) { SttEngineInstance() }
+    inst.recognizer?.release()
+    inst.recognizer = null
+    val config = configFactory.buildRecognizerConfig(
+      pathStrings,
+      modelTypeStr,
+      hotwordsFile = resolvedHotwordsPath,
+      hotwordsScore = parsed.hotwordsScore?.toFloat() ?: 1.5f,
+      numThreads = parsed.numThreads?.toInt(),
+      provider = parsed.provider,
+      ruleFsts = resolvedRuleFsts,
+      ruleFars = resolvedRuleFars,
+      dither = parsed.dither?.toFloat() ?: 0f,
+      modelOptions = parsed.modelOptions,
+      modelingUnit = parsed.modelingUnit?.trim().orEmpty(),
+      bpeVocab = parsed.bpeVocab?.trim().orEmpty()
+    )
+    inst.lastRecognizerConfig = config
+    inst.currentSttModelType = modelTypeStr
+    inst.qwen3HotwordsForStream = if (modelTypeStr == "qwen3_asr") {
+      normalizeQwen3HotwordsCsv(parsed.modelOptions?.getMap("qwen3Asr")?.getString("hotwords")?.trim().orEmpty())
+    } else ""
+    initHandler.post {
+      try {
+        inst.recognizer = OfflineRecognizer(config = config)
+        val resultMap = Arguments.createMap()
+        resultMap.putBoolean("success", true)
+        resultMap.putString("modelType", modelTypeStr)
+        resultMap.putString("decodingMethod", config.decodingMethod)
+        val detectedModelsArray = Arguments.createArray()
+        for (model in detectedModels) {
+          val modelMap = model as? HashMap<*, *>
+          if (modelMap != null) {
+            val modelResultMap = Arguments.createMap()
+            modelResultMap.putString("type", modelMap["type"] as? String ?: "")
+            modelResultMap.putString("modelDir", modelMap["modelDir"] as? String ?: "")
+            detectedModelsArray.pushMap(modelResultMap)
+          }
+        }
+        resultMap.putArray("detectedModels", detectedModelsArray)
+        promise.resolve(resultMap)
+      } catch (e: Exception) {
+        val errorMsg = "Exception creating recognizer: ${e.message ?: e.javaClass.simpleName}"
+        Log.e(logTag, errorMsg, e)
+        promise.reject(SttErrorCodes.INIT_FAILED, errorMsg, e)
+      }
     }
   }
 

--- a/android/src/main/java/com/sherpaonnx/tts/config/TtsInitOptionsParser.kt
+++ b/android/src/main/java/com/sherpaonnx/tts/config/TtsInitOptionsParser.kt
@@ -1,28 +1,57 @@
 package com.sherpaonnx.tts.config
 
 import com.facebook.react.bridge.ReadableMap
+import com.sherpaonnx.bridge.InitModeModelPathsParser
 
+/** Parse `initializeTts(instanceId, options)` TurboModule map. */
 internal object TtsInitOptionsParser {
-  fun modelDir(options: ReadableMap): String? = options.getString("modelDir")?.trim()?.takeIf { it.isNotEmpty() }
+  data class Parsed(
+    val initMode: String,
+    val modelDir: String?,
+    val modelPaths: Map<String, String>?,
+    val modelType: String,
+    val numThreads: Double,
+    val debug: Boolean,
+    val noiseScale: Double?,
+    val noiseScaleW: Double?,
+    val lengthScale: Double?,
+    val ruleFsts: String?,
+    val ruleFars: String?,
+    val maxNumSentences: Double?,
+    val silenceScale: Double?,
+    val provider: String?,
+    val lexiconLanguageId: String?,
+    val kokoroLang: String?,
+  )
 
-  fun modelType(options: ReadableMap): String = options.getString("modelType")?.trim()?.takeIf { it.isNotEmpty() } ?: "auto"
+  fun parse(options: ReadableMap): Parsed? {
+    val core = InitModeModelPathsParser.parseCore(options) ?: return null
 
-  fun numThreads(options: ReadableMap): Double =
-    if (options.hasKey("numThreads")) options.getDouble("numThreads") else 2.0
-
-  fun debug(options: ReadableMap): Boolean =
-    if (options.hasKey("debug")) options.getBoolean("debug") else false
+    return Parsed(
+      initMode = core.initMode,
+      modelDir = core.modelDir,
+      modelPaths = core.modelPaths,
+      modelType = core.modelType?.trim()?.takeIf { it.isNotEmpty() } ?: "auto",
+      numThreads = if (options.hasKey("numThreads")) options.getDouble("numThreads") else 2.0,
+      debug = if (options.hasKey("debug")) options.getBoolean("debug") else false,
+      noiseScale = optionalDouble(options, "noiseScale"),
+      noiseScaleW = optionalDouble(options, "noiseScaleW"),
+      lengthScale = optionalDouble(options, "lengthScale"),
+      ruleFsts = optionalString(options, "ruleFsts"),
+      ruleFars = optionalString(options, "ruleFars"),
+      maxNumSentences = optionalDouble(options, "maxNumSentences"),
+      silenceScale = optionalDouble(options, "silenceScale"),
+      provider = optionalString(options, "provider"),
+      lexiconLanguageId = optionalString(options, "lexiconLanguageId"),
+      kokoroLang = optionalString(options, "kokoroLang"),
+    )
+  }
 
   fun optionalDouble(options: ReadableMap, key: String): Double? =
     if (options.hasKey(key)) options.getDouble(key) else null
 
   fun optionalString(options: ReadableMap, key: String): String? =
     if (options.hasKey(key)) options.getString(key)?.trim()?.takeIf { it.isNotEmpty() } else null
-
-  fun lexiconLanguageId(options: ReadableMap): String? = optionalString(options, "lexiconLanguageId")
-
-  /** Bridge-only: maps public `modelOptions.kokoro.lang`. */
-  fun kokoroLang(options: ReadableMap): String? = optionalString(options, "kokoroLang")
 
   fun resolveLexiconPathFromDetect(
     lexiconLanguages: ArrayList<*>?,

--- a/android/src/main/java/com/sherpaonnx/tts/service/TtsInitializationService.kt
+++ b/android/src/main/java/com/sherpaonnx/tts/service/TtsInitializationService.kt
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReactApplicationContext
 import com.k2fsa.sherpa.onnx.OfflineTts
+import com.sherpaonnx.detect.ModelPathValidationNative
 import com.sherpaonnx.tts.config.TtsInitOptionsParser
 import com.sherpaonnx.tts.config.TtsOfflineConfigBuilder
 import com.sherpaonnx.tts.core.TtsEngineInstance
@@ -50,168 +51,236 @@ internal class TtsInitializationService(
     options: ReadableMap,
     promise: Promise
   ) {
-    val modelDir = TtsInitOptionsParser.modelDir(options)
-    if (modelDir == null) {
-      rejectOnUiThread(promise, "TTS_INIT_ERROR", "modelDir is required")
+    val parsed = TtsInitOptionsParser.parse(options)
+    if (parsed == null) {
+      rejectOnUiThread(
+        promise,
+        "TTS_INIT_ERROR",
+        if (options.hasKey("initMode") && options.getString("initMode") == "custom") {
+          "custom init requires initMode, modelType, and modelPaths"
+        } else {
+          "auto init requires modelDir"
+        }
+      )
       return
     }
-  val modelType = TtsInitOptionsParser.modelType(options)
-    val numThreads = TtsInitOptionsParser.numThreads(options)
-    val debug = TtsInitOptionsParser.debug(options)
-    val noiseScale = TtsInitOptionsParser.optionalDouble(options, "noiseScale")
-    val noiseScaleW = TtsInitOptionsParser.optionalDouble(options, "noiseScaleW")
-    val lengthScale = TtsInitOptionsParser.optionalDouble(options, "lengthScale")
-    val ruleFsts = TtsInitOptionsParser.optionalString(options, "ruleFsts")
-    val ruleFars = TtsInitOptionsParser.optionalString(options, "ruleFars")
-    val maxNumSentences = TtsInitOptionsParser.optionalDouble(options, "maxNumSentences")
-    val silenceScale = TtsInitOptionsParser.optionalDouble(options, "silenceScale")
-    val provider = TtsInitOptionsParser.optionalString(options, "provider")
-    val lexiconLanguageId = TtsInitOptionsParser.lexiconLanguageId(options)
-    val kokoroLang = TtsInitOptionsParser.kokoroLang(options)
 
     ttsInitExecutor.execute init@{
       try {
-        val result = detectTtsModel(modelDir, null, modelType)
-        if (result == null) {
-          Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: Failed to detect TTS model: native call returned null")
-          rejectOnUiThread(promise, "TTS_INIT_ERROR", "Failed to detect TTS model: native call returned null")
-          return@init
-        }
-        val success = result["success"] as? Boolean ?: false
-        if (!success) {
-          val reason = result["error"] as? String
-          Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: ${reason ?: "Failed to detect TTS model"}")
-          rejectOnUiThread(promise, "TTS_INIT_ERROR", reason ?: "Failed to detect TTS model")
-          return@init
-        }
-        var paths = (result["paths"] as? Map<*, *>)?.mapValues { (_, v) -> (v as? String).orEmpty() }?.mapKeys { it.key.toString() } ?: emptyMap()
-        val lexiconLanguages = result["lexiconLanguages"] as? ArrayList<*>
-        if (!lexiconLanguageId.isNullOrBlank()) {
-          val resolvedLexicon = TtsInitOptionsParser.resolveLexiconPathFromDetect(lexiconLanguages, lexiconLanguageId)
-          if (resolvedLexicon.isNullOrBlank()) {
-            val msg = "lexiconLanguageId '$lexiconLanguageId' not found in detected lexiconLanguages"
-            Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: $msg")
-            rejectOnUiThread(promise, "TTS_INIT_ERROR", msg)
-            return@init
-          }
-          paths = paths + ("lexicon" to resolvedLexicon)
+        if (parsed.initMode == "custom") {
+          initializeTtsCustom(instanceId, parsed, promise)
         } else {
-          paths = pathsWithLexiconOverride(paths, lexiconLanguages, null)
+          initializeTtsAuto(instanceId, parsed, promise)
         }
-        val modelTypeStr = result["modelType"] as? String ?: "vits"
-        val detectedModels = result["detectedModels"] as? ArrayList<*>
-
-        val inst = repository.getOrPut(instanceId) { TtsEngineInstance() }
-        inst.releaseEngines()
-
-        val sampleRate: Int
-        val numSpeakers: Int
-
-        if (modelTypeStr == "zipvoice") {
-          val vocoderPath = TtsOfflineConfigBuilder.path(paths, "vocoder")
-          if (vocoderPath.isBlank()) {
-            val msg = "Zipvoice distill models (encoder+decoder only, no vocoder) are not supported. Use the full Zipvoice model that includes vocos_24khz.onnx (or similar vocoder file)."
-            Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: $msg")
-            rejectOnUiThread(promise, "TTS_INIT_ERROR", msg)
-            return@init
-          }
-          val lexiconPath = TtsOfflineConfigBuilder.path(paths, "lexicon")
-          if (lexiconPath.isBlank()) {
-            val msg = "Zipvoice requires lexicon.txt (or lexicon-<lang>.txt) in the model directory. The sherpa-onnx engine aborts if it is missing. Copy lexicon from the official k2-fsa sherpa-onnx Zipvoice model package or hr-files release next to tokens.txt."
-            Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: $msg")
-            rejectOnUiThread(promise, "TTS_INIT_ERROR", msg)
-            return@init
-          }
-          val am = context.applicationContext.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
-          if (am != null) {
-            val memInfo = ActivityManager.MemoryInfo()
-            am.getMemoryInfo(memInfo)
-            val availMb = memInfo.availMem / (1024 * 1024)
-            if (memInfo.availMem < 800L * 1024 * 1024) {
-              val msg = "Not enough free memory to load the Zipvoice model (available: ${availMb} MB). Close other apps to free memory or use a smaller Zipvoice model that includes all required components (encoder, decoder, and vocoder)."
-              Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: $msg")
-              rejectOnUiThread(promise, "TTS_INIT_ERROR", msg)
-              return@init
-            }
-          }
-          System.gc()
-          if (am != null) {
-            val memInfoBefore = ActivityManager.MemoryInfo()
-            am.getMemoryInfo(memInfoBefore)
-            Log.i("SherpaOnnxTts", "Zipvoice init: availMem=${memInfoBefore.availMem / (1024 * 1024)} MB (before load)")
-          }
-          val zipvoiceNumThreads = 1
-          val config = TtsOfflineConfigBuilder.buildTtsConfig(
-            paths, "zipvoice", zipvoiceNumThreads, debug,
-            noiseScale, noiseScaleW, lengthScale,
-            ruleFsts, ruleFars, maxNumSentences?.toInt(), silenceScale,
-            provider
-          )
-          if (am != null) {
-            val memInfo = ActivityManager.MemoryInfo()
-            am.getMemoryInfo(memInfo)
-            Log.i("SherpaOnnxTts", "Zipvoice init: availMem=${memInfo.availMem / (1024 * 1024)} MB (after load)")
-          }
-          try {
-            inst.tts = OfflineTts(config = config)
-          } catch (e: Exception) {
-            Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: Failed to create Zipvoice OfflineTts: ${e.message}", e)
-            rejectOnUiThread(promise, "TTS_INIT_ERROR", "Failed to create Zipvoice TTS engine: ${e.message}", e)
-            return@init
-          }
-          sampleRate = inst.tts!!.sampleRate()
-          numSpeakers = inst.tts!!.numSpeakers()
-        } else {
-          val config = TtsOfflineConfigBuilder.buildTtsConfig(
-            paths, modelTypeStr, numThreads.toInt(), debug,
-            noiseScale, noiseScaleW, lengthScale,
-            ruleFsts, ruleFars, maxNumSentences?.toInt(), silenceScale,
-            provider,
-            kokoroLang
-          )
-          inst.tts = OfflineTts(config = config)
-          sampleRate = inst.tts!!.sampleRate()
-          numSpeakers = inst.tts!!.numSpeakers()
-        }
-
-        val modelsArray = Arguments.createArray()
-        detectedModels?.forEach { modelObj ->
-          if (modelObj is HashMap<*, *>) {
-            val modelMap = Arguments.createMap()
-            modelMap.putString("type", modelObj["type"] as? String ?: "")
-            modelMap.putString("modelDir", modelObj["modelDir"] as? String ?: "")
-            modelsArray.pushMap(modelMap)
-          }
-        }
-
-        inst.ttsInitState = TtsInitState(
-          modelDir,
-          modelTypeStr,
-          numThreads.toInt(),
-          debug,
-          noiseScale?.takeUnless { it.isNaN() },
-          noiseScaleW?.takeUnless { it.isNaN() },
-          lengthScale?.takeUnless { it.isNaN() },
-          ruleFsts?.takeIf { it.isNotBlank() },
-          ruleFars?.takeIf { it.isNotBlank() },
-          maxNumSentences?.toInt()?.takeIf { it > 0 },
-          silenceScale?.takeUnless { it.isNaN() },
-          provider?.takeIf { it.isNotBlank() }
-        )
-
-        Log.i("SherpaOnnxTts", "initializeTts: instanceId=$instanceId, engine=kotlin-api modelType=$modelTypeStr, sampleRate=$sampleRate, numSpeakers=$numSpeakers")
-
-        val resultMap = Arguments.createMap()
-        resultMap.putBoolean("success", true)
-        resultMap.putArray("detectedModels", modelsArray)
-        resultMap.putInt("sampleRate", sampleRate)
-        resultMap.putInt("numSpeakers", numSpeakers)
-        resolveOnUiThread(promise, resultMap)
       } catch (e: Exception) {
         Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: Failed to initialize TTS: ${e.message}", e)
         rejectOnUiThread(promise, "TTS_INIT_ERROR", "Failed to initialize TTS: ${e.message}", e)
       }
     }
+  }
+
+  private fun initializeTtsAuto(
+    instanceId: String,
+    parsed: TtsInitOptionsParser.Parsed,
+    promise: Promise
+  ) {
+    val modelDir = parsed.modelDir.orEmpty()
+    val result = detectTtsModel(modelDir, null, parsed.modelType)
+    if (result == null) {
+      Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: Failed to detect TTS model: native call returned null")
+      rejectOnUiThread(promise, "TTS_INIT_ERROR", "Failed to detect TTS model: native call returned null")
+      return
+    }
+    val success = result["success"] as? Boolean ?: false
+    if (!success) {
+      val reason = result["error"] as? String
+      Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: ${reason ?: "Failed to detect TTS model"}")
+      rejectOnUiThread(promise, "TTS_INIT_ERROR", reason ?: "Failed to detect TTS model")
+      return
+    }
+    var paths = (result["paths"] as? Map<*, *>)?.mapValues { (_, v) -> (v as? String).orEmpty() }?.mapKeys { it.key.toString() } ?: emptyMap()
+    val lexiconLanguages = result["lexiconLanguages"] as? ArrayList<*>
+    if (!parsed.lexiconLanguageId.isNullOrBlank()) {
+      val resolvedLexicon = TtsInitOptionsParser.resolveLexiconPathFromDetect(lexiconLanguages, parsed.lexiconLanguageId)
+      if (resolvedLexicon.isNullOrBlank()) {
+        val msg = "lexiconLanguageId '${parsed.lexiconLanguageId}' not found in detected lexiconLanguages"
+        Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: $msg")
+        rejectOnUiThread(promise, "TTS_INIT_ERROR", msg)
+        return
+      }
+      paths = paths + ("lexicon" to resolvedLexicon)
+    } else {
+      paths = pathsWithLexiconOverride(paths, lexiconLanguages, null)
+    }
+    val modelTypeStr = result["modelType"] as? String ?: "vits"
+    val detectedModels = result["detectedModels"] as? ArrayList<*>
+
+    finishInitializeWithPaths(
+      instanceId = instanceId,
+      modelDir = modelDir,
+      paths = paths,
+      modelTypeStr = modelTypeStr,
+      detectedModels = detectedModels,
+      parsed = parsed,
+      promise = promise
+    )
+  }
+
+  private fun initializeTtsCustom(
+    instanceId: String,
+    parsed: TtsInitOptionsParser.Parsed,
+    promise: Promise
+  ) {
+    val modelTypeStr = parsed.modelType.trim()
+    if (modelTypeStr.isEmpty() || modelTypeStr == "auto") {
+      rejectOnUiThread(promise, "TTS_INIT_ERROR", "custom init requires a concrete modelType")
+      return
+    }
+    if (!parsed.lexiconLanguageId.isNullOrBlank()) {
+      rejectOnUiThread(
+        promise,
+        "TTS_INIT_ERROR",
+        "lexiconLanguageId is only supported for initMode auto"
+      )
+      return
+    }
+
+    val pathStrings = parsed.modelPaths.orEmpty()
+    ModelPathValidationNative.validate("tts", modelTypeStr, pathStrings)?.let { errorMsg ->
+      Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: $errorMsg")
+      rejectOnUiThread(promise, "TTS_INIT_ERROR", errorMsg)
+      return
+    }
+
+    finishInitializeWithPaths(
+      instanceId = instanceId,
+      modelDir = "custom",
+      paths = pathStrings,
+      modelTypeStr = modelTypeStr,
+      detectedModels = arrayListOf(
+        hashMapOf("type" to modelTypeStr, "modelDir" to "custom")
+      ),
+      parsed = parsed,
+      promise = promise
+    )
+  }
+
+  private fun finishInitializeWithPaths(
+    instanceId: String,
+    modelDir: String,
+    paths: Map<String, String>,
+    modelTypeStr: String,
+    detectedModels: ArrayList<*>?,
+    parsed: TtsInitOptionsParser.Parsed,
+    promise: Promise
+  ) {
+    val inst = repository.getOrPut(instanceId) { TtsEngineInstance() }
+    inst.releaseEngines()
+
+    val sampleRate: Int
+    val numSpeakers: Int
+
+    if (modelTypeStr == "zipvoice") {
+      val vocoderPath = TtsOfflineConfigBuilder.path(paths, "vocoder")
+      if (vocoderPath.isBlank()) {
+        val msg = "Zipvoice distill models (encoder+decoder only, no vocoder) are not supported. Use the full Zipvoice model that includes vocos_24khz.onnx (or similar vocoder file)."
+        Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: $msg")
+        rejectOnUiThread(promise, "TTS_INIT_ERROR", msg)
+        return
+      }
+      val lexiconPath = TtsOfflineConfigBuilder.path(paths, "lexicon")
+      if (lexiconPath.isBlank()) {
+        val msg = "Zipvoice requires lexicon.txt (or lexicon-<lang>.txt) in the model directory. The sherpa-onnx engine aborts if it is missing. Copy lexicon from the official k2-fsa sherpa-onnx Zipvoice model package or hr-files release next to tokens.txt."
+        Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: $msg")
+        rejectOnUiThread(promise, "TTS_INIT_ERROR", msg)
+        return
+      }
+      val am = context.applicationContext.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+      if (am != null) {
+        val memInfo = ActivityManager.MemoryInfo()
+        am.getMemoryInfo(memInfo)
+        val availMb = memInfo.availMem / (1024 * 1024)
+        if (memInfo.availMem < 800L * 1024 * 1024) {
+          val msg = "Not enough free memory to load the Zipvoice model (available: ${availMb} MB). Close other apps to free memory or use a smaller Zipvoice model that includes all required components (encoder, decoder, and vocoder)."
+          Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: $msg")
+          rejectOnUiThread(promise, "TTS_INIT_ERROR", msg)
+          return
+        }
+      }
+      System.gc()
+      if (am != null) {
+        val memInfoBefore = ActivityManager.MemoryInfo()
+        am.getMemoryInfo(memInfoBefore)
+        Log.i("SherpaOnnxTts", "Zipvoice init: availMem=${memInfoBefore.availMem / (1024 * 1024)} MB (before load)")
+      }
+      val zipvoiceNumThreads = 1
+      val config = TtsOfflineConfigBuilder.buildTtsConfig(
+        paths, "zipvoice", zipvoiceNumThreads, parsed.debug,
+        parsed.noiseScale, parsed.noiseScaleW, parsed.lengthScale,
+        parsed.ruleFsts, parsed.ruleFars, parsed.maxNumSentences?.toInt(), parsed.silenceScale,
+        parsed.provider,
+        parsed.kokoroLang
+      )
+      if (am != null) {
+        val memInfo = ActivityManager.MemoryInfo()
+        am.getMemoryInfo(memInfo)
+        Log.i("SherpaOnnxTts", "Zipvoice init: availMem=${memInfo.availMem / (1024 * 1024)} MB (after load)")
+      }
+      try {
+        inst.tts = OfflineTts(config = config)
+      } catch (e: Exception) {
+        Log.e("SherpaOnnxTts", "TTS_INIT_ERROR: Failed to create Zipvoice OfflineTts: ${e.message}", e)
+        rejectOnUiThread(promise, "TTS_INIT_ERROR", "Failed to create Zipvoice TTS engine: ${e.message}", e)
+        return
+      }
+      sampleRate = inst.tts!!.sampleRate()
+      numSpeakers = inst.tts!!.numSpeakers()
+    } else {
+      val config = TtsOfflineConfigBuilder.buildTtsConfig(
+        paths, modelTypeStr, parsed.numThreads.toInt(), parsed.debug,
+        parsed.noiseScale, parsed.noiseScaleW, parsed.lengthScale,
+        parsed.ruleFsts, parsed.ruleFars, parsed.maxNumSentences?.toInt(), parsed.silenceScale,
+        parsed.provider,
+        parsed.kokoroLang
+      )
+      inst.tts = OfflineTts(config = config)
+      sampleRate = inst.tts!!.sampleRate()
+      numSpeakers = inst.tts!!.numSpeakers()
+    }
+
+    val modelsArray = Arguments.createArray()
+    detectedModels?.forEach { modelObj ->
+      if (modelObj is HashMap<*, *>) {
+        val modelMap = Arguments.createMap()
+        modelMap.putString("type", modelObj["type"] as? String ?: "")
+        modelMap.putString("modelDir", modelObj["modelDir"] as? String ?: "")
+        modelsArray.pushMap(modelMap)
+      }
+    }
+
+    inst.ttsInitState = TtsInitState(
+      modelDir,
+      modelTypeStr,
+      if (modelTypeStr == "zipvoice") 1 else parsed.numThreads.toInt(),
+      parsed.debug,
+      parsed.noiseScale?.takeUnless { it.isNaN() },
+      parsed.noiseScaleW?.takeUnless { it.isNaN() },
+      parsed.lengthScale?.takeUnless { it.isNaN() },
+      parsed.ruleFsts?.takeIf { it.isNotBlank() },
+      parsed.ruleFars?.takeIf { it.isNotBlank() },
+      parsed.maxNumSentences?.toInt()?.takeIf { it > 0 },
+      parsed.silenceScale?.takeUnless { it.isNaN() },
+      parsed.provider?.takeIf { it.isNotBlank() }
+    )
+
+    Log.i("SherpaOnnxTts", "initializeTts: instanceId=$instanceId, engine=kotlin-api modelType=$modelTypeStr, sampleRate=$sampleRate, numSpeakers=$numSpeakers")
+
+    val resultMap = Arguments.createMap()
+    resultMap.putBoolean("success", true)
+    resultMap.putArray("detectedModels", modelsArray)
+    resultMap.putInt("sampleRate", sampleRate)
+    resultMap.putInt("numSpeakers", numSpeakers)
+    resolveOnUiThread(promise, resultMap)
   }
 
   fun updateTtsParams(

--- a/android/src/main/java/com/sherpaonnx/vad/config/VadInitOptionsParser.kt
+++ b/android/src/main/java/com/sherpaonnx/vad/config/VadInitOptionsParser.kt
@@ -1,0 +1,62 @@
+package com.sherpaonnx.vad.config
+
+import com.facebook.react.bridge.ReadableMap
+import com.sherpaonnx.bridge.InitModeModelPathsParser
+
+/** Parse `initializeVad(instanceId, options)` TurboModule map. */
+internal object VadInitOptionsParser {
+  data class Parsed(
+    val initMode: String,
+    val modelDir: String?,
+    val modelPaths: Map<String, String>?,
+    val modelType: String,
+    val sampleRate: Int,
+    val threshold: Double?,
+    val minSpeechDurationMs: Int,
+    val minSilenceDurationMs: Int,
+    val windowSize: Int?,
+    val maxSpeechDurationMs: Int?,
+    val provider: String,
+    val numThreads: Int,
+    val debug: Boolean,
+  )
+
+  fun parse(options: ReadableMap?): Parsed? {
+    if (options == null) return null
+    val core = InitModeModelPathsParser.parseCore(options) ?: return null
+
+    val minSpeech = optionalInt(options, "minSpeechDurationMs")
+      ?: optionalInt(options, "speechDurationMs")
+      ?: 250
+    val minSilence = optionalInt(options, "silenceDurationMs") ?: 250
+
+    return Parsed(
+      initMode = core.initMode,
+      modelDir = core.modelDir,
+      modelPaths = core.modelPaths,
+      modelType = core.modelType?.trim()?.takeIf { it.isNotEmpty() } ?: "auto",
+      sampleRate = optionalInt(options, "sampleRate") ?: 16000,
+      threshold = optionalDouble(options, "threshold"),
+      minSpeechDurationMs = minSpeech,
+      minSilenceDurationMs = minSilence,
+      windowSize = optionalInt(options, "windowSize"),
+      maxSpeechDurationMs = optionalDouble(options, "maxSpeechDurationS")?.times(1000.0)?.toInt(),
+      provider = optionalString(options, "provider") ?: "cpu",
+      numThreads = optionalInt(options, "numThreads") ?: 1,
+      debug = if (options.hasKey("debug")) options.getBoolean("debug") else false,
+    )
+  }
+
+  private fun optionalDouble(options: ReadableMap, key: String): Double? =
+    if (options.hasKey(key) && !options.isNull(key)) options.getDouble(key) else null
+
+  private fun optionalInt(options: ReadableMap, key: String): Int? =
+    if (options.hasKey(key) && !options.isNull(key)) options.getDouble(key).toInt() else null
+
+  private fun optionalString(options: ReadableMap, key: String): String? =
+    if (options.hasKey(key) && !options.isNull(key)) {
+      options.getString(key)?.trim()?.takeIf { it.isNotEmpty() }
+    } else {
+      null
+    }
+}

--- a/android/src/main/java/com/sherpaonnx/vad/facade/SherpaOnnxVadHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/vad/facade/SherpaOnnxVadHelper.kt
@@ -9,6 +9,8 @@ import com.sherpaonnx.audio.pipeline.PipelineAudioRegistry
 import com.sherpaonnx.audio.pipeline.StreamingPipelineRegistry
 import com.sherpaonnx.segment.pipeline.SegmentRecord
 import com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry
+import com.sherpaonnx.detect.ModelPathValidationNative
+import com.sherpaonnx.vad.config.VadInitOptionsParser
 import com.sherpaonnx.vad.core.VadErrorCodes
 import com.sherpaonnx.vad.core.VadInstanceConfig
 import com.sherpaonnx.vad.core.VadRuntimeOptions
@@ -129,96 +131,147 @@ class SherpaOnnxVadHelper(
       promise.reject(VadErrorCodes.INVALID_ARGUMENT, "instanceId is required")
       return
     }
-    val sampleRate = options?.takeIf { it.hasKey("sampleRate") && !it.isNull("sampleRate") }?.getDouble("sampleRate")?.toInt()
-      ?: 16000
-    val threshold = options?.takeIf { it.hasKey("threshold") && !it.isNull("threshold") }?.getDouble("threshold")
-    val minSpeech = options?.takeIf { it.hasKey("minSpeechDurationMs") && !it.isNull("minSpeechDurationMs") }?.getDouble("minSpeechDurationMs")?.toInt()
-      ?: options?.takeIf { it.hasKey("speechDurationMs") && !it.isNull("speechDurationMs") }?.getDouble("speechDurationMs")?.toInt()
-      ?: 250
-    val minSilence = options?.takeIf { it.hasKey("silenceDurationMs") && !it.isNull("silenceDurationMs") }?.getDouble("silenceDurationMs")?.toInt()
-      ?: 250
-    val windowSize = options?.takeIf { it.hasKey("windowSize") && !it.isNull("windowSize") }?.getDouble("windowSize")?.toInt()
-    val maxSpeechDurationMs = options
-      ?.takeIf { it.hasKey("maxSpeechDurationS") && !it.isNull("maxSpeechDurationS") }
-      ?.getDouble("maxSpeechDurationS")
-      ?.times(1000.0)
-      ?.toInt()
-    val provider = options?.takeIf { it.hasKey("provider") && !it.isNull("provider") }?.getString("provider")
-      ?: "cpu"
-    val numThreads = options?.takeIf { it.hasKey("numThreads") && !it.isNull("numThreads") }?.getDouble("numThreads")?.toInt()
-      ?: 1
-    val debug = options?.takeIf { it.hasKey("debug") && !it.isNull("debug") }?.getBoolean("debug") ?: false
-    val modelDir = options?.takeIf { it.hasKey("modelDir") && !it.isNull("modelDir") }?.getString("modelDir")
-    val requestedModelType = options?.takeIf { it.hasKey("modelType") && !it.isNull("modelType") }?.getString("modelType")
-      ?: "auto"
-    if (modelDir.isNullOrBlank()) {
-      promise.reject(VadErrorCodes.MODEL_INIT_FAILED, "modelDir is required for VAD initialization")
+    val parsed = VadInitOptionsParser.parse(options)
+    if (parsed == null) {
+      promise.reject(
+        VadErrorCodes.MODEL_INIT_FAILED,
+        if (options?.hasKey("initMode") == true && options.getString("initMode") == "custom") {
+          "custom init requires initMode, modelType, and modelPaths"
+        } else {
+          "auto init requires modelDir"
+        }
+      )
       return
     }
     try {
-      val detect = nativeDetectVadModel(modelDir, null, requestedModelType)
-      val ok = detect?.get("success") as? Boolean ?: false
-      if (!ok) {
-        val reason = detect?.get("error") as? String ?: "Failed to detect VAD model"
-        promise.reject(VadErrorCodes.MODEL_INIT_FAILED, reason)
-        return
+      if (parsed.initMode == "custom") {
+        initializeVadCustom(instanceId, parsed, promise)
+      } else {
+        initializeVadAuto(instanceId, parsed, promise)
       }
-      val resolvedModelType = (detect["modelType"] as? String)?.trim().orEmpty()
-      if (resolvedModelType != "silero_vad" && resolvedModelType != "ten_vad") {
-        promise.reject(
-          VadErrorCodes.MODEL_INIT_FAILED,
-          "Unsupported VAD model type: $resolvedModelType",
-        )
-        return
-      }
-      @Suppress("UNCHECKED_CAST")
-      val detectedPaths = detect["paths"] as? HashMap<String, Any?>
-      val modelPath = (detectedPaths?.get("model") as? String)?.takeIf { it.isNotBlank() } ?: modelDir
-      val baseRuntime = defaultRuntimeOptions(resolvedModelType)
-      val runtimeOptions = withRuntimeOverrides(
-        base = baseRuntime,
-        scoreThreshold = threshold,
-        minSpeechDurationMs = minSpeech,
-        minSilenceDurationMs = minSilence,
-        windowSize = windowSize,
-        maxSpeechDurationMs = maxSpeechDurationMs,
-      )
-      // Enforce strict model/options pairing.
-      val strictRuntimeOptions = when (resolvedModelType) {
-        "silero_vad" -> (runtimeOptions as? VadRuntimeOptions.Silero)
-        "ten_vad" -> (runtimeOptions as? VadRuntimeOptions.Ten)
-        else -> null
-      }
-      if (strictRuntimeOptions == null) {
-        promise.reject(
-          VadErrorCodes.MODEL_INIT_FAILED,
-          "VAD runtime options mismatch for model type: $resolvedModelType",
-        )
-        return
-      }
-      val runtime = createVadRuntime(
-        modelType = resolvedModelType,
-        modelPath = modelPath,
-        sampleRate = sampleRate,
-        provider = provider,
-        numThreads = numThreads,
-        debug = debug,
-        runtimeOptions = strictRuntimeOptions,
-      )
-      instances[instanceId] = VadInstanceConfig(
-        modelType = resolvedModelType,
-        modelDir = modelDir,
-        sampleRate = sampleRate,
-        provider = provider,
-        numThreads = numThreads,
-        debug = debug,
-        runtimeOptions = strictRuntimeOptions,
-        runtime = runtime,
-      )
-      promise.resolve(null)
     } catch (e: Exception) {
       promise.reject(VadErrorCodes.MODEL_INIT_FAILED, "Failed to initialize VAD runtime: ${e.message}", e)
     }
+  }
+
+  private fun initializeVadCustom(
+    instanceId: String,
+    parsed: VadInitOptionsParser.Parsed,
+    promise: Promise,
+  ) {
+    val modelTypeStr = parsed.modelType.trim()
+    if (modelTypeStr.isEmpty() || modelTypeStr == "auto") {
+      promise.reject(VadErrorCodes.MODEL_INIT_FAILED, "custom init requires a concrete modelType")
+      return
+    }
+    if (modelTypeStr != "silero_vad" && modelTypeStr != "ten_vad") {
+      promise.reject(
+        VadErrorCodes.MODEL_INIT_FAILED,
+        "Unsupported VAD model type: $modelTypeStr",
+      )
+      return
+    }
+
+    val pathStrings = parsed.modelPaths.orEmpty()
+    ModelPathValidationNative.validate("vad", modelTypeStr, pathStrings)?.let { errorMsg ->
+      promise.reject(VadErrorCodes.MODEL_INIT_FAILED, errorMsg)
+      return
+    }
+
+    val modelPath = pathStrings["model"].orEmpty()
+    finishInitializeWithModelPath(
+      instanceId = instanceId,
+      modelDir = "custom",
+      resolvedModelType = modelTypeStr,
+      modelPath = modelPath,
+      parsed = parsed,
+      promise = promise,
+    )
+  }
+
+  private fun initializeVadAuto(
+    instanceId: String,
+    parsed: VadInitOptionsParser.Parsed,
+    promise: Promise,
+  ) {
+    val modelDir = parsed.modelDir.orEmpty()
+    val detect = nativeDetectVadModel(modelDir, null, parsed.modelType)
+    val ok = detect?.get("success") as? Boolean ?: false
+    if (!ok) {
+      val reason = detect?.get("error") as? String ?: "Failed to detect VAD model"
+      promise.reject(VadErrorCodes.MODEL_INIT_FAILED, reason)
+      return
+    }
+    val resolvedModelType = (detect["modelType"] as? String)?.trim().orEmpty()
+    if (resolvedModelType != "silero_vad" && resolvedModelType != "ten_vad") {
+      promise.reject(
+        VadErrorCodes.MODEL_INIT_FAILED,
+        "Unsupported VAD model type: $resolvedModelType",
+      )
+      return
+    }
+    @Suppress("UNCHECKED_CAST")
+    val detectedPaths = detect["paths"] as? HashMap<String, Any?>
+    val modelPath = (detectedPaths?.get("model") as? String)?.takeIf { it.isNotBlank() } ?: modelDir
+    finishInitializeWithModelPath(
+      instanceId = instanceId,
+      modelDir = modelDir,
+      resolvedModelType = resolvedModelType,
+      modelPath = modelPath,
+      parsed = parsed,
+      promise = promise,
+    )
+  }
+
+  private fun finishInitializeWithModelPath(
+    instanceId: String,
+    modelDir: String,
+    resolvedModelType: String,
+    modelPath: String,
+    parsed: VadInitOptionsParser.Parsed,
+    promise: Promise,
+  ) {
+    val baseRuntime = defaultRuntimeOptions(resolvedModelType)
+    val runtimeOptions = withRuntimeOverrides(
+      base = baseRuntime,
+      scoreThreshold = parsed.threshold,
+      minSpeechDurationMs = parsed.minSpeechDurationMs,
+      minSilenceDurationMs = parsed.minSilenceDurationMs,
+      windowSize = parsed.windowSize,
+      maxSpeechDurationMs = parsed.maxSpeechDurationMs,
+    )
+    val strictRuntimeOptions = when (resolvedModelType) {
+      "silero_vad" -> (runtimeOptions as? VadRuntimeOptions.Silero)
+      "ten_vad" -> (runtimeOptions as? VadRuntimeOptions.Ten)
+      else -> null
+    }
+    if (strictRuntimeOptions == null) {
+      promise.reject(
+        VadErrorCodes.MODEL_INIT_FAILED,
+        "VAD runtime options mismatch for model type: $resolvedModelType",
+      )
+      return
+    }
+    val runtime = createVadRuntime(
+      modelType = resolvedModelType,
+      modelPath = modelPath,
+      sampleRate = parsed.sampleRate,
+      provider = parsed.provider,
+      numThreads = parsed.numThreads,
+      debug = parsed.debug,
+      runtimeOptions = strictRuntimeOptions,
+    )
+    instances[instanceId] = VadInstanceConfig(
+      modelType = resolvedModelType,
+      modelDir = modelDir,
+      sampleRate = parsed.sampleRate,
+      provider = parsed.provider,
+      numThreads = parsed.numThreads,
+      debug = parsed.debug,
+      runtimeOptions = strictRuntimeOptions,
+      runtime = runtime,
+    )
+    promise.resolve(null)
   }
 
   fun startVadPipeline(instanceId: String, audioInBufferId: String, segmentOutBufferId: String, options: ReadableMap?, promise: Promise) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # react-native-sherpa-onnx — Documentation Index
 
-> For installation and a feature overview, start at the [root README](../README.md).
+> For installation and a feature overview, start at the [root README](../README.md).  
+> **New to models?** Follow the [How to start](../README.md#how-to-start) reading path under Feature Support in the root README.
 
 This index maps every user-facing guide to its canonical file. Internal and migration docs live in separate sub-folders and are **not** listed here.
 
@@ -12,10 +13,10 @@ This index maps every user-facing guide to its canonical file. Internal and migr
 |-------|-------------|
 | [memory-and-models.md](./memory-and-models.md) | OOM awareness, model sizing, concurrent engine budgets, buffer planning |
 | [feature-pipelines.md](./feature-pipelines.md) | Named end-to-end pipeline recipes across offline/streaming features |
-| [model-setup.md](./model-setup.md) | Bundled assets, model discovery APIs, path helpers, troubleshooting |
+| [model-setup.md](./model-setup.md) | `FileSource`, bundled/PAD/downloaded paths, discovery APIs, expected folder layouts |
 | [model-delivery-pad-odr.md](./model-delivery-pad-odr.md) | Ship models: PAD (install-time / fast-follow / on-demand) & iOS ODR / bundle |
-| [model-detect.md](./model-detect.md) | Unified `detectModel` / `detectModelsBatch`, inputs, QNN, vs feature `detect*Model` |
-| [model-languages.md](./model-languages.md) | Language codes and model language support |
+| [model-detect.md](./model-detect.md) | Detection (cheap preflight), init modes (auto vs custom), validation, unified vs feature detect |
+| [model-languages.md](./model-languages.md) | Language tables and hints for picker UI / `modelOptions` |
 | [execution-providers.md](./execution-providers.md) | CPU, NNAPI, XNNPACK, Core ML, QNN |
 | [streaming-pipelines-overview.md](./streaming-pipelines-overview.md) | Shared streaming pipeline lifecycle — handles (`stop` / `flush` / …), registry, buffer finalization |
 | [native-diagnostics.md](./native-diagnostics.md) | Native crash ring buffer, signal-handler dumps (`SherpaNativeDiag`), snapshot API |

--- a/docs/alignment-offline.md
+++ b/docs/alignment-offline.md
@@ -140,6 +140,48 @@ const write = await engine.alignTextToAudio(textBuf, audioBuf, segmentOut, {
 });
 ```
 
+## Custom model path (`initMode: 'custom'`)
+
+Alignment has **no** TurboModule engine init — `createAlignment()` stays lightweight. Custom paths apply **per accurate call** on `engine.alignTextToAudio(..., { mode: 'accurate', ... })` only (plain accurate, `asr_mediated`, and `chunked_forced_ctc`). Proportional, estimated, and `vad` modes do not load a wav2vec2 model.
+
+Use custom paths when the wav2vec2 ONNX is **not** in a detectable folder layout (non-standard name, scattered path, or detection fails but you know the file).
+
+- Set `initMode: 'custom'` and `modelType: 'wav2vec2'` (concrete, not `'auto'`).
+- Pass `customConfig` with a single **`model`** {@link FileSource} pointing at the `.onnx` file.
+- Validation uses native `validate-alignment` (key `model` for `wav2vec2`). See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
+- Auto mode (default): pass `modelSource` — the SDK runs `detectAlignmentModel` once per call to resolve the ONNX path.
+
+```ts
+await engine.alignTextToAudio(textBuf, audioBuf, segmentOut, {
+  mode: 'accurate',
+  granularity: 'word',
+  initMode: 'custom',
+  modelType: 'wav2vec2',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/wav2vec2-align.onnx' },
+  },
+});
+```
+
+Anchor-constrained accurate modes use the same model union:
+
+```ts
+await engine.alignTextToAudio(textBuf, audioBuf, segmentOut, {
+  mode: 'accurate',
+  granularity: 'word',
+  initMode: 'custom',
+  modelType: 'wav2vec2',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/wav2vec2-align.onnx' },
+  },
+  segmentation: {
+    mode: 'auto',
+    anchorSegmentBuffer: anchorBufferId,
+    mappingStrategy: 'chunked_forced_ctc',
+  },
+});
+```
+
 ### `vad` (standalone)
 
 ```ts

--- a/docs/alignment-offline.md
+++ b/docs/alignment-offline.md
@@ -1,12 +1,17 @@
 # AlignmentEngine (buffer-first)
 
-Alignment is offline and buffer-first:
-- input transcript from `OfflineTextBuffer`
-- input waveform from `OfflineAudioBuffer`
-- output written into a caller-provided `OfflineSegmentBuffer` as `kind: 'alignment'`
+## Introduction
 
-Use `createAlignment()` and `engine.alignTextToAudio(...)`.
-The freestanding public `alignTextToAudio` symbol is removed (hard cut).
+Offline forced alignment with a **buffer-first** API.
+
+| Role | Type | Notes |
+| --- | --- | --- |
+| **Input (text)** | [`OfflineTextBuffer`](textbuffer-offline.md) | Reference transcript |
+| **Input (audio)** | [`OfflineAudioBuffer`](audiobuffer-offline.md) | Waveform to align against |
+| **Output** | [`OfflineSegmentBuffer`](segmentbuffer-offline.md) | Caller-provided buffer; segments written with `kind: 'alignment'` |
+| **Engine** | `AlignmentEngine` via `createAlignment` | `alignTextToAudio(textIn, audioIn, segmentOut, options)` |
+
+Import path: `react-native-sherpa-onnx/alignment`
 
 ## Modes
 
@@ -140,47 +145,7 @@ const write = await engine.alignTextToAudio(textBuf, audioBuf, segmentOut, {
 });
 ```
 
-## Custom model path (`initMode: 'custom'`)
-
-Alignment has **no** TurboModule engine init — `createAlignment()` stays lightweight. Custom paths apply **per accurate call** on `engine.alignTextToAudio(..., { mode: 'accurate', ... })` only (plain accurate, `asr_mediated`, and `chunked_forced_ctc`). Proportional, estimated, and `vad` modes do not load a wav2vec2 model.
-
-Use custom paths when the wav2vec2 ONNX is **not** in a detectable folder layout (non-standard name, scattered path, or detection fails but you know the file).
-
-- Set `initMode: 'custom'` and `modelType: 'wav2vec2'` (concrete, not `'auto'`).
-- Pass `customConfig` with a single **`model`** {@link FileSource} pointing at the `.onnx` file.
-- Validation uses native `validate-alignment` (key `model` for `wav2vec2`). See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
-- Auto mode (default): pass `modelSource` — the SDK runs `detectAlignmentModel` once per call to resolve the ONNX path.
-
-```ts
-await engine.alignTextToAudio(textBuf, audioBuf, segmentOut, {
-  mode: 'accurate',
-  granularity: 'word',
-  initMode: 'custom',
-  modelType: 'wav2vec2',
-  customConfig: {
-    model: { kind: 'fs', path: '/data/models/wav2vec2-align.onnx' },
-  },
-});
-```
-
-Anchor-constrained accurate modes use the same model union:
-
-```ts
-await engine.alignTextToAudio(textBuf, audioBuf, segmentOut, {
-  mode: 'accurate',
-  granularity: 'word',
-  initMode: 'custom',
-  modelType: 'wav2vec2',
-  customConfig: {
-    model: { kind: 'fs', path: '/data/models/wav2vec2-align.onnx' },
-  },
-  segmentation: {
-    mode: 'auto',
-    anchorSegmentBuffer: anchorBufferId,
-    mappingStrategy: 'chunked_forced_ctc',
-  },
-});
-```
+## Mode examples
 
 ### `vad` (standalone)
 
@@ -308,12 +273,6 @@ const subtitleRows = alignmentSegments.map((segment) => ({
 }));
 ```
 
-## Model detection
-
-Unified cross-feature detection: [model-detect.md](model-detect.md).
-
-`detectAlignmentModel` checks wav2vec2 alignment packs before `createAlignment` or per-call `modelSource` in `accurate` mode. See [`detectAlignmentModel`](#detectalignmentmodelsource-options) below.
-
 ## API reference
 
 ### `createAlignment(options?)`
@@ -350,6 +309,36 @@ function assertAlignmentGranularityForMode(
   mode: 'proportional' | 'estimated' | 'aligned' | 'vad' | 'off' ,
   granularity: AlignmentGranularity
 ): void;
+```
+
+## Validation required files
+
+| `modelType` | Required files | Optional | Custom-init keys |
+| --- | --- | --- | --- |
+| `wav2vec2` | `*.onnx` (alignment CTC model) | — | `model` |
+
+## Model detection
+
+`detectAlignmentModel` checks wav2vec2 packs before accurate alignment. Unified catalog: [model-detect.md](model-detect.md). Auto mode (default): pass `modelSource` — the SDK runs `detectAlignmentModel` per call.
+
+## Custom model path (`initMode: 'custom'`)
+
+Per-call custom path on `alignTextToAudio` — **no engine init**. Applies to **`mode: 'accurate'`** only. Concept: [model-detect.md — Init modes](model-detect.md#init-modes-auto-vs-custom).
+
+| `modelType` | Custom-init keys |
+| --- | --- |
+| `wav2vec2` | `model` |
+
+```ts
+await engine.alignTextToAudio(textBuf, audioBuf, segmentOut, {
+  mode: 'accurate',
+  granularity: 'word',
+  initMode: 'custom',
+  modelType: 'wav2vec2',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/wav2vec2-align.onnx' },
+  },
+});
 ```
 
 ## Pipeline composition

--- a/docs/enhancement-offline.md
+++ b/docs/enhancement-offline.md
@@ -2,81 +2,21 @@
 
 ## Introduction
 
-On-device batch speech denoising with a **pipeline-first** API:
+On-device batch speech denoising with a **pipeline-first** API.
 
-- **Input:** offline pipeline audio buffer ([`audiobuffer` — offline](audiobuffer-offline.md)) — populated noisy PCM (file-backed or in-memory).
-- **Output:** offline pipeline audio buffer ([`audiobuffer` — offline](audiobuffer-offline.md)) — empty buffer at the denoiser sample rate (`createEmptyOfflineAudioBuffer`); **`enhance`** writes denoised PCM once.
-- **Engine:** `createEnhancement` exposes **`enhance(audioIn, audioOut, options?)`** (plus `getSampleRate` / `destroy`). `enhance` returns an `EnhancementResult` (`status`, segment counters, timing) while denoised PCM is read from **`audioOut`**.
+| Role | Type | Notes |
+| --- | --- | --- |
+| **Input** | [`OfflineAudioBuffer`](audiobuffer-offline.md) | Populated noisy PCM (file-backed or in-memory) |
+| **Output** | [`OfflineAudioBuffer`](audiobuffer-offline.md) | Empty buffer at denoiser sample rate (`createEmptyOfflineAudioBuffer`); `enhance` writes denoised PCM once |
+| **Engine** | `EnhancementEngine` via `createEnhancement` | `enhance(audioIn, audioOut, options?)`, `getSampleRate`, `destroy`; returns `EnhancementResult` with segment stats |
 
 Import path: `react-native-sherpa-onnx/enhancement`
 
-For **streaming** enhancement (`LiveAudioBuffer` → `LiveAudioBuffer` via **`enhance`**), see [Speech enhancement (streaming)](enhancement-streaming.md).
+For **streaming** enhancement (`LiveAudioBuffer` → `LiveAudioBuffer`), see [Speech enhancement (streaming)](enhancement-streaming.md).
 
 For **offline STT / TTS / alignment** composition with pipeline buffers, see [stt-offline.md](stt-offline.md), [tts-offline.md](tts-offline.md), and [alignment-offline.md](alignment-offline.md).
 
 If the enhancement model rate is not `16000`, set `targetSampleRateHz` (or offline buffer `sampleRate` from `getSampleRate()`) explicitly to the model rate.
-
-## Models and paths
-
-- **`FileSource`:** `{ kind: 'fs' | 'app' | 'contentUri' | 'securityScoped' | 'pad', ... }` (from `react-native-sherpa-onnx`) — used by all detect functions.
-- In-app downloads: [download-manager.md](download-manager.md) with category **`ModelCategory.Enhancement`** (when exposed in your app catalog).
-- Model detection without loading the denoiser: **`detectEnhancementModel(...)`**.
-- File expectations per family: [model-setup.md](model-setup.md) where applicable.
-
----
-
-## Model detection
-
-Unified cross-feature detection: [model-detect.md](model-detect.md). Below, enhancement-specific rules for **`detectEnhancementModel`**.
-
-`detectEnhancementModel` does **not** load the denoiser — use it as a **pre-check** before **`createEnhancement`** (same idea as `detectTtsModel` / `detectSttModel`).
-
-**Rules (directory scan):**
-
-- Recursively finds `.onnx` under the resolved model directory (depth 4, same family as other detectors).
-- Filename / path contains `gtcrn` → candidate **`gtcrn`**; contains `dpdfnet` or `dpcrn` → candidate **`dpdfnet`**.
-- **`modelType: 'auto'`** (default): prefers **`gtcrn`** if both ONNX stacks are present, else **`dpdfnet`**.
-- **`assetName`:** optional. If omitted, native catalog hints use the **last segment** of `modelSource.path` (with common archive suffixes stripped). If set, that string wins for **`languages`** / **`quantization`** when both directory and asset id are passed to native.
-
-**`detectionSources`:** optional ordered trace (`fileListing`, `dirName`, `fallbackOrder`, `explicitModelType`, `nameOnly`). **`nameOnly`** means no file list was scanned — see native `error` when `success` is false.
-
----
-
-## Custom initialization (`initMode: 'custom'`)
-
-Use custom init when the enhancement ONNX file is **not** in a detectable folder layout (non-standard name, scattered path, or detection fails but you know the family).
-
-- Set `initMode: 'custom'` and a concrete `modelType` (`gtcrn` or `dpdfnet`, not `'auto'`).
-- Pass `customConfig` with a single **`model`** {@link FileSource} pointing at the `.onnx` file.
-- Validation uses native `validate-enhancement` (same `model` key for both families). See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
-- `numThreads`, `provider`, and `debug` work the same as auto mode.
-
-```ts
-import { createEnhancement } from 'react-native-sherpa-onnx/enhancement';
-
-const enhancement = await createEnhancement({
-  initMode: 'custom',
-  modelType: 'gtcrn',
-  customConfig: {
-    model: { kind: 'fs', path: '/data/models/gtcrn.onnx' },
-  },
-  numThreads: 2,
-});
-```
-
-DPCRN / DPDFNet example:
-
-```ts
-const enhancement = await createEnhancement({
-  initMode: 'custom',
-  modelType: 'dpdfnet',
-  customConfig: {
-    model: { kind: 'fs', path: '/data/models/dpdfnet.onnx' },
-  },
-});
-```
-
----
 
 ## Quick start
 
@@ -129,26 +69,6 @@ try {
   await enhancement.destroy();
 }
 ```
-
----
-
-## Data model and lifetime
-
-| Item | Behaviour |
-| --- | --- |
-| **Offline engine** | Created with **`createEnhancement`**. Holds native **`OfflineSpeechDenoiser`**. Call **`destroy()`** when done. |
-| **`OfflineAudioBuffer` (input)** | Populated buffer from file, samples, or live snapshot. Read-only during enhancement. |
-| **`OfflineAudioBuffer` (output)** | Empty buffer created at the denoiser's sample rate. Filled exactly once by **`enhance()`**. Inspect via **`getPipelineAudioBufferInfo()`**, persist via `saveAudioAsFile(...)`. |
-
----
-
-## Setup (iOS and Android)
-
-| Topic | Requirement |
-| --- | --- |
-| Execution provider | Optional **`provider`** on init; see [execution-providers.md](execution-providers.md) |
-| Input format | Any format supported by **`createOfflineAudioBufferFromFile()`** (WAV, etc.) |
-| Instance lifetime | Always **`destroy()`** the offline engine; **`releasePipelineAudioBuffer()`** on created buffers |
 
 ---
 
@@ -295,6 +215,55 @@ import { saveAudioAsFile } from 'react-native-sherpa-onnx/audio';
 ```
 
 See [audiobuffer — offline](audiobuffer-offline.md) and [audiobuffer — live / streaming](audiobuffer-streaming.md).
+
+### Buffer data model and lifetime
+
+| Item | Behaviour |
+| --- | --- |
+| **Offline engine** | Created with **`createEnhancement`**. Holds native **`OfflineSpeechDenoiser`**. Call **`destroy()`** when done. |
+| **`OfflineAudioBuffer` (input)** | Populated buffer from file, samples, or live snapshot. Read-only during enhancement. |
+| **`OfflineAudioBuffer` (output)** | Empty buffer created at the denoiser's sample rate. Filled exactly once by **`enhance()`**. Inspect via **`getPipelineAudioBufferInfo()`**, persist via `saveAudioAsFile(...)`. |
+
+## Models and paths
+
+- **`FileSource`** — [model-setup.md](model-setup.md)
+- **Detection & init** — [model-detect.md](model-detect.md)
+- Downloads: [download-manager.md](download-manager.md) · `ModelCategory.Enhancement`
+
+## Validation required files
+
+| `modelType` | Required files | Optional | Custom-init keys |
+| --- | --- | --- | --- |
+| `gtcrn` | `*.onnx` (filename/path contains `gtcrn`) | — | `model` |
+| `dpdfnet` | `*.onnx` (contains `dpdfnet` or `dpcrn`) | — | `model` |
+
+Auto mode prefers `gtcrn` when both ONNX stacks are present.
+
+## Model detection
+
+`detectEnhancementModel` is a pre-check before `createEnhancement` — no denoiser load. Unified catalog: [model-detect.md](model-detect.md).
+
+Filename rules: recursive `.onnx` scan (depth 4); `gtcrn` in path → `gtcrn`; `dpdfnet`/`dpcrn` → `dpdfnet`. Optional `assetName` for catalog hints.
+
+## Custom initialization (`initMode: 'custom'`)
+
+Concept: [model-detect.md — Init modes](model-detect.md#init-modes-auto-vs-custom).
+
+| `modelType` | Custom-init keys |
+| --- | --- |
+| `gtcrn`, `dpdfnet` | `model` |
+
+```ts
+import { createEnhancement } from 'react-native-sherpa-onnx/enhancement';
+
+const enhancement = await createEnhancement({
+  initMode: 'custom',
+  modelType: 'gtcrn',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/gtcrn.onnx' },
+  },
+});
+```
 
 ## Segmentation
 

--- a/docs/enhancement-offline.md
+++ b/docs/enhancement-offline.md
@@ -101,7 +101,7 @@ const det = await detectEnhancementModel(
   { kind: 'fs', path: '/absolute/path/to/sherpa-onnx-speech-enhancement-gtcrn' },
   { modelType: 'auto' }
 );
-console.log(det.success, det.modelType, det.isStreaming, det.detectedModels);
+console.log(det.success, det.modelType, det.isStreaming, det.paths?.model, det.detectedModels);
 ```
 
 ```ts
@@ -242,6 +242,8 @@ Auto mode prefers `gtcrn` when both ONNX stacks are present.
 ## Model detection
 
 `detectEnhancementModel` is a pre-check before `createEnhancement` — no denoiser load. Unified catalog: [model-detect.md](model-detect.md).
+
+On filesystem-backed detection, the result includes `paths.model` (resolved `.onnx` file) when native file listing finds one. Name-only heuristics may omit `paths`.
 
 Filename rules: recursive `.onnx` scan (depth 4); `gtcrn` in path → `gtcrn`; `dpdfnet`/`dpcrn` → `dpdfnet`. Optional `assetName` for catalog hints.
 

--- a/docs/enhancement-offline.md
+++ b/docs/enhancement-offline.md
@@ -42,6 +42,42 @@ Unified cross-feature detection: [model-detect.md](model-detect.md). Below, enha
 
 ---
 
+## Custom initialization (`initMode: 'custom'`)
+
+Use custom init when the enhancement ONNX file is **not** in a detectable folder layout (non-standard name, scattered path, or detection fails but you know the family).
+
+- Set `initMode: 'custom'` and a concrete `modelType` (`gtcrn` or `dpdfnet`, not `'auto'`).
+- Pass `customConfig` with a single **`model`** {@link FileSource} pointing at the `.onnx` file.
+- Validation uses native `validate-enhancement` (same `model` key for both families). See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
+- `numThreads`, `provider`, and `debug` work the same as auto mode.
+
+```ts
+import { createEnhancement } from 'react-native-sherpa-onnx/enhancement';
+
+const enhancement = await createEnhancement({
+  initMode: 'custom',
+  modelType: 'gtcrn',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/gtcrn.onnx' },
+  },
+  numThreads: 2,
+});
+```
+
+DPCRN / DPDFNet example:
+
+```ts
+const enhancement = await createEnhancement({
+  initMode: 'custom',
+  modelType: 'dpdfnet',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/dpdfnet.onnx' },
+  },
+});
+```
+
+---
+
 ## Quick start
 
 All buffer parameters accept refs directly. Raw string ids are optional; malformed ids are rejected early with `AUDIO_INVALID_ARGUMENT`.

--- a/docs/enhancement-streaming.md
+++ b/docs/enhancement-streaming.md
@@ -46,6 +46,25 @@ Unified cross-feature detection: [model-detect.md](model-detect.md). Below, enha
 
 ---
 
+## Custom initialization (`initMode: 'custom'`)
+
+Streaming enhancement uses the same init union as offline — `createStreamingEnhancement` accepts `initMode: 'custom'` with a concrete `modelType` and a single `model` path in `customConfig`. See [Speech enhancement (offline) — Custom initialization](enhancement-offline.md#custom-initialization-initmode-custom) for path keys and validation rules.
+
+```ts
+import { createStreamingEnhancement } from 'react-native-sherpa-onnx/enhancement';
+
+const denoiser = await createStreamingEnhancement({
+  initMode: 'custom',
+  modelType: 'gtcrn',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/gtcrn.onnx' },
+  },
+  numThreads: 2,
+});
+```
+
+---
+
 ## Quick start
 
 All buffer parameters accept refs directly. Raw string ids are optional; malformed ids are rejected early with `AUDIO_INVALID_ARGUMENT`.

--- a/docs/enhancement-streaming.md
+++ b/docs/enhancement-streaming.md
@@ -99,7 +99,7 @@ const det = await detectEnhancementModel(
   { kind: 'fs', path: '/absolute/path/to/sherpa-onnx-speech-enhancement-gtcrn' },
   { modelType: 'auto' }
 );
-console.log(det.success, det.modelType, det.detectedModels);
+console.log(det.success, det.modelType, det.paths?.model, det.detectedModels);
 ```
 
 ```ts

--- a/docs/enhancement-streaming.md
+++ b/docs/enhancement-streaming.md
@@ -2,15 +2,19 @@
 
 ## Introduction
 
-On-device streaming speech denoising with a **pipeline-first** API:
+On-device streaming speech denoising with a **pipeline-first** API.
 
-- **Input:** live pipeline audio buffer ([`audiobuffer` — live / streaming](audiobuffer-streaming.md)) — ring/spool buffer the denoiser **drains** (mic, append, or upstream native pipeline).
-- **Output:** live pipeline audio buffer ([`audiobuffer` — live / streaming](audiobuffer-streaming.md)) — separate live buffer; native worker **appends** denoised PCM (`source: "enhancement"` on append events).
-- **Engine:** `createStreamingEnhancement` exposes **`enhance(audioIn, audioOut)`** → `Promise<EnhancementPipelineHandle>` (plus `getSampleRate` / `getFrameShiftInSamples` / `destroy`). There is **no** JS API to push raw sample arrays into the online denoiser; control the running worker via **`EnhancementPipelineHandle`** (`flush`, `stop`, `reset`, `getStatus`). In this guide **`denoiser`** means the returned `StreamingEnhancementEngine` and **`pipeline`** means that handle.
+| Role | Type | Notes |
+| --- | --- | --- |
+| **Input** | [`LiveAudioBuffer`](audiobuffer-streaming.md) | Ring/spool buffer the denoiser drains (mic, append, or upstream pipeline) |
+| **Output** | [`LiveAudioBuffer`](audiobuffer-streaming.md) | Separate live buffer; native worker appends denoised PCM |
+| **Engine** | `StreamingEnhancementEngine` via `createStreamingEnhancement` | `enhance(audioIn, audioOut)` returns `EnhancementPipelineHandle` (`flush`, `stop`, `reset`, `getStatus`, `completed`) |
 
 Import path: `react-native-sherpa-onnx/enhancement`
 
-For **offline batch** enhancement (`OfflineAudioBuffer` → `OfflineAudioBuffer`), see [Speech enhancement (offline)](enhancement-offline.md).
+In this guide **`denoiser`** means the `StreamingEnhancementEngine` and **`pipeline`** means the `EnhancementPipelineHandle`.
+
+For **offline batch** enhancement, see [Speech enhancement (offline)](enhancement-offline.md).
 
 For **offline STT / TTS / alignment** composition with pipeline buffers, see [stt-offline.md](stt-offline.md), [tts-offline.md](tts-offline.md), and [alignment-offline.md](alignment-offline.md).
 
@@ -18,52 +22,7 @@ If the enhancement model rate is not `16000`, set live buffer `sampleRate` (or i
 
 ## Streaming pipeline system
 
-`enhance` registers a **native worker** that drains **`inputBuf`** in frame-sized steps and appends denoised PCM to **`outputBuf`**. There is no JS API to push samples into the denoiser directly — only buffer producers and the **`EnhancementPipelineHandle`**. Shared semantics of **`stop` / `flush` / `reset` / `getStatus` / `completed`** are described in **[Streaming pipelines — shared lifecycle](streaming-pipelines-overview.md)**. **Streaming enhancement** is special in that **finalizing the live input audio buffer** normally causes the worker to **auto-flush and stop**; explicit `flush()` is still available for mid-run tail flush without stopping.
-
-## Models and paths
-
-- **`FileSource`:** `FileSource` (from `react-native-sherpa-onnx/fileio`, same as STT/TTS).
-- In-app downloads: [download-manager.md](download-manager.md) with category **`ModelCategory.Enhancement`** (when exposed in your app catalog).
-- Model detection without loading the denoiser: **`detectEnhancementModel(...)`** (same rules as offline; see [Model detection](enhancement-offline.md#model-detection) on the offline page for the full rule list).
-- File expectations per family: [model-setup.md](model-setup.md) where applicable.
-
----
-
-## Model detection
-
-Unified cross-feature detection: [model-detect.md](model-detect.md). Below, enhancement-specific rules for **`detectEnhancementModel`**.
-
-`detectEnhancementModel` does **not** load the denoiser — use it as a **pre-check** before **`createStreamingEnhancement`** (same idea as `detectTtsModel` / `detectSttModel`).
-
-**Rules (directory scan):**
-
-- Recursively finds `.onnx` under the resolved model directory (depth 4, same family as other detectors).
-- Filename / path contains `gtcrn` → candidate **`gtcrn`**; contains `dpdfnet` or `dpcrn` → candidate **`dpdfnet`**.
-- **`modelType: 'auto'`** (default): prefers **`gtcrn`** if both ONNX stacks are present, else **`dpdfnet`**.
-- **`assetName`:** optional. If omitted, native catalog hints use the **last segment** of `modelSource.path` (with common archive suffixes stripped). If set, that string wins for **`languages`** / **`quantization`** when both directory and asset id are passed to native.
-
-**`detectionSources`:** optional ordered trace (`fileListing`, `dirName`, `fallbackOrder`, `explicitModelType`, `nameOnly`). **`nameOnly`** means no file list was scanned — see native `error` when `success` is false.
-
----
-
-## Custom initialization (`initMode: 'custom'`)
-
-Streaming enhancement uses the same init union as offline — `createStreamingEnhancement` accepts `initMode: 'custom'` with a concrete `modelType` and a single `model` path in `customConfig`. See [Speech enhancement (offline) — Custom initialization](enhancement-offline.md#custom-initialization-initmode-custom) for path keys and validation rules.
-
-```ts
-import { createStreamingEnhancement } from 'react-native-sherpa-onnx/enhancement';
-
-const denoiser = await createStreamingEnhancement({
-  initMode: 'custom',
-  modelType: 'gtcrn',
-  customConfig: {
-    model: { kind: 'fs', path: '/data/models/gtcrn.onnx' },
-  },
-  numThreads: 2,
-});
-```
-
----
+`enhance` registers a **native worker** that drains **`inputBuf`** in frame-sized steps and appends denoised PCM to **`outputBuf`**. Audio enters via buffer producers (mic, append, upstream pipeline); control the worker through **`EnhancementPipelineHandle`**. Shared semantics of **`stop` / `flush` / `reset` / `getStatus` / `completed`** are described in **[Streaming pipelines — shared lifecycle](streaming-pipelines-overview.md)**. **Streaming enhancement** is special in that **finalizing the live input audio buffer** normally causes the worker to **auto-flush and stop**; explicit `flush()` is still available for mid-run tail flush without stopping.
 
 ## Quick start
 
@@ -114,25 +73,6 @@ await denoiser.destroy();
 ```
 
 The pipeline handle supports **`flush()`** / **`reset()`** / **`getStatus()`** while running. When the input buffer **finalizes**, the worker auto-flushes and stops.
-
----
-
-## Data model and lifetime
-
-| Item | Behaviour |
-| --- | --- |
-| **`StreamingEnhancementEngine`** | From **`createStreamingEnhancement`** (the **denoiser** in examples). **`destroy()`** releases native **`OnlineSpeechDenoiser`**. |
-| **Pipeline handle** | Returned by **`enhance()`** as **`EnhancementPipelineHandle`**. **`stop()`** / **`flush()`** / **`reset()`** / **`getStatus()`**. Registered in **`StreamingPipelineRegistry`**. |
-
----
-
-## Setup (iOS and Android)
-
-| Topic | Requirement |
-| --- | --- |
-| Execution provider | Optional **`provider`** on init; see [execution-providers.md](execution-providers.md) |
-| Live buffers | Float PCM at the **model sample rate**; input/output **`LiveAudioBuffer`** sample rates must match **`getSampleRate()`** |
-| Instance lifetime | **`destroy()`** the denoiser; **`releasePipelineAudioBuffer()`** on buffers; **`pipeline.stop()`** before tearing down buffers |
 
 ---
 
@@ -378,6 +318,44 @@ import {
 ```
 
 See [audiobuffer — live / streaming](audiobuffer-streaming.md) and [audiobuffer — offline](audiobuffer-offline.md).
+
+### Buffer data model and lifetime
+
+| Item | Behaviour |
+| --- | --- |
+| **`StreamingEnhancementEngine`** | From **`createStreamingEnhancement`** (the **denoiser** in examples). **`destroy()`** releases native **`OnlineSpeechDenoiser`**. |
+| **Pipeline handle** | Returned by **`enhance()`** as **`EnhancementPipelineHandle`**. **`stop()`** / **`flush()`** / **`reset()`** / **`getStatus()`**. Registered in **`StreamingPipelineRegistry`**. |
+
+> Input/output **`LiveAudioBuffer`** sample rates must match **`getSampleRate()`** (Float PCM at the model sample rate). Call **`pipeline.stop()`** before tearing down buffers, then **`destroy()`** the denoiser and **`releasePipelineAudioBuffer()`** on buffers.
+
+## Models and paths
+
+- **`FileSource`** — [model-setup.md](model-setup.md)
+- **Detection & init** — [model-detect.md](model-detect.md) · same families as [enhancement-offline](enhancement-offline.md#validation-required-files)
+
+## Validation required files
+
+Same as offline — see [enhancement-offline.md — Validation required files](enhancement-offline.md#validation-required-files).
+
+## Model detection
+
+`detectEnhancementModel` pre-check before `createStreamingEnhancement`. Rules: [enhancement-offline.md — Model detection](enhancement-offline.md#model-detection).
+
+## Custom initialization (`initMode: 'custom'`)
+
+Same init union as offline. Concept: [model-detect.md — Init modes](model-detect.md#init-modes-auto-vs-custom). Keys: [enhancement-offline — Custom init](enhancement-offline.md#custom-initialization-initmode-custom).
+
+```ts
+import { createStreamingEnhancement } from 'react-native-sherpa-onnx/enhancement';
+
+const denoiser = await createStreamingEnhancement({
+  initMode: 'custom',
+  modelType: 'gtcrn',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/gtcrn.onnx' },
+  },
+});
+```
 
 ## Segmentation
 

--- a/docs/model-detect.md
+++ b/docs/model-detect.md
@@ -365,7 +365,7 @@ const r = await detectModel({ kind: 'fs', path: '/path/to/model' });
 if (r.matched) console.log(r.category, r.modelType);
 ```
 
-Single unified detect call after input resolution. Returns compact category/type metadata — no required-file validation.
+Single unified detect call after input resolution. On folder scans, matched results may include `paths`, `detectionSources`, and `detectedModels` when native file-based detection resolves them.
 
 ---
 
@@ -374,15 +374,16 @@ Single unified detect call after input resolution. Returns compact category/type
 ```typescript
 function detectModelsBatch(
   inputs: readonly DetectModelInput[],
-  options?: { concurrency?: number }
+  options?: { concurrency?: number; includePaths?: boolean }
 ): Promise<DetectModelResult[]>;
 ```
 
 ```typescript
 const rows = await detectModelsBatch([{ assetName: 'foo' }, { assetName: 'bar' }], { concurrency: 4 });
+const withPaths = await detectModelsBatch(inputs, { includePaths: true });
 ```
 
-Default concurrency: `8`. One native batch call per chunk. Result order matches input order.
+Default concurrency: `8`. `includePaths` defaults to `false` (omit `paths` from matched batch rows). Single `detectModel` always includes `paths` when present. One native batch call per chunk. Result order matches input order.
 
 ---
 
@@ -498,8 +499,14 @@ type DetectModelResult =
       isStreaming: boolean;
       isHardwareSpecificUnsupported?: boolean;
       supportsQnn?: boolean;
+      /** Non-empty resolved path keys from native folder detection. */
+      paths?: Record<string, string>;
+      detectionSources?: DetectionSource[];
+      detectedModels?: DetectedModelEntry[];
     };
 ```
+
+`paths` uses the same string keys as `validateCustomModelPaths` / custom init (`encoder`, `ttsModel`, `dataDir`, …). Only non-empty values are included.
 
 Name-only input (`{ assetName }`) uses native name heuristics when no listable directory exists.
 

--- a/docs/model-detect.md
+++ b/docs/model-detect.md
@@ -1,104 +1,129 @@
-# Model detection
+# Model detection & initialization
 
-## Introduction
+Inspect model folders, validate required files, and choose how to pass paths to engines — **without loading weights**.
 
-Model detection inspects a **model directory** and/or a **release asset name** to determine **which Sherpa feature owns the pack** (`ModelCategory`) and the **concrete model family** (`modelType`, e.g. `whisper`, `vits`, `silero_vad`). Detection is **stateless**: it does not load recognizers, TTS engines, or other runtime weights.
+| Doc | Question it answers |
+| --- | --- |
+| [model-setup.md](model-setup.md) | Where is my model? How do I build a `FileSource`? |
+| **This page** | What type is this? Is it valid? Auto or custom init? |
+| [model-languages.md](model-languages.md) | Language codes for pickers / `modelOptions` |
 
-Two APIs exist:
+**Import:** `react-native-sherpa-onnx/detect` (unified) · feature packages (`/stt`, `/tts`, `/vad`, …) for feature-specific detect
 
-| API | Import | When to use |
-| --- | --- | --- |
-| **Unified** | `react-native-sherpa-onnx/detect` | Category unknown; catalog / library UX; batch scans (one native call per item in batch) |
-| **Feature-specific** | `react-native-sherpa-onnx/stt`, `/tts`, `/vad`, … | You already know the feature; need full detect payloads (`detectedModels`, `paths`, `detectionSources`, required-file validation) |
+---
 
-Unified detection runs the same native domain detectors as the feature APIs, in a **fixed order** (first hit wins). Feature-specific detectors expose richer results documented on each feature page.
+## Table of contents
 
-## Import path
+- [Why detection exists](#why-detection-exists)
+- [Quick start](#quick-start)
+- [Unified vs feature-specific detection](#unified-vs-feature-specific-detection)
+- [Init modes: auto vs custom](#init-modes-auto-vs-custom)
+- [Custom path validation](#custom-path-validation)
+- [Required files per feature](#required-files-per-feature)
+- [Unified detector order](#unified-detector-order)
+- [QNN and ModelCategory](#qnn-and-modelcategory)
+- [API reference](#api-reference)
+- [Feature-specific detect APIs](#feature-specific-detect-apis)
+- [See also](#see-also)
 
-```ts
-import {
-  detectModel,
-  detectModelsBatch,
-  detectModelResultMatchesCategory,
-  isQnnModelName,
-  resolveFileSourceForDetect,
-  type DetectModelInput,
-  type DetectModelResult,
-} from 'react-native-sherpa-onnx/detect';
+---
+
+## Why detection exists
+
+`detect*Model` functions answer three questions **before** you pay for engine init:
+
+1. **What model family is this?** (`modelType` — e.g. `whisper`, `vits`, `silero_vad`)
+2. **Are the required files present?** (`success` / `error`, missing-file messages)
+3. **What else can I show in UI?** (languages, quantization, streaming hint, lexicon list)
+
+```mermaid
+flowchart LR
+  folder["Model folder\nFileSource"]
+  detect["detectSttModel\n(cheap preflight)"]
+  init["createSTT\n(loads weights)"]
+
+  folder --> detect
+  detect -->|"success: true"| init
+  detect -->|"success: false"| error["Show error\nno allocation"]
 ```
 
-`react-native-sherpa-onnx/download` still re-exports the unified APIs for backward compatibility; prefer `./detect` for new code.
-
-## Models and paths
-
-| Input | Type | Notes |
+| | Detection | Engine init |
 | --- | --- | --- |
-| Filesystem / bundled tree | `FileSource` from `react-native-sherpa-onnx/fileio` | Resolved to `modelDir` + `assetName` via `resolveFileSourceForDetect` |
-| Name-only (no listable dir) | `{ assetName: string; modelDir?: string }` | Heuristics from the asset/folder name; `modelDir` may be `''` |
-| Catalog category filter | `detectModelResultMatchesCategory` | Maps unified results to `ModelCategory` slices (incl. QNN) |
+| Loads ONNX weights | **No** | Yes |
+| Allocates recognizer / TTS / VAD runtime | **No** | Yes |
+| Speed | Fast (file scan + validate) | Slow (ORT session creation) |
+| Returns | `modelType`, `success`, `error`, `paths` | Live engine handle |
+| When to skip | Single known-good bundled pack | Model pickers, downloads, diagnostics |
 
-See also [model-setup.md](model-setup.md), [fileio.md](fileio.md), [download-manager.md](download-manager.md).
+> [!NOTE]
+> **`createSTT({ modelType: 'auto' })` runs the same native auto-selection internally.** You do not *need* a separate detect call for init to work. Use detect when you want to **validate early**, build a model picker, or show errors before allocation.
 
-## When to use unified vs feature-specific detection
-
-| Scenario | Recommended API |
-| --- | --- |
-| Model library row: “what is this download?” | `detectModel` |
-| Scan many repos/folders (HF author test, catalog hints) | `detectModelsBatch` |
-| Filter unified result for download category `Stt` vs `Qnn` | `detectModelResultMatchesCategory` |
-| Before `createSTT` / `createStreamingSTT` with required-file checks | `detectSttModel` — [stt-offline.md](stt-offline.md#detection-and-factory) |
-| Before `createTTS` with lexicon / speaker metadata | `detectTtsModel` — [tts-offline.md](tts-offline.md#detectttsmodelsource-options) |
-| VAD / punctuation / enhancement / alignment init | `detectVadModel`, `detectPunctuationModel`, `detectEnhancementModel`, `detectAlignmentModel` on the matching feature package |
-
-Unified `detectModel` returns a **compact** result (`category`, `modelType`, `languages`, `quantization`, `sizeTier`, `isStreaming`, optional `supportsQnn`). It does **not** replace feature detect APIs when you need `detectedModels`, per-family `paths`, or `success` / `error` from required-file validation.
+---
 
 ## Quick start
 
-### 1) Detect category from a downloaded folder
+### 1) Preflight before STT init
 
-```ts
+```typescript
+import { bundledModelFileSource } from 'react-native-sherpa-onnx/utils';
+import { detectSttModel, createSTT } from 'react-native-sherpa-onnx/stt';
+
+const modelSource = bundledModelFileSource('models/sherpa-onnx-whisper-tiny-en');
+
+const det = await detectSttModel(modelSource);
+if (!det.success) throw new Error(det.error ?? 'STT pack invalid');
+
+// Prefer modelType: 'auto' on create — same native selection path
+const stt = await createSTT({ modelSource, modelType: 'auto' });
+```
+
+### 2) Catalog row — unknown category
+
+```typescript
 import { detectModel } from 'react-native-sherpa-onnx/detect';
-import { ModelCategory } from 'react-native-sherpa-onnx/download';
 
 const result = await detectModel({
   kind: 'fs',
   path: '/absolute/path/to/extracted-model-dir',
 });
 
-if (!result.matched) {
-  console.log('No Sherpa category matched');
-} else {
+if (result.matched) {
   console.log(result.category, result.modelType, result.languages);
-  // e.g. ModelCategory.Stt, 'zipformer2_ctc', ['en']
 }
 ```
 
-### 2) Name-only detect (asset id before files exist)
+### 3) Custom init — skip folder detection
 
-```ts
-import { detectModel } from 'react-native-sherpa-onnx/detect';
+```typescript
+import { createSTT } from 'react-native-sherpa-onnx/stt';
 
-const result = await detectModel({
-  assetName: 'sherpa-onnx-streaming-zipformer-en-2023-06-26',
+const stt = await createSTT({
+  initMode: 'custom',
+  modelType: 'transducer',
+  customConfig: {
+    encoder: { kind: 'fs', path: '/data/models/encoder.onnx' },
+    decoder: { kind: 'fs', path: '/data/models/decoder.onnx' },
+    joiner: { kind: 'fs', path: '/data/models/joiner.onnx' },
+    tokens: { kind: 'fs', path: '/data/models/tokens.txt' },
+  },
 });
-// Uses native name heuristics; modelDir defaults to ''.
 ```
 
-### 3) Batch detect for a model library
+No `detectSttModel` call — validation runs via native `validateCustomModelPaths`. See [Init modes](#init-modes-auto-vs-custom).
 
-```ts
-import {
-  detectModelsBatch,
-  detectModelResultMatchesCategory,
-} from 'react-native-sherpa-onnx/detect';
+### 4) Batch scan for a model library
+
+```typescript
+import { detectModelsBatch, detectModelResultMatchesCategory } from 'react-native-sherpa-onnx/detect';
 import { ModelCategory } from 'react-native-sherpa-onnx/download';
 
-const inputs = [
-  { kind: 'fs' as const, path: '/data/models/pack-a' },
-  { assetName: 'vits-piper-en_US-lessac-medium' },
-];
-
-const results = await detectModelsBatch(inputs, { concurrency: 8 });
+const results = await detectModelsBatch(
+  [
+    { kind: 'fs', path: '/data/models/pack-a' },
+    { assetName: 'vits-piper-en_US-lessac-medium' },
+  ],
+  { concurrency: 8 }
+);
 
 results.forEach((r, i) => {
   if (r.matched && detectModelResultMatchesCategory(ModelCategory.Stt, r)) {
@@ -107,182 +132,140 @@ results.forEach((r, i) => {
 });
 ```
 
-### 4) Resolve `FileSource`, then call feature-specific detect
+---
 
-```ts
-import { resolveFileSourceForDetect } from 'react-native-sherpa-onnx/detect';
-import { detectSttModel } from 'react-native-sherpa-onnx/stt';
+## Unified vs feature-specific detection
 
-const source = { kind: 'app' as const, base: 'apkAsset' as const, path: 'models/whisper-tiny' };
-const { modelDir, assetName } = await resolveFileSourceForDetect(source);
-// Same resolution path unified detect uses internally.
+Two API layers — same native detectors, different JS payloads.
 
-const det = await detectSttModel(source);
-if (!det.success) throw new Error(det.error ?? 'STT detect failed');
-```
+| | Unified (`detect`) | Feature-specific (`detectSttModel`, …) |
+| --- | --- | --- |
+| **Import** | `react-native-sherpa-onnx/detect` | Feature package (`/stt`, `/tts`, …) |
+| **Input** | `FileSource` or `{ assetName }` | `FileSource` |
+| **Output** | Compact: `category`, `modelType`, `languages`, `quantization`, `isStreaming` | Full: `success`, `error`, `detectedModels`, `paths`, `detectionSources` |
+| **Validates required files** | No (category/type only) | **Yes** |
+| **Best for** | Model library UX, batch scans, HF catalog hints | Before `create*` / per-call init when you know the feature |
 
-## Unified detector order (first hit wins)
-
-Native unified detection (`DetectModel` / `DetectModelsBatch`) tries domains in this order:
-
-1. **TTS**
-2. **STT**
-3. **VAD**
-4. **Punctuation**
-5. **Enhancement**
-6. **Alignment**
-
-A domain counts as a hit when native detection succeeds and `modelType !== 'unknown'`. If nothing matches, `detectModel` returns `{ matched: false }` (no thrown error).
-
-Implications:
-
-- A directory that could be misread by an earlier detector is classified by the **first** matching domain. This matches catalog/library use cases where each folder is intended for one feature.
-- When you **know** the target feature, prefer that feature’s `detect*Model` so validation and `paths` match engine init exactly.
-
-## QNN and `ModelCategory`
-
-QNN release packs are **STT** models with a specific naming convention. Unified detect sets:
-
-- `category: ModelCategory.Stt`
-- `supportsQnn: true` when the asset name matches the QNN binary pattern (see `isQnnModelName`)
-
-Use `detectModelResultMatchesCategory(ModelCategory.Qnn, result)` to treat QNN as its own catalog slice, or `ModelCategory.Stt` to exclude QNN-named packs from the regular STT list.
-
-## Input resolution
-
-### `DetectModelInput`
-
-```ts
-type DetectModelInput = FileSource | { assetName: string; modelDir?: string };
-```
-
-### `resolveFileSourceForDetect(source)`
-
-Maps `FileSource` (`fs` / `app` / `pad`) to native inputs. This lives on **`detect`**, not `fileio`: `fileio` defines source types and copy/save/share; engines need a directory path and/or basename for heuristics.
-
-```ts
-function resolveFileSourceForDetect(source: FileSource): Promise<ResolvedDetectInput>;
-
-type ResolvedDetectInput = {
-  modelDir: string;   // absolute path, or '' for name-only
-  assetName: string | null;
-};
-```
-
-`resolveFileSourceForModelInit` uses the same mapping for `createSTT`, `createTTS`, etc.
-
-**Errors:** invalid or unsafe paths reject with `FILEIO_*` **before** native detection (same as feature `detect*Model` when passed a `FileSource`).
-
-**`assetName` derivation:** last path segment with common archive suffixes stripped (`.tar.bz2`, `.zip`, …). Optional explicit `assetName` on feature detect options overrides catalog hints when passed through to native.
-
-## Data model
-
-### `DetectModelResult`
-
-```ts
-type DetectModelResult = { matched: false } | DetectModelMatchedResult;
-
-type DetectModelMatchedResult = {
-  matched: true;
-  category: ModelCategory;
-  modelType: string;
-  languages: string[];       // ISO 639-1 hints via model-languages helpers
-  quantization: Quantization;
-  sizeTier: SizeTier;
-  isStreaming: boolean;
-  isHardwareSpecificUnsupported?: boolean;
-  supportsQnn?: boolean;    // STT + QNN naming convention
-};
-```
-
-| Field | Meaning |
+| Scenario | Use |
 | --- | --- |
-| `matched` | `false` = no domain hit; unified API does not throw |
-| `category` | `ModelCategory` enum value for routing downloads / UI |
-| `modelType` | Family string (`whisper`, `vits`, `silero_vad`, …) |
-| `languages` | Public language hints normalized in JS |
-| `isStreaming` | Native streaming/offline hint for the matched family |
-| `isHardwareSpecificUnsupported` | STT packs that need special hardware paths |
-| `supportsQnn` | STT hit that also matches QNN release naming |
+| "What is this download?" (category unknown) | `detectModel` |
+| Scan many folders (catalog, author validation) | `detectModelsBatch` |
+| Filter STT vs QNN in a unified result | `detectModelResultMatchesCategory` |
+| Before `createSTT` with required-file checks | `detectSttModel` |
+| Before `createTTS` with lexicon metadata | `detectTtsModel` |
+| VAD / punctuation / enhancement / alignment init | Matching `detect*Model` on the feature package |
 
-## API reference
+Unified detection tries domains in fixed order (first hit wins) — see [Unified detector order](#unified-detector-order). When you **know** the target feature, prefer that feature's `detect*Model` so validation and `paths` match engine init exactly.
 
-### `detectModel(input)`
+---
 
-```ts
-function detectModel(input: DetectModelInput): Promise<DetectModelResult>;
+## Init modes: auto vs custom
+
+Every engine that loads model weights accepts one of two init modes. Policy-level features (alignment accurate, segmentation `speech_vad_model`) follow the same pattern on their options object — no persistent engine init.
+
+```mermaid
+flowchart TD
+  call["createSTT / createTTS / createStreamingVAD / …\nor alignTextToAudio / segmentOfflineBuffer policy"]
+  branch{initMode?}
+  auto["auto (default)\nmodelSource: FileSource folder\n→ detect*Model internally\n→ resolved paths → native init"]
+  custom["custom\ninitMode: 'custom'\nmodelType: concrete\n customConfig: FileSource per file\n→ validateCustomModelPaths\n→ resolved paths → native init"]
+  native["Native engine / policy"]
+
+  call --> branch
+  branch -->|"default / omitted"| auto --> native
+  branch -->|"'custom'"| custom --> native
 ```
 
-Single native bridge call after input resolution.
+### Auto mode (default)
 
-```ts
-const r = await detectModel({ kind: 'fs', path: '/path/to/model' });
-if (r.matched) {
-  console.log(r.category, r.modelType);
-}
+Pass a **folder** as `modelSource` (`FileSource`). The SDK:
+
+1. Resolves `FileSource` → absolute directory ([model-setup.md](model-setup.md))
+2. Runs native file scan + type selection (`modelType: 'auto'` or explicit type)
+3. Validates required files for the chosen type
+4. Loads weights
+
+```typescript
+const stt = await createSTT({
+  modelSource: bundledModelFileSource('models/sherpa-onnx-whisper-tiny-en'),
+  modelType: 'auto', // native picks from folder contents
+});
 ```
 
-### `detectModelsBatch(inputs, options?)`
+**Expected folder layout:** one directory with ONNX + sidecar files for one model family. See [Expected folder layouts](model-setup.md#expected-folder-layouts).
 
-```ts
-function detectModelsBatch(
-  inputs: readonly DetectModelInput[],
-  options?: { concurrency?: number }
-): Promise<DetectModelResult[]>;
-```
+Optional **`detect*Model` preflight** before init — same scan, no allocation ([Why detection exists](#why-detection-exists)).
 
-- Default `concurrency`: `8`
-- Each batch chunk uses one native `detectModelsBatch` call (not N sequential `detectModel` calls)
-- Result order matches `inputs`
+### Custom mode (`initMode: 'custom'`)
 
-```ts
-const rows = await detectModelsBatch(
-  [{ assetName: 'foo' }, { assetName: 'bar' }],
-  { concurrency: 4 }
-);
-```
+Use when files are **not** in one detectable folder — non-standard names, scattered paths, or detection fails but you know the model family.
 
-### `detectModelResultMatchesCategory(category, result)`
-
-```ts
-function detectModelResultMatchesCategory(
-  category: ModelCategory,
-  result: DetectModelMatchedResult
-): boolean;
-```
-
-Only call when `result.matched === true`. Special cases:
-
-| `category` | Matches when |
+| Field | Value |
 | --- | --- |
-| `ModelCategory.Qnn` | `category === Stt` && `supportsQnn === true` |
-| `ModelCategory.Stt` | `category === Stt` && `supportsQnn !== true` |
-| Other | `result.category === category` |
+| `initMode` | `'custom'` |
+| `modelType` | Concrete type (`'transducer'`, `'vits'`, `'silero_vad'`, …) — **not** `'auto'` |
+| `customConfig` | One **`FileSource` per required file** (keys match native validate tables) |
 
-### `isQnnModelName(name)`
+Auto-detection is **skipped**. Each `FileSource` is resolved to an absolute path, then native **`validateCustomModelPaths(category, modelType, paths)`** runs (C++ `validate-*.cpp` tables).
 
-```ts
-function isQnnModelName(name: string): boolean;
+```typescript
+const vad = await createStreamingVAD({
+  initMode: 'custom',
+  modelType: 'silero_vad',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/silero_vad.onnx' },
+  },
+  sampleRate: 16000,
+});
 ```
 
-Shared naming check for QNN binary releases (also used when building `supportsQnn` on unified STT hits).
+Query required vs optional keys for UI forms:
+
+```typescript
+import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+
+const { required, optional } = await getCustomModelPathRequirements('stt', 'transducer');
+// required: ['encoder', 'decoder', 'joiner', 'tokens']
+```
+
+Path keys per feature: [Required files per feature](#required-files-per-feature) below and each feature doc.
+
+### Init by feature (where custom applies)
+
+| Feature | Init point | Auto field | Custom field |
+| --- | --- | --- | --- |
+| STT offline | `createSTT` | `modelSource` | `customConfig` |
+| STT streaming | `createStreamingSTT` | `modelSource` | `customConfig` (category `stt_streaming`) |
+| TTS | `createTTS` | `modelSource` | `customConfig` |
+| VAD | `createStreamingVAD` | `modelSource` | `customConfig` |
+| Enhancement | `createEnhancement` / `createStreamingEnhancement` | `modelSource` | `customConfig` |
+| Punctuation offline | `createOfflinePunctuation` | `modelSource` | `customConfig` |
+| Punctuation streaming | `createStreamingPunctuation` | `modelSource` | `customConfig` |
+| Alignment | `alignTextToAudio` (`mode: 'accurate'` only) | `modelSource` | `customConfig` — **per call**, no engine init |
+| Segmentation | `segmentOfflineBuffer` / policy (`speech_vad_model`) | `modelPath` | `customConfig` — reuses VAD keys |
+
+No TurboModule `initialize*` entry for alignment or segmentation — see [sdk-init-bridge.md](sdk-init-bridge.md).
+
+TypeScript helpers: `src/stt/customConfig.ts`, `src/vad/customConfig.ts`, etc. Runtime truth is native validate tables.
+
+---
 
 ## Custom path validation
 
-For **`initMode: 'custom'`** (and early app-side checks), use the unified native validation layer backed by C++ `validate-*.cpp` tables (STT, TTS, VAD, Enhancement, Punctuation, Alignment):
+Native C++ `validate-*.cpp` tables are the single source of truth for which path keys each model type requires.
 
-```ts
+```typescript
 import {
   getCustomModelPathRequirements,
   validateCustomModelPaths,
 } from 'react-native-sherpa-onnx/detect';
-import { ModelCategory } from 'react-native-sherpa-onnx/download';
 
-// Schema for forms / slot pickers (required vs optional keys)
-const schema = await getCustomModelPathRequirements(ModelCategory.Stt, 'paraformer');
+// 1) Schema for forms / slot pickers
+const schema = await getCustomModelPathRequirements('stt', 'transducer');
+// { required: ['encoder','decoder','joiner','tokens'], optional: ['bpeVocab'] }
 
-// Runtime check on resolved absolute paths (Record<string, string>)
-const result = await validateCustomModelPaths(ModelCategory.Tts, 'vits', {
+// 2) Runtime check on resolved absolute paths
+const result = await validateCustomModelPaths('tts', 'vits', {
   ttsModel: '/path/model.onnx',
   tokens: '/path/tokens.txt',
 });
@@ -291,40 +274,226 @@ if (!result.ok) {
 }
 ```
 
-Categories match unified detect literals: `stt`, `stt_streaming`, `tts`, `vad`, `enhancement`, `punctuation`, `alignment`.
+| API | Purpose |
+| --- | --- |
+| `getCustomModelPathRequirements(category, modelType)` | Read-only schema — required vs optional keys |
+| `validateCustomModelPaths(category, modelType, paths)` | Enforces non-empty paths + family-specific rules |
 
-- **`stt_streaming`** — online/streaming STT custom init (`createStreamingSTT` with `initMode: 'custom'`). Path keys differ from offline `stt`: transducer uses `encoder`/`decoder`/`joiner`/`tokens`; CTC streaming types use `model`/`tokens` (not offline `ctcModel`).
+Categories: `stt`, `stt_streaming`, `tts`, `vad`, `enhancement`, `punctuation`, `alignment`.
 
-- **`getCustomModelPathRequirements`** — read-only schema; paraformer includes optional offline/streaming keys (`paraformerModel`, `encoder`, `decoder`) with `tokens` required.
-- **`validateCustomModelPaths`** — enforces non-empty paths and feature-specific rules (e.g. paraformer OR-layout, `moonshine` vs `moonshine_v2`).
+> [!NOTE]
+> **`stt_streaming`** keys differ from offline `stt` (e.g. streaming transducer uses `encoder`/`decoder`/`joiner`/`tokens`; offline CTC uses `ctcModel`/`tokens`). Always query the schema for the exact category.
 
-TypeScript discriminated unions in `src/stt/customConfig.ts`, `src/tts/customConfig.ts`, `src/vad/customConfig.ts`, `src/enhancement/customConfig.ts`, `src/punctuation/customConfig.ts`, and `src/alignment/customConfig.ts` remain compile-time helpers; **runtime truth is native**.
+Segmentation `speech_vad_model` custom policy reuses **`vad`** category and key `model` — no separate `src/segment/customConfig.ts`. See [segmentation-engine.md](segmentation-engine.md#custom-model-path-initmode-custom).
 
-**Segmentation `speech_vad_model` custom policy** reuses `src/vad/customConfig.ts` and native category `vad` (key `model`) — there is no separate `src/segment/customConfig.ts`. See [segmentation-engine.md — Custom model path](segmentation-engine.md#custom-model-path-initmode-custom).
+Validation checks **non-empty resolved path strings** — not ONNX correctness or on-disk existence at validate time.
 
-## Feature-specific detection APIs
+---
 
-Use these when initializing engines or when you need validation details. Each page documents required files, `paths`, and `detectionSources`.
+## Required files per feature
+
+Each feature doc has the full per-`modelType` table. Summary of where to look:
+
+| Feature | Doc | Detect function | Validate category |
+| --- | --- | --- | --- |
+| STT offline | [stt-offline.md](stt-offline.md#validation-required-files) | `detectSttModel` | `stt` |
+| STT streaming | [stt-streaming.md](stt-streaming.md#validation-required-files) | `detectSttModel` | `stt_streaming` |
+| TTS | [tts-offline.md](tts-offline.md#validation-required-files) | `detectTtsModel` | `tts` |
+| VAD | [vad-streaming.md](vad-streaming.md#validation-required-files) | `detectVadModel` | `vad` |
+| Enhancement | [enhancement-offline.md](enhancement-offline.md#validation-required-files) | `detectEnhancementModel` | `enhancement` |
+| Punctuation offline | [punctuation-offline.md](punctuation-offline.md#validation-required-files) | `detectPunctuationModel` | `punctuation` |
+| Punctuation streaming | [punctuation-streaming.md](punctuation-streaming.md#validation-required-files) | `detectPunctuationModel` | `punctuation` |
+| Alignment | [alignment-offline.md](alignment-offline.md#validation-required-files) | `detectAlignmentModel` | `alignment` |
+| Segmentation VAD policy | [segmentation-engine.md](segmentation-engine.md#custom-model-path-initmode-custom) | `detectVadModel` (auto) | `vad` (custom) |
+
+**How native detection picks files:** scans the resolved directory recursively, maps filenames to engine roles, lists all matching families in `detectedModels`, then validates the highest-probability one as `modelType`. Same rules as `create*` with `modelType: 'auto'`.
+
+---
+
+## Unified detector order
+
+Native unified detection (`detectModel` / `detectModelsBatch`) tries domains in this order — **first hit wins**:
+
+```mermaid
+flowchart LR
+  input["DetectModelInput"] --> tts[TTS]
+  tts -->|no match| stt[STT]
+  stt -->|no match| vad[VAD]
+  vad -->|no match| punct[Punctuation]
+  punct -->|no match| enh[Enhancement]
+  enh -->|no match| align[Alignment]
+  align -->|no match| none["matched: false"]
+```
+
+A domain counts as a hit when native detection succeeds and `modelType !== 'unknown'`. No match → `{ matched: false }` (no thrown error).
+
+When you **know** the target feature, use that feature's `detect*Model` — avoids misclassification and returns full validation payload.
+
+---
+
+## QNN and ModelCategory
+
+QNN release packs are **STT** models with a specific naming convention. Unified detect sets:
+
+- `category: ModelCategory.Stt`
+- `supportsQnn: true` when the asset name matches the QNN binary pattern (`isQnnModelName`)
+
+| Filter | Matches when |
+| --- | --- |
+| `ModelCategory.Qnn` | `category === Stt` && `supportsQnn === true` |
+| `ModelCategory.Stt` | `category === Stt` && `supportsQnn !== true` |
+| Other categories | `result.category === category` |
+
+Use `detectModelResultMatchesCategory(ModelCategory.Qnn, result)` for QNN catalog slices.
+
+---
+
+## API reference
+
+### `detectModel(input)`
+
+```typescript
+function detectModel(input: DetectModelInput): Promise<DetectModelResult>;
+```
+
+```typescript
+const r = await detectModel({ kind: 'fs', path: '/path/to/model' });
+if (r.matched) console.log(r.category, r.modelType);
+```
+
+Single unified detect call after input resolution. Returns compact category/type metadata — no required-file validation.
+
+---
+
+### `detectModelsBatch(inputs, options?)`
+
+```typescript
+function detectModelsBatch(
+  inputs: readonly DetectModelInput[],
+  options?: { concurrency?: number }
+): Promise<DetectModelResult[]>;
+```
+
+```typescript
+const rows = await detectModelsBatch([{ assetName: 'foo' }, { assetName: 'bar' }], { concurrency: 4 });
+```
+
+Default concurrency: `8`. One native batch call per chunk. Result order matches input order.
+
+---
+
+### `detectModelResultMatchesCategory(category, result)`
+
+```typescript
+function detectModelResultMatchesCategory(
+  category: ModelCategory,
+  result: DetectModelMatchedResult
+): boolean;
+```
+
+Call only when `result.matched === true`. Handles QNN / STT split — see [QNN](#qnn-and-modelcategory).
+
+---
+
+### `isQnnModelName(name)`
+
+```typescript
+function isQnnModelName(name: string): boolean;
+```
+
+Shared naming check for QNN binary releases.
+
+---
+
+### `resolveFileSourceForDetect(source)`
+
+```typescript
+function resolveFileSourceForDetect(source: FileSource): Promise<{
+  modelDir: string;
+  assetName: string | null;
+}>;
+```
+
+Maps `FileSource` to native detect inputs. Same resolution path used internally by unified and feature detect. `resolveFileSourceForModelInit` uses the same mapping for engine init.
+
+Invalid paths reject with `FILEIO_*` before native detection runs.
+
+---
+
+### `getCustomModelPathRequirements(category, modelType)`
+
+```typescript
+function getCustomModelPathRequirements(
+  category: string,
+  modelType: string
+): Promise<{ required: string[]; optional: string[] }>;
+```
+
+Read-only schema for custom-init UI. Do not hardcode key lists in app code.
+
+---
+
+### `validateCustomModelPaths(category, modelType, paths)`
+
+```typescript
+function validateCustomModelPaths(
+  category: string,
+  modelType: string,
+  paths: Record<string, string>
+): Promise<{ ok: boolean; error?: string; missingRequired?: string[] }>;
+```
+
+Runtime validation on resolved absolute path strings. Used internally by `resolve*CustomConfigPaths` helpers.
+
+---
+
+### `DetectModelInput` / `DetectModelResult`
+
+```typescript
+type DetectModelInput = FileSource | { assetName: string; modelDir?: string };
+
+type DetectModelResult =
+  | { matched: false }
+  | {
+      matched: true;
+      category: ModelCategory;
+      modelType: string;
+      languages: string[];
+      quantization: Quantization;
+      sizeTier: SizeTier;
+      isStreaming: boolean;
+      isHardwareSpecificUnsupported?: boolean;
+      supportsQnn?: boolean;
+    };
+```
+
+Name-only input (`{ assetName }`) uses native name heuristics when no listable directory exists.
+
+---
+
+## Feature-specific detect APIs
+
+Full payloads (`success`, `error`, `detectedModels`, `paths`, `detectionSources`) — use when initializing engines.
 
 | Feature | Function | Guide |
 | --- | --- | --- |
-| STT (offline / streaming) | `detectSttModel` | [stt-offline.md — Detection](stt-offline.md#detection-and-factory), [stt-streaming.md](stt-streaming.md#detection-and-initialization) |
-| TTS | `detectTtsModel` | [tts-offline.md — `detectTtsModel`](tts-offline.md#detectttsmodelsource-options) |
-| VAD | `detectVadModel` | [vad-streaming.md](vad-streaming.md#model-detection) |
-| Punctuation | `detectPunctuationModel` | [punctuation-offline.md](punctuation-offline.md#model-detection), [punctuation-streaming.md](punctuation-streaming.md#model-detection) |
+| STT offline | `detectSttModel` | [stt-offline.md — Detection](stt-offline.md#detection-and-factory) |
+| STT streaming | `detectSttModel` | [stt-streaming.md](stt-streaming.md#model-detection) |
+| TTS | `detectTtsModel` | [tts-offline.md — Model detection](tts-offline.md#model-detection) |
+| VAD | `detectVadModel` | [vad-streaming.md — Model detection](vad-streaming.md#model-detection) |
+| Punctuation | `detectPunctuationModel` | [punctuation-offline.md](punctuation-offline.md#model-detection) |
 | Enhancement | `detectEnhancementModel` | [enhancement-offline.md](enhancement-offline.md#model-detection) |
 | Alignment | `detectAlignmentModel` | [alignment-offline.md](alignment-offline.md#model-detection) |
 
-## Download manager and catalogs
+The download module uses unified batch detection internally. App catalog code should prefer `detect` over calling multiple `detect*Model` APIs in sequence.
 
-The download module uses unified batch detection internally for catalog hints and Hugging Face author validation. App code that builds custom libraries should use the same `detect` entry point rather than calling multiple `detect*Model` APIs in sequence (fewer bridge round-trips, consistent category order).
+---
 
-See [download-manager.md](download-manager.md) and [model-languages.md](model-languages.md) for category enums and language display.
+## See also
 
-## Related docs
-
-- [model-setup.md](model-setup.md) — bundled assets, discovery
-- [model-delivery-pad-odr.md](model-delivery-pad-odr.md) — PAD & ODR (install-time, on-demand)
-- [memory-and-models.md](memory-and-models.md) — detect before heavy engine init
-- [execution-providers.md](execution-providers.md) — QNN provider setup (after you know the pack is QNN-capable)
-- [fileio.md](fileio.md) — `FileSource` shapes
+- [Model setup](model-setup.md) — `FileSource`, bundled/PAD/downloaded paths
+- [Model languages](model-languages.md) — language pickers
+- [Ship model delivery (PAD & ODR)](model-delivery-pad-odr.md)
+- [Memory & models](memory-and-models.md) — detect before heavy init
+- [Execution providers](execution-providers.md) — QNN setup after identifying QNN packs
+- [File I/O](fileio.md) — `FileSource` type reference

--- a/docs/model-detect.md
+++ b/docs/model-detect.md
@@ -298,7 +298,7 @@ Categories match unified detect literals: `stt`, `stt_streaming`, `tts`, `vad`, 
 - **`getCustomModelPathRequirements`** — read-only schema; paraformer includes optional offline/streaming keys (`paraformerModel`, `encoder`, `decoder`) with `tokens` required.
 - **`validateCustomModelPaths`** — enforces non-empty paths and feature-specific rules (e.g. paraformer OR-layout, `moonshine` vs `moonshine_v2`).
 
-TypeScript discriminated unions in `src/stt/customConfig.ts`, `src/tts/customConfig.ts`, `src/vad/customConfig.ts`, and `src/enhancement/customConfig.ts` remain compile-time helpers; **runtime truth is native**.
+TypeScript discriminated unions in `src/stt/customConfig.ts`, `src/tts/customConfig.ts`, `src/vad/customConfig.ts`, `src/enhancement/customConfig.ts`, and `src/punctuation/customConfig.ts` remain compile-time helpers; **runtime truth is native**.
 
 ## Feature-specific detection APIs
 

--- a/docs/model-detect.md
+++ b/docs/model-detect.md
@@ -219,13 +219,17 @@ const vad = await createStreamingVAD({
 });
 ```
 
-Query required vs optional keys for UI forms:
+Query path keys for UI forms:
 
 ```typescript
-import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import {
+  getCustomModelPathRequirements,
+  requiredCustomModelPathFieldKeys,
+} from 'react-native-sherpa-onnx/detect';
 
-const { required, optional } = await getCustomModelPathRequirements('stt', 'transducer');
-// required: ['encoder', 'decoder', 'joiner', 'tokens']
+const { fields } = await getCustomModelPathRequirements('stt', 'transducer');
+// fields: [{ key: 'encoder', required: true, kind: 'file' }, ...]
+const requiredKeys = requiredCustomModelPathFieldKeys({ fields });
 ```
 
 Path keys per feature: [Required files per feature](#required-files-per-feature) below and each feature doc.
@@ -262,7 +266,7 @@ import {
 
 // 1) Schema for forms / slot pickers
 const schema = await getCustomModelPathRequirements('stt', 'transducer');
-// { required: ['encoder','decoder','joiner','tokens'], optional: ['bpeVocab'] }
+// { fields: [{ key: 'encoder', required: true, kind: 'file' }, ...] }
 
 // 2) Runtime check on resolved absolute paths
 const result = await validateCustomModelPaths('tts', 'vits', {
@@ -276,7 +280,7 @@ if (!result.ok) {
 
 | API | Purpose |
 | --- | --- |
-| `getCustomModelPathRequirements(category, modelType)` | Read-only schema — required vs optional keys |
+| `getCustomModelPathRequirements(category, modelType)` | Read-only schema — ordered `fields[]` with `required` and `kind` (`file` \| `dir`) |
 | `validateCustomModelPaths(category, modelType, paths)` | Enforces non-empty paths + family-specific rules |
 
 Categories: `stt`, `stt_streaming`, `tts`, `vad`, `enhancement`, `punctuation`, `alignment`.
@@ -423,13 +427,43 @@ Invalid paths reject with `FILEIO_*` before native detection runs.
 ### `getCustomModelPathRequirements(category, modelType)`
 
 ```typescript
+type CustomModelPathFieldKind = 'file' | 'dir';
+
+type CustomModelPathField = {
+  key: string;
+  required: boolean;
+  kind: CustomModelPathFieldKind;
+};
+
+type CustomModelPathRequirements = {
+  fields: ReadonlyArray<CustomModelPathField>;
+};
+
 function getCustomModelPathRequirements(
   category: string,
   modelType: string
-): Promise<{ required: string[]; optional: string[] }>;
+): Promise<CustomModelPathRequirements>;
 ```
 
-Read-only schema for custom-init UI. Do not hardcode key lists in app code.
+Read-only schema for custom-init. Do not hardcode key lists in app code.
+
+`fields` preserves declaration order from native C++ requirement tables. Each entry carries:
+
+- `key` — config key passed to `customConfig` / `validateCustomModelPaths`
+- `required` — whether native validation treats the key as mandatory
+- `kind` — `'file'` or `'dir'` (for example TTS `dataDir` → `'dir'`)
+
+Helpers (same module):
+
+```typescript
+function customModelPathFieldKeys(
+  requirements: CustomModelPathRequirements
+): string[];
+
+function requiredCustomModelPathFieldKeys(
+  requirements: CustomModelPathRequirements
+): string[];
+```
 
 ---
 

--- a/docs/model-detect.md
+++ b/docs/model-detect.md
@@ -298,7 +298,7 @@ Categories match unified detect literals: `stt`, `stt_streaming`, `tts`, `vad`, 
 - **`getCustomModelPathRequirements`** — read-only schema; paraformer includes optional offline/streaming keys (`paraformerModel`, `encoder`, `decoder`) with `tokens` required.
 - **`validateCustomModelPaths`** — enforces non-empty paths and feature-specific rules (e.g. paraformer OR-layout, `moonshine` vs `moonshine_v2`).
 
-TypeScript discriminated unions in `src/stt/customConfig.ts`, `src/tts/customConfig.ts`, `src/vad/customConfig.ts`, `src/enhancement/customConfig.ts`, and `src/punctuation/customConfig.ts` remain compile-time helpers; **runtime truth is native**.
+TypeScript discriminated unions in `src/stt/customConfig.ts`, `src/tts/customConfig.ts`, `src/vad/customConfig.ts`, `src/enhancement/customConfig.ts`, `src/punctuation/customConfig.ts`, and `src/alignment/customConfig.ts` remain compile-time helpers; **runtime truth is native**.
 
 ## Feature-specific detection APIs
 

--- a/docs/model-detect.md
+++ b/docs/model-detect.md
@@ -298,7 +298,7 @@ Categories match unified detect literals: `stt`, `stt_streaming`, `tts`, `vad`, 
 - **`getCustomModelPathRequirements`** — read-only schema; paraformer includes optional offline/streaming keys (`paraformerModel`, `encoder`, `decoder`) with `tokens` required.
 - **`validateCustomModelPaths`** — enforces non-empty paths and feature-specific rules (e.g. paraformer OR-layout, `moonshine` vs `moonshine_v2`).
 
-TypeScript discriminated unions in `src/stt/customConfig.ts` and `src/tts/customConfig.ts` remain compile-time helpers; **runtime truth is native**.
+TypeScript discriminated unions in `src/stt/customConfig.ts`, `src/tts/customConfig.ts`, and `src/vad/customConfig.ts` remain compile-time helpers; **runtime truth is native**.
 
 ## Feature-specific detection APIs
 

--- a/docs/model-detect.md
+++ b/docs/model-detect.md
@@ -298,7 +298,7 @@ Categories match unified detect literals: `stt`, `stt_streaming`, `tts`, `vad`, 
 - **`getCustomModelPathRequirements`** — read-only schema; paraformer includes optional offline/streaming keys (`paraformerModel`, `encoder`, `decoder`) with `tokens` required.
 - **`validateCustomModelPaths`** — enforces non-empty paths and feature-specific rules (e.g. paraformer OR-layout, `moonshine` vs `moonshine_v2`).
 
-TypeScript discriminated unions in `src/stt/customConfig.ts`, `src/tts/customConfig.ts`, and `src/vad/customConfig.ts` remain compile-time helpers; **runtime truth is native**.
+TypeScript discriminated unions in `src/stt/customConfig.ts`, `src/tts/customConfig.ts`, `src/vad/customConfig.ts`, and `src/enhancement/customConfig.ts` remain compile-time helpers; **runtime truth is native**.
 
 ## Feature-specific detection APIs
 

--- a/docs/model-detect.md
+++ b/docs/model-detect.md
@@ -300,6 +300,8 @@ Categories match unified detect literals: `stt`, `stt_streaming`, `tts`, `vad`, 
 
 TypeScript discriminated unions in `src/stt/customConfig.ts`, `src/tts/customConfig.ts`, `src/vad/customConfig.ts`, `src/enhancement/customConfig.ts`, `src/punctuation/customConfig.ts`, and `src/alignment/customConfig.ts` remain compile-time helpers; **runtime truth is native**.
 
+**Segmentation `speech_vad_model` custom policy** reuses `src/vad/customConfig.ts` and native category `vad` (key `model`) — there is no separate `src/segment/customConfig.ts`. See [segmentation-engine.md — Custom model path](segmentation-engine.md#custom-model-path-initmode-custom).
+
 ## Feature-specific detection APIs
 
 Use these when initializing engines or when you need validation details. Each page documents required files, `paths`, and `detectionSources`.

--- a/docs/model-detect.md
+++ b/docs/model-detect.md
@@ -298,7 +298,7 @@ Categories match unified detect literals: `stt`, `stt_streaming`, `tts`, `vad`, 
 - **`getCustomModelPathRequirements`** — read-only schema; paraformer includes optional offline/streaming keys (`paraformerModel`, `encoder`, `decoder`) with `tokens` required.
 - **`validateCustomModelPaths`** — enforces non-empty paths and feature-specific rules (e.g. paraformer OR-layout, `moonshine` vs `moonshine_v2`).
 
-TypeScript discriminated unions in `src/stt/customConfig.ts` remain compile-time helpers; **runtime truth is native**.
+TypeScript discriminated unions in `src/stt/customConfig.ts` and `src/tts/customConfig.ts` remain compile-time helpers; **runtime truth is native**.
 
 ## Feature-specific detection APIs
 

--- a/docs/model-detect.md
+++ b/docs/model-detect.md
@@ -267,6 +267,39 @@ function isQnnModelName(name: string): boolean;
 
 Shared naming check for QNN binary releases (also used when building `supportsQnn` on unified STT hits).
 
+## Custom path validation
+
+For **`initMode: 'custom'`** (and early app-side checks), use the unified native validation layer backed by C++ `validate-*.cpp` tables (STT, TTS, VAD, Enhancement, Punctuation, Alignment):
+
+```ts
+import {
+  getCustomModelPathRequirements,
+  validateCustomModelPaths,
+} from 'react-native-sherpa-onnx/detect';
+import { ModelCategory } from 'react-native-sherpa-onnx/download';
+
+// Schema for forms / slot pickers (required vs optional keys)
+const schema = await getCustomModelPathRequirements(ModelCategory.Stt, 'paraformer');
+
+// Runtime check on resolved absolute paths (Record<string, string>)
+const result = await validateCustomModelPaths(ModelCategory.Tts, 'vits', {
+  ttsModel: '/path/model.onnx',
+  tokens: '/path/tokens.txt',
+});
+if (!result.ok) {
+  console.warn(result.error, result.missingRequired);
+}
+```
+
+Categories match unified detect literals: `stt`, `stt_streaming`, `tts`, `vad`, `enhancement`, `punctuation`, `alignment`.
+
+- **`stt_streaming`** — online/streaming STT custom init (`createStreamingSTT` with `initMode: 'custom'`). Path keys differ from offline `stt`: transducer uses `encoder`/`decoder`/`joiner`/`tokens`; CTC streaming types use `model`/`tokens` (not offline `ctcModel`).
+
+- **`getCustomModelPathRequirements`** — read-only schema; paraformer includes optional offline/streaming keys (`paraformerModel`, `encoder`, `decoder`) with `tokens` required.
+- **`validateCustomModelPaths`** — enforces non-empty paths and feature-specific rules (e.g. paraformer OR-layout, `moonshine` vs `moonshine_v2`).
+
+TypeScript discriminated unions in `src/stt/customConfig.ts` remain compile-time helpers; **runtime truth is native**.
+
 ## Feature-specific detection APIs
 
 Use these when initializing engines or when you need validation details. Each page documents required files, `paths`, and `detectionSources`.

--- a/docs/model-languages.md
+++ b/docs/model-languages.md
@@ -1,63 +1,107 @@
 # Model language helpers
 
-## Introduction
+Language tables and normalized hints for picker UI and `modelOptions` wiring.
 
-**Import path:** `react-native-sherpa-onnx/model-languages`
+**Import:** `react-native-sherpa-onnx/model-languages`
 
-This module provides language tables and normalized language-hint utilities used by STT/TTS/alignment integrations. It is intended for picker UI and model-option wiring.
+| Doc | Question it answers |
+| --- | --- |
+| [model-detect.md](model-detect.md) | What model type / category is this pack? |
+| **This page** | Which language codes can I show in a picker? |
+| Feature docs | Per-family `modelOptions` (e.g. `whisper.language`) |
 
 > [!CAUTION]
-> The APIs in this module are convenience helpers only. They return commonly referenced language codes and labels, not a guarantee that a specific checkpoint supports every entry. Confirm supported languages in upstream model documentation for your exact model bundle.
+> APIs here are **convenience helpers** — commonly referenced language codes and labels, not a guarantee that your exact checkpoint supports every entry. Confirm supported languages in upstream model documentation.
+
+---
 
 ## Quick start
 
-### Fun-ASR language hint to modelOptions mapping
+### Whisper language picker → `modelOptions`
 
-`resolvePublicLanguageHints` returns `{ iso6391Hint, id }[]`: use `iso6391Hint` for catalog/filter UI and `id` for model options where required.
+```typescript
+import { getWhisperLanguages } from 'react-native-sherpa-onnx/model-languages';
 
-```ts
+const rows = getWhisperLanguages();
+const selected = rows.find((r) => r.id === 'en') ?? rows[0];
+
+await stt.transcribe(audioIn, textOut, {
+  modelOptions: { whisper: { language: selected.id } },
+});
+```
+
+### Normalize hints from detection metadata
+
+```typescript
 import { resolvePublicLanguageHints } from 'react-native-sherpa-onnx/model-languages';
 import { ModelCategory } from 'react-native-sherpa-onnx/download';
 
-const rows = resolvePublicLanguageHints({
+const hints = resolvePublicLanguageHints({
   domain: ModelCategory.Stt,
-  modelType: 'funasr_nano',
+  modelType: detection.modelType,
+  rawFromNative: detection.languages,
 });
 
-for (const row of rows) {
-  console.log(row.iso6391Hint, row.id);
+for (const row of hints) {
+  console.log(row.iso6391Hint, row.id); // iso6391Hint for UI filter; id for modelOptions
 }
 ```
+
+---
+
+## Language tables overview
+
+Static tables for building pickers. Each returns `ModelLanguage[]` (`{ id, name }`).
+
+| Getter | Model family | Notes |
+| --- | --- | --- |
+| `getWhisperLanguages()` | Whisper STT | Full multilingual set |
+| `getSenseVoiceLanguages()` | SenseVoice STT | |
+| `getCanaryLanguages()` | Canary STT | |
+| `getFunasrNanoLanguages()` | Fun-ASR Nano | `id` → `modelOptions` |
+| `getFunasrMltNanoLanguages()` | Fun-ASR MLT Nano | |
+| `getCohereTranscribeLanguages()` | Cohere Transcribe | |
+| `getQwen3AsrLanguages()` | Qwen3 ASR | |
+| `getDolphinInfoLanguages()` | Dolphin (informational) | |
+
+TTS / alignment hint helpers (ISO 639-1 strings only):
+
+| Function | Scope |
+| --- | --- |
+| `iso6391HintsForTtsModelType(modelType?, modelKey?)` | TTS families |
+| `iso6391HintsForAlignmentModelType(modelType?)` | Alignment (e.g. `wav2vec2`) |
+
+Constants (`WHISPER_LANGUAGES`, `POCKET_TTS_ISO6391_HINTS`, `SUPERTONIC3_TTS_ISO6391_HINTS`, …) mirror the getters — import when you need the raw array without a function call.
+
+---
 
 ## API reference
 
 ### `resolvePublicLanguageHints(input)`
 
-```ts
+```typescript
 function resolvePublicLanguageHints(input: {
   domain: ModelCategory;
   modelType?: string;
   modelKey?: string;
   rawFromNative?: readonly string[];
-}): Array<{
-  iso6391Hint: string;
-  id: string;
-}>;
+}): Array<{ iso6391Hint: string; id: string }>;
 ```
 
-```ts
-const hints = resolvePublicLanguageHints({
+```typescript
+const rows = resolvePublicLanguageHints({
   domain: ModelCategory.Stt,
-  modelType: 'whisper',
+  modelType: 'funasr_nano',
 });
-console.log(hints);
 ```
 
-Resolves normalized public language tags. For stacks with curated language ids (for example Fun-ASR), `id` is the value intended for `modelOptions`.
+Normalizes public language tags from detection metadata or curated tables. For stacks with language ids (Fun-ASR), `id` is the value for `modelOptions`.
 
-### STT getter APIs
+---
 
-```ts
+### STT language getters
+
+```typescript
 function getWhisperLanguages(): readonly ModelLanguage[];
 function getSenseVoiceLanguages(): readonly ModelLanguage[];
 function getCanaryLanguages(): readonly ModelLanguage[];
@@ -68,110 +112,45 @@ function getQwen3AsrLanguages(): readonly ModelLanguage[];
 function getDolphinInfoLanguages(): readonly ModelLanguage[];
 ```
 
-```ts
+```typescript
 const whisper = getWhisperLanguages();
 console.log(whisper[0]?.id, whisper[0]?.name);
 ```
 
-These getters return static language tables from the package and are suitable for building language pickers.
+Static tables — suitable for dropdown / chip pickers. Does not validate on-disk model folders.
 
-### Hint helpers for TTS and alignment
+---
 
-```ts
-function iso6391HintsForTtsModelType(
-  modelType?: string,
-  modelKey?: string
-): readonly string[];
+### TTS and alignment hint helpers
+
+```typescript
+function iso6391HintsForTtsModelType(modelType?: string, modelKey?: string): readonly string[];
 function iso6391HintsForAlignmentModelType(modelType?: string): readonly string[];
 ```
 
-```ts
-const alignmentHints = iso6391HintsForAlignmentModelType('wav2vec2');
-console.log(alignmentHints);
+```typescript
+const hints = iso6391HintsForAlignmentModelType('wav2vec2');
 ```
 
-These helpers expose normalized public language hints by model type; they do not validate on-disk model folders.
+Normalized ISO 639-1 hints by model type — for catalog labels, not runtime validation.
 
-## Types and constants
+---
 
-```ts
-import {
-  resolvePublicLanguageHints, // normalize and map language hints for model categories
-  getWhisperLanguages, // Whisper language table getter
-  getSenseVoiceLanguages, // SenseVoice language table getter
-  getCanaryLanguages, // Canary language table getter
-  getFunasrNanoLanguages, // Fun-ASR Nano language table getter
-  getFunasrMltNanoLanguages, // Fun-ASR MLT Nano language table getter
-  getCohereTranscribeLanguages, // Cohere Transcribe language table getter
-  getQwen3AsrLanguages, // Qwen3 ASR language table getter
-  getDolphinInfoLanguages, // Dolphin informational language list getter
-  iso6391HintsForTtsModelType, // TTS public language hint resolver by model type
-  iso6391HintsForAlignmentModelType, // alignment public language hint resolver by model type
-  WHISPER_LANGUAGES, // Whisper language constants
-  SENSEVOICE_LANGUAGES, // SenseVoice language constants
-  CANARY_LANGUAGES, // Canary language constants
-  FUNASR_NANO_LANGUAGES, // Fun-ASR Nano language constants
-  FUNASR_MLT_NANO_LANGUAGES, // Fun-ASR MLT Nano language constants
-  COHERE_TRANSCRIBE_LANGUAGES, // Cohere Transcribe language constants
-  QWEN3_ASR_LANGUAGES, // Qwen3 ASR language constants
-  DOLPHIN_INFO_LANGUAGES, // Dolphin informational language constants
-  POCKET_TTS_ISO6391_HINTS, // Pocket TTS ISO639-1 hints
-  SUPERTONIC_TTS_ISO6391_HINTS, // Supertonic (legacy) TTS ISO639-1 hints
-  SUPERTONIC3_TTS_ISO6391_HINTS, // Supertonic 3 multilingual + na
-  isSupertonic3ModelKey, // true when catalog/folder id denotes Supertonic 3
-} from 'react-native-sherpa-onnx/model-languages';
+## Types
 
+```typescript
 import type {
-  ModelLanguage, // language row shape: id + name
-  PublicLanguageHint, // normalized hint row: iso6391Hint + id
-  ResolvePublicLanguageHintsInput, // input shape for resolvePublicLanguageHints
+  ModelLanguage,              // { id: string; name: string }
+  PublicLanguageHint,         // { iso6391Hint: string; id: string }
+  ResolvePublicLanguageHintsInput,
 } from 'react-native-sherpa-onnx/model-languages';
 ```
 
-## Error codes
-
-This module is table/transform based and does not define dedicated `*_ERROR` constants. Errors may still surface from caller-side validation or unsupported model-option combinations in feature modules (`stt`, `tts`, `alignment`).
+---
 
 ## See also
 
-- [Speech-to-Text (STT)](stt-offline.md) — `createSTT`, `detectSttModel`, `modelOptions`
-- [Offline TTS](tts-offline.md)
-- [Alignment (offline)](alignment-offline.md)
-
-## Use case examples
-
-<details>
-<summary>Build a language picker for Whisper and pass selected id to modelOptions</summary>
-
-```ts
-const rows = getWhisperLanguages();
-const selected = rows.find((r) => r.id === 'en') ?? rows[0];
-
-await stt.transcribe(audioIn, textOut, {
-  modelOptions: {
-    whisper: { language: selected.id },
-  },
-});
-```
-
-</details>
-
-<details>
-<summary>Resolve public language hints from model detection metadata</summary>
-
-```ts
-const hints = resolvePublicLanguageHints({
-  domain: ModelCategory.Stt,
-  modelType: detection.modelType,
-  rawFromNative: detection.languages,
-});
-
-console.log(hints.map((h) => `${h.iso6391Hint}:${h.id}`));
-```
-
-</details>
-
-## Native crash diagnostics
-
-If native code fails or the app crashes but the tombstone shows only a UI/GPU thread, inspect the SDK **last-activity ring buffer** (enabled by default when the native library loads). Full details: [native-diagnostics.md](./native-diagnostics.md) — Android log tag `SherpaNativeDiag`; iOS subsystem `com.sherpaonnx.diag`. Optional JS: `getNativeDiagnosticSnapshot` / `configureNativeDiagnostics` from `react-native-sherpa-onnx/diagnostics`.
-
+- [STT offline](stt-offline.md) — `modelOptions` per family
+- [TTS offline](tts-offline.md) — lexicon languages from `detectTtsModel`
+- [Alignment offline](alignment-offline.md)
+- [Model detection](model-detect.md) — `languages` field on unified detect results

--- a/docs/model-setup.md
+++ b/docs/model-setup.md
@@ -415,6 +415,23 @@ For `.tar.zst` ship archives, extract to a sandbox directory and use `{ kind: 'f
 
 When model files are not in a single detectable folder, pass explicit paths per file with `initMode: 'custom'`. Each path is a {@link FileSource}; the SDK resolves them to absolute paths before native init. See [STT custom initialization](stt-offline.md#custom-initialization-initmode-custom) for required path keys per model type.
 
+### Custom TTS init (skip auto-detection)
+
+Same pattern for TTS: `initMode: 'custom'`, concrete `modelType`, and `customConfig` with per-file {@link FileSource} paths. See [TTS custom initialization](tts-offline.md#custom-initialization-initmode-custom). `lexiconLanguageId` is auto-only; pass `lexicon` in `customConfig` when needed.
+
+```typescript
+import { createTTS } from 'react-native-sherpa-onnx/tts';
+
+const tts = await createTTS({
+  initMode: 'custom',
+  modelType: 'vits',
+  customConfig: {
+    ttsModel: { kind: 'fs', path: '/data/models/model.onnx' },
+    tokens: { kind: 'fs', path: '/data/models/tokens.txt' },
+  },
+});
+```
+
 ```typescript
 import { createSTT } from 'react-native-sherpa-onnx/stt';
 

--- a/docs/model-setup.md
+++ b/docs/model-setup.md
@@ -470,6 +470,26 @@ const streaming = await createStreamingPunctuation({
 });
 ```
 
+### Custom Alignment path (per accurate call)
+
+Alignment does **not** use `initializeAlignment`. For `mode: 'accurate'` only, pass `initMode: 'custom'`, `modelType: 'wav2vec2'`, and `customConfig` with a single **`model`** {@link FileSource}. See [Alignment custom model path](alignment-offline.md#custom-model-path-initmode-custom).
+
+```typescript
+import { createAlignment } from 'react-native-sherpa-onnx/alignment';
+
+const engine = createAlignment();
+await engine.alignTextToAudio(textBuf, audioBuf, segmentOut, {
+  mode: 'accurate',
+  initMode: 'custom',
+  modelType: 'wav2vec2',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/wav2vec2.onnx' },
+  },
+  granularity: 'word',
+});
+await engine.destroy();
+```
+
 ```typescript
 import { createStreamingVAD } from 'react-native-sherpa-onnx/vad';
 

--- a/docs/model-setup.md
+++ b/docs/model-setup.md
@@ -439,6 +439,37 @@ const enhancement = await createEnhancement({
 });
 ```
 
+### Custom Punctuation init (skip auto-detection)
+
+Offline CT punctuation: `initMode: 'custom'`, `modelType: 'ct_transformer'`, and `customConfig` with **`ct_transformer`** {@link FileSource}. See [Punctuation offline custom initialization](punctuation-offline.md#custom-initialization-initmode-custom).
+
+Streaming CNN-BiLSTM: `initMode: 'custom'`, `modelType: 'cnn_bilstm'`, and `customConfig` with **`cnn_bilstm`** + **`bpe_vocab`** {@link FileSource} paths. See [Punctuation streaming custom initialization](punctuation-streaming.md#custom-initialization-initmode-custom).
+
+```typescript
+import { createOfflinePunctuation } from 'react-native-sherpa-onnx/punctuation';
+
+const offline = await createOfflinePunctuation({
+  initMode: 'custom',
+  modelType: 'ct_transformer',
+  customConfig: {
+    ct_transformer: { kind: 'fs', path: '/data/models/ct.onnx' },
+  },
+});
+```
+
+```typescript
+import { createStreamingPunctuation } from 'react-native-sherpa-onnx/punctuation';
+
+const streaming = await createStreamingPunctuation({
+  initMode: 'custom',
+  modelType: 'cnn_bilstm',
+  customConfig: {
+    cnn_bilstm: { kind: 'fs', path: '/data/models/cnn.onnx' },
+    bpe_vocab: { kind: 'fs', path: '/data/models/bpe.vocab' },
+  },
+});
+```
+
 ```typescript
 import { createStreamingVAD } from 'react-native-sherpa-onnx/vad';
 

--- a/docs/model-setup.md
+++ b/docs/model-setup.md
@@ -423,6 +423,22 @@ Same pattern for TTS: `initMode: 'custom'`, concrete `modelType`, and `customCon
 
 Same pattern for VAD: `initMode: 'custom'`, concrete `modelType` (`silero_vad` or `ten_vad`), and `customConfig` with a single `model` {@link FileSource}. See [VAD custom initialization](vad-streaming.md#custom-initialization-initmode-custom).
 
+### Custom Enhancement init (skip auto-detection)
+
+Same pattern for Enhancement (offline and streaming): `initMode: 'custom'`, concrete `modelType` (`gtcrn` or `dpdfnet`), and `customConfig` with a single `model` {@link FileSource}. See [Enhancement custom initialization](enhancement-offline.md#custom-initialization-initmode-custom).
+
+```typescript
+import { createEnhancement } from 'react-native-sherpa-onnx/enhancement';
+
+const enhancement = await createEnhancement({
+  initMode: 'custom',
+  modelType: 'gtcrn',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/gtcrn.onnx' },
+  },
+});
+```
+
 ```typescript
 import { createStreamingVAD } from 'react-native-sherpa-onnx/vad';
 

--- a/docs/model-setup.md
+++ b/docs/model-setup.md
@@ -411,6 +411,25 @@ if (sttFolder) {
 
 For `.tar.zst` ship archives, extract to a sandbox directory and use `{ kind: 'fs', path }` there — see [extraction.md](./extraction.md) and the quick start in [model-delivery-pad-odr.md](./model-delivery-pad-odr.md).
 
+### Custom STT init (skip auto-detection)
+
+When model files are not in a single detectable folder, pass explicit paths per file with `initMode: 'custom'`. Each path is a {@link FileSource}; the SDK resolves them to absolute paths before native init. See [STT custom initialization](stt-offline.md#custom-initialization-initmode-custom) for required path keys per model type.
+
+```typescript
+import { createSTT } from 'react-native-sherpa-onnx/stt';
+
+const stt = await createSTT({
+  initMode: 'custom',
+  modelType: 'transducer',
+  customConfig: {
+    encoder: { kind: 'fs', path: '/data/models/encoder.onnx' },
+    decoder: { kind: 'fs', path: '/data/models/decoder.onnx' },
+    joiner: { kind: 'fs', path: '/data/models/joiner.onnx' },
+    tokens: { kind: 'fs', path: '/data/models/tokens.txt' },
+  },
+});
+```
+
 ### Validation: check before init
 
 ```typescript

--- a/docs/model-setup.md
+++ b/docs/model-setup.md
@@ -419,6 +419,22 @@ When model files are not in a single detectable folder, pass explicit paths per 
 
 Same pattern for TTS: `initMode: 'custom'`, concrete `modelType`, and `customConfig` with per-file {@link FileSource} paths. See [TTS custom initialization](tts-offline.md#custom-initialization-initmode-custom). `lexiconLanguageId` is auto-only; pass `lexicon` in `customConfig` when needed.
 
+### Custom VAD init (skip auto-detection)
+
+Same pattern for VAD: `initMode: 'custom'`, concrete `modelType` (`silero_vad` or `ten_vad`), and `customConfig` with a single `model` {@link FileSource}. See [VAD custom initialization](vad-streaming.md#custom-initialization-initmode-custom).
+
+```typescript
+import { createStreamingVAD } from 'react-native-sherpa-onnx/vad';
+
+const vad = await createStreamingVAD({
+  initMode: 'custom',
+  modelType: 'silero_vad',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/silero_vad.onnx' },
+  },
+});
+```
+
 ```typescript
 import { createTTS } from 'react-native-sherpa-onnx/tts';
 

--- a/docs/model-setup.md
+++ b/docs/model-setup.md
@@ -1,40 +1,28 @@
-# Model Setup
+# Model setup
 
-Discover, resolve, and validate model paths across bundled assets, on-demand ship packs (PAD / ODR), and downloaded models.
+Discover model locations, build `FileSource` descriptors, and list available packs — **before** detection or engine init.
 
-**Import paths:** path helpers (`bundledModelFileSource`, `listAssetModels`, …) live in `react-native-sherpa-onnx/utils`. The **`FileSource`** type is exported from **`react-native-sherpa-onnx/fileio`**.
+| Doc | Question it answers |
+| --- | --- |
+| **This page** | Where is my model? How do I point the SDK at it? |
+| [model-detect.md](model-detect.md) | What model type is this? Is it valid? How do I init (auto vs custom)? |
+| [model-languages.md](model-languages.md) | Which language codes / pickers apply to a model family? |
+| [model-delivery-pad-odr.md](model-delivery-pad-odr.md) | How do I ship large models via PAD (Android) or ODR (iOS)? |
 
----
-
-## Table of Contents
-
-- [Overview](#overview)
-- [Quick Start](#quick-start)
-- [API Reference](#api-reference)
-  - [Path Helpers](#path-helpers)
-  - [Asset Discovery](#asset-discovery)
-  - [On-demand packs (PAD / ODR)](#on-demand-packs-pad--odr)
-  - [Model Detection](#model-detection)
-  - [Model detection internals](#model-detection-internals)
-- [SDK init bridge (create* vs initialize*)](#sdk-init-bridge)
-- [Model Sources at a Glance](#model-sources-at-a-glance)
-- [Detailed Examples](#detailed-examples)
-- [Troubleshooting & Tuning](#troubleshooting--tuning)
-- [See Also](#see-also)
+**Imports:** path helpers → `react-native-sherpa-onnx/utils` · `FileSource` type → `react-native-sherpa-onnx/fileio`
 
 ---
 
-## Overview
+## Table of contents
 
-| Feature | Status | Notes |
-| --- | --- | --- |
-| Bundled model path | ✅ | `bundledModelFileSource()` — Android `apkAsset`, iOS `appBundle` |
-| Multi-source fallback | ✅ | `kind: 'auto'` + explicit `tryOrder` (model detect/init only) |
-| Asset listing | ✅ | `listAssetModels()` — scans `assets/models/` (Android) / bundle `models/` (iOS) |
-| Filesystem listing | ✅ | `listModelsAtPath()` — scans any directory |
-| PAD / ODR ship packs | ✅ | [model-delivery-pad-odr.md](./model-delivery-pad-odr.md) (install-time, on-demand, …); `{ kind: 'pad' }` FileSource **Android only** |
-| STT model detection | ✅ | `detectSttModel()` — file-based type detection + required-file validation |
-| TTS model detection | ✅ | `detectTtsModel()` — file-based type detection |
+- [Quick start](#quick-start)
+- [FileSource — the common thread](#filesource--the-common-thread)
+- [Model sources at a glance](#model-sources-at-a-glance)
+- [Expected folder layouts](#expected-folder-layouts)
+- [PAD / ODR (large models)](#pad--odr-large-models)
+- [API reference](#api-reference)
+- [Troubleshooting](#troubleshooting)
+- [See also](#see-also)
 
 ---
 
@@ -49,315 +37,84 @@ import { detectSttModel, createSTT } from 'react-native-sherpa-onnx/stt';
 
 // 1) Discover bundled models
 const models = await listAssetModels();
-// [{ folder: 'sherpa-onnx-whisper-tiny-en', hint: 'stt' }, ...]
+// [{ folder: 'sherpa-onnx-whisper-tiny-en', hint: 'stt' }, …]
 
-// 2) Detect model type before loading (FileSource)
-const detection = await detectSttModel({ kind: 'fs', path: '/absolute/path/to/model' });
-console.log(detection.modelType);    // 'whisper'
-console.log(detection.isStreaming);   // false (whisper is offline-only)
-
-// 3) Create engine
+// 2) Build a FileSource for the pack you want
 const modelSource = bundledModelFileSource('models/sherpa-onnx-whisper-tiny-en');
-const stt = await createSTT({
-  modelSource,
-  modelType: 'auto', // uses detected type
-});
-```
 
----
+// 3) Optional cheap pre-check (no engine load) — see model-detect.md
+const detection = await detectSttModel(modelSource);
+if (!detection.success) throw new Error(detection.error ?? 'Invalid pack');
 
-## API reference
-
-### Path Helpers
-
-#### `bundledModelFileSource(relativePath)`
-
-Create a {@link FileSource} for models shipped inside the app package. Resolution is deterministic per platform:
-
-```ts
-function bundledModelFileSource(relativePath: string): FileSource;
-// Android: { kind: 'app', base: 'apkAsset', path }
-// iOS:     { kind: 'app', base: 'appBundle', path }
-```
-
-**Android:** relative to `assets/` (e.g. `'models/sherpa-onnx-whisper-tiny-en'`). Materialized to a readable directory under the app sandbox.
-
-**iOS:** relative to the main app bundle (Copy Bundle Resources in Xcode).
-
-Use `{ kind: 'fs', path: absolutePath }` for downloaded or extracted models on disk.
-
-#### `autoModelFileSource(path, tryOrder)` / `kind: 'auto'`
-
-When a model folder name is the same across bundled assets, sandbox, PAD, and/or an absolute path, you can probe multiple locations **in a fixed order** instead of hardcoding one `FileSource` per platform.
-
-```ts
-import { autoModelFileSource } from 'react-native-sherpa-onnx/utils';
-import { createSTT } from 'react-native-sherpa-onnx/stt';
-
-// Equivalent to:
-// { kind: 'auto', path: 'models/my-pack', tryOrder: [...] }
-const modelSource = autoModelFileSource('models/my-pack', [
-  'apkAsset',   // Android APK assets/models/my-pack
-  'appBundle',  // iOS bundle models/my-pack (skipped on Android)
-  'files',      // app sandbox files/models/my-pack
-  { pad: 'sherpa_models' }, // Android PAD pack (skipped on iOS)
-  'fs',         // treat path as absolute FS directory (useful after download/extract)
-]);
-
+// 4) Create engine (auto mode — SDK detects type from folder)
 const stt = await createSTT({ modelSource, modelType: 'auto' });
 ```
 
-**Rules:**
+---
 
-| Rule | Detail |
-| --- | --- |
-| **`tryOrder` required** | `{ kind: 'auto', path, tryOrder: [] }` or missing `tryOrder` → `FILEIO_INVALID_ARGUMENT` |
-| **Explicit order only** | First target that resolves to an **existing directory** wins; no hidden defaults |
-| **Same `path` string** | Relative for `app` / `pad` / bundled bases; absolute when `'fs'` is tried |
-| **Platform skips** | Unsupported targets (e.g. `appBundle` on Android) are skipped; resolution continues |
-| **Failure** | If nothing matches → `FILEIO_NOT_FOUND` with `tryOrder` and per-target errors in the message |
-| **Scope** | Model detect/init (`detectSttModel`, `createSTT`, …) — **not** `copyFile` / `shareFile` |
+## FileSource — the common thread
 
-**Typical Android try order:** `['apkAsset', 'files', { pad: 'sherpa_models' }, 'fs']`  
-**Typical iOS try order:** `['appBundle', 'files', 'fs']`
+Every model path in the SDK is a **`FileSource`** — a small descriptor that tells native code **where** to read files. The same type is used for detection, engine init, alignment, and segmentation policy.
 
-Prefer **`bundledModelFileSource()`** when you know the model is shipped in the app package — it stays fully deterministic without probing.
+```typescript
+type FileSource =
+  | { kind: 'fs'; path: string }                              // absolute path on disk
+  | { kind: 'app'; base: AppBaseDir; path: string }           // app sandbox or bundled tree
+  | { kind: 'contentUri'; uri: string }                       // Android SAF document (Android only)
+  | { kind: 'securityScoped'; uri: string }                   // iOS security-scoped URL (iOS only)
+  | { kind: 'pad'; packName: string; path: string }            // installed PAD pack (Android only)
+  | { kind: 'auto'; path: string; tryOrder: AutoTryTarget[] }; // probe multiple locations
+```
 
-#### Bundled bases (`apkAsset` vs `appBundle`)
-
-| `AppBaseDir` | Android | iOS |
+| `kind` | Typical use | Platform |
 | --- | --- | --- |
-| `apkAsset` | APK `assets/<path>` | `FILEIO_UNSUPPORTED_ON_PLATFORM` |
-| `appBundle` | `FILEIO_UNSUPPORTED_ON_PLATFORM` | Main bundle `<path>` |
-| `files`, `cache`, … | App sandbox only | App sandbox only — **no** bundle fallback |
+| `fs` | Downloaded / extracted models | Both |
+| `app` + `apkAsset` | Models in `android/app/src/main/assets/` | Android |
+| `app` + `appBundle` | Models in the iOS app bundle (Copy Bundle Resources) | iOS |
+| `app` + `files` / `documents` | App sandbox after download or extract | Both |
+| `pad` | Read from an **already installed** PAD pack | Android |
+| `auto` | Try bundled → sandbox → PAD → fs in order | Detect/init only |
 
-`pad` (`FileSource`) is Android-only; on iOS use [model-delivery-pad-odr.md](./model-delivery-pad-odr.md) (`fetchAssetPack` / `getAssetPackPath`) then `{ kind: 'fs', path }` for extracted models.
+> [!NOTE]
+> **`FileSource` describes a location, not a single file.** For auto init you pass a **folder**; native detection scans it. For custom init you pass one `FileSource` **per required file** — see [Init modes](model-detect.md#init-modes-auto-vs-custom) in model-detect.md.
 
----
+Full `FileSource` / copy / share API: [fileio.md](fileio.md).
 
-### Asset Discovery
+### Bundled bases (`apkAsset` vs `appBundle`)
 
-#### `listAssetModels()`
-
-Scan the bundled assets model directory and return discovered model folders with a hint.
-
-```ts
-function listAssetModels(): Promise<Array<{
-  folder: string;
-  hint: 'stt' | 'tts' | 'unknown';
-}>>;
-```
-
-On Android scans `assets/models/`; on iOS scans the `models/` bundle directory.
-
-#### `listModelsAtPath(path, recursive?)`
-
-Scan a filesystem directory for model folders.
-
-```ts
-function listModelsAtPath(
-  path: string,
-  recursive?: boolean
-): Promise<Array<{ folder: string; hint: 'stt' | 'tts' | 'unknown' }>>;
-```
-
-When `recursive` is `true`, returns relative folder paths under the base path. Useful for listing downloaded or PAD-delivered models.
-
----
-
-### On-demand packs (PAD / ODR)
-
-**PAD & ODR delivery** (install-time, fast-follow, on-demand, iOS bundle) is documented in **[model-delivery-pad-odr.md](./model-delivery-pad-odr.md)** (`fetchAssetPack`, `ensureAssetPackReady`, `getAssetPackState`, `removeAssetPack`).
-
-#### `getAssetPackPath(packName)`
-
-Returns the path to the `models` directory inside an installed pack or downloaded ODR tag, or `null` if not available yet.
-
-```ts
-function getAssetPackPath(packName: string): Promise<string | null>;
-```
-
-| Platform | `packName` | Notes |
+| `AppBaseDir` | Resolves to | Platform |
 | --- | --- | --- |
-| Android | PAD pack name (e.g. `core_models`) | STORAGE_FILES path when pack is on disk; `null` until fetched for on-demand packs |
-| iOS | ODR tag (e.g. `core_models`) | `<bundle>/<tag>/models` after `fetchAssetPack` / ODR completes |
+| `apkAsset` | APK `assets/<path>` | Android only |
+| `appBundle` | Main bundle `<path>` | iOS only |
+| `files`, `cache`, `documents`, … | App sandbox | Both — **no** bundle fallback |
 
-Alias: `getPlayAssetDeliveryModelsPath` (same function).
-
-After fetch, list **uncompressed** folders with `listModelsAtPath`, or **compressed** archives via [extraction.md](./extraction.md) (`listBundledArchives` on `getAssetPackPath` after PAD/ODR fetch).
-
-```typescript
-const packPath = await getAssetPackPath('core_models');
-if (packPath) {
-  const models = await listModelsAtPath(packPath, true);
-  console.log('Ship pack models:', models);
-}
-```
+Use **`bundledModelFileSource('models/my-pack')`** when you know the model ships inside the app — it picks the correct base per platform.
 
 ---
 
-### Model Detection
+## Model sources at a glance
 
-Cross-feature unified detection (`detectModel`, batch, QNN): [model-detect.md](model-detect.md). The APIs below are STT/TTS-specific.
-
-#### `detectSttModel(source, options?)`
-
-Detect the STT model type and validate required files without loading the model.
-
-```ts
-function detectSttModel(
-  source: FileSource,
-  options?: { preferInt8?: boolean; modelType?: STTModelType }
-): Promise<{
-  success: boolean;
-  /** When `success` is `false`: native validation/detect message. Omitted if the native layer returned an empty string. */
-  error?: string;
-  /** Unsupported-hardware model (e.g. RK35xx, Ascend); from native when applicable. */
-  isHardwareSpecificUnsupported?: boolean;
-  detectedModels: Array<{ type: string; modelDir: string }>;
-  modelType?: string;
-  /** `true` when the detected model type is a streaming-capable online engine (transducer, paraformer, zipformer2_ctc, nemo_ctc, tone_ctc). */
-  isStreaming: boolean;
-}>;
-```
-
-Returns `success: false` when required files are missing or validation fails; use **`error`** for the user-facing message when present.
-
-For `FileSource` resolution problems (unsupported location kind/platform, traversal, permissions, path resolution), the promise can reject with `FILEIO_*` errors before native model detection runs.
-
-#### `detectTtsModel(source, options?)`
-
-Detect the TTS model type without loading.
-
-```ts
-function detectTtsModel(
-  source: FileSource,
-  options?: { modelType?: TTSModelType }
-): Promise<{
-  success: boolean;
-  /** When `success` is `false`: native validation/detect message. Omitted if the native layer returned an empty string. */
-  error?: string;
-  detectedModels: Array<{ type: string; modelDir: string }>;
-  modelType?: string;
-  lexiconLanguages?: Array<{ id: string; path: string }>;
-  /** Always `true` for TTS models. */
-  isStreaming: boolean;
-}>;
-```
-
-Returns `success: false` when required files are missing or validation fails; use **`error`** for the user-facing message when present.
-
-For `FileSource` resolution problems, the promise can reject with `FILEIO_*` errors (for example `FILEIO_UNSUPPORTED_ON_PLATFORM`, `FILEIO_PATH_TRAVERSAL_BLOCKED`, `FILEIO_PERMISSION_DENIED`, `FILEIO_NOT_FOUND`, `FILEIO_RESOLVE_ERROR`).
-
-`lexiconLanguages` lists detected lexicon files (`id` + absolute `path`) for vits, matcha, kokoro, and zipvoice. Pass `lexiconLanguageId` to `createTTS` to select one; re-init to change. Not the same as catalog `languages` hints.
-
-### Model detection internals
-
-Native code scans the **resolved** model directory (recursive), maps filenames to engine roles, then (a) lists **every** engine kind that *could* fit --> `detectedModels`, and (b) picks based on the highest probability **one** kind for validation --> `modelType` (same rules as `createSTT` / `createTTS` with `modelType: 'auto'`). Full pipeline: comments at the top of `sherpa-onnx-model-detect-stt.cpp` / `sherpa-onnx-model-detect-tts.cpp`.
-
-**Why `detectSttModel` / `detectTtsModel` if `createSTT` / `createTTS` already support `modelType: 'auto'`?**  
-Detection is a **cheap preflight**: no recognizer / TTS engine allocation, faster when probing many folders, and you get **`success` / `error` / `isHardwareSpecificUnsupported`** (STT) before paying for full init. Use it for validation UI, model pickers, and diagnostics; skip it if you only need to load one known-good pack.
-
-**STT — return shape, options, and matching `createSTT`:**
-
-```typescript
-import { assetModelPath } from 'react-native-sherpa-onnx/utils';
-import { detectSttModel, createSTT } from 'react-native-sherpa-onnx/stt';
-
-const modelPath = assetModelPath('models/my-pack');
-// detectSttModel resolves the FileSource internally, then runs native file scan (no recognizer init).
-
-const det = await detectSttModel({ kind: 'fs', path: '/absolute/path/to/my-pack' }, {
-  // preferInt8 omitted: do not filter by int8 in filenames (native picks among matches by its own rule).
-  // preferInt8: true  --> use int8-named ONNX where applicable (e.g. *-int8.onnx).
-  // preferInt8: false --> skip int8-named ONNX files (float / full-precision variants).
-  preferInt8: true,
-
-  // modelType omitted or 'auto': choose kind from folder-name hints, else fixed fallback order.
-  // modelType: 'whisper' | 'nemo_transducer' | … --> use only if that engine is supported by the files.
-  modelType: 'auto',
-});
-
-// Array = all engine types this folder might represent (often length 1). Same modelDir per entry;
-// multiple entries = ambiguous pack — e.g. build a picker from det.detectedModels.map(m => m.type).
-const candidates = det.detectedModels;
-
-// Kind native used for validation (informative). Usually you do NOT pass this into createSTT — see below.
-const chosen = det.modelType;
-
-if (!det.success) {
-  console.error(det.error, det.isHardwareSpecificUnsupported); // wrong/missing files or unsupported HW pack
-} else {
-  // Same preferInt8 as detectSttModel so the same ONNX files are chosen for init.
-  //
-  // Prefer modelType: 'auto' here (not det.modelType): createSTT re-runs the same native auto-selection
-  // on this path + preferInt8, so behavior stays one code path and matches future heuristic changes.
-  // Pass an explicit modelType only when the user overrides auto, e.g. picked from det.detectedModels.
-  await createSTT({ modelSource: modelPath, modelType: 'auto', preferInt8: true });
-}
-```
-
-**TTS — same split (`detectedModels` vs `modelType`) plus lexicon languages:**
-
-```typescript
-import { detectTtsModel, createTTS } from 'react-native-sherpa-onnx/tts';
-
-const det = await detectTtsModel({ kind: 'fs', path: '/absolute/path/to/tts-pack' }, {
-  // 'auto' vs 'vits' | 'matcha' | 'kokoro' | 'kitten' | 'pocket' | 'zipvoice' — same idea as STT.
-  modelType: 'auto',
-});
-
-// Same pattern as STT: use modelType: 'auto' on createTTS unless the user picked a candidate from
-// det.detectedModels. detectTtsModel is still useful for cheap checks + lexiconLanguages.
-// Multi-lexicon packs: use lexiconLanguages for a dropdown; pass id via createTTS({ lexiconLanguageId: 'zh' }).
-const lexicons = det.lexiconLanguages;
-```
-
----
-
-## SDK init bridge
-
-Public factories (`createTTS`, `createSTT`, `createStreamingSTT`) use typed options. Native TurboModule methods take a single flat options map per instance: `initializeTts`, `initializeStt`, `initializeOnlineStt` (no positional-arg overloads, no `*WithOptions` suffix).
-
-See [sdk-init-bridge.md](./sdk-init-bridge.md) for the two-layer pattern, bridge type names, and mapping builders.
-
----
-
-## Model Sources at a Glance
-
-| Source | Path Helper | Discovery | Use Case |
+| Source | Helper | Discovery | When to use |
 | --- | --- | --- | --- |
-| Bundled assets | `bundledModelFileSource()` | `listAssetModels()` | Ship models with the app |
-| Multi-source probe | `autoModelFileSource(path, tryOrder)` | — | Same folder name in bundle, sandbox, PAD, or FS |
-| PAD / ODR ship | [guide](./model-delivery-pad-odr.md): `getAssetPackPath` → `listBundledArchives` | `extractArchive()` | Tiered or bundled ship archives |
-| PAD `FileSource` (installed pack) | `{ kind: 'pad', … }` or `auto` `{ pad: … }` | `getAssetPackPath()` + `listModelsAtPath()` | Android only — read/copy from pack without re-download API |
-| Downloaded models | `{ kind: 'fs', path }` | Download Manager or `listModelsAtPath()` | User-selected models at runtime |
-
-`app:files`, `app:apkAsset`, and `app:appBundle` have different semantics and must not be mixed:
-
-| FileSource | Meaning | Platform |
-| --- | --- | --- |
-| `{ kind: 'app', base: 'files', path: 'models/foo' }` | App sandbox internal files directory | Both |
-| `{ kind: 'app', base: 'apkAsset', path: 'models/foo' }` | Bundled APK asset tree | Android only |
-| `{ kind: 'app', base: 'appBundle', path: 'models/foo' }` | Main bundle resources | iOS only |
-| `{ kind: 'auto', path: 'models/foo', tryOrder: ['apkAsset', 'files', …] }` | Try locations in order; first existing directory | Detect/init only |
-
-Combining multiple sources:
+| **Bundled** | `bundledModelFileSource(path)` | `listAssetModels()` | Small models shipped with the app |
+| **Downloaded** | `{ kind: 'fs', path }` | [download-manager.md](download-manager.md) | User downloads at runtime |
+| **PAD / ODR** | `getAssetPackPath(pack)` → `listModelsAtPath` | `fetchAssetPack` + `ensureAssetPackReady` | Large tiered ship packs — see [PAD/ODR section](#pad--odr-large-models) |
+| **Multi-location** | `autoModelFileSource(path, tryOrder)` | — | Same folder name in bundle, sandbox, and/or PAD |
 
 ```typescript
 import {
-  assetModelPath,
-  fileModelPath,
-  getAssetPackPath,
+  bundledModelFileSource,
+  autoModelFileSource,
   listAssetModels,
   listModelsAtPath,
+  getAssetPackPath,
 } from 'react-native-sherpa-onnx/utils';
-import { getLocalModelPathByCategory, listDownloadedModelsByCategory, ModelCategory } from 'react-native-sherpa-onnx/download';
+import { listDownloadedModelsByCategory, ModelCategory } from 'react-native-sherpa-onnx/download';
 
 // Bundled
 const bundled = await listAssetModels();
 
-// On-demand pack (Android PAD or iOS ODR tag) — fetch first; see model-delivery-pad-odr.md
+// On-demand pack (fetch first — see model-delivery-pad-odr.md)
 const packPath = await getAssetPackPath('core_models');
 const packModels = packPath ? await listModelsAtPath(packPath, true) : [];
 
@@ -365,238 +122,238 @@ const packModels = packPath ? await listModelsAtPath(packPath, true) : [];
 const downloaded = await listDownloadedModelsByCategory(ModelCategory.Stt);
 ```
 
----
+### `kind: 'auto'` — probe multiple locations
 
-## Detailed Examples
-
-### Auto-detect and init the first available STT model
+When the same folder name may exist in the bundle, sandbox, PAD, or as an absolute path:
 
 ```typescript
-import { assetModelPath, listAssetModels } from 'react-native-sherpa-onnx/utils';
-import { createSTT, detectSttModel } from 'react-native-sherpa-onnx/stt';
+import { autoModelFileSource } from 'react-native-sherpa-onnx/utils';
 
-const models = await listAssetModels();
-const sttModels = models.filter((m) => m.hint === 'stt');
-
-for (const m of sttModels) {
-  const mp = assetModelPath(`models/${m.folder}`);
-  const detection = await detectSttModel(mp, { preferInt8: true });
-  if (detection.success) {
-    const stt = await createSTT({ modelSource: mp, modelType: 'auto', preferInt8: true });
-    return stt;
-  }
-}
-throw new Error('No valid STT model found');
+const modelSource = autoModelFileSource('models/my-pack', [
+  'apkAsset',              // Android APK assets/models/my-pack
+  'appBundle',             // iOS bundle models/my-pack (skipped on Android)
+  'files',                 // app sandbox files/models/my-pack
+  { pad: 'sherpa_models' }, // Android PAD pack (skipped on iOS)
+  'fs',                    // treat path as absolute directory
+]);
 ```
 
-### On-demand pack — uncompressed models
+| Rule | Detail |
+| --- | --- |
+| `tryOrder` required | Missing or empty → `FILEIO_INVALID_ARGUMENT` |
+| First match wins | First target that resolves to an **existing directory** |
+| Platform skips | Unsupported targets (e.g. `appBundle` on Android) are skipped silently |
+| Scope | Model detect/init only — **not** `copyFile` / `shareFile` |
 
-Requires `fetchAssetPack` / `ensureAssetPackReady` first ([model-delivery-pad-odr.md](./model-delivery-pad-odr.md)).
+Typical Android: `['apkAsset', 'files', { pad: 'sherpa_models' }, 'fs']`  
+Typical iOS: `['appBundle', 'files', 'fs']`
+
+Prefer **`bundledModelFileSource()`** when you know the model is in the app package — fully deterministic, no probing.
+
+---
+
+## Expected folder layouts
+
+Auto init expects a **directory** containing the ONNX files and sidecar files for one Sherpa model family. Native detection scans recursively and maps filenames to roles.
+
+### Bundled (`apkAsset` / `appBundle`)
+
+```
+assets/models/                          ← Android root (iOS: bundle models/)
+└── sherpa-onnx-whisper-tiny-en/        ← one folder = one model pack
+    ├── tiny-encoder.onnx
+    ├── tiny-decoder.onnx
+    └── tiny-tokens.txt
+```
+
+```typescript
+const source = bundledModelFileSource('models/sherpa-onnx-whisper-tiny-en');
+// Android → { kind: 'app', base: 'apkAsset', path: 'models/sherpa-onnx-whisper-tiny-en' }
+// iOS     → { kind: 'app', base: 'appBundle', path: 'models/sherpa-onnx-whisper-tiny-en' }
+```
+
+### Downloaded / extracted (`fs`)
+
+```
+/data/user/0/com.myapp/files/models/
+└── sherpa-onnx-streaming-zipformer-en/
+    ├── encoder-epoch-99-avg-1.onnx
+    ├── decoder-epoch-99-avg-1.onnx
+    ├── joiner-epoch-99-avg-1.onnx
+    └── tokens.txt
+```
+
+```typescript
+const source = { kind: 'fs', path: '/data/user/0/com.myapp/files/models/sherpa-onnx-streaming-zipformer-en' };
+```
+
+### PAD / ODR pack (after fetch)
+
+Uncompressed folders:
+
+```
+…/core_models/models/
+└── sherpa-onnx-whisper-tiny-en/
+    ├── tiny-encoder.onnx
+    ├── tiny-decoder.onnx
+    └── tiny-tokens.txt
+```
+
+Compressed ship archives (`.tar.zst`):
+
+```
+…/core_models/models/
+└── studio_models.tar.zst    ← extract first, then use fs path
+```
+
+After extract → `{ kind: 'fs', path: '<sandbox>/models/<modelId>' }`. See [extraction.md](extraction.md).
+
+> [!CAUTION]
+> **Custom init (`initMode: 'custom'`)** does **not** require a detectable folder layout. You pass explicit `FileSource` per file instead. See [Init modes](model-detect.md#init-modes-auto-vs-custom).
+
+Required files per model type: feature docs (e.g. [STT required files](stt-offline.md#validation-required-files)) and [model-detect.md — Required files](model-detect.md#required-files-per-feature).
+
+---
+
+## PAD / ODR (large models)
+
+For models too large to ship in the main APK/IPA, use **Play Asset Delivery** (Android) or **On-Demand Resources** (iOS). The SDK provides transport APIs; your app orchestrates fetch, extract, and init.
+
+| Step | API | Notes |
+| --- | --- | --- |
+| Fetch | `fetchAssetPack` / `ensureAssetPackReady` | On-demand packs download at runtime |
+| Resolve path | `getAssetPackPath(packName)` | Returns `…/models/` or `null` if not ready |
+| List | `listModelsAtPath(packPath)` or `listBundledArchives(packPath)` | Folders vs compressed archives |
+| Extract (optional) | `extractArchive(archive, targetDir)` | For `.tar.zst` ship packs |
+| Init | `{ kind: 'fs', path: extractedDir }` | Same as any downloaded model |
+
+```typescript
+import { ensureAssetPackReady, getAssetPackPath, listModelsAtPath } from 'react-native-sherpa-onnx/utils';
+
+await ensureAssetPackReady('core_models', {
+  onProgress: (_state, percent) => console.log('download', percent),
+});
+
+const packPath = await getAssetPackPath('core_models');
+if (!packPath) throw new Error('Pack not available');
+
+const models = await listModelsAtPath(packPath, true);
+// → [{ folder: 'sherpa-onnx-whisper-tiny-en', hint: 'stt' }, …]
+```
+
+Full guide: **[model-delivery-pad-odr.md](model-delivery-pad-odr.md)** (delivery modes, native setup, troubleshooting).
+
+---
+
+## API reference
+
+### `bundledModelFileSource(relativePath)`
+
+```typescript
+function bundledModelFileSource(relativePath: string): FileSource;
+```
+
+```typescript
+const source = bundledModelFileSource('models/sherpa-onnx-whisper-tiny-en');
+// Android: { kind: 'app', base: 'apkAsset', path: '…' }
+// iOS:     { kind: 'app', base: 'appBundle', path: '…' }
+```
+
+Returns a platform-correct `FileSource` for models inside the app package. Prefer this over hardcoding `apkAsset` / `appBundle`.
+
+---
+
+### `autoModelFileSource(path, tryOrder)`
+
+```typescript
+function autoModelFileSource(
+  path: string,
+  tryOrder: AutoTryTarget[]
+): FileSource;
+```
+
+```typescript
+const source = autoModelFileSource('models/my-pack', ['apkAsset', 'files', 'fs']);
+const stt = await createSTT({ modelSource: source, modelType: 'auto' });
+```
+
+Builds `{ kind: 'auto', path, tryOrder }`. First existing directory wins. Detect/init only.
+
+---
+
+### `listAssetModels()`
+
+```typescript
+function listAssetModels(): Promise<Array<{
+  folder: string;
+  hint: 'stt' | 'tts' | 'unknown';
+}>>;
+```
+
+```typescript
+const models = await listAssetModels();
+// Android: scans assets/models/ · iOS: scans bundle models/
+```
+
+Returns folder names with a best-effort category hint. Use `detect*Model` or `detectModel` for definitive type detection — hints are naming heuristics only.
+
+---
+
+### `listModelsAtPath(path, recursive?)`
+
+```typescript
+function listModelsAtPath(
+  path: string,
+  recursive?: boolean
+): Promise<Array<{ folder: string; hint: 'stt' | 'tts' | 'unknown' }>>;
+```
 
 ```typescript
 const packPath = await getAssetPackPath('core_models');
-if (!packPath) throw new Error('Pack/tag not available');
-
-const models = await listModelsAtPath(packPath, true);
-const sttFolder = models.find((m) => m.hint === 'stt');
-
-if (sttFolder) {
-  const fullPath = `${packPath}/${sttFolder.folder}`;
-  const stt = await createSTT({
-    modelSource: fileModelPath(fullPath),
-    modelType: 'auto',
-  });
-}
+const models = packPath ? await listModelsAtPath(packPath, true) : [];
 ```
 
-For `.tar.zst` ship archives, extract to a sandbox directory and use `{ kind: 'fs', path }` there — see [extraction.md](./extraction.md) and the quick start in [model-delivery-pad-odr.md](./model-delivery-pad-odr.md).
-
-### Custom STT init (skip auto-detection)
-
-When model files are not in a single detectable folder, pass explicit paths per file with `initMode: 'custom'`. Each path is a {@link FileSource}; the SDK resolves them to absolute paths before native init. See [STT custom initialization](stt-offline.md#custom-initialization-initmode-custom) for required path keys per model type.
-
-### Custom TTS init (skip auto-detection)
-
-Same pattern for TTS: `initMode: 'custom'`, concrete `modelType`, and `customConfig` with per-file {@link FileSource} paths. See [TTS custom initialization](tts-offline.md#custom-initialization-initmode-custom). `lexiconLanguageId` is auto-only; pass `lexicon` in `customConfig` when needed.
-
-### Custom VAD init (skip auto-detection)
-
-Same pattern for VAD: `initMode: 'custom'`, concrete `modelType` (`silero_vad` or `ten_vad`), and `customConfig` with a single `model` {@link FileSource}. See [VAD custom initialization](vad-streaming.md#custom-initialization-initmode-custom).
-
-### Custom Enhancement init (skip auto-detection)
-
-Same pattern for Enhancement (offline and streaming): `initMode: 'custom'`, concrete `modelType` (`gtcrn` or `dpdfnet`), and `customConfig` with a single `model` {@link FileSource}. See [Enhancement custom initialization](enhancement-offline.md#custom-initialization-initmode-custom).
-
-```typescript
-import { createEnhancement } from 'react-native-sherpa-onnx/enhancement';
-
-const enhancement = await createEnhancement({
-  initMode: 'custom',
-  modelType: 'gtcrn',
-  customConfig: {
-    model: { kind: 'fs', path: '/data/models/gtcrn.onnx' },
-  },
-});
-```
-
-### Custom Punctuation init (skip auto-detection)
-
-Offline CT punctuation: `initMode: 'custom'`, `modelType: 'ct_transformer'`, and `customConfig` with **`ct_transformer`** {@link FileSource}. See [Punctuation offline custom initialization](punctuation-offline.md#custom-initialization-initmode-custom).
-
-Streaming CNN-BiLSTM: `initMode: 'custom'`, `modelType: 'cnn_bilstm'`, and `customConfig` with **`cnn_bilstm`** + **`bpe_vocab`** {@link FileSource} paths. See [Punctuation streaming custom initialization](punctuation-streaming.md#custom-initialization-initmode-custom).
-
-```typescript
-import { createOfflinePunctuation } from 'react-native-sherpa-onnx/punctuation';
-
-const offline = await createOfflinePunctuation({
-  initMode: 'custom',
-  modelType: 'ct_transformer',
-  customConfig: {
-    ct_transformer: { kind: 'fs', path: '/data/models/ct.onnx' },
-  },
-});
-```
-
-```typescript
-import { createStreamingPunctuation } from 'react-native-sherpa-onnx/punctuation';
-
-const streaming = await createStreamingPunctuation({
-  initMode: 'custom',
-  modelType: 'cnn_bilstm',
-  customConfig: {
-    cnn_bilstm: { kind: 'fs', path: '/data/models/cnn.onnx' },
-    bpe_vocab: { kind: 'fs', path: '/data/models/bpe.vocab' },
-  },
-});
-```
-
-### Custom Alignment path (per accurate call)
-
-Alignment does **not** use `initializeAlignment`. For `mode: 'accurate'` only, pass `initMode: 'custom'`, `modelType: 'wav2vec2'`, and `customConfig` with a single **`model`** {@link FileSource}. See [Alignment custom model path](alignment-offline.md#custom-model-path-initmode-custom).
-
-### Custom Segmentation path (`speech_vad_model` policy)
-
-Segmentation has **no** engine init. For `evaluator: 'speech_vad_model'` only, pass `initMode: 'custom'`, concrete `modelType` (`silero_vad` or `ten_vad`), and `customConfig` with a single **`model`** {@link FileSource} — same VAD keys as streaming VAD. See [Segmentation custom model path](segmentation-engine.md#custom-model-path-initmode-custom).
-
-```typescript
-import { segmentOfflineBuffer } from 'react-native-sherpa-onnx/segment';
-
-await segmentOfflineBuffer(offlineAudio, {
-  evaluator: 'speech_vad_model',
-  initMode: 'custom',
-  modelType: 'silero_vad',
-  customConfig: {
-    model: { kind: 'fs', path: '/data/models/silero_vad.onnx' },
-  },
-  vadThreshold: 0.5,
-});
-```
-
-```typescript
-import { createAlignment } from 'react-native-sherpa-onnx/alignment';
-
-const engine = createAlignment();
-await engine.alignTextToAudio(textBuf, audioBuf, segmentOut, {
-  mode: 'accurate',
-  initMode: 'custom',
-  modelType: 'wav2vec2',
-  customConfig: {
-    model: { kind: 'fs', path: '/data/models/wav2vec2.onnx' },
-  },
-  granularity: 'word',
-});
-await engine.destroy();
-```
-
-```typescript
-import { createStreamingVAD } from 'react-native-sherpa-onnx/vad';
-
-const vad = await createStreamingVAD({
-  initMode: 'custom',
-  modelType: 'silero_vad',
-  customConfig: {
-    model: { kind: 'fs', path: '/data/models/silero_vad.onnx' },
-  },
-});
-```
-
-```typescript
-import { createTTS } from 'react-native-sherpa-onnx/tts';
-
-const tts = await createTTS({
-  initMode: 'custom',
-  modelType: 'vits',
-  customConfig: {
-    ttsModel: { kind: 'fs', path: '/data/models/model.onnx' },
-    tokens: { kind: 'fs', path: '/data/models/tokens.txt' },
-  },
-});
-```
-
-```typescript
-import { createSTT } from 'react-native-sherpa-onnx/stt';
-
-const stt = await createSTT({
-  initMode: 'custom',
-  modelType: 'transducer',
-  customConfig: {
-    encoder: { kind: 'fs', path: '/data/models/encoder.onnx' },
-    decoder: { kind: 'fs', path: '/data/models/decoder.onnx' },
-    joiner: { kind: 'fs', path: '/data/models/joiner.onnx' },
-    tokens: { kind: 'fs', path: '/data/models/tokens.txt' },
-  },
-});
-```
-
-### Validation: check before init
-
-```typescript
-const detection = await detectSttModel(
-  assetModelPath('models/my-model'),
-  { preferInt8: true }
-);
-
-if (!detection.success) {
-  // detection contains error info about missing files
-  console.error('Model validation failed:', detection);
-  return;
-}
-```
+Scans any filesystem directory. `recursive: true` returns relative paths under the base.
 
 ---
 
-## Troubleshooting & Tuning
+### `getAssetPackPath(packName)`
+
+```typescript
+function getAssetPackPath(packName: string): Promise<string | null>;
+```
+
+```typescript
+const packPath = await getAssetPackPath('core_models');
+// Android: PAD STORAGE_FILES path …/models
+// iOS: ODR tag path …/{tag}/models
+// null until pack is fetched / ready
+```
+
+Returns the `models` directory inside an installed pack. Alias: `getPlayAssetDeliveryModelsPath`.
+
+Fetch workflow: [model-delivery-pad-odr.md](model-delivery-pad-odr.md).
+
+---
+
+## Troubleshooting
 
 | Issue | Solution |
 | --- | --- |
-| `listAssetModels()` returns empty | Ensure models are in `android/app/src/main/assets/models/` or the iOS bundle `models/` group |
-| Bundled model resolution fails | Check that the model directory exists at the expected location on the platform; use `bundledModelFileSource('models/...')` with `app:apkAsset` (Android) or `app:appBundle` (iOS) |
-| `getAssetPackPath` returns `null` | On-demand: run `fetchAssetPack` + `ensureAssetPackReady` ([model-delivery-pad-odr.md](./model-delivery-pad-odr.md)); check pack/tag name and native Gradle/Xcode setup |
-| `detectSttModel` says missing files | The model directory doesn't contain all required files for the detected type; check the [STT doc](stt-offline.md#validation-required-files) for the file-per-type table |
-| Int8 model not found | Set `preferInt8: true` and ensure `*-int8.onnx` variants are present |
-| Wrong `hint` value | `hint` is a best-effort heuristic based on folder naming; use `detectSttModel`/`detectTtsModel` for definitive type detection |
-| TTS init fails with `Error processing file '/usr/share/espeak-ng-data/phontab'` | Path to `espeak-ng-data` is too long; espeak-ng truncates it and falls back to `/usr/share`. See [issue: TTS espeak-ng path length](../third_party/sherpa-onnx-prebuilt/issue-tts-espeak-ng-path-length.md) for workarounds. |
-
-**Tips:**
-
-- Use `listAssetModels()` for discovery, then `detectSttModel()`/`detectTtsModel()` for accurate type detection — the `hint` is based on naming heuristics only
-- Always prefer `modelType: 'auto'` with `detectSttModel()`/`detectTtsModel()` rather than hardcoding model types
-- Combine bundled assets, on-demand packs, and downloads into a single model picker by merging all sources
+| `listAssetModels()` returns empty | Models must be in `android/app/src/main/assets/models/` or iOS bundle `models/` group |
+| Bundled resolution fails | Verify folder exists; use `bundledModelFileSource('models/…')` |
+| `getAssetPackPath` returns `null` | Run `fetchAssetPack` + `ensureAssetPackReady` first — [model-delivery-pad-odr.md](model-delivery-pad-odr.md) |
+| `FILEIO_NOT_FOUND` with `kind: 'auto'` | No location in `tryOrder` matched; check each target path |
+| `detect*Model` says missing files | Folder layout doesn't match expected files — see feature [required files](stt-offline.md#validation-required-files) table |
+| Wrong `hint` from listing | Hint is naming heuristic only; run feature detect for definitive type |
 
 ---
 
 ## See also
 
-- [Ship model delivery (PAD & ODR)](model-delivery-pad-odr.md) — install-time, fast-follow, on-demand, bundle
-- [Extraction API](extraction.md) — `listBundledArchives`, `listBundledArchivesFromApkAssets`, `extractArchive`
-- [STT](stt-offline.md) — Speech-to-Text API
-- [TTS](tts-offline.md) — Text-to-Speech API
-- [SDK init bridge](sdk-init-bridge.md) — `create*` public API vs `initialize*` TurboModule maps
-- [Download Manager](download-manager.md) — Download models in-app
-- [Execution Providers](execution-providers.md) — QNN, NNAPI, XNNPACK, Core ML
-- [Issue: TTS espeak-ng path length](../third_party/sherpa-onnx-prebuilt/issue-tts-espeak-ng-path-length.md) — When TTS init fails due to long `data_dir` path (phontab /usr/share error)
-
-## Native crash diagnostics
-
-If native code fails or the app crashes but the tombstone shows only a UI/GPU thread, inspect the SDK **last-activity ring buffer** (enabled by default when the native library loads). Full details: [native-diagnostics.md](./native-diagnostics.md) — Android log tag `SherpaNativeDiag`; iOS subsystem `com.sherpaonnx.diag`. Optional JS: `getNativeDiagnosticSnapshot` / `configureNativeDiagnostics` from `react-native-sherpa-onnx/diagnostics`.
-
+- [Model detection & init](model-detect.md) — detect, validate, auto vs custom init
+- [Ship model delivery (PAD & ODR)](model-delivery-pad-odr.md)
+- [Extraction API](extraction.md) — `.tar.zst` / `.tar.bz2` archives
+- [Download Manager](download-manager.md) — runtime model downloads
+- [File I/O](fileio.md) — `FileSource` shapes, copy/share
+- [SDK init bridge](sdk-init-bridge.md) — `create*` vs native `initialize*` maps

--- a/docs/model-setup.md
+++ b/docs/model-setup.md
@@ -474,6 +474,24 @@ const streaming = await createStreamingPunctuation({
 
 Alignment does **not** use `initializeAlignment`. For `mode: 'accurate'` only, pass `initMode: 'custom'`, `modelType: 'wav2vec2'`, and `customConfig` with a single **`model`** {@link FileSource}. See [Alignment custom model path](alignment-offline.md#custom-model-path-initmode-custom).
 
+### Custom Segmentation path (`speech_vad_model` policy)
+
+Segmentation has **no** engine init. For `evaluator: 'speech_vad_model'` only, pass `initMode: 'custom'`, concrete `modelType` (`silero_vad` or `ten_vad`), and `customConfig` with a single **`model`** {@link FileSource} — same VAD keys as streaming VAD. See [Segmentation custom model path](segmentation-engine.md#custom-model-path-initmode-custom).
+
+```typescript
+import { segmentOfflineBuffer } from 'react-native-sherpa-onnx/segment';
+
+await segmentOfflineBuffer(offlineAudio, {
+  evaluator: 'speech_vad_model',
+  initMode: 'custom',
+  modelType: 'silero_vad',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/silero_vad.onnx' },
+  },
+  vadThreshold: 0.5,
+});
+```
+
 ```typescript
 import { createAlignment } from 'react-native-sherpa-onnx/alignment';
 

--- a/docs/punctuation-offline.md
+++ b/docs/punctuation-offline.md
@@ -28,6 +28,29 @@ Unified cross-feature detection: [model-detect.md](model-detect.md).
 
 ---
 
+## Custom initialization (`initMode: 'custom'`)
+
+Use custom init when the CT-Transformer ONNX file is **not** in a detectable folder layout.
+
+- Set `initMode: 'custom'` and `modelType: 'ct_transformer'` (concrete, not `'auto'`).
+- Pass `customConfig` with a single **`ct_transformer`** {@link FileSource} pointing at the `.onnx` file.
+- Validation uses native `validate-punctuation`. See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
+
+```ts
+import { createOfflinePunctuation } from 'react-native-sherpa-onnx/punctuation';
+
+const engine = await createOfflinePunctuation({
+  initMode: 'custom',
+  modelType: 'ct_transformer',
+  customConfig: {
+    ct_transformer: { kind: 'fs', path: '/data/models/ct-punct.onnx' },
+  },
+  numThreads: 2,
+});
+```
+
+---
+
 ## Quick start
 
 `textIn` is **populated**; `textOut` is **empty** before the call. Both are offline text buffers. Raw string ids are rejected early with **`TEXT_*`** or **`PUNCTUATION_*`** error codes as appropriate.

--- a/docs/punctuation-offline.md
+++ b/docs/punctuation-offline.md
@@ -2,54 +2,15 @@
 
 ## Introduction
 
-**CT-Transformer** batch punctuation: **Input** = populated [offline text buffer](textbuffer-offline.md) (`lang` pass-through, not from the model). **Output** = empty buffer, one write; v1 leaves tokens/timestamps/etc. empty. **Return value** in JS always includes `processingTimeMs`; when segmentation is enabled it also includes orchestration fields (`status`, segment counters, optional failed/skipped segment details). Engine: `createOfflinePunctuation` → `punctuate` / `punctuateString`.
+**CT-Transformer** batch punctuation with a **pipeline-first** API.
 
-`react-native-sherpa-onnx/punctuation` — loads **offline CT** only; online CNN is out of scope here ([`detectPunctuationModel`](#model-detection) for family checks). The offline engine supports both batch `txt_off_*` and the Phase-3 live overload `punctuate(txt_live_*, txt_live_*, { segmentation })`. For online CNN pipelines, see [punctuation-streaming.md](punctuation-streaming.md).
+| Role | Type | Notes |
+| --- | --- | --- |
+| **Input** | [`OfflineTextBuffer`](textbuffer-offline.md) | Populated plain text; `lang` is pass-through from input |
+| **Output** | [`OfflineTextBuffer`](textbuffer-offline.md) | Empty buffer before the call; filled once with punctuated text |
+| **Engine** | `OfflinePunctuationEngine` via `createOfflinePunctuation` | `punctuate` / `punctuateString`; returns `processingTimeMs` (plus segment stats when segmentation is enabled) |
 
-Live-overload contract references:
-
-- Design note: [offline-stt-live-pipeline-mandatory-segmentation.md](migration/liveOverload/offline-stt-live-pipeline-mandatory-segmentation.md)
-- Overview: [live_overload_overview.md](migration/liveOverload/live_overload_overview.md)
-- Phase plan: [sub-04-punctuation-live-overload.md](migration/liveOverload/sub-04-punctuation-live-overload.md)
-
----
-
-## Models and paths
-
-**`FileSource`** (`{ kind: 'fs' | 'app' | 'pad', path, ... }`) for **`createOfflinePunctuation`**. **`FileSource`** for **`detectPunctuationModel`**. See [download-manager.md](download-manager.md), [model-setup.md](model-setup.md). **Init** always re-runs **ct_transformer** detect (no CNN fallback) — online-only trees **fail** init.
-
-## Model detection
-
-Unified cross-feature detection: [model-detect.md](model-detect.md).
-
-`detectPunctuationModel` = **pre-check** only (no engine load). Splits **ct_transformer** vs **cnn_bilstm**+bpe; `modelType` = `auto` | `ct_transformer` | `cnn_bilstm`. Optional `assetName` for catalog hints. Returns `paths.*`, `isStreaming` (reserved), `detectionSources`; vocabs come from **ONNX**, not a separate tokens arg.
-
-`detectPunctuationModel` with `auto` can succeed while **still** not CT-only — `createOfflinePunctuation` only accepts a valid **CT offline** directory. `FILEIO_*` if `FileSource` resolution fails.
-
----
-
-## Custom initialization (`initMode: 'custom'`)
-
-Use custom init when the CT-Transformer ONNX file is **not** in a detectable folder layout.
-
-- Set `initMode: 'custom'` and `modelType: 'ct_transformer'` (concrete, not `'auto'`).
-- Pass `customConfig` with a single **`ct_transformer`** {@link FileSource} pointing at the `.onnx` file.
-- Validation uses native `validate-punctuation`. See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
-
-```ts
-import { createOfflinePunctuation } from 'react-native-sherpa-onnx/punctuation';
-
-const engine = await createOfflinePunctuation({
-  initMode: 'custom',
-  modelType: 'ct_transformer',
-  customConfig: {
-    ct_transformer: { kind: 'fs', path: '/data/models/ct-punct.onnx' },
-  },
-  numThreads: 2,
-});
-```
-
----
+Import path: `react-native-sherpa-onnx/punctuation` — **offline CT-Transformer** only. For online CNN pipelines, see [punctuation-streaming.md](punctuation-streaming.md). The offline engine also supports a [live overload](#live-overload-on-offline-punctuation-offline-weights-live-consumption) on `LiveTextBuffer` pairs.
 
 ## Quick start
 
@@ -124,64 +85,6 @@ try {
 }
 ```
 
----
-
-## Live overload on offline punctuation (offline weights, live consumption)
-
-> Mandatory `segmentation.policy`. Commit-only — no partials.
-
-The offline punctuation engine can drive a live pipeline directly. This is useful when you want to punctuate a live stream of text (e.g. from an STT live buffer) using a high-quality CT-Transformer model without the latency/BPE-size constraints of streaming CNN models.
-
-```ts
-const punct = await createOfflinePunctuation({
-  modelSource: { kind: 'fs', path: '/absolute/path/to/sherpa-onnx-punct-ct-en' },
-});
-
-const handle = await punct.punctuate(liveTextIn, liveTextOut, {
-  segmentation: {
-    mode: 'auto',
-    policy: { evaluator: 'text_synthetic_auto', maxLengthChars: 500 },
-  },
-});
-
-// handle.stop() / .flush() / .completed as usual
-const completion = await handle.completed;
-console.log(`Punctuated ${completion.unitsRead} characters`);
-```
-
-| Aspect | Live overload (`createOfflinePunctuation`) | Streaming engine (`createStreamingPunctuation`) |
-| --- | --- | --- |
-| Weights | CT-Transformer (Higher quality) | CNN-BiLSTM (Lower quality) |
-| Latency | Per-segment (higher) | Per-token (lower) |
-| Context | Global (per segment) | Local (sliding window) |
-
-
-
----
-
-## Data model and lifetime
-
-| Item | Behaviour |
-| --- | --- |
-| **Offline punctuation engine** | Created with **`createOfflinePunctuation`**. Holds native **`OfflinePunctuation`**. Call **`destroy()`** when done. |
-| **`OfflineTextBuffer` (input)** | **Populated** (immutable). Must contain the **plain** text to punctuate. |
-| **`OfflineTextBuffer` (output)** | **Empty** before **`punctuate` / `punctuateString`**. Filled **once** with punctuated `text` and `lang` **from input** (buffer path only for `lang`). |
-| **Result in JS** | **`{ processingTimeMs: number }`** only (native add-punctuation duration). Read full text with **`getOfflineTextBufferTextSlice`**. |
-
----
-
-## Setup (iOS and Android)
-
-| Topic | Requirement |
-| --- | --- |
-| **Execution provider** | Optional **`provider`** on init (e.g. **`cpu`**); see [execution-providers.md](execution-providers.md). |
-| **Model layout** | **Offline CT-Transformer** only. Online CNN packs **cannot** drive **`createOfflinePunctuation`**. |
-| **Instance lifetime** | Always **`destroy()`** the engine; **`releasePipelineTextBuffer()`** on created buffers. |
-
-On module teardown, native text registry invalidation and offline engine teardown follow the same ordering as other features (see native **`invalidate`** ordering).
-
----
-
 ## API reference
 
 Signatures are exported from **`react-native-sherpa-onnx/punctuation`**. Types are defined in **`src/punctuation/types.ts`**; detection types mirror **`src/punctuation/detect.ts`** and **`PunctuationDetectModelResult`**.
@@ -240,7 +143,7 @@ const engine = await createOfflinePunctuation({
 });
 ```
 
-- If native init **rejects** (e.g. not CT), the promise **rejects** with a **`PUNCTUATION_*`** or **`PUNCT_DETECT_ERROR`**-related code. If a legacy bridge ever **resolves** with `{ success: false }`, **`createOfflinePunctuation`** throws a **`Error`** with a short message so callers do not get a no-op engine.
+- If native init rejects (e.g. CNN-only pack), the promise rejects with a **`PUNCTUATION_*`** or detection-related code. **`createOfflinePunctuation`** throws an **`Error`** on init failure so callers do not get a no-op engine.
 
 ### Offline engine (`OfflinePunctuationEngine`)
 
@@ -314,6 +217,85 @@ import {
 ```
 
 See [textbuffer — offline](textbuffer-offline.md) and [textbuffer — streaming](textbuffer-streaming.md) for the live side of the pipeline.
+
+### Buffer data model and lifetime
+
+| Item | Behaviour |
+| --- | --- |
+| **Offline punctuation engine** | Created with **`createOfflinePunctuation`**. Holds native **`OfflinePunctuation`**. Call **`destroy()`** when done. |
+| **`OfflineTextBuffer` (input)** | **Populated** (immutable). Must contain the **plain** text to punctuate. |
+| **`OfflineTextBuffer` (output)** | **Empty** before **`punctuate` / `punctuateString`**. Filled **once** with punctuated `text` and `lang` **from input** (buffer path only for `lang`). |
+| **Result in JS** | **`{ processingTimeMs: number }`** only (native add-punctuation duration). Read full text with **`getOfflineTextBufferTextSlice`**. |
+
+> Always **`destroy()`** the engine and **`releasePipelineTextBuffer()`** created buffers.
+
+## Models and paths
+
+- **`FileSource`** — [model-setup.md](model-setup.md)
+- **Detection & init** — [model-detect.md](model-detect.md)
+- Offline CT only — `createOfflinePunctuation` rejects CNN-only trees
+
+## Validation required files
+
+| `modelType` | Required files | Optional | Custom-init keys |
+| --- | --- | --- | --- |
+| `ct_transformer` | `*.onnx` (CT-Transformer) | — | `ct_transformer` |
+| `cnn_bilstm` | `*.onnx`, `bpe_vocab` | — | `cnn_bilstm`, `bpe_vocab` (streaming only) |
+
+`detectPunctuationModel` with `auto` may detect either family; **`createOfflinePunctuation`** accepts **`ct_transformer`** only.
+
+## Model detection
+
+`detectPunctuationModel` pre-check — no engine load. Unified catalog: [model-detect.md](model-detect.md). Returns `paths.*`, `detectionSources`; vocabs from ONNX.
+
+## Custom initialization (`initMode: 'custom'`)
+
+Concept: [model-detect.md — Init modes](model-detect.md#init-modes-auto-vs-custom).
+
+| `modelType` | Custom-init keys |
+| --- | --- |
+| `ct_transformer` | `ct_transformer` |
+
+```ts
+import { createOfflinePunctuation } from 'react-native-sherpa-onnx/punctuation';
+
+const engine = await createOfflinePunctuation({
+  initMode: 'custom',
+  modelType: 'ct_transformer',
+  customConfig: {
+    ct_transformer: { kind: 'fs', path: '/data/models/ct-punct.onnx' },
+  },
+});
+```
+
+## Live overload on offline punctuation (offline weights, live consumption)
+
+> Mandatory `segmentation.policy`. Commit-only — no partials.
+
+The offline punctuation engine can drive a live pipeline directly. This is useful when you want to punctuate a live stream of text (e.g. from an STT live buffer) using a high-quality CT-Transformer model without the latency/BPE-size constraints of streaming CNN models.
+
+```ts
+const punct = await createOfflinePunctuation({
+  modelSource: { kind: 'fs', path: '/absolute/path/to/sherpa-onnx-punct-ct-en' },
+});
+
+const handle = await punct.punctuate(liveTextIn, liveTextOut, {
+  segmentation: {
+    mode: 'auto',
+    policy: { evaluator: 'text_synthetic_auto', maxLengthChars: 500 },
+  },
+});
+
+// handle.stop() / .flush() / .completed as usual
+const completion = await handle.completed;
+console.log(`Punctuated ${completion.unitsRead} characters`);
+```
+
+| Aspect | Live overload (`createOfflinePunctuation`) | Streaming engine (`createStreamingPunctuation`) |
+| --- | --- | --- |
+| Weights | CT-Transformer (Higher quality) | CNN-BiLSTM (Lower quality) |
+| Latency | Per-segment (higher) | Per-token (lower) |
+| Context | Global (per segment) | Local (sliding window) |
 
 ## Segmentation
 

--- a/docs/punctuation-streaming.md
+++ b/docs/punctuation-streaming.md
@@ -2,9 +2,13 @@
 
 ## Introduction
 
-On-device streaming punctuation with a pipeline-first API:
+On-device streaming punctuation with a **pipeline-first** API.
 
-- Pipeline handle: `PunctuationPipelineHandle` provides `stop`, `flush`, `reset`, `getStatus`, and `completed`.
+| Role | Type | Notes |
+| --- | --- | --- |
+| **Input** | [`LiveTextBuffer`](textbuffer-streaming.md) | Committed text segments from upstream (e.g. live STT) |
+| **Output** | [`LiveTextBuffer`](textbuffer-streaming.md) | Punctuated committed segments |
+| **Engine** | `StreamingPunctuationEngine` via `createStreamingPunctuation` | `punctuate(textIn, textOut)` returns `PunctuationPipelineHandle` (`stop`, `flush`, `reset`, `getStatus`, `completed`) |
 
 Import path: `react-native-sherpa-onnx/punctuation`
 
@@ -13,55 +17,6 @@ For batch punctuation with offline text buffers, see [punctuation-offline.md](pu
 ## Streaming pipeline system
 
 `punctuate` starts a **native worker** that reads **committed text segments** from the live **input** buffer and writes punctuated segments to the live **output** buffer (not the raw partial window). Shared **`stop` / `flush` / `reset` / `getStatus` / `completed`** semantics are in **[Streaming pipelines — shared lifecycle](streaming-pipelines-overview.md)**; punctuation additionally requires a **post-input-finalize `flush()`** barrier — see Quick start and **`pipeline.flush()`** below.
-
-## Models and paths
-
-- `FileSource` (type from `react-native-sherpa-onnx/fileio`): `FileSource`
-- `FileSource` is used by `detectPunctuationModel(...)` for preflight checks.
-- Streaming punctuation requires an online-capable `cnn_bilstm` layout. Offline `ct_transformer` models are not valid for this API.
-- **Input normalization:** `textInputNormalization` defaults to `'lower'` so ALL-CAPS ASR text is normalized before inference. Pass `'none'` to disable.
-- Download/catalog setup: [download-manager.md](download-manager.md), [model-setup.md](model-setup.md)
-
-## Model detection
-
-Unified cross-feature detection: [model-detect.md](model-detect.md).
-
-Use `detectPunctuationModel` as preflight before initialization:
-- `modelType: 'auto'` may detect either offline `ct_transformer` or online `cnn_bilstm`.
-- Streaming initialization requires `modelType === 'cnn_bilstm'` with `isStreaming === true`.
-
-```ts
-import { detectPunctuationModel } from 'react-native-sherpa-onnx/punctuation';
-
-const det = await detectPunctuationModel(
-  { kind: 'fs', path: '/path/to/punctuation-online-pack' },
-  { modelType: 'auto' }
-);
-
-if (!det.success || det.modelType !== 'cnn_bilstm' || !det.isStreaming) {
-  throw new Error(det.error ?? 'Streaming punctuation requires cnn_bilstm');
-}
-```
-
----
-
-## Custom initialization (`initMode: 'custom'`)
-
-Streaming punctuation uses a separate init union from offline. Pass `initMode: 'custom'`, concrete `modelType: 'cnn_bilstm'`, and both required paths in `customConfig`. See [Punctuation offline — Custom initialization](punctuation-offline.md#custom-initialization-initmode-custom) for validation rules (offline uses one key; streaming uses two).
-
-```ts
-import { createStreamingPunctuation } from 'react-native-sherpa-onnx/punctuation';
-
-const engine = await createStreamingPunctuation({
-  initMode: 'custom',
-  modelType: 'cnn_bilstm',
-  customConfig: {
-    cnn_bilstm: { kind: 'fs', path: '/data/models/cnn.onnx' },
-    bpe_vocab: { kind: 'fs', path: '/data/models/bpe.vocab' },
-  },
-  provider: 'cpu',
-});
-```
 
 ## Quick start
 
@@ -239,6 +194,55 @@ console.log(status.isRunning, status.chunksProcessed, status.unitsRead, status.u
 #### `pipeline.completed`
 
 Await after **`flush()`** / **`stop()`** in the recommended order so teardown and buffer release do not race.
+
+## Models and paths
+
+- **`FileSource`** — [model-setup.md](model-setup.md)
+- Streaming requires online `cnn_bilstm` — offline `ct_transformer` is not valid here
+- **`textInputNormalization`:** defaults to `'lower'`; pass `'none'` to disable
+
+## Validation required files
+
+| `modelType` | Required files | Optional | Custom-init keys |
+| --- | --- | --- | --- |
+| `cnn_bilstm` | `*.onnx`, `bpe_vocab` | — | `cnn_bilstm`, `bpe_vocab` |
+
+## Model detection
+
+`detectPunctuationModel` pre-check. Require `det.modelType === 'cnn_bilstm' && det.isStreaming`. Unified catalog: [model-detect.md](model-detect.md).
+
+```ts
+import { detectPunctuationModel } from 'react-native-sherpa-onnx/punctuation';
+
+const det = await detectPunctuationModel(
+  { kind: 'fs', path: '/path/to/punctuation-online-pack' },
+  { modelType: 'auto' }
+);
+if (!det.success || det.modelType !== 'cnn_bilstm' || !det.isStreaming) {
+  throw new Error(det.error ?? 'Streaming punctuation requires cnn_bilstm');
+}
+```
+
+## Custom initialization (`initMode: 'custom'`)
+
+Concept: [model-detect.md — Init modes](model-detect.md#init-modes-auto-vs-custom).
+
+| `modelType` | Custom-init keys |
+| --- | --- |
+| `cnn_bilstm` | `cnn_bilstm`, `bpe_vocab` |
+
+```ts
+import { createStreamingPunctuation } from 'react-native-sherpa-onnx/punctuation';
+
+const engine = await createStreamingPunctuation({
+  initMode: 'custom',
+  modelType: 'cnn_bilstm',
+  customConfig: {
+    cnn_bilstm: { kind: 'fs', path: '/data/models/cnn.onnx' },
+    bpe_vocab: { kind: 'fs', path: '/data/models/bpe.vocab' },
+  },
+});
+```
 
 ## Segmentation
 

--- a/docs/punctuation-streaming.md
+++ b/docs/punctuation-streaming.md
@@ -43,6 +43,26 @@ if (!det.success || det.modelType !== 'cnn_bilstm' || !det.isStreaming) {
 }
 ```
 
+---
+
+## Custom initialization (`initMode: 'custom'`)
+
+Streaming punctuation uses a separate init union from offline. Pass `initMode: 'custom'`, concrete `modelType: 'cnn_bilstm'`, and both required paths in `customConfig`. See [Punctuation offline — Custom initialization](punctuation-offline.md#custom-initialization-initmode-custom) for validation rules (offline uses one key; streaming uses two).
+
+```ts
+import { createStreamingPunctuation } from 'react-native-sherpa-onnx/punctuation';
+
+const engine = await createStreamingPunctuation({
+  initMode: 'custom',
+  modelType: 'cnn_bilstm',
+  customConfig: {
+    cnn_bilstm: { kind: 'fs', path: '/data/models/cnn.onnx' },
+    bpe_vocab: { kind: 'fs', path: '/data/models/bpe.vocab' },
+  },
+  provider: 'cpu',
+});
+```
+
 ## Quick start
 
 ```ts

--- a/docs/sdk-init-bridge.md
+++ b/docs/sdk-init-bridge.md
@@ -65,6 +65,32 @@ createStreamingSTT({
 { modelDir, modelType, rule1MinTrailingSilence: 2.4, ... }
 ```
 
+**TTS — custom init:**
+
+```ts
+// Public
+createTTS({
+  initMode: 'custom',
+  modelType: 'vits',
+  customConfig: {
+    ttsModel: { kind: 'fs', path: '/models/en.onnx' },
+    tokens: { kind: 'fs', path: '/models/tokens.txt' },
+  },
+});
+
+// Bridge map (internal)
+{ initMode: 'custom', modelType: 'vits', modelPaths: { ttsModel: '...', tokens: '...' } }
+```
+
+Bridge fields for TTS init:
+
+| Public | Bridge key | Notes |
+|--------|------------|--------|
+| `initMode: 'custom'` | `initMode`, `modelPaths`, `modelType` | No `modelDir` |
+| `initMode: 'auto'` (default) | `initMode`, `modelDir`, `modelType` | No `modelPaths` |
+| `modelOptions.kokoro.lang` | `kokoroLang` | Bridge-only |
+| `lexiconLanguageId` | `lexiconLanguageId` | Auto mode only |
+
 ## TTS language fields (bridge)
 
 | Public | Bridge key | Notes |

--- a/docs/sdk-init-bridge.md
+++ b/docs/sdk-init-bridge.md
@@ -19,7 +19,7 @@ The React Native package uses two layers for engine initialization:
 |---------------|--------------|--------------|---------|
 | `initializeTts(instanceId, options)` | `createTTS` | `TtsInitBridgeOptions` | `buildTtsInitBridgeOptions` in `src/tts/ttsNativeBridge.ts` |
 | `initializeStt(instanceId, options)` | `createSTT` | `SttInitBridgeOptions` | `buildSttInitBridgeOptions` in `src/stt/sttNativeBridge.ts` |
-| `initializeOnlineStt(instanceId, options)` | `createStreamingSTT` | `OnlineSttInitBridgeOptions` | `buildOnlineSttInitBridgeOptions` in `src/stt/sttNativeBridge.ts` |
+| `initializeOnlineStt(instanceId, options)` | `createStreamingSTT` | `OnlineSttInitBridgeOptions` | `buildStreamingSttInitBridgeOptions` in `src/stt/sttNativeBridge.ts` |
 
 Bridge option types are defined in `src/NativeSherpaOnnx.ts` (required for React Native codegen) and re-exported from `src/nativeBridge/initBridgeTypes.ts` for builders.
 

--- a/docs/sdk-init-bridge.md
+++ b/docs/sdk-init-bridge.md
@@ -4,8 +4,8 @@ The React Native package uses two layers for engine initialization:
 
 | Layer | Examples | Shape |
 |-------|----------|--------|
-| **Public** | `createTTS`, `createSTT`, `createStreamingSTT`, `createStreamingVAD`, `createEnhancement`, `createStreamingEnhancement` | Typed, nested options (`TTSInitializeOptions`, `STTInitializeOptions`, `StreamingSttInitOptions`, `VADInitializeOptions`, `EnhancementInitializeOptions`) |
-| **Bridge** | `initializeTts`, `initializeStt`, `initializeOnlineStt`, `initializeVad`, `initializeEnhancement`, `initializeOnlineEnhancement` | Flat `ReadableMap` / `NSDictionary` per instance — **not** the primary app API |
+| **Public** | `createTTS`, `createSTT`, `createStreamingSTT`, `createStreamingVAD`, `createEnhancement`, `createStreamingEnhancement`, `createOfflinePunctuation`, `createStreamingPunctuation` | Typed init unions per feature |
+| **Bridge** | `initializeTts`, `initializeStt`, `initializeOnlineStt`, `initializeVad`, `initializeEnhancement`, `initializeOnlineEnhancement`, `initializeOfflinePunctuation`, `initializeOnlinePunctuation` | Flat `ReadableMap` / `NSDictionary` per instance — **not** the primary app API |
 
 ## Why two layers?
 
@@ -23,6 +23,8 @@ The React Native package uses two layers for engine initialization:
 | `initializeVad(instanceId, options)` | `createStreamingVAD` | `VadInitBridgeOptions` | `buildVadInitBridgeOptions` in `src/vad/vadNativeBridge.ts` |
 | `initializeEnhancement(instanceId, options)` | `createEnhancement` | `EnhancementInitBridgeOptions` | `buildEnhancementInitBridgeOptions` in `src/enhancement/enhancementNativeBridge.ts` |
 | `initializeOnlineEnhancement(instanceId, options)` | `createStreamingEnhancement` | `EnhancementInitBridgeOptions` | `buildEnhancementInitBridgeOptions` in `src/enhancement/enhancementNativeBridge.ts` |
+| `initializeOfflinePunctuation(instanceId, options)` | `createOfflinePunctuation` | `PunctuationInitBridgeOptions` | `buildOfflinePunctuationInitBridgeOptions` in `src/punctuation/punctuationNativeBridge.ts` |
+| `initializeOnlinePunctuation(instanceId, options)` | `createStreamingPunctuation` | `PunctuationInitBridgeOptions` | `buildStreamingPunctuationInitBridgeOptions` in `src/punctuation/punctuationNativeBridge.ts` |
 
 Bridge option types are defined in `src/NativeSherpaOnnx.ts` (required for React Native codegen) and re-exported from `src/nativeBridge/initBridgeTypes.ts` for builders.
 
@@ -145,6 +147,45 @@ Bridge fields for Enhancement init:
 | `numThreads`, `provider`, `debug` | same names | Scalars on both modes |
 
 **Positional → options migration:** `initializeEnhancement` and `initializeOnlineEnhancement` previously accepted positional `(instanceId, modelDir, modelType?, …)` arguments. They now take `(instanceId, options: EnhancementInitBridgeOptions)` only. App code should use `createEnhancement` / `createStreamingEnhancement`; direct TurboModule callers must pass an options map.
+
+**Punctuation — custom init (offline and streaming use separate public unions, shared bridge shape):**
+
+```ts
+// Public — offline
+createOfflinePunctuation({
+  initMode: 'custom',
+  modelType: 'ct_transformer',
+  customConfig: {
+    ct_transformer: { kind: 'fs', path: '/models/ct.onnx' },
+  },
+});
+
+// Bridge map (internal) — buildOfflinePunctuationInitBridgeOptions
+{ initMode: 'custom', modelType: 'ct_transformer', modelPaths: { ct_transformer: '...' } }
+
+// Public — streaming
+createStreamingPunctuation({
+  initMode: 'custom',
+  modelType: 'cnn_bilstm',
+  customConfig: {
+    cnn_bilstm: { kind: 'fs', path: '/models/cnn.onnx' },
+    bpe_vocab: { kind: 'fs', path: '/models/bpe.vocab' },
+  },
+});
+
+// Bridge map (internal) — buildStreamingPunctuationInitBridgeOptions
+{ initMode: 'custom', modelType: 'cnn_bilstm', modelPaths: { cnn_bilstm: '...', bpe_vocab: '...' } }
+```
+
+Bridge fields for Punctuation init:
+
+| Public | Bridge key | Notes |
+|--------|------------|--------|
+| `initMode: 'custom'` | `initMode`, `modelPaths`, `modelType` | No `modelDir`; offline: `ct_transformer`; streaming: `cnn_bilstm` + `bpe_vocab` |
+| `initMode: 'auto'` (default) | `initMode`, `modelDir`, `modelType` | No `modelPaths` |
+| `numThreads`, `provider`, `debug` | same names | Scalars on both modes |
+
+**Positional → options migration:** `initializeOfflinePunctuation` and `initializeOnlinePunctuation` previously accepted positional `(instanceId, modelDir, modelType?, …)` arguments. They now take `(instanceId, options: PunctuationInitBridgeOptions)` only.
 
 ## TTS language fields (bridge)
 

--- a/docs/sdk-init-bridge.md
+++ b/docs/sdk-init-bridge.md
@@ -4,8 +4,8 @@ The React Native package uses two layers for engine initialization:
 
 | Layer | Examples | Shape |
 |-------|----------|--------|
-| **Public** | `createTTS`, `createSTT`, `createStreamingSTT` | Typed, nested options (`TTSInitializeOptions`, `STTInitializeOptions`, `StreamingSttInitOptions`) |
-| **Bridge** | `initializeTts`, `initializeStt`, `initializeOnlineStt` | Flat `ReadableMap` / `NSDictionary` per instance — **not** the primary app API |
+| **Public** | `createTTS`, `createSTT`, `createStreamingSTT`, `createStreamingVAD` | Typed, nested options (`TTSInitializeOptions`, `STTInitializeOptions`, `StreamingSttInitOptions`, `VADInitializeOptions`) |
+| **Bridge** | `initializeTts`, `initializeStt`, `initializeOnlineStt`, `initializeVad` | Flat `ReadableMap` / `NSDictionary` per instance — **not** the primary app API |
 
 ## Why two layers?
 
@@ -20,6 +20,7 @@ The React Native package uses two layers for engine initialization:
 | `initializeTts(instanceId, options)` | `createTTS` | `TtsInitBridgeOptions` | `buildTtsInitBridgeOptions` in `src/tts/ttsNativeBridge.ts` |
 | `initializeStt(instanceId, options)` | `createSTT` | `SttInitBridgeOptions` | `buildSttInitBridgeOptions` in `src/stt/sttNativeBridge.ts` |
 | `initializeOnlineStt(instanceId, options)` | `createStreamingSTT` | `OnlineSttInitBridgeOptions` | `buildStreamingSttInitBridgeOptions` in `src/stt/sttNativeBridge.ts` |
+| `initializeVad(instanceId, options)` | `createStreamingVAD` | `VadInitBridgeOptions` | `buildVadInitBridgeOptions` in `src/vad/vadNativeBridge.ts` |
 
 Bridge option types are defined in `src/NativeSherpaOnnx.ts` (required for React Native codegen) and re-exported from `src/nativeBridge/initBridgeTypes.ts` for builders.
 
@@ -82,6 +83,22 @@ createTTS({
 { initMode: 'custom', modelType: 'vits', modelPaths: { ttsModel: '...', tokens: '...' } }
 ```
 
+**VAD — custom init:**
+
+```ts
+// Public
+createStreamingVAD({
+  initMode: 'custom',
+  modelType: 'silero_vad',
+  customConfig: {
+    model: { kind: 'fs', path: '/models/silero_vad.onnx' },
+  },
+});
+
+// Bridge map (internal) — buildVadInitBridgeOptions
+{ initMode: 'custom', modelType: 'silero_vad', modelPaths: { model: '...' } }
+```
+
 Bridge fields for TTS init:
 
 | Public | Bridge key | Notes |
@@ -90,6 +107,14 @@ Bridge fields for TTS init:
 | `initMode: 'auto'` (default) | `initMode`, `modelDir`, `modelType` | No `modelPaths` |
 | `modelOptions.kokoro.lang` | `kokoroLang` | Bridge-only |
 | `lexiconLanguageId` | `lexiconLanguageId` | Auto mode only |
+
+Bridge fields for VAD init:
+
+| Public | Bridge key | Notes |
+|--------|------------|--------|
+| `initMode: 'custom'` | `initMode`, `modelPaths`, `modelType` | No `modelDir`; single key `model` |
+| `initMode: 'auto'` (default) | `initMode`, `modelDir`, `modelType` | No `modelPaths` |
+| `runtimeOptions.*` | `threshold`, `silenceDurationMs`, `speechDurationMs`, `minSpeechDurationMs`, `maxSpeechDurationS`, `windowSize` | Flattened scalars |
 
 ## TTS language fields (bridge)
 

--- a/docs/sdk-init-bridge.md
+++ b/docs/sdk-init-bridge.md
@@ -4,8 +4,8 @@ The React Native package uses two layers for engine initialization:
 
 | Layer | Examples | Shape |
 |-------|----------|--------|
-| **Public** | `createTTS`, `createSTT`, `createStreamingSTT`, `createStreamingVAD` | Typed, nested options (`TTSInitializeOptions`, `STTInitializeOptions`, `StreamingSttInitOptions`, `VADInitializeOptions`) |
-| **Bridge** | `initializeTts`, `initializeStt`, `initializeOnlineStt`, `initializeVad` | Flat `ReadableMap` / `NSDictionary` per instance — **not** the primary app API |
+| **Public** | `createTTS`, `createSTT`, `createStreamingSTT`, `createStreamingVAD`, `createEnhancement`, `createStreamingEnhancement` | Typed, nested options (`TTSInitializeOptions`, `STTInitializeOptions`, `StreamingSttInitOptions`, `VADInitializeOptions`, `EnhancementInitializeOptions`) |
+| **Bridge** | `initializeTts`, `initializeStt`, `initializeOnlineStt`, `initializeVad`, `initializeEnhancement`, `initializeOnlineEnhancement` | Flat `ReadableMap` / `NSDictionary` per instance — **not** the primary app API |
 
 ## Why two layers?
 
@@ -21,6 +21,8 @@ The React Native package uses two layers for engine initialization:
 | `initializeStt(instanceId, options)` | `createSTT` | `SttInitBridgeOptions` | `buildSttInitBridgeOptions` in `src/stt/sttNativeBridge.ts` |
 | `initializeOnlineStt(instanceId, options)` | `createStreamingSTT` | `OnlineSttInitBridgeOptions` | `buildStreamingSttInitBridgeOptions` in `src/stt/sttNativeBridge.ts` |
 | `initializeVad(instanceId, options)` | `createStreamingVAD` | `VadInitBridgeOptions` | `buildVadInitBridgeOptions` in `src/vad/vadNativeBridge.ts` |
+| `initializeEnhancement(instanceId, options)` | `createEnhancement` | `EnhancementInitBridgeOptions` | `buildEnhancementInitBridgeOptions` in `src/enhancement/enhancementNativeBridge.ts` |
+| `initializeOnlineEnhancement(instanceId, options)` | `createStreamingEnhancement` | `EnhancementInitBridgeOptions` | `buildEnhancementInitBridgeOptions` in `src/enhancement/enhancementNativeBridge.ts` |
 
 Bridge option types are defined in `src/NativeSherpaOnnx.ts` (required for React Native codegen) and re-exported from `src/nativeBridge/initBridgeTypes.ts` for builders.
 
@@ -99,6 +101,24 @@ createStreamingVAD({
 { initMode: 'custom', modelType: 'silero_vad', modelPaths: { model: '...' } }
 ```
 
+**Enhancement — custom init (offline and streaming share one builder):**
+
+```ts
+// Public
+createEnhancement({
+  initMode: 'custom',
+  modelType: 'gtcrn',
+  customConfig: {
+    model: { kind: 'fs', path: '/models/gtcrn.onnx' },
+  },
+});
+
+// Bridge map (internal) — buildEnhancementInitBridgeOptions
+{ initMode: 'custom', modelType: 'gtcrn', modelPaths: { model: '...' } }
+```
+
+`createStreamingEnhancement` uses the same public union and `initializeOnlineEnhancement` with the same bridge shape.
+
 Bridge fields for TTS init:
 
 | Public | Bridge key | Notes |
@@ -115,6 +135,16 @@ Bridge fields for VAD init:
 | `initMode: 'custom'` | `initMode`, `modelPaths`, `modelType` | No `modelDir`; single key `model` |
 | `initMode: 'auto'` (default) | `initMode`, `modelDir`, `modelType` | No `modelPaths` |
 | `runtimeOptions.*` | `threshold`, `silenceDurationMs`, `speechDurationMs`, `minSpeechDurationMs`, `maxSpeechDurationS`, `windowSize` | Flattened scalars |
+
+Bridge fields for Enhancement init:
+
+| Public | Bridge key | Notes |
+|--------|------------|--------|
+| `initMode: 'custom'` | `initMode`, `modelPaths`, `modelType` | No `modelDir`; single key `model` |
+| `initMode: 'auto'` (default) | `initMode`, `modelDir`, `modelType` | No `modelPaths` |
+| `numThreads`, `provider`, `debug` | same names | Scalars on both modes |
+
+**Positional → options migration:** `initializeEnhancement` and `initializeOnlineEnhancement` previously accepted positional `(instanceId, modelDir, modelType?, …)` arguments. They now take `(instanceId, options: EnhancementInitBridgeOptions)` only. App code should use `createEnhancement` / `createStreamingEnhancement`; direct TurboModule callers must pass an options map.
 
 ## TTS language fields (bridge)
 

--- a/docs/segmentation-engine.md
+++ b/docs/segmentation-engine.md
@@ -191,14 +191,11 @@ Materializes segments for offline text/audio. For `speech_vad_model`, pass eithe
 
 ## Custom model path (`initMode: 'custom'`)
 
-Segmentation has **no** TurboModule engine init — custom paths apply on **`segmentOfflineBuffer`** and **`attachSegmentationEngine`** policy only, and **only** when `evaluator: 'speech_vad_model'`.
+Policy-level custom path — **no engine init**. Concept: [model-detect.md — Init modes](model-detect.md#init-modes-auto-vs-custom). Applies to **`speech_vad_model`** only (on `segmentOfflineBuffer` / `attachSegmentationEngine` policy).
 
-Use custom paths when the VAD ONNX is **not** in a detectable folder layout (non-standard name, scattered path, or detection fails but you know the file).
-
-- Set `initMode: 'custom'` and a concrete `modelType` (`silero_vad` or `ten_vad`, not `'auto'`).
-- Pass `customConfig` with a single **`model`** {@link FileSource} pointing at the `.onnx` file.
-- Validation reuses native `validate-vad` (category `vad`, key `model`). TypeScript helpers live in [`src/vad/customConfig.ts`](../src/vad/customConfig.ts) — there is no separate segment customConfig module. See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
-- Auto mode (default): pass `modelPath` — the SDK runs `detectVadModel` before native (same pipeline as streaming VAD init).
+| `modelType` | Custom-init keys | Validate category |
+| --- | --- | --- |
+| `silero_vad`, `ten_vad` | `model` | `vad` (reuses [VAD customConfig](../src/vad/customConfig.ts)) |
 
 ```ts
 await segmentOfflineBuffer(offlineAudioBuffer, {
@@ -209,26 +206,10 @@ await segmentOfflineBuffer(offlineAudioBuffer, {
     model: { kind: 'fs', path: '/data/models/silero_vad.onnx' },
   },
   vadThreshold: 0.5,
-  vadMinSpeechMs: 250,
-  vadMinSilenceMs: 200,
 });
 ```
 
-Live attach uses the same policy union:
-
-```ts
-await attachSegmentationEngine(liveAudioBuffer, {
-  policy: {
-    evaluator: 'speech_vad_model',
-    initMode: 'custom',
-    modelType: 'ten_vad',
-    customConfig: {
-      model: { kind: 'fs', path: '/data/models/ten-vad.onnx' },
-    },
-    vadThreshold: 0.5,
-  },
-});
-```
+Auto mode (default): pass `modelPath` (`FileSource`) — SDK runs `detectVadModel` before native.
 
 ### Live text helpers
 

--- a/docs/segmentation-engine.md
+++ b/docs/segmentation-engine.md
@@ -37,7 +37,7 @@ Policies are **domain-specific**: only **text** evaluators go on text buffers; o
 | `text_synthetic_auto` | Text | Offline + live (text) | **Offline:** forward scan — delimiter first ([delimiters below](#text-sentenceboundary-delimiters)), else `maxLengthChars`. **Live:** commit at **last** delimiter or length cap in partial. |
 | `text_punctuation_assisted` | Text | Offline + live (text); needs `policy.punctuationInstanceId` | Punctuation pass (`punctuationInstanceId`), then same split as `text_synthetic_auto`. Missing instance → `POLICY_PUNCTUATION_INSTANCE_NOT_FOUND`. |
 | `speech_energy_silence` | Speech | Offline + live (speech) | Spans from energy + silence (`silenceThresholdMs`, `energyThresholdDb`, `minSegmentMs`, `maxSegmentMs`, `hangoverMs`). No VAD ONNX. |
-| `speech_vad_model` | Speech | Offline + live (speech); needs `policy.modelPath` (**`FileSource`**) | Spans from VAD ONNX. JS runs **`detectVadModel`** on `modelPath` (same plumbing as **`createStreamingVAD`** / `detectVadModel`), then native uses the resolved `.onnx` file + `modelType` (`vadThreshold`, `vadMinSpeechMs`, `vadMinSilenceMs`, …). |
+| `speech_vad_model` | Speech | Offline + live (speech); needs VAD model config | Spans from VAD ONNX. **Auto:** `modelPath` (**`FileSource`**) — JS runs **`detectVadModel`**, then native uses resolved `.onnx` + `modelType`. **Custom:** `initMode: 'custom'`, concrete `modelType` (`silero_vad` / `ten_vad`), `customConfig.model` — no detect (same VAD keys as [`createStreamingVAD`](vad-streaming.md)). Runtime fields: `vadThreshold`, `vadMinSpeechMs`, `vadMinSilenceMs`, … |
 | `continuous_frames` | Speech | **Live speech only** (offline → `POLICY_INVALID_FOR_OFFLINE`) | Frame checkpoints (`checkpointIntervalMs`). |
 
 ### Text `sentenceBoundary` delimiters
@@ -187,7 +187,48 @@ const ref = await segmentOfflineBuffer(offlineAudioBuffer, {
 });
 ```
 
-Materializes segments for offline text/audio. For `speech_vad_model`, `modelPath` (**`FileSource`**) is required; JS resolves it with **`detectVadModel`** and forwards a concrete `.onnx` path plus `modelType` to native (no directory heuristics on the native side).
+Materializes segments for offline text/audio. For `speech_vad_model`, pass either auto `modelPath` (**`FileSource`**) or custom `initMode: 'custom'` with `customConfig.model` — see [Custom model path](#custom-model-path-initmode-custom) below.
+
+## Custom model path (`initMode: 'custom'`)
+
+Segmentation has **no** TurboModule engine init — custom paths apply on **`segmentOfflineBuffer`** and **`attachSegmentationEngine`** policy only, and **only** when `evaluator: 'speech_vad_model'`.
+
+Use custom paths when the VAD ONNX is **not** in a detectable folder layout (non-standard name, scattered path, or detection fails but you know the file).
+
+- Set `initMode: 'custom'` and a concrete `modelType` (`silero_vad` or `ten_vad`, not `'auto'`).
+- Pass `customConfig` with a single **`model`** {@link FileSource} pointing at the `.onnx` file.
+- Validation reuses native `validate-vad` (category `vad`, key `model`). TypeScript helpers live in [`src/vad/customConfig.ts`](../src/vad/customConfig.ts) — there is no separate segment customConfig module. See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
+- Auto mode (default): pass `modelPath` — the SDK runs `detectVadModel` before native (same pipeline as streaming VAD init).
+
+```ts
+await segmentOfflineBuffer(offlineAudioBuffer, {
+  evaluator: 'speech_vad_model',
+  initMode: 'custom',
+  modelType: 'silero_vad',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/silero_vad.onnx' },
+  },
+  vadThreshold: 0.5,
+  vadMinSpeechMs: 250,
+  vadMinSilenceMs: 200,
+});
+```
+
+Live attach uses the same policy union:
+
+```ts
+await attachSegmentationEngine(liveAudioBuffer, {
+  policy: {
+    evaluator: 'speech_vad_model',
+    initMode: 'custom',
+    modelType: 'ten_vad',
+    customConfig: {
+      model: { kind: 'fs', path: '/data/models/ten-vad.onnx' },
+    },
+    vadThreshold: 0.5,
+  },
+});
+```
 
 ### Live text helpers
 

--- a/docs/stt-offline.md
+++ b/docs/stt-offline.md
@@ -2,90 +2,17 @@
 
 ## Introduction
 
-On-device batch transcription with a **pipeline-first** API:
+On-device batch transcription with a **pipeline-first** API.
 
-- **Input:** offline pipeline audio buffer ([`audiobuffer` — offline](audiobuffer-offline.md)) — file-backed or in-memory PCM.
-- **Output:** offline pipeline text buffer ([`textbuffer` — offline](textbuffer-offline.md)) — STT writes the hypothesis and optional token/timestamp metadata into a buffer you allocate (`createEmptyOfflineTextBuffer`).
-- **Engine:** `createSTT` exposes **`transcribe(audio, textOut)`** (plus `setConfig` / `destroy`). There are **no** JS-side `getSttResult*` methods or `resultId`-based lazy getters anymore; all transcript payload access goes through **textbuffer** slice APIs. `transcribe` writes directly into the output buffer and returns a `SttTranscribeResult` with orchestration stats (segments, time).
+| Role | Type | Notes |
+| --- | --- | --- |
+| **Input** | [`OfflineAudioBuffer`](audiobuffer-offline.md) | File-backed or in-memory PCM |
+| **Output** | [`OfflineTextBuffer`](textbuffer-offline.md) | Empty buffer from `createEmptyOfflineTextBuffer`; STT writes the hypothesis and optional token/timestamp metadata |
+| **Engine** | `SttEngine` via `createSTT` | `transcribe(audio, textOut)`, `setConfig`, `destroy`; returns `SttTranscribeResult` with orchestration stats (segments, time). Read transcript data via textbuffer slice APIs |
 
 Import path: `react-native-sherpa-onnx/stt`
 
-For live/real-time recognition, see [Streaming STT](stt-streaming.md). 
-
-## Models and paths
-
-- `FileSource` (type from `react-native-sherpa-onnx/fileio`): `FileSource`
-- In-app model downloads: [download-manager.md](download-manager.md) with category `ModelCategory.Stt`
-- Model detection without engine init: `detectSttModel(...)` — see [model-detect.md](model-detect.md) for unified `detectModel` when category is unknown
-- Model setup and expected files: [model-setup.md](model-setup.md)
-- Hotwords details: [hotwords.md](hotwords.md)
-
-## Validation required files
-
-`detectSttModel(...)` and `createSTT(...)` both validate required files per detected model type.
-
-| Model type | Typical required files |
-| --- | --- |
-| `transducer`, `nemo_transducer` | `encoder*.onnx`, `decoder*.onnx`, `joiner*.onnx`, `tokens.txt` |
-| `paraformer` | `model*.onnx` or paraformer model file, plus `tokens.txt` |
-| `zipformer_ctc`, `ctc`, `nemo_ctc`, `wenet_ctc`, `sense_voice`, `telespeech_ctc` | `model*.onnx`, `tokens.txt` |
-| `whisper` | `encoder*.onnx`, `decoder*.onnx`, `tokens.txt` |
-| `qwen3_asr` | qwen3 frontend/encoder/decoder/tokenizer files |
-| `cohere_transcribe` | cohere encoder/decoder files, plus `tokens.txt` |
-| `fire_red_asr`, `canary` | encoder and decoder files |
-| `moonshine`, `dolphin`, `omnilingual`, `medasr`, `funasr_nano` | model-family specific required files |
-
-If validation fails, `success` is `false` and `error` contains the missing-file reason.
-
-## Custom initialization (`initMode: 'custom'`)
-
-Use custom init when model files are **not** in one detectable directory layout (non-standard names, scattered paths, or detection fails but you know the Sherpa model family).
-
-- Set `initMode: 'custom'` and a concrete `modelType` (not `'auto'`).
-- Pass `customConfig` with **`FileSource`** per required file (same path keys as native detection uses internally, e.g. `encoder`, `whisperEncoder`, `ctcModel`, `tokens`).
-- Auto-detection is **skipped**; **`resolveSttCustomConfigPaths`** resolves each `FileSource` and calls native **`validateCustomModelPaths('stt', modelType, paths)`** (C++ `validate-stt` tables — single source of truth). Sherpa ONNX load errors are forwarded unchanged.
-- Query required vs optional keys for UI with **`getCustomModelPathRequirements('stt', modelType)`** from `react-native-sherpa-onnx/detect` (do not hardcode key lists in app code).
-- Auxiliary paths (`hotwordsFile`, `bpeVocab`, `ruleFsts`, `ruleFars`) also use **`FileSource`**.
-
-```ts
-import { createSTT } from 'react-native-sherpa-onnx/stt';
-
-const engine = await createSTT({
-  initMode: 'custom',
-  modelType: 'transducer',
-  customConfig: {
-    encoder: { kind: 'fs', path: '/data/models/my-encoder.onnx' },
-    decoder: { kind: 'app', base: 'files', path: 'weights/decoder.onnx' },
-    joiner: {
-      kind: 'app',
-      base: 'apkAsset',
-      path: 'models/my-pack/joiner.onnx',
-    },
-    tokens: { kind: 'fs', path: '/data/vocab/tokens.txt' },
-  },
-  hotwordsFile: { kind: 'fs', path: '/data/hotwords.txt' },
-});
-```
-
-Required path keys depend on `modelType` (including `moonshine_v2`, `tone_ctc`, paraformer offline vs streaming layouts). Use the native schema API instead of duplicating tables:
-
-```ts
-import {
-  getCustomModelPathRequirements,
-  validateCustomModelPaths,
-} from 'react-native-sherpa-onnx/detect';
-
-const { required, optional } = await getCustomModelPathRequirements('stt', 'transducer');
-// required: ['encoder', 'decoder', 'joiner', 'tokens']; optional: ['bpeVocab']
-
-const resolved = await resolveSttCustomConfigPaths('transducer', customConfig);
-// or validate resolved paths directly:
-const check = await validateCustomModelPaths('stt', 'transducer', resolved);
-```
-
-Validation checks **non-empty resolved path strings** only (not ONNX correctness or on-disk existence). See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
-
-File resolution uses the same helpers as model init: `resolveFileSourceForModelFile` (see `react-native-sherpa-onnx/detect`). Bundled single files use `{ kind: 'app', base: 'apkAsset' | 'appBundle', path: '…/file.onnx' }` — no manual copy step.
+For live/real-time recognition, see [Streaming STT](stt-streaming.md).
 
 ## Quick start
 
@@ -227,38 +154,13 @@ await engine.destroy();
 
 `transcribe` accepts **`OfflineAudioBufferRef`**, a branded offline handle, or a raw **`bufferId` string** for the first argument; the same idea applies to **`textOut`** (`OfflineTextBufferRef` | handle | string). Prefer passing **refs** so call sites stay typed (see [audiobuffer — offline](audiobuffer-offline.md) / [textbuffer — offline](textbuffer-offline.md)). Raw strings are optional; malformed ids are rejected early with `AUDIO_INVALID_ARGUMENT` or `TEXT_INVALID_ARGUMENT`. Timestamps, durations, lang, emotion, and other dimensions use the matching **`getOfflineTextBuffer*`** helpers; see [textbuffer-offline.md](textbuffer-offline.md).
 
-## Data model and lifetime
-
-| Item | Behavior |
-| --- | --- |
-| **Audio buffer** | Created via `audiobuffer` (e.g. `createOfflineAudioBufferFromFile`). Released with `releasePipelineAudioBuffer` when no longer needed. |
-| **Text output buffer** | Empty offline buffer from `createEmptyOfflineTextBuffer`. **`transcribe`** fills it on the native side. Read via **`getPipelineTextBufferInfo`** + textbuffer getters. Released with **`releasePipelineTextBuffer`**. |
-| **Re-transcription** | Use a **new** empty offline text buffer per decode unless your app explicitly manages buffer reuse; writing again into the same populated buffer is rejected natively (`TEXT_ALREADY_POPULATED` / `SttErrorCode.TEXT_ALREADY_POPULATED`). |
-| **STT engine** | Holds the loaded offline model. Call **`destroy()`** when done. Destroying the engine does **not** release pipeline buffers you still own. |
-
-Slice defaults and limits for **text** payloads are defined on the textbuffer module:
-
-| Area | Constants (import from `react-native-sherpa-onnx/textbuffer`) |
-| --- | --- |
-| Default / max slice sizes | `TEXT_DEFAULT_SLICE_COUNT`, `TEXT_MAX_SLICE_COUNT` |
-
-Use **`getPipelineTextBufferInfo(textOut)`** to obtain `utf16Length`, `tokenCount`, `timestampCount`, etc., then request slices with explicit `start` / `maxCount` (or full range up to limits).
-
-## Setup (iOS and Android)
-
-| Topic | Requirement |
-| --- | --- |
-| Execution provider | Optional `provider` on init; details: [execution-providers.md](execution-providers.md) |
-| Audio preprocessing | Use [audio-conversion.md](audio-conversion.md) when the source is not suitable PCM/WAV |
-| Instance lifetime | Always call **`destroy()`** on the STT engine when done |
-
 ## API reference
 
 Signatures below are exported from **`react-native-sherpa-onnx/stt`**. Reading transcript data is documented under **`react-native-sherpa-onnx/textbuffer`** ([textbuffer-offline.md](textbuffer-offline.md)).
 
 ### Detection and factory
 
-For cross-feature catalog scans use unified detection: [model-detect.md](model-detect.md). The APIs below are STT-specific (required files, `detectedModels`, `paths`).
+For cross-feature catalog scans use unified detection: [model-detect.md](model-detect.md). STT-specific validation and `paths` below.
 
 #### `detectSttModel(source, options?)`
 
@@ -276,7 +178,7 @@ console.log(det.success, det.modelType, det.detectedModels);
 
 For `FileSource` resolution problems, the promise can reject with `FILEIO_*` errors before native model detection runs.
 
-For multi-location probing (bundled → sandbox → PAD → absolute path), use `kind: 'auto'` with an explicit `tryOrder` — see [model-setup.md — kind: auto](model-setup.md).
+For multi-location probing (bundled → sandbox → PAD → absolute path), use `kind: 'auto'` with an explicit `tryOrder` — see [model-setup.md — `kind: 'auto'`](model-setup.md#kind-auto--probe-multiple-locations).
 
 #### `createSTT(options)`
 
@@ -361,6 +263,76 @@ import {
 ```
 
 See [textbuffer-offline.md](textbuffer-offline.md).
+
+### Buffer data model and lifetime
+
+| Item | Behavior |
+| --- | --- |
+| **Audio buffer** | Created via `audiobuffer` (e.g. `createOfflineAudioBufferFromFile`). Released with `releasePipelineAudioBuffer` when no longer needed. |
+| **Text output buffer** | Empty offline buffer from `createEmptyOfflineTextBuffer`. **`transcribe`** fills it on the native side. Read via **`getPipelineTextBufferInfo`** + textbuffer getters. Released with **`releasePipelineTextBuffer`**. |
+| **Re-transcription** | Use a **new** empty offline text buffer per decode unless your app explicitly manages buffer reuse; writing again into the same populated buffer is rejected natively (`TEXT_ALREADY_POPULATED` / `SttErrorCode.TEXT_ALREADY_POPULATED`). |
+| **STT engine** | Holds the loaded offline model. Call **`destroy()`** when done. Destroying the engine does **not** release pipeline buffers you still own. |
+
+Slice defaults and limits for **text** payloads are defined on the textbuffer module:
+
+| Area | Constants (import from `react-native-sherpa-onnx/textbuffer`) |
+| --- | --- |
+| Default / max slice sizes | `TEXT_DEFAULT_SLICE_COUNT`, `TEXT_MAX_SLICE_COUNT` |
+
+Use **`getPipelineTextBufferInfo(textOut)`** to obtain `utf16Length`, `tokenCount`, `timestampCount`, etc., then request slices with explicit `start` / `maxCount` (or full range up to limits).
+
+## Models and paths
+
+- **`FileSource`** — see [model-setup.md](model-setup.md) for building paths (bundled, downloaded, PAD/ODR).
+- **Detection & init modes** — [model-detect.md](model-detect.md) (preflight, auto vs custom).
+- **Downloads:** [download-manager.md](download-manager.md) · category `ModelCategory.Stt`
+- **Hotwords:** [hotwords.md](hotwords.md)
+
+## Validation required files
+
+`detectSttModel` and `createSTT` validate the same required files per detected type. If validation fails, `success` is `false` and `error` describes missing files.
+
+| `modelType` | Required files | Optional | Custom-init keys |
+| --- | --- | --- | --- |
+| `transducer`, `nemo_transducer` | `encoder*.onnx`, `decoder*.onnx`, `joiner*.onnx`, `tokens.txt` | `bpeVocab` | `encoder`, `decoder`, `joiner`, `tokens` |
+| `paraformer` | `model*.onnx` or paraformer model, `tokens.txt` | `paraformerModel`, `encoder`, `decoder` | `paraformerModel` or `encoder`+`decoder`, `tokens` |
+| `zipformer_ctc`, `ctc`, `nemo_ctc`, `wenet_ctc`, `sense_voice`, `telespeech_ctc` | `model*.onnx`, `tokens.txt` | — | `ctcModel`, `tokens` |
+| `whisper` | `encoder*.onnx`, `decoder*.onnx`, `tokens.txt` | — | `whisperEncoder`, `whisperDecoder`, `tokens` |
+| `qwen3_asr` | qwen3 frontend / encoder / decoder / tokenizer files | — | family-specific keys |
+| `cohere_transcribe` | cohere encoder / decoder, `tokens.txt` | — | family-specific keys |
+| `fire_red_asr`, `canary` | encoder, decoder | — | family-specific keys |
+| `moonshine`, `dolphin`, `omnilingual`, `medasr`, `funasr_nano` | model-family specific | — | query `getCustomModelPathRequirements('stt', modelType)` |
+
+Query exact keys: `getCustomModelPathRequirements('stt', modelType)` from `react-native-sherpa-onnx/detect`.
+
+## Custom initialization (`initMode: 'custom'`)
+
+Use when files are scattered or folder detection fails. Concept: [model-detect.md — Init modes](model-detect.md#init-modes-auto-vs-custom).
+
+| `modelType` | Custom-init keys |
+| --- | --- |
+| `transducer` | `encoder`, `decoder`, `joiner`, `tokens` |
+| `whisper` | `whisperEncoder`, `whisperDecoder`, `tokens` |
+| `paraformer` | `paraformerModel` or `encoder`+`decoder`, `tokens` |
+| CTC families | `ctcModel`, `tokens` |
+
+```ts
+import { createSTT } from 'react-native-sherpa-onnx/stt';
+
+const engine = await createSTT({
+  initMode: 'custom',
+  modelType: 'transducer',
+  customConfig: {
+    encoder: { kind: 'fs', path: '/data/models/encoder.onnx' },
+    decoder: { kind: 'fs', path: '/data/models/decoder.onnx' },
+    joiner: { kind: 'fs', path: '/data/models/joiner.onnx' },
+    tokens: { kind: 'fs', path: '/data/models/tokens.txt' },
+  },
+  hotwordsFile: { kind: 'fs', path: '/data/hotwords.txt' },
+});
+```
+
+Auxiliary paths (`hotwordsFile`, `bpeVocab`, `ruleFsts`, `ruleFars`) also accept `FileSource`. Full key list: `getCustomModelPathRequirements('stt', modelType)`.
 
 ## Segmentation
 
@@ -641,6 +613,7 @@ Quality may degrade slightly at segment boundaries. See [segmentation-engine.md]
 - [Hotwords](hotwords.md)
 - [Model Setup](model-setup.md)
 - [Execution Providers](execution-providers.md)
+- [Audio Conversion](audio-conversion.md)
 
 ## Native crash diagnostics
 

--- a/docs/stt-offline.md
+++ b/docs/stt-offline.md
@@ -173,8 +173,10 @@ function detectSttModel(
 
 ```ts
 const det = await detectSttModel({ kind: 'fs', path: '/absolute/path/to/sherpa-onnx-whisper-tiny-en' });
-console.log(det.success, det.modelType, det.detectedModels);
+console.log(det.success, det.modelType, det.detectedModels, det.paths);
 ```
+
+On folder scans, `paths` contains resolved non-empty config keys (`encoder`, `tokens`, `whisperEncoder`, …) suitable for custom init or `validateCustomModelPaths`.
 
 For `FileSource` resolution problems, the promise can reject with `FILEIO_*` errors before native model detection runs.
 

--- a/docs/stt-offline.md
+++ b/docs/stt-offline.md
@@ -37,6 +37,56 @@ For live/real-time recognition, see [Streaming STT](stt-streaming.md).
 
 If validation fails, `success` is `false` and `error` contains the missing-file reason.
 
+## Custom initialization (`initMode: 'custom'`)
+
+Use custom init when model files are **not** in one detectable directory layout (non-standard names, scattered paths, or detection fails but you know the Sherpa model family).
+
+- Set `initMode: 'custom'` and a concrete `modelType` (not `'auto'`).
+- Pass `customConfig` with **`FileSource`** per required file (same path keys as native detection uses internally, e.g. `encoder`, `whisperEncoder`, `ctcModel`, `tokens`).
+- Auto-detection is **skipped**; **`resolveSttCustomConfigPaths`** resolves each `FileSource` and calls native **`validateCustomModelPaths('stt', modelType, paths)`** (C++ `validate-stt` tables — single source of truth). Sherpa ONNX load errors are forwarded unchanged.
+- Query required vs optional keys for UI with **`getCustomModelPathRequirements('stt', modelType)`** from `react-native-sherpa-onnx/detect` (do not hardcode key lists in app code).
+- Auxiliary paths (`hotwordsFile`, `bpeVocab`, `ruleFsts`, `ruleFars`) also use **`FileSource`**.
+
+```ts
+import { createSTT } from 'react-native-sherpa-onnx/stt';
+
+const engine = await createSTT({
+  initMode: 'custom',
+  modelType: 'transducer',
+  customConfig: {
+    encoder: { kind: 'fs', path: '/data/models/my-encoder.onnx' },
+    decoder: { kind: 'app', base: 'files', path: 'weights/decoder.onnx' },
+    joiner: {
+      kind: 'app',
+      base: 'apkAsset',
+      path: 'models/my-pack/joiner.onnx',
+    },
+    tokens: { kind: 'fs', path: '/data/vocab/tokens.txt' },
+  },
+  hotwordsFile: { kind: 'fs', path: '/data/hotwords.txt' },
+});
+```
+
+Required path keys depend on `modelType` (including `moonshine_v2`, `tone_ctc`, paraformer offline vs streaming layouts). Use the native schema API instead of duplicating tables:
+
+```ts
+import {
+  getCustomModelPathRequirements,
+  validateCustomModelPaths,
+} from 'react-native-sherpa-onnx/detect';
+
+const { required, optional } = await getCustomModelPathRequirements('stt', 'transducer');
+// required: ['encoder', 'decoder', 'joiner', 'tokens']; optional: ['bpeVocab']
+
+const resolved = await resolveSttCustomConfigPaths('transducer', customConfig);
+// or validate resolved paths directly:
+const check = await validateCustomModelPaths('stt', 'transducer', resolved);
+```
+
+Validation checks **non-empty resolved path strings** only (not ONNX correctness or on-disk existence). See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
+
+File resolution uses the same helpers as model init: `resolveFileSourceForModelFile` (see `react-native-sherpa-onnx/detect`). Bundled single files use `{ kind: 'app', base: 'apkAsset' | 'appBundle', path: '…/file.onnx' }` — no manual copy step.
+
 ## Quick start
 
 ### `createSTT`, `modelOptions`, and `setConfig`

--- a/docs/stt-streaming.md
+++ b/docs/stt-streaming.md
@@ -37,6 +37,30 @@ Live **audio** segment commits (`onSegment` on `createEmptyLiveAudioBuffer`) are
 - If your model is offline-only (for example Whisper), you can still use it for live consumption via the **[Live overload](stt-offline.md#live-overload-offline-weights-live-consumption)** pattern.
 - Model setup details: [model-setup.md](model-setup.md)
 
+## Custom initialization (`initMode: 'custom'`)
+
+Use when streaming model files are scattered or not in the directory layout native auto-scan expects.
+
+- Set `initMode: 'custom'` and a concrete online `modelType` (not `'auto'`).
+- Pass `customConfig` with **`FileSource`** per required file. Keys match native online layout: transducer / nemo_transducer → `encoder`, `decoder`, `joiner`, `tokens`; paraformer → `encoder`, `decoder`, `tokens`; zipformer2_ctc / nemo_ctc / tone_ctc → `model`, `tokens`.
+- Validation category is **`stt_streaming`** (separate from offline `stt`). See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
+
+```ts
+import { createStreamingSTT } from 'react-native-sherpa-onnx/stt';
+
+const engine = await createStreamingSTT({
+  initMode: 'custom',
+  modelType: 'transducer',
+  customConfig: {
+    encoder: { kind: 'fs', path: '/path/encoder.onnx' },
+    decoder: { kind: 'fs', path: '/path/decoder.onnx' },
+    joiner: { kind: 'fs', path: '/path/joiner.onnx' },
+    tokens: { kind: 'fs', path: '/path/tokens.txt' },
+  },
+  enableEndpoint: true,
+});
+```
+
 ## Quick start
 
 ```ts

--- a/docs/stt-streaming.md
+++ b/docs/stt-streaming.md
@@ -2,23 +2,19 @@
 
 ## Introduction
 
-Low-latency online recognition in pipeline mode.
+Low-latency online recognition with a **pipeline-first** API.
+
+| Role | Type | Notes |
+| --- | --- | --- |
+| **Input** | [`LiveAudioBuffer`](audiobuffer-streaming.md) | One live PCM buffer the native worker reads |
+| **Output** | [`LiveTextBuffer`](textbuffer-streaming.md) | Partial hypotheses and committed text segments |
+| **Engine** | `LiveSttEngine` via `createStreamingSTT` | `transcribe(audioIn, textOut)` returns `SttPipelineHandle` for pipeline control |
 
 Import path: `react-native-sherpa-onnx/stt`
 
 For full-file/batch transcription, see [Offline STT](stt-offline.md).
 
-## Pipeline model
-
-Streaming STT now runs as a native worker pipeline:
-
-- Input: one live audio buffer (`livePcmBuffer`)
-- Output: one live text buffer (`liveTextBuffer`)
-- Runtime: one STT pipeline handle (`SttPipelineHandle`)
-
-There is no per-chunk stream object in the JS API anymore.
-
-**Naming in this doc:** **`engine`** is the value returned by **`createStreamingSTT`** / **`createLiveSTT`** (`LiveSttEngine`). **`pipeline`** is the handle returned by **`engine.transcribe(...)`** (`SttPipelineHandle`).
+**Naming in this doc:** **`engine`** = `LiveSttEngine`; **`pipeline`** = `SttPipelineHandle` from `engine.transcribe(...)`.
 
 ## Streaming pipeline system
 
@@ -29,37 +25,6 @@ There is no per-chunk stream object in the JS API anymore.
 Committed transcripts are **text segments** on the output `LiveTextBuffer`. Prefer **`onSegment`** on that buffer (or `subscribeLiveTextBufferEvents`) instead of polling `getLiveTextBufferSegmentCount` in a timer. See **[Pipeline text buffers — live / Committed text segments](textbuffer-streaming.md#committed-text-segments-onsegment-no-polling)**.
 
 Live **audio** segment commits (`onSegment` on `createEmptyLiveAudioBuffer`) are a separate concern — they require **live audio segmentation** and carry **speech** metadata, not STT text. See **[Pipeline audio buffers — live / `onSegment`](audiobuffer-streaming.md#live-buffer-callbacks-onframesappended-vs-onsegment)**.
-
-## Models and paths
-
-- `FileSource` (type from `react-native-sherpa-onnx/fileio`): `FileSource`
-- Streaming-capable model types: `transducer`, `nemo_transducer` (NeMo/Nemotron streaming transducers), `paraformer`, `zipformer2_ctc`, `nemo_ctc`, `tone_ctc`
-- If your model is offline-only (for example Whisper), you can still use it for live consumption via the **[Live overload](stt-offline.md#live-overload-offline-weights-live-consumption)** pattern.
-- Model setup details: [model-setup.md](model-setup.md)
-
-## Custom initialization (`initMode: 'custom'`)
-
-Use when streaming model files are scattered or not in the directory layout native auto-scan expects.
-
-- Set `initMode: 'custom'` and a concrete online `modelType` (not `'auto'`).
-- Pass `customConfig` with **`FileSource`** per required file. Keys match native online layout: transducer / nemo_transducer → `encoder`, `decoder`, `joiner`, `tokens`; paraformer → `encoder`, `decoder`, `tokens`; zipformer2_ctc / nemo_ctc / tone_ctc → `model`, `tokens`.
-- Validation category is **`stt_streaming`** (separate from offline `stt`). See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
-
-```ts
-import { createStreamingSTT } from 'react-native-sherpa-onnx/stt';
-
-const engine = await createStreamingSTT({
-  initMode: 'custom',
-  modelType: 'transducer',
-  customConfig: {
-    encoder: { kind: 'fs', path: '/path/encoder.onnx' },
-    decoder: { kind: 'fs', path: '/path/decoder.onnx' },
-    joiner: { kind: 'fs', path: '/path/joiner.onnx' },
-    tokens: { kind: 'fs', path: '/path/tokens.txt' },
-  },
-  enableEndpoint: true,
-});
-```
 
 ## Quick start
 
@@ -193,16 +158,6 @@ const engine = await createStreamingSTT({
 | 6 | `getLiveTextBufferPartialSlice(...)` + segment reads | Partial + committed text |
 | 7 | `pipeline.flush()` / `pipeline.reset()` / `pipeline.stop()` | Pipeline control |
 | 8 | `engine.destroy()` + release buffers | Cleanup |
-
-## Setup (iOS and Android)
-
-| Topic | Requirement |
-| --- | --- |
-| Input format | Float PCM `[-1, 1]` at buffer sample rate |
-| Live microphone | [audiobuffer-streaming.md](audiobuffer-streaming.md): `startMicToLiveAudioBuffer` / `stopMicToLiveAudioBuffer` |
-| Text output | [textbuffer-streaming.md](textbuffer-streaming.md): partial slice + segment log getters |
-| Sample rate | Live audio buffer sample rate must match STT model sample rate |
-| Lifecycle | Stop pipeline, destroy engine, and release both buffers |
 
 ## API reference
 
@@ -388,6 +343,55 @@ import {
 ```
 
 See [textbuffer-streaming.md](textbuffer-streaming.md).
+
+## Models and paths
+
+- **`FileSource`** — [model-setup.md](model-setup.md)
+- **Detection & init** — [model-detect.md](model-detect.md)
+- Streaming types: `transducer`, `nemo_transducer`, `paraformer`, `zipformer2_ctc`, `nemo_ctc`, `tone_ctc`
+- Offline-only models (Whisper): use [Live overload](stt-offline.md#live-overload-offline-weights-live-consumption)
+
+## Validation required files
+
+Streaming STT uses validate category **`stt_streaming`** (keys differ from offline `stt`).
+
+| `modelType` | Required files | Optional | Custom-init keys |
+| --- | --- | --- | --- |
+| `transducer`, `nemo_transducer` | `encoder*.onnx`, `decoder*.onnx`, `joiner*.onnx`, `tokens.txt` | — | `encoder`, `decoder`, `joiner`, `tokens` |
+| `paraformer` | `encoder*.onnx`, `decoder*.onnx`, `tokens.txt` | — | `encoder`, `decoder`, `tokens` |
+| `zipformer2_ctc`, `nemo_ctc`, `tone_ctc` | `model*.onnx`, `tokens.txt` | — | `model`, `tokens` |
+
+Query keys: `getCustomModelPathRequirements('stt_streaming', modelType)`.
+
+## Model detection
+
+`detectSttModel` validates streaming-capable packs before `createStreamingSTT`. See [model-detect.md](model-detect.md). Check `det.isStreaming === true` for online engines.
+
+## Custom initialization (`initMode: 'custom'`)
+
+Concept: [model-detect.md — Init modes](model-detect.md#init-modes-auto-vs-custom). Validate category: **`stt_streaming`**.
+
+| `modelType` | Custom-init keys |
+| --- | --- |
+| `transducer`, `nemo_transducer` | `encoder`, `decoder`, `joiner`, `tokens` |
+| `paraformer` | `encoder`, `decoder`, `tokens` |
+| `zipformer2_ctc`, `nemo_ctc`, `tone_ctc` | `model`, `tokens` |
+
+```ts
+import { createStreamingSTT } from 'react-native-sherpa-onnx/stt';
+
+const engine = await createStreamingSTT({
+  initMode: 'custom',
+  modelType: 'transducer',
+  customConfig: {
+    encoder: { kind: 'fs', path: '/path/encoder.onnx' },
+    decoder: { kind: 'fs', path: '/path/decoder.onnx' },
+    joiner: { kind: 'fs', path: '/path/joiner.onnx' },
+    tokens: { kind: 'fs', path: '/path/tokens.txt' },
+  },
+  enableEndpoint: true,
+});
+```
 
 ## Pipeline composition
 

--- a/docs/tts-offline.md
+++ b/docs/tts-offline.md
@@ -18,6 +18,42 @@ import { saveAudioAsFile } from 'react-native-sherpa-onnx/audio';
 
 `detectTtsModel` is the TTS-specific pre-check before `createTTS` (family, lexicons, quantization). When the feature category is not known yet (model library, multi-category folders), use unified [`detectModel`](model-detect.md) from `react-native-sherpa-onnx/detect` — see [model-detect.md](model-detect.md).
 
+## Custom initialization (`initMode: 'custom'`)
+
+Use custom init when model files are **not** in one detectable directory layout (non-standard names, scattered paths, or detection fails but you know the Sherpa TTS family).
+
+- Set `initMode: 'custom'` and a concrete `modelType` (not `'auto'`).
+- Pass `customConfig` with **`FileSource`** per required file. Path keys match native detection (`ttsModel`, `tokens`, `acousticModel`, `vocoder`, … — see [model-detect.md](model-detect.md#custom-path-validation)).
+- Auto-detection is **skipped**; **`resolveTtsCustomConfigPaths`** resolves each `FileSource` and calls native **`validateCustomModelPaths('tts', modelType, paths)`** (C++ `validate-tts` tables).
+- Query required vs optional keys for UI with **`getCustomModelPathRequirements('tts', modelType)`** from `react-native-sherpa-onnx/detect`.
+- **`lexiconLanguageId`** is **auto mode only**; in custom mode pass `lexicon` directly in `customConfig` when needed.
+- **`modelOptions`** (noise scales, Kokoro init `lang`, etc.) are allowed on custom init the same as auto.
+
+```ts
+import { createTTS } from 'react-native-sherpa-onnx/tts';
+
+const tts = await createTTS({
+  initMode: 'custom',
+  modelType: 'vits',
+  customConfig: {
+    ttsModel: { kind: 'fs', path: '/data/models/en_US-lessac-medium.onnx' },
+    tokens: { kind: 'fs', path: '/data/models/tokens.txt' },
+    lexicon: { kind: 'fs', path: '/data/models/lexicon.txt' },
+  },
+  modelOptions: { vits: { noiseScale: 0.667, noiseScaleW: 0.8, lengthScale: 1.0 } },
+  numThreads: 2,
+});
+```
+
+| Model type | Required path keys |
+| --- | --- |
+| `vits` | `ttsModel`, `tokens` (+ optional `dataDir`, `lexicon`) |
+| `matcha` | `acousticModel`, `vocoder`, `tokens` (+ optional `dataDir`, `lexicon`) |
+| `kokoro`, `kitten` | `ttsModel`, `tokens`, `voices`, `dataDir` (+ optional `lexicon` for kokoro) |
+| `pocket` | `lmFlow`, `lmMain`, `encoder`, `decoder`, `textConditioner`, `vocabJson`, `tokenScoresJson` |
+| `zipvoice` | `encoder`, `decoder`, `vocoder`, `tokens`, `dataDir`, `lexicon` |
+| `supertonic` | `durationPredictor`, `textEncoder`, `vectorEstimator`, `vocoder`, `ttsJson`, `unicodeIndexer`, `voiceStyle` |
+
 ## Quick start
 
 All buffer parameters accept refs directly. Prefer refs over raw string ids. If you pass raw ids, malformed values are rejected early with `AUDIO_INVALID_ARGUMENT` or `TEXT_INVALID_ARGUMENT`.

--- a/docs/tts-offline.md
+++ b/docs/tts-offline.md
@@ -156,6 +156,7 @@ function detectTtsModel(
 const det = await detectTtsModel({ kind: 'fs', path: '/absolute/path/to/kokoro' });
 // det.modelType       → e.g. 'kokoro'
 // det.isStreaming     → true
+// det.paths           → { ttsModel, tokens, dataDir, voices, ... } on folder scans
 // det.lexiconLanguages → [{ id: 'us-en', path: '.../lexicon-us-en.txt' }, ...] (vits/matcha/kokoro/zipvoice)
 // det.languages       → [{ iso6391Hint: 'en', id: 'us-en' }, ...]
 // det.quantization    → 'int8' | 'fp32' | ...

--- a/docs/tts-offline.md
+++ b/docs/tts-offline.md
@@ -2,9 +2,15 @@
 
 ## Introduction
 
-On-device **batch** synthesis via a buffer-to-buffer pipeline: text goes in as an `OfflineTextBuffer`, audio comes out in an `OfflineAudioBuffer`. The engine is **instance-based** — create with `createTTS()`, call `destroy()` when done.
+On-device **batch** synthesis with a **pipeline-first** API.
 
-**For live synthesis with PCM playback:** use the Live overload section in this document.
+| Role | Type | Notes |
+| --- | --- | --- |
+| **Input** | [`OfflineTextBuffer`](textbuffer-offline.md) | Populated text buffer |
+| **Output** | [`OfflineAudioBuffer`](audiobuffer-offline.md) | Empty buffer at model sample rate; synthesis fills it once |
+| **Engine** | `TtsEngine` via `createTTS` | Instance-based — call `destroy()` when done |
+
+For live synthesis with PCM playback, see [Live overload](#live-overload-on-offline-tts-offline-weights-live-consumption) below.
 
 **Import paths:**
 ```ts
@@ -13,46 +19,6 @@ import { createOfflineTextBufferFromText, releasePipelineTextBuffer } from 'reac
 import { createEmptyOfflineAudioBuffer, releasePipelineAudioBuffer } from 'react-native-sherpa-onnx/audiobuffer';
 import { saveAudioAsFile } from 'react-native-sherpa-onnx/audio';
 ```
-
-## Model detection
-
-`detectTtsModel` is the TTS-specific pre-check before `createTTS` (family, lexicons, quantization). When the feature category is not known yet (model library, multi-category folders), use unified [`detectModel`](model-detect.md) from `react-native-sherpa-onnx/detect` — see [model-detect.md](model-detect.md).
-
-## Custom initialization (`initMode: 'custom'`)
-
-Use custom init when model files are **not** in one detectable directory layout (non-standard names, scattered paths, or detection fails but you know the Sherpa TTS family).
-
-- Set `initMode: 'custom'` and a concrete `modelType` (not `'auto'`).
-- Pass `customConfig` with **`FileSource`** per required file. Path keys match native detection (`ttsModel`, `tokens`, `acousticModel`, `vocoder`, … — see [model-detect.md](model-detect.md#custom-path-validation)).
-- Auto-detection is **skipped**; **`resolveTtsCustomConfigPaths`** resolves each `FileSource` and calls native **`validateCustomModelPaths('tts', modelType, paths)`** (C++ `validate-tts` tables).
-- Query required vs optional keys for UI with **`getCustomModelPathRequirements('tts', modelType)`** from `react-native-sherpa-onnx/detect`.
-- **`lexiconLanguageId`** is **auto mode only**; in custom mode pass `lexicon` directly in `customConfig` when needed.
-- **`modelOptions`** (noise scales, Kokoro init `lang`, etc.) are allowed on custom init the same as auto.
-
-```ts
-import { createTTS } from 'react-native-sherpa-onnx/tts';
-
-const tts = await createTTS({
-  initMode: 'custom',
-  modelType: 'vits',
-  customConfig: {
-    ttsModel: { kind: 'fs', path: '/data/models/en_US-lessac-medium.onnx' },
-    tokens: { kind: 'fs', path: '/data/models/tokens.txt' },
-    lexicon: { kind: 'fs', path: '/data/models/lexicon.txt' },
-  },
-  modelOptions: { vits: { noiseScale: 0.667, noiseScaleW: 0.8, lengthScale: 1.0 } },
-  numThreads: 2,
-});
-```
-
-| Model type | Required path keys |
-| --- | --- |
-| `vits` | `ttsModel`, `tokens` (+ optional `dataDir`, `lexicon`) |
-| `matcha` | `acousticModel`, `vocoder`, `tokens` (+ optional `dataDir`, `lexicon`) |
-| `kokoro`, `kitten` | `ttsModel`, `tokens`, `voices`, `dataDir` (+ optional `lexicon` for kokoro) |
-| `pocket` | `lmFlow`, `lmMain`, `encoder`, `decoder`, `textConditioner`, `vocabJson`, `tokenScoresJson` |
-| `zipvoice` | `encoder`, `decoder`, `vocoder`, `tokens`, `dataDir`, `lexicon` |
-| `supertonic` | `durationPredictor`, `textEncoder`, `vectorEstimator`, `vocoder`, `ttsJson`, `unicodeIndexer`, `voiceStyle` |
 
 ## Quick start
 
@@ -170,15 +136,6 @@ try {
   await releasePipelineAudioBuffer(audioBuf).catch(() => {});
 }
 ```
-
-## Setup
-
-| Topic | Notes |
-| --- | --- |
-| `audioOut.sampleRate` | Must equal model output rate. Get it via `tts.getSampleRate()` before allocating. |
-| Execution providers | Optional `provider` on init — see [execution-providers.md](execution-providers.md) |
-| Multi-instance | Each `createTTS()` has a unique `instanceId`; do not use after `destroy()` |
-| Voice cloning | Zipvoice and Pocket only; requires `OfflineAudioBuffer` as reference (not raw samples) |
 
 ## API reference
 
@@ -309,6 +266,8 @@ const buf = await createEmptyOfflineAudioBuffer(22050);
 // buf.info.numSamples === 0 — synthesis fills it exactly once
 ```
 
+> The output buffer's `sampleRate` must equal the model output rate — read it with `tts.getSampleRate()` before allocating. Each `createTTS()` has a unique `instanceId`; do not use it after `destroy()`. Voice cloning (Zipvoice / Pocket only) requires an `OfflineAudioBuffer` reference, not raw samples.
+
 ### Convert output buffer to file
 
 Use audio save helpers from `react-native-sherpa-onnx/audio`:
@@ -360,6 +319,51 @@ const info = await getPipelineAudioBufferInfo(audioBuf);
 ```ts
 await releasePipelineAudioBuffer(audioBuf); // frees native audio buffer
 await releasePipelineTextBuffer(textBuf);   // frees native text buffer
+```
+
+## Model detection
+
+`detectTtsModel` is a cheap pre-check before `createTTS` (family, lexicons, required files). Unified catalog detect: [model-detect.md](model-detect.md).
+
+## Validation required files
+
+| `modelType` | Required files | Optional | Custom-init keys |
+| --- | --- | --- | --- |
+| `vits` | `ttsModel`, `tokens` | `dataDir`, `lexicon` | `ttsModel`, `tokens` (+ optional `dataDir`, `lexicon`) |
+| `matcha` | `acousticModel`, `vocoder`, `tokens` | `dataDir`, `lexicon` | `acousticModel`, `vocoder`, `tokens` |
+| `kokoro`, `kitten` | `ttsModel`, `tokens`, `voices`, `dataDir` | `lexicon` (kokoro) | same as required |
+| `pocket` | `lmFlow`, `lmMain`, `encoder`, `decoder`, `textConditioner`, `vocabJson`, `tokenScoresJson` | — | same as required |
+| `zipvoice` | `encoder`, `decoder`, `vocoder`, `tokens`, `dataDir`, `lexicon` | — | same as required |
+| `supertonic` | `durationPredictor`, `textEncoder`, `vectorEstimator`, `vocoder`, `ttsJson`, `unicodeIndexer`, `voiceStyle` | — | same as required |
+
+Query keys: `getCustomModelPathRequirements('tts', modelType)`.
+
+## Custom initialization (`initMode: 'custom'`)
+
+Concept: [model-detect.md — Init modes](model-detect.md#init-modes-auto-vs-custom). **`lexiconLanguageId`** is auto-only; pass `lexicon` in `customConfig` when needed.
+
+| `modelType` | Custom-init keys |
+| --- | --- |
+| `vits` | `ttsModel`, `tokens` (+ optional `dataDir`, `lexicon`) |
+| `matcha` | `acousticModel`, `vocoder`, `tokens` |
+| `kokoro`, `kitten` | `ttsModel`, `tokens`, `voices`, `dataDir` |
+| `pocket` | 7 keys — see table above |
+| `zipvoice` | `encoder`, `decoder`, `vocoder`, `tokens`, `dataDir`, `lexicon` |
+| `supertonic` | 7 keys — see table above |
+
+```ts
+import { createTTS } from 'react-native-sherpa-onnx/tts';
+
+const tts = await createTTS({
+  initMode: 'custom',
+  modelType: 'vits',
+  customConfig: {
+    ttsModel: { kind: 'fs', path: '/data/models/model.onnx' },
+    tokens: { kind: 'fs', path: '/data/models/tokens.txt' },
+    lexicon: { kind: 'fs', path: '/data/models/lexicon.txt' },
+  },
+  modelOptions: { vits: { noiseScale: 0.667, noiseScaleW: 0.8, lengthScale: 1.0 } },
+});
 ```
 
 ## Segmentation

--- a/docs/vad-streaming.md
+++ b/docs/vad-streaming.md
@@ -2,68 +2,20 @@
 
 ## Introduction
 
-On-device streaming VAD with a pipeline-first API:
+On-device streaming VAD with a **pipeline-first** API.
 
-- **Input:** live or offline pipeline audio buffer (`audiobuffer`)
-- **Output:** live or offline segment buffer (`segmentbuffer`)
-- **Engine:** `createStreamingVAD` exposes `process(...)`, `isSpeechDetected()`, and `destroy()` (no engine-level data events)
-- **Pipeline handle (live):** `onSpeechStateChanged` for speech activity; **segment buffer:** `onSegmentAppended` / `streamEvents.segmentAppended` for new segments (fat metadata; pull APIs remain)
+| Role | Type | Notes |
+| --- | --- | --- |
+| **Input** | Pipeline audio buffer ([`audiobuffer`](audiobuffer-streaming.md)) | Live or offline PCM |
+| **Output** | Segment buffer ([`segmentbuffer`](segmentbuffer-streaming.md)) | Speech segments; subscribe via `onSegmentAppended` / `streamEvents.segmentAppended` |
+| **Engine** | `StreamingVadEngine` via `createStreamingVAD` | `process(...)`, `isSpeechDetected()`, `destroy()` |
+| **Pipeline handle (live)** | `VADPipelineHandle` | `onSpeechStateChanged` for speech activity |
 
 Import path: `react-native-sherpa-onnx/vad`
 
 ## Streaming pipeline system
 
 `process` starts a **native VAD worker** that consumes **audio** and emits **speech segments** (and optional speech-state callbacks). Control uses **`VADPipelineHandle`** (`stop`, `flush`, `reset`, `getStatus`, `completed`) — same **registry-backed** pattern as STT/enhancement; see **[Streaming pipelines — shared lifecycle](streaming-pipelines-overview.md)**. **Important:** with **`autoFlushOnInputEnded: true`** (quick start), **`finalizeLiveAudioBuffer(audioIn)`** already triggers **terminal draining** — do **not** call **`pipeline.flush()`** again afterward (redundant / race-prone). For **parallel pipelines** (VAD + STT on the same `audioIn`), call each feature’s **`flush()`** before **`stop()`** when you need a coordinated end-of-session drain.
-
-## Models and paths
-
-- `FileSource` (type from `react-native-sherpa-onnx/fileio`): `FileSource`
-- Model detection without engine init: `detectVadModel(...)` — unified category detect: [model-detect.md](model-detect.md)
-- Supported model families: `silero_vad`, `ten_vad`
-
-## Model detection
-
-`detectVadModel` validates Silero / Ten VAD layouts before `createStreamingVAD`. For library rows where the Sherpa category is unknown, use unified detection in [model-detect.md](model-detect.md).
-
-## Custom initialization (`initMode: 'custom'`)
-
-Use custom init when the VAD ONNX file is **not** in a detectable folder layout (non-standard name, scattered path, or detection fails but you know the family).
-
-- Set `initMode: 'custom'` and a concrete `modelType` (`silero_vad` or `ten_vad`, not `'auto'`).
-- Pass `customConfig` with a single **`model`** {@link FileSource} pointing at the `.onnx` file.
-- Validation uses native `validate-vad` (same `model` key for both families). See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
-- `runtimeOptions` (threshold, silence/speech ms, `windowSize`) work the same as auto mode.
-
-```ts
-import { createStreamingVAD } from 'react-native-sherpa-onnx/vad';
-
-const vad = await createStreamingVAD({
-  initMode: 'custom',
-  modelType: 'silero_vad',
-  customConfig: {
-    model: { kind: 'fs', path: '/data/models/silero_vad.onnx' },
-  },
-  sampleRate: 16000,
-  runtimeOptions: {
-    sileroVad: { scoreThreshold: 0.5, minSpeechDurationMs: 250, minSilenceDurationMs: 250 },
-  },
-});
-```
-
-Ten VAD example:
-
-```ts
-const vad = await createStreamingVAD({
-  initMode: 'custom',
-  modelType: 'ten_vad',
-  customConfig: {
-    model: { kind: 'fs', path: '/data/models/ten-vad.onnx' },
-  },
-  runtimeOptions: {
-    tenVad: { scoreThreshold: 0.5, windowSize: 256 },
-  },
-});
-```
 
 ## Quick start
 
@@ -204,15 +156,6 @@ await releasePipelineTextBuffer(textOut);
 await releasePipelineAudioBuffer(audioIn);
 ```
 
-## Setup (iOS and Android)
-
-| Topic | Requirement |
-| --- | --- |
-| Input format | Float PCM `[-1, 1]` in a pipeline audio buffer |
-| Sample rate | VAD `sampleRate` and input buffer sample rate must match model expectations (typically 16kHz) |
-| Model detection | Run `detectVadModel(...)` before engine init when you want explicit preflight checks |
-| Lifecycle | Finalize input for graceful completion, or stop explicitly for early abort; destroy engine(s), then release buffers |
-
 ## API reference
 
 All signatures below are exported from `react-native-sherpa-onnx/vad`.
@@ -349,6 +292,49 @@ Snapshot of worker progress and VAD-specific flags (see exported `VADPipelineSta
 
 Resolves when the worker has **fully stopped** (normal completion after finalize + auto-flush, `stop()`, or error). Use with **`await finalizeLiveAudioBuffer`** in the graceful path shown in the quick start.
 
+## Models and paths
+
+- **`FileSource`** — [model-setup.md](model-setup.md)
+- **Detection & init** — [model-detect.md](model-detect.md)
+- Families: `silero_vad`, `ten_vad`
+
+## Validation required files
+
+| `modelType` | Required files | Optional | Custom-init keys |
+| --- | --- | --- | --- |
+| `silero_vad` | `*.onnx` (silero VAD) | — | `model` |
+| `ten_vad` | `*.onnx` (ten VAD) | — | `model` |
+
+## Model detection
+
+`detectVadModel` validates Silero / Ten layouts before `createStreamingVAD`. Unified catalog: [model-detect.md](model-detect.md).
+
+## Custom initialization (`initMode: 'custom'`)
+
+Concept: [model-detect.md — Init modes](model-detect.md#init-modes-auto-vs-custom).
+
+| `modelType` | Custom-init keys |
+| --- | --- |
+| `silero_vad`, `ten_vad` | `model` |
+
+```ts
+import { createStreamingVAD } from 'react-native-sherpa-onnx/vad';
+
+const vad = await createStreamingVAD({
+  initMode: 'custom',
+  modelType: 'silero_vad',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/silero_vad.onnx' },
+  },
+  sampleRate: 16000,
+  runtimeOptions: {
+    sileroVad: { scoreThreshold: 0.5, minSpeechDurationMs: 250, minSilenceDurationMs: 250 },
+  },
+});
+```
+
+`runtimeOptions` work the same as auto mode.
+
 ## Pipeline composition
 
 ### Typical upstream
@@ -392,7 +378,7 @@ More end-to-end patterns: [feature-pipelines.md#vad-streaming-patterns](feature-
 ### Modes (offline only)
 
 - **`'off'`** (default) — one `runVadOffline` over the **entire** `off_*` buffer; smallest surprise vs. pre-segmentation behavior.
-- **`'auto'`** — `segmentOfflineBuffer` + `getSegments` (domain **speech**); one `runVadOffline` per slice; results merged into `segmentOut`. **Segment boundaries can differ** from single-pass `off`; keep `off` if you rely on legacy whole-file semantics.
+- **`'auto'`** — `segmentOfflineBuffer` + `getSegments` (domain **speech**); one `runVadOffline` per slice; results merged into `segmentOut`. **Segment boundaries can differ** from single-pass `off`; keep `'off'` if you need single-pass whole-file boundaries.
 
 For `mode: 'auto'`, **`policy` is required** (validation). The snippet below uses the same default shape as `validateSegmentationConfig` for offline VAD (`speech_energy_silence`, …). Tune in [segmentation-engine.md](segmentation-engine.md).
 
@@ -462,7 +448,7 @@ const { summary } = await vad.process({
 });
 ```
 
-**Edge cases (`auto`):** zero speech slices → zero summary, **no** native calls, **no** `onProgress`. `onProgress` throws → run aborts. Fail-fast per segment in v1 (no STT-style retries on `VADOfflineRunOptions`). Details: [ADR-002 — VAD offline segmentation & progress](./migration/OrchestrationProgressVADAli/ADR-002-vad-offline-segmentation-progress-strategy.md).
+**Edge cases (`auto`):** zero speech slices → zero summary, **no** native calls, **no** `onProgress`. `onProgress` throws → run aborts. Fail-fast per segment (no STT-style retries on `VADOfflineRunOptions`).
 
 ### Streaming: live buffers (no `segmentation` options)
 

--- a/docs/vad-streaming.md
+++ b/docs/vad-streaming.md
@@ -25,6 +25,46 @@ Import path: `react-native-sherpa-onnx/vad`
 
 `detectVadModel` validates Silero / Ten VAD layouts before `createStreamingVAD`. For library rows where the Sherpa category is unknown, use unified detection in [model-detect.md](model-detect.md).
 
+## Custom initialization (`initMode: 'custom'`)
+
+Use custom init when the VAD ONNX file is **not** in a detectable folder layout (non-standard name, scattered path, or detection fails but you know the family).
+
+- Set `initMode: 'custom'` and a concrete `modelType` (`silero_vad` or `ten_vad`, not `'auto'`).
+- Pass `customConfig` with a single **`model`** {@link FileSource} pointing at the `.onnx` file.
+- Validation uses native `validate-vad` (same `model` key for both families). See [model-detect.md — Custom path validation](model-detect.md#custom-path-validation).
+- `runtimeOptions` (threshold, silence/speech ms, `windowSize`) work the same as auto mode.
+
+```ts
+import { createStreamingVAD } from 'react-native-sherpa-onnx/vad';
+
+const vad = await createStreamingVAD({
+  initMode: 'custom',
+  modelType: 'silero_vad',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/silero_vad.onnx' },
+  },
+  sampleRate: 16000,
+  runtimeOptions: {
+    sileroVad: { scoreThreshold: 0.5, minSpeechDurationMs: 250, minSilenceDurationMs: 250 },
+  },
+});
+```
+
+Ten VAD example:
+
+```ts
+const vad = await createStreamingVAD({
+  initMode: 'custom',
+  modelType: 'ten_vad',
+  customConfig: {
+    model: { kind: 'fs', path: '/data/models/ten-vad.onnx' },
+  },
+  runtimeOptions: {
+    tenVad: { scoreThreshold: 0.5, windowSize: 256 },
+  },
+});
+```
+
 ## Quick start
 
 ### 1) Streaming VAD with live segment output

--- a/example/src/components/SegmentationPolicyControls.tsx
+++ b/example/src/components/SegmentationPolicyControls.tsx
@@ -25,7 +25,10 @@ import {
   View,
 } from 'react-native';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
-import type { SegmentationPolicy } from 'react-native-sherpa-onnx/segment';
+import type {
+  SegmentationPolicy,
+  SpeechVadSegmentationPolicy,
+} from 'react-native-sherpa-onnx/segment';
 import {
   ModelCategory,
   onModelsListUpdated,
@@ -114,24 +117,18 @@ function getAvailableModes(variant: SegmentationVariant): SegmentationMode[] {
   return ['off', 'manual', 'auto'];
 }
 
-function defaultEvaluator(variant: SegmentationVariant): string {
-  if (variant === 'speech-streaming') return 'continuous_frames';
-  if (variant === 'speech-offline') return 'speech_energy_silence';
-  return 'text_synthetic_auto';
-}
-
 function defaultPolicy(variant: SegmentationVariant): SegmentationPolicy {
-  const evaluator = defaultEvaluator(
-    variant
-  ) as SegmentationPolicy['evaluator'];
   if (variant === 'text-offline' || variant === 'text-streaming') {
     return {
-      evaluator,
+      evaluator: 'text_synthetic_auto',
       maxLengthChars: 320,
       sentenceBoundary: true,
     };
   }
-  return { evaluator };
+  if (variant === 'speech-streaming') {
+    return { evaluator: 'continuous_frames' };
+  }
+  return { evaluator: 'speech_energy_silence' };
 }
 
 /** Placeholder when the field is empty: shows the effective native default. */
@@ -212,7 +209,7 @@ type PolicyFieldsProps = {
 };
 
 type VadPolicyFieldsProps = {
-  policy: SegmentationPolicy;
+  policy: SpeechVadSegmentationPolicy;
   disabled: boolean;
   onPolicyChange: (p: SegmentationPolicy) => void;
 };
@@ -351,7 +348,7 @@ function PunctuationPolicyFields({
 
   const update = useCallback(
     (patch: Partial<SegmentationPolicy>) =>
-      onPolicyChange({ ...policy, ...patch }),
+      onPolicyChange({ ...policy, ...patch } as SegmentationPolicy),
     [policy, onPolicyChange]
   );
 
@@ -514,7 +511,7 @@ function VadPolicyFields({
         onPolicyChange({
           ...policyRef.current,
           modelPath: fileSource,
-        });
+        } as SpeechVadSegmentationPolicy);
         setVadStatusLine(
           `policy.modelPath set · detected: ${
             det.modelType
@@ -532,8 +529,8 @@ function VadPolicyFields({
   }, [snapshot, selectedVadModelId, onPolicyChange]);
 
   const update = useCallback(
-    (patch: Partial<SegmentationPolicy>) =>
-      onPolicyChange({ ...policy, ...patch }),
+    (patch: Partial<SpeechVadSegmentationPolicy>) =>
+      onPolicyChange({ ...policy, ...patch } as SegmentationPolicy),
     [policy, onPolicyChange]
   );
 
@@ -624,7 +621,7 @@ function VadPolicyFields({
 function PolicyFields({ policy, disabled, onPolicyChange }: PolicyFieldsProps) {
   const update = useCallback(
     (patch: Partial<SegmentationPolicy>) =>
-      onPolicyChange({ ...policy, ...patch }),
+      onPolicyChange({ ...policy, ...patch } as SegmentationPolicy),
     [policy, onPolicyChange]
   );
 
@@ -669,7 +666,7 @@ function PolicyFields({ policy, disabled, onPolicyChange }: PolicyFieldsProps) {
       {/* ── speech_vad_model ── */}
       {evaluator === 'speech_vad_model' && (
         <VadPolicyFields
-          policy={policy}
+          policy={policy as SpeechVadSegmentationPolicy}
           disabled={disabled}
           onPolicyChange={onPolicyChange}
         />
@@ -753,27 +750,30 @@ export function SegmentationPolicyControls({
     (evaluator: string) => {
       const current = value.policy;
       // Preserve evaluator-agnostic numeric fields (maxLengthChars, etc.) when switching
-      const base: SegmentationPolicy = {
+      const base = {
         ...defaultPolicy(variant),
         ...current,
         evaluator: evaluator as SegmentationPolicy['evaluator'],
-      };
+      } as SegmentationPolicy;
       // Remove fields that don't apply to the new evaluator
       if (evaluator !== 'speech_energy_silence') {
-        delete base.silenceThresholdMs;
-        delete base.energyThresholdDb;
-        delete base.minSegmentMs;
-        delete base.maxSegmentMs;
-        delete base.hangoverMs;
+        delete (base as Record<string, unknown>).silenceThresholdMs;
+        delete (base as Record<string, unknown>).energyThresholdDb;
+        delete (base as Record<string, unknown>).minSegmentMs;
+        delete (base as Record<string, unknown>).maxSegmentMs;
+        delete (base as Record<string, unknown>).hangoverMs;
       }
       if (evaluator !== 'speech_vad_model') {
-        delete base.vadThreshold;
-        delete base.vadMinSpeechMs;
-        delete base.vadMinSilenceMs;
-        delete base.modelPath;
+        delete (base as Record<string, unknown>).vadThreshold;
+        delete (base as Record<string, unknown>).vadMinSpeechMs;
+        delete (base as Record<string, unknown>).vadMinSilenceMs;
+        delete (base as Record<string, unknown>).modelPath;
+        delete (base as Record<string, unknown>).initMode;
+        delete (base as Record<string, unknown>).modelType;
+        delete (base as Record<string, unknown>).customConfig;
       }
       if (evaluator !== 'continuous_frames') {
-        delete base.checkpointIntervalMs;
+        delete (base as Record<string, unknown>).checkpointIntervalMs;
       }
       if (
         evaluator !== 'text_synthetic_auto' &&

--- a/example/src/components/modelInit/AlignmentCustomInitForm.tsx
+++ b/example/src/components/modelInit/AlignmentCustomInitForm.tsx
@@ -7,7 +7,10 @@ import {
   View,
 } from 'react-native';
 import type { AlignmentCustomPathKey } from 'react-native-sherpa-onnx/alignment';
-import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import {
+  getCustomModelPathRequirements,
+  type CustomModelPathRequirements,
+} from 'react-native-sherpa-onnx/detect';
 import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 import { FileSourceSlotPicker } from './FileSourceSlotPicker';
 import { labelForAlignmentCustomPathKey } from '../../utils/alignmentCustomInitLabels';
@@ -37,10 +40,9 @@ export function AlignmentCustomInitForm({
   disabled = false,
   fillHint = null,
 }: AlignmentCustomInitFormProps) {
-  const [schema, setSchema] = useState<{
-    required: string[];
-    optional: string[];
-  }>({ required: [], optional: [] });
+  const [schema, setSchema] = useState<CustomModelPathRequirements>({
+    fields: [],
+  });
   const [schemaLoading, setSchemaLoading] = useState(false);
 
   useEffect(() => {
@@ -62,30 +64,14 @@ export function AlignmentCustomInitForm({
     };
   }, []);
 
-  const slotKeys = useMemo(() => {
-    const requiredSet = new Set(schema.required);
-    const seen = new Set<string>();
-    const keys: Array<{ key: AlignmentCustomPathKey; required: boolean }> = [];
-    for (const key of schema.required) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({
-          key: key as AlignmentCustomPathKey,
-          required: true,
-        });
-      }
-    }
-    for (const key of schema.optional) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({
-          key: key as AlignmentCustomPathKey,
-          required: requiredSet.has(key),
-        });
-      }
-    }
-    return keys;
-  }, [schema]);
+  const slotKeys = useMemo(
+    () =>
+      schema.fields.map((field) => ({
+        key: field.key as AlignmentCustomPathKey,
+        required: field.required,
+      })),
+    [schema.fields]
+  );
 
   const setFileSource = (
     key: AlignmentCustomPathKey,

--- a/example/src/components/modelInit/AlignmentCustomInitForm.tsx
+++ b/example/src/components/modelInit/AlignmentCustomInitForm.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import type { AlignmentCustomPathKey } from 'react-native-sherpa-onnx/alignment';
+import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import { FileSourceSlotPicker } from './FileSourceSlotPicker';
+import { labelForAlignmentCustomPathKey } from '../../utils/alignmentCustomInitLabels';
+
+export type AlignmentCustomInitFormState = {
+  fileSources: Partial<Record<AlignmentCustomPathKey, FileSource>>;
+};
+
+type AlignmentCustomInitFormProps = {
+  value: AlignmentCustomInitFormState;
+  onChange: (next: AlignmentCustomInitFormState) => void;
+  selectedCatalogModelId: string | null;
+  onFillFromSelectedModel: () => void;
+  onPrepareScatteredTest: () => void;
+  fillLoading?: boolean;
+  disabled?: boolean;
+  fillHint?: string | null;
+};
+
+export function AlignmentCustomInitForm({
+  value,
+  onChange,
+  selectedCatalogModelId,
+  onFillFromSelectedModel,
+  onPrepareScatteredTest,
+  fillLoading = false,
+  disabled = false,
+  fillHint = null,
+}: AlignmentCustomInitFormProps) {
+  const [schema, setSchema] = useState<{
+    required: string[];
+    optional: string[];
+  }>({ required: [], optional: [] });
+  const [schemaLoading, setSchemaLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSchemaLoading(true);
+    getCustomModelPathRequirements('alignment', 'wav2vec2')
+      .then((requirements) => {
+        if (!cancelled) {
+          setSchema(requirements);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setSchemaLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const slotKeys = useMemo(() => {
+    const requiredSet = new Set(schema.required);
+    const seen = new Set<string>();
+    const keys: Array<{ key: AlignmentCustomPathKey; required: boolean }> = [];
+    for (const key of schema.required) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({
+          key: key as AlignmentCustomPathKey,
+          required: true,
+        });
+      }
+    }
+    for (const key of schema.optional) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({
+          key: key as AlignmentCustomPathKey,
+          required: requiredSet.has(key),
+        });
+      }
+    }
+    return keys;
+  }, [schema]);
+
+  const setFileSource = (
+    key: AlignmentCustomPathKey,
+    source: FileSource | undefined
+  ) => {
+    const next = { ...value.fileSources };
+    if (source) {
+      next[key] = source;
+    } else {
+      delete next[key];
+    }
+    onChange({ fileSources: next });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.subheading}>Custom paths (wav2vec2)</Text>
+      {schemaLoading ? (
+        <ActivityIndicator style={styles.loader} />
+      ) : (
+        slotKeys.map(({ key, required }) => (
+          <FileSourceSlotPicker
+            key={key}
+            label={labelForAlignmentCustomPathKey(key)}
+            value={value.fileSources[key]}
+            onChange={(source) => setFileSource(key, source)}
+            disabled={disabled}
+            required={required}
+          />
+        ))
+      )}
+      <View style={styles.actions}>
+        <TouchableOpacity
+          style={[
+            styles.actionButton,
+            (!selectedCatalogModelId || fillLoading || disabled) &&
+              styles.actionDisabled,
+          ]}
+          disabled={!selectedCatalogModelId || fillLoading || disabled}
+          onPress={onFillFromSelectedModel}
+        >
+          {fillLoading ? (
+            <ActivityIndicator color="#fff" size="small" />
+          ) : (
+            <Text style={styles.actionText}>Fill from selected catalog</Text>
+          )}
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.actionButton, disabled && styles.actionDisabled]}
+          disabled={disabled}
+          onPress={onPrepareScatteredTest}
+        >
+          <Text style={styles.actionText}>Scattered test</Text>
+        </TouchableOpacity>
+      </View>
+      {fillHint ? <Text style={styles.fillHint}>{fillHint}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { marginTop: 12, gap: 8 },
+  subheading: { fontSize: 14, fontWeight: '600', color: '#333' },
+  loader: { marginVertical: 8 },
+  actions: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 8 },
+  actionButton: {
+    backgroundColor: '#555',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  actionDisabled: { opacity: 0.45 },
+  actionText: { color: '#fff', fontSize: 13 },
+  fillHint: { fontSize: 12, color: '#666', marginTop: 4 },
+});

--- a/example/src/components/modelInit/EnhancementCustomInitForm.tsx
+++ b/example/src/components/modelInit/EnhancementCustomInitForm.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  ENHANCEMENT_MODEL_TYPES,
+  type EnhancementConcreteModelType,
+  type EnhancementCustomPathKey,
+} from 'react-native-sherpa-onnx/enhancement';
+import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import { FileSourceSlotPicker } from './FileSourceSlotPicker';
+import { labelForEnhancementCustomPathKey } from '../../utils/enhancementCustomInitLabels';
+
+export type EnhancementCustomInitFormState = {
+  modelType: EnhancementConcreteModelType;
+  fileSources: Partial<Record<EnhancementCustomPathKey, FileSource>>;
+};
+
+type EnhancementCustomInitFormProps = {
+  value: EnhancementCustomInitFormState;
+  onChange: (next: EnhancementCustomInitFormState) => void;
+  selectedCatalogModelId: string | null;
+  onFillFromSelectedModel: () => void;
+  onPrepareScatteredTest: () => void;
+  fillLoading?: boolean;
+  disabled?: boolean;
+  fillHint?: string | null;
+};
+
+export function EnhancementCustomInitForm({
+  value,
+  onChange,
+  selectedCatalogModelId,
+  onFillFromSelectedModel,
+  onPrepareScatteredTest,
+  fillLoading = false,
+  disabled = false,
+  fillHint = null,
+}: EnhancementCustomInitFormProps) {
+  const [schema, setSchema] = useState<{
+    required: string[];
+    optional: string[];
+  }>({ required: [], optional: [] });
+  const [schemaLoading, setSchemaLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSchemaLoading(true);
+    getCustomModelPathRequirements('enhancement', value.modelType)
+      .then((requirements) => {
+        if (!cancelled) {
+          setSchema(requirements);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setSchemaLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value.modelType]);
+
+  const slotKeys = useMemo(() => {
+    const requiredSet = new Set(schema.required);
+    const seen = new Set<string>();
+    const keys: Array<{ key: EnhancementCustomPathKey; required: boolean }> =
+      [];
+    for (const key of schema.required) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({ key: key as EnhancementCustomPathKey, required: true });
+      }
+    }
+    for (const key of schema.optional) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({
+          key: key as EnhancementCustomPathKey,
+          required: requiredSet.has(key),
+        });
+      }
+    }
+    return keys;
+  }, [schema]);
+
+  const setModelType = (modelType: EnhancementConcreteModelType) => {
+    onChange({ modelType, fileSources: {} });
+  };
+
+  const setFileSource = (
+    key: EnhancementCustomPathKey,
+    source: FileSource | undefined
+  ) => {
+    const next = { ...value.fileSources };
+    if (source) {
+      next[key] = source;
+    } else {
+      delete next[key];
+    }
+    onChange({ ...value, fileSources: next });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.subheading}>Enhancement model type</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.typeRow}
+      >
+        {ENHANCEMENT_MODEL_TYPES.map((type) => {
+          const active = value.modelType === type;
+          return (
+            <TouchableOpacity
+              key={type}
+              style={[styles.typeChip, active && styles.typeChipActive]}
+              onPress={() => setModelType(type)}
+              disabled={disabled || fillLoading}
+            >
+              <Text
+                style={[
+                  styles.typeChipText,
+                  active && styles.typeChipTextActive,
+                ]}
+              >
+                {type}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+
+      <View style={styles.helperRow}>
+        <TouchableOpacity
+          style={[
+            styles.helperButton,
+            (!selectedCatalogModelId || fillLoading || disabled) &&
+              styles.helperButtonDisabled,
+          ]}
+          onPress={onFillFromSelectedModel}
+          disabled={!selectedCatalogModelId || fillLoading || disabled}
+        >
+          {fillLoading ? (
+            <ActivityIndicator size="small" color="#FFFFFF" />
+          ) : (
+            <Text style={styles.helperButtonText}>
+              Fill from selected model
+            </Text>
+          )}
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[
+            styles.helperButtonSecondary,
+            disabled && styles.helperButtonDisabled,
+          ]}
+          onPress={onPrepareScatteredTest}
+          disabled={disabled || fillLoading}
+        >
+          <Text style={styles.helperButtonSecondaryText}>
+            Scattered test (clear slots)
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {fillHint ? <Text style={styles.fillHint}>{fillHint}</Text> : null}
+
+      <Text style={styles.subheading}>Model file</Text>
+      <Text style={styles.hint}>
+        Pick the denoiser ONNX file. Use Fill to pre-populate from the catalog
+        selection, then override for scattered layouts.
+      </Text>
+
+      {schemaLoading ? (
+        <ActivityIndicator
+          size="small"
+          color="#5856D6"
+          style={styles.schemaLoader}
+        />
+      ) : null}
+
+      {slotKeys.map(({ key, required }) => (
+        <FileSourceSlotPicker
+          key={key}
+          label={labelForEnhancementCustomPathKey(key)}
+          value={value.fileSources[key]}
+          onChange={(source) => setFileSource(key, source)}
+          disabled={disabled || fillLoading}
+          required={required}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 4,
+  },
+  subheading: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#000000',
+    marginBottom: 8,
+    marginTop: 8,
+  },
+  hint: {
+    fontSize: 13,
+    color: '#8E8E93',
+    marginBottom: 8,
+  },
+  schemaLoader: {
+    marginVertical: 8,
+  },
+  typeRow: {
+    gap: 8,
+    paddingBottom: 4,
+  },
+  typeChip: {
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#C7C7CC',
+    backgroundColor: '#F2F2F7',
+  },
+  typeChipActive: {
+    borderColor: '#007AFF',
+    backgroundColor: '#E3F2FD',
+  },
+  typeChipText: {
+    fontSize: 12,
+    color: '#3A3A3C',
+  },
+  typeChipTextActive: {
+    color: '#007AFF',
+    fontWeight: '600',
+  },
+  helperRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginVertical: 8,
+  },
+  helperButton: {
+    backgroundColor: '#5856D6',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    minWidth: 160,
+    alignItems: 'center',
+  },
+  helperButtonSecondary: {
+    backgroundColor: '#F2F2F7',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#C7C7CC',
+  },
+  helperButtonDisabled: {
+    opacity: 0.5,
+  },
+  helperButtonText: {
+    color: '#FFFFFF',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  helperButtonSecondaryText: {
+    color: '#3A3A3C',
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  fillHint: {
+    fontSize: 12,
+    color: '#5856D6',
+    marginBottom: 4,
+  },
+});

--- a/example/src/components/modelInit/EnhancementCustomInitForm.tsx
+++ b/example/src/components/modelInit/EnhancementCustomInitForm.tsx
@@ -12,7 +12,10 @@ import {
   type EnhancementConcreteModelType,
   type EnhancementCustomPathKey,
 } from 'react-native-sherpa-onnx/enhancement';
-import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import {
+  getCustomModelPathRequirements,
+  type CustomModelPathRequirements,
+} from 'react-native-sherpa-onnx/detect';
 import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 import { FileSourceSlotPicker } from './FileSourceSlotPicker';
 import { labelForEnhancementCustomPathKey } from '../../utils/enhancementCustomInitLabels';
@@ -43,10 +46,9 @@ export function EnhancementCustomInitForm({
   disabled = false,
   fillHint = null,
 }: EnhancementCustomInitFormProps) {
-  const [schema, setSchema] = useState<{
-    required: string[];
-    optional: string[];
-  }>({ required: [], optional: [] });
+  const [schema, setSchema] = useState<CustomModelPathRequirements>({
+    fields: [],
+  });
   const [schemaLoading, setSchemaLoading] = useState(false);
 
   useEffect(() => {
@@ -68,28 +70,14 @@ export function EnhancementCustomInitForm({
     };
   }, [value.modelType]);
 
-  const slotKeys = useMemo(() => {
-    const requiredSet = new Set(schema.required);
-    const seen = new Set<string>();
-    const keys: Array<{ key: EnhancementCustomPathKey; required: boolean }> =
-      [];
-    for (const key of schema.required) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({ key: key as EnhancementCustomPathKey, required: true });
-      }
-    }
-    for (const key of schema.optional) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({
-          key: key as EnhancementCustomPathKey,
-          required: requiredSet.has(key),
-        });
-      }
-    }
-    return keys;
-  }, [schema]);
+  const slotKeys = useMemo(
+    () =>
+      schema.fields.map((field) => ({
+        key: field.key as EnhancementCustomPathKey,
+        required: field.required,
+      })),
+    [schema.fields]
+  );
 
   const setModelType = (modelType: EnhancementConcreteModelType) => {
     onChange({ modelType, fileSources: {} });

--- a/example/src/components/modelInit/FileSourceSlotPicker.tsx
+++ b/example/src/components/modelInit/FileSourceSlotPicker.tsx
@@ -1,0 +1,142 @@
+import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import * as DocumentPicker from '@react-native-documents/picker';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import {
+  describeFileSource,
+  toFileSource,
+} from '../../utils/fileSourceFromUri';
+
+type FileSourceSlotPickerProps = {
+  label: string;
+  value?: FileSource;
+  onChange: (source: FileSource | undefined) => void;
+  disabled?: boolean;
+  required?: boolean;
+  pickTypes?: string[];
+};
+
+function isPickerCancelled(err: unknown): boolean {
+  const e = err as { name?: string; code?: string };
+  return (
+    (DocumentPicker as { isCancel?: (error: unknown) => boolean }).isCancel?.(
+      err
+    ) === true ||
+    e?.name === 'DocumentPickerCanceled' ||
+    e?.code === 'DOCUMENT_PICKER_CANCELED'
+  );
+}
+
+export function FileSourceSlotPicker({
+  label,
+  value,
+  onChange,
+  disabled = false,
+  required = false,
+  pickTypes = [DocumentPicker.types.allFiles],
+}: FileSourceSlotPickerProps) {
+  const handlePick = async () => {
+    try {
+      const [picked] = await DocumentPicker.pick({
+        type: pickTypes,
+        allowMultiSelection: false,
+      });
+      const uri = picked?.uri?.trim();
+      if (!uri) {
+        return;
+      }
+      onChange(toFileSource(uri));
+    } catch (err) {
+      if (isPickerCancelled(err)) {
+        return;
+      }
+      Alert.alert('File pick failed', String(err));
+    }
+  };
+
+  return (
+    <View style={styles.row}>
+      <View style={styles.labelBlock}>
+        <Text style={styles.label}>
+          {label}
+          {required ? ' *' : ''}
+        </Text>
+        <Text style={styles.path} numberOfLines={2}>
+          {value ? describeFileSource(value) : 'No file selected'}
+        </Text>
+      </View>
+      <View style={styles.actions}>
+        <TouchableOpacity
+          style={[styles.pickButton, disabled && styles.pickButtonDisabled]}
+          onPress={handlePick}
+          disabled={disabled}
+        >
+          <Text style={styles.pickButtonText}>Pick</Text>
+        </TouchableOpacity>
+        {value != null && (
+          <TouchableOpacity
+            style={[styles.clearButton, disabled && styles.pickButtonDisabled]}
+            onPress={() => onChange(undefined)}
+            disabled={disabled}
+          >
+            <Text style={styles.clearButtonText}>Clear</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#E5E5EA',
+  },
+  labelBlock: {
+    flex: 1,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#000000',
+    marginBottom: 2,
+  },
+  path: {
+    fontSize: 12,
+    color: '#8E8E93',
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  pickButton: {
+    backgroundColor: '#007AFF',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 6,
+  },
+  pickButtonDisabled: {
+    opacity: 0.5,
+  },
+  pickButtonText: {
+    color: '#FFFFFF',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  clearButton: {
+    backgroundColor: '#F2F2F7',
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#C7C7CC',
+  },
+  clearButtonText: {
+    color: '#3A3A3C',
+    fontSize: 13,
+    fontWeight: '500',
+  },
+});

--- a/example/src/components/modelInit/InitModeSelector.tsx
+++ b/example/src/components/modelInit/InitModeSelector.tsx
@@ -1,0 +1,94 @@
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+export type ModelInitMode = 'auto' | 'custom';
+
+type InitModeSelectorProps = {
+  value: ModelInitMode;
+  onChange: (mode: ModelInitMode) => void;
+  disabled?: boolean;
+};
+
+export function InitModeSelector({
+  value,
+  onChange,
+  disabled = false,
+}: InitModeSelectorProps) {
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={[
+          styles.segment,
+          value === 'auto' && styles.segmentActive,
+          disabled && styles.segmentDisabled,
+        ]}
+        onPress={() => onChange('auto')}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityState={{ selected: value === 'auto' }}
+      >
+        <Text
+          style={[
+            styles.segmentText,
+            value === 'auto' && styles.segmentTextActive,
+          ]}
+        >
+          Auto detect
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={[
+          styles.segment,
+          value === 'custom' && styles.segmentActive,
+          disabled && styles.segmentDisabled,
+        ]}
+        onPress={() => onChange('custom')}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityState={{ selected: value === 'custom' }}
+      >
+        <Text
+          style={[
+            styles.segmentText,
+            value === 'custom' && styles.segmentTextActive,
+          ]}
+        >
+          Custom files
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 12,
+  },
+  segment: {
+    flex: 1,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#C7C7CC',
+    backgroundColor: '#F2F2F7',
+    alignItems: 'center',
+  },
+  segmentActive: {
+    borderColor: '#007AFF',
+    backgroundColor: '#E3F2FD',
+  },
+  segmentDisabled: {
+    opacity: 0.5,
+  },
+  segmentText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#3A3A3C',
+  },
+  segmentTextActive: {
+    color: '#007AFF',
+    fontWeight: '600',
+  },
+});

--- a/example/src/components/modelInit/ModelFolderGrid.tsx
+++ b/example/src/components/modelInit/ModelFolderGrid.tsx
@@ -1,0 +1,180 @@
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@react-native-vector-icons/ionicons';
+import { getSizeHint, getQualityHint } from '../../utils/recommendedModels';
+
+export type ModelFolderGridEntry = {
+  id: string;
+  label: string;
+  recommended?: boolean;
+};
+
+type ModelFolderGridProps = {
+  entries: ModelFolderGridEntry[];
+  selectedId: string | null;
+  initializedId: string | null;
+  onSelect: (modelId: string) => void;
+  loading?: boolean;
+  disabled?: boolean;
+  emptyMessage?: string;
+};
+
+export function ModelFolderGrid({
+  entries,
+  selectedId,
+  initializedId,
+  onSelect,
+  loading = false,
+  disabled = false,
+  emptyMessage = 'No models found.',
+}: ModelFolderGridProps) {
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#007AFF" />
+        <Text style={styles.loadingText}>Discovering available models…</Text>
+      </View>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <View style={styles.warningContainer}>
+        <Text style={styles.warningText}>{emptyMessage}</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.grid}>
+      {entries.map((entry) => {
+        const isSelected = selectedId === entry.id;
+        const isInitialized = initializedId === entry.id;
+        const sizeHintInfo = getSizeHint(entry.id);
+        const qualityHintInfo = getQualityHint(entry.id);
+
+        return (
+          <TouchableOpacity
+            key={entry.id}
+            style={[
+              styles.modelButton,
+              isSelected && styles.modelButtonActive,
+              isInitialized && styles.modelButtonInitialized,
+              disabled && styles.modelButtonDisabled,
+            ]}
+            onPress={() => onSelect(entry.id)}
+            disabled={disabled}
+          >
+            <Text
+              style={[
+                styles.modelButtonText,
+                isSelected && styles.modelButtonTextActive,
+              ]}
+            >
+              {entry.label}
+            </Text>
+            <View style={styles.modelHintRow}>
+              <View style={styles.modelHintGroup}>
+                <Ionicons
+                  name={sizeHintInfo.iconName as any}
+                  size={12}
+                  color={sizeHintInfo.iconColor}
+                />
+                <Text style={styles.modelHintText}>{sizeHintInfo.tier}</Text>
+              </View>
+              <View style={styles.modelHintGroup}>
+                <Ionicons
+                  name={qualityHintInfo.iconName as any}
+                  size={12}
+                  color={qualityHintInfo.iconColor}
+                />
+                <Text style={styles.modelHintText}>
+                  {qualityHintInfo.text.split(',')[0]}
+                </Text>
+              </View>
+            </View>
+            <Text style={styles.modelFolderText}>{entry.id}</Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  modelButton: {
+    width: '48%',
+    padding: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#E5E5EA',
+    backgroundColor: '#F9F9F9',
+  },
+  modelButtonActive: {
+    borderColor: '#007AFF',
+    backgroundColor: '#E3F2FD',
+  },
+  modelButtonInitialized: {
+    borderColor: '#34C759',
+    backgroundColor: '#E8F5E9',
+  },
+  modelButtonDisabled: {
+    opacity: 0.6,
+  },
+  modelButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#000000',
+    marginBottom: 4,
+  },
+  modelButtonTextActive: {
+    color: '#007AFF',
+  },
+  modelHintRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginBottom: 4,
+  },
+  modelHintGroup: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  modelHintText: {
+    fontSize: 11,
+    color: '#8E8E93',
+  },
+  modelFolderText: {
+    fontSize: 10,
+    color: '#8E8E93',
+  },
+  loadingContainer: {
+    alignItems: 'center',
+    paddingVertical: 24,
+    gap: 8,
+  },
+  loadingText: {
+    fontSize: 14,
+    color: '#8E8E93',
+  },
+  warningContainer: {
+    padding: 12,
+    borderRadius: 8,
+    backgroundColor: '#FFF3E0',
+  },
+  warningText: {
+    fontSize: 14,
+    color: '#E65100',
+  },
+});

--- a/example/src/components/modelInit/PunctuationOfflineCustomInitForm.tsx
+++ b/example/src/components/modelInit/PunctuationOfflineCustomInitForm.tsx
@@ -7,7 +7,10 @@ import {
   View,
 } from 'react-native';
 import type { OfflinePunctuationCustomPathKey } from 'react-native-sherpa-onnx/punctuation';
-import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import {
+  getCustomModelPathRequirements,
+  type CustomModelPathRequirements,
+} from 'react-native-sherpa-onnx/detect';
 import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 import { FileSourceSlotPicker } from './FileSourceSlotPicker';
 import { labelForOfflinePunctuationCustomPathKey } from '../../utils/punctuationCustomInitLabels';
@@ -37,10 +40,9 @@ export function PunctuationOfflineCustomInitForm({
   disabled = false,
   fillHint = null,
 }: PunctuationOfflineCustomInitFormProps) {
-  const [schema, setSchema] = useState<{
-    required: string[];
-    optional: string[];
-  }>({ required: [], optional: [] });
+  const [schema, setSchema] = useState<CustomModelPathRequirements>({
+    fields: [],
+  });
   const [schemaLoading, setSchemaLoading] = useState(false);
 
   useEffect(() => {
@@ -62,33 +64,14 @@ export function PunctuationOfflineCustomInitForm({
     };
   }, []);
 
-  const slotKeys = useMemo(() => {
-    const requiredSet = new Set(schema.required);
-    const seen = new Set<string>();
-    const keys: Array<{
-      key: OfflinePunctuationCustomPathKey;
-      required: boolean;
-    }> = [];
-    for (const key of schema.required) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({
-          key: key as OfflinePunctuationCustomPathKey,
-          required: true,
-        });
-      }
-    }
-    for (const key of schema.optional) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({
-          key: key as OfflinePunctuationCustomPathKey,
-          required: requiredSet.has(key),
-        });
-      }
-    }
-    return keys;
-  }, [schema]);
+  const slotKeys = useMemo(
+    () =>
+      schema.fields.map((field) => ({
+        key: field.key as OfflinePunctuationCustomPathKey,
+        required: field.required,
+      })),
+    [schema.fields]
+  );
 
   const setFileSource = (
     key: OfflinePunctuationCustomPathKey,

--- a/example/src/components/modelInit/PunctuationOfflineCustomInitForm.tsx
+++ b/example/src/components/modelInit/PunctuationOfflineCustomInitForm.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import type { OfflinePunctuationCustomPathKey } from 'react-native-sherpa-onnx/punctuation';
+import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import { FileSourceSlotPicker } from './FileSourceSlotPicker';
+import { labelForOfflinePunctuationCustomPathKey } from '../../utils/punctuationCustomInitLabels';
+
+export type PunctuationOfflineCustomInitFormState = {
+  fileSources: Partial<Record<OfflinePunctuationCustomPathKey, FileSource>>;
+};
+
+type PunctuationOfflineCustomInitFormProps = {
+  value: PunctuationOfflineCustomInitFormState;
+  onChange: (next: PunctuationOfflineCustomInitFormState) => void;
+  selectedCatalogModelId: string | null;
+  onFillFromSelectedModel: () => void;
+  onPrepareScatteredTest: () => void;
+  fillLoading?: boolean;
+  disabled?: boolean;
+  fillHint?: string | null;
+};
+
+export function PunctuationOfflineCustomInitForm({
+  value,
+  onChange,
+  selectedCatalogModelId,
+  onFillFromSelectedModel,
+  onPrepareScatteredTest,
+  fillLoading = false,
+  disabled = false,
+  fillHint = null,
+}: PunctuationOfflineCustomInitFormProps) {
+  const [schema, setSchema] = useState<{
+    required: string[];
+    optional: string[];
+  }>({ required: [], optional: [] });
+  const [schemaLoading, setSchemaLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSchemaLoading(true);
+    getCustomModelPathRequirements('punctuation', 'ct_transformer')
+      .then((requirements) => {
+        if (!cancelled) {
+          setSchema(requirements);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setSchemaLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const slotKeys = useMemo(() => {
+    const requiredSet = new Set(schema.required);
+    const seen = new Set<string>();
+    const keys: Array<{
+      key: OfflinePunctuationCustomPathKey;
+      required: boolean;
+    }> = [];
+    for (const key of schema.required) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({
+          key: key as OfflinePunctuationCustomPathKey,
+          required: true,
+        });
+      }
+    }
+    for (const key of schema.optional) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({
+          key: key as OfflinePunctuationCustomPathKey,
+          required: requiredSet.has(key),
+        });
+      }
+    }
+    return keys;
+  }, [schema]);
+
+  const setFileSource = (
+    key: OfflinePunctuationCustomPathKey,
+    source: FileSource | undefined
+  ) => {
+    const next = { ...value.fileSources };
+    if (source) {
+      next[key] = source;
+    } else {
+      delete next[key];
+    }
+    onChange({ fileSources: next });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.subheading}>Custom paths (ct_transformer)</Text>
+      {schemaLoading ? (
+        <ActivityIndicator style={styles.loader} />
+      ) : (
+        slotKeys.map(({ key, required }) => (
+          <FileSourceSlotPicker
+            key={key}
+            label={labelForOfflinePunctuationCustomPathKey(key)}
+            value={value.fileSources[key]}
+            onChange={(source) => setFileSource(key, source)}
+            disabled={disabled}
+            required={required}
+          />
+        ))
+      )}
+      <View style={styles.actions}>
+        <TouchableOpacity
+          style={[
+            styles.actionButton,
+            (!selectedCatalogModelId || fillLoading || disabled) &&
+              styles.actionDisabled,
+          ]}
+          disabled={!selectedCatalogModelId || fillLoading || disabled}
+          onPress={onFillFromSelectedModel}
+        >
+          {fillLoading ? (
+            <ActivityIndicator color="#fff" size="small" />
+          ) : (
+            <Text style={styles.actionText}>Fill from selected catalog</Text>
+          )}
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.actionButton, disabled && styles.actionDisabled]}
+          disabled={disabled}
+          onPress={onPrepareScatteredTest}
+        >
+          <Text style={styles.actionText}>Scattered test</Text>
+        </TouchableOpacity>
+      </View>
+      {fillHint ? <Text style={styles.fillHint}>{fillHint}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { marginTop: 12, gap: 8 },
+  subheading: { fontSize: 14, fontWeight: '600', color: '#333' },
+  loader: { marginVertical: 8 },
+  actions: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 8 },
+  actionButton: {
+    backgroundColor: '#555',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  actionDisabled: { opacity: 0.45 },
+  actionText: { color: '#fff', fontSize: 13 },
+  fillHint: { fontSize: 12, color: '#666', marginTop: 4 },
+});

--- a/example/src/components/modelInit/PunctuationStreamingCustomInitForm.tsx
+++ b/example/src/components/modelInit/PunctuationStreamingCustomInitForm.tsx
@@ -7,7 +7,10 @@ import {
   View,
 } from 'react-native';
 import type { StreamingPunctuationCustomPathKey } from 'react-native-sherpa-onnx/punctuation';
-import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import {
+  getCustomModelPathRequirements,
+  type CustomModelPathRequirements,
+} from 'react-native-sherpa-onnx/detect';
 import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 import { FileSourceSlotPicker } from './FileSourceSlotPicker';
 import { labelForStreamingPunctuationCustomPathKey } from '../../utils/punctuationCustomInitLabels';
@@ -37,10 +40,9 @@ export function PunctuationStreamingCustomInitForm({
   disabled = false,
   fillHint = null,
 }: PunctuationStreamingCustomInitFormProps) {
-  const [schema, setSchema] = useState<{
-    required: string[];
-    optional: string[];
-  }>({ required: [], optional: [] });
+  const [schema, setSchema] = useState<CustomModelPathRequirements>({
+    fields: [],
+  });
   const [schemaLoading, setSchemaLoading] = useState(false);
 
   useEffect(() => {
@@ -62,33 +64,14 @@ export function PunctuationStreamingCustomInitForm({
     };
   }, []);
 
-  const slotKeys = useMemo(() => {
-    const requiredSet = new Set(schema.required);
-    const seen = new Set<string>();
-    const keys: Array<{
-      key: StreamingPunctuationCustomPathKey;
-      required: boolean;
-    }> = [];
-    for (const key of schema.required) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({
-          key: key as StreamingPunctuationCustomPathKey,
-          required: true,
-        });
-      }
-    }
-    for (const key of schema.optional) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({
-          key: key as StreamingPunctuationCustomPathKey,
-          required: requiredSet.has(key),
-        });
-      }
-    }
-    return keys;
-  }, [schema]);
+  const slotKeys = useMemo(
+    () =>
+      schema.fields.map((field) => ({
+        key: field.key as StreamingPunctuationCustomPathKey,
+        required: field.required,
+      })),
+    [schema.fields]
+  );
 
   const setFileSource = (
     key: StreamingPunctuationCustomPathKey,

--- a/example/src/components/modelInit/PunctuationStreamingCustomInitForm.tsx
+++ b/example/src/components/modelInit/PunctuationStreamingCustomInitForm.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import type { StreamingPunctuationCustomPathKey } from 'react-native-sherpa-onnx/punctuation';
+import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import { FileSourceSlotPicker } from './FileSourceSlotPicker';
+import { labelForStreamingPunctuationCustomPathKey } from '../../utils/punctuationCustomInitLabels';
+
+export type PunctuationStreamingCustomInitFormState = {
+  fileSources: Partial<Record<StreamingPunctuationCustomPathKey, FileSource>>;
+};
+
+type PunctuationStreamingCustomInitFormProps = {
+  value: PunctuationStreamingCustomInitFormState;
+  onChange: (next: PunctuationStreamingCustomInitFormState) => void;
+  selectedCatalogModelId: string | null;
+  onFillFromSelectedModel: () => void;
+  onPrepareScatteredTest: () => void;
+  fillLoading?: boolean;
+  disabled?: boolean;
+  fillHint?: string | null;
+};
+
+export function PunctuationStreamingCustomInitForm({
+  value,
+  onChange,
+  selectedCatalogModelId,
+  onFillFromSelectedModel,
+  onPrepareScatteredTest,
+  fillLoading = false,
+  disabled = false,
+  fillHint = null,
+}: PunctuationStreamingCustomInitFormProps) {
+  const [schema, setSchema] = useState<{
+    required: string[];
+    optional: string[];
+  }>({ required: [], optional: [] });
+  const [schemaLoading, setSchemaLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSchemaLoading(true);
+    getCustomModelPathRequirements('punctuation', 'cnn_bilstm')
+      .then((requirements) => {
+        if (!cancelled) {
+          setSchema(requirements);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setSchemaLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const slotKeys = useMemo(() => {
+    const requiredSet = new Set(schema.required);
+    const seen = new Set<string>();
+    const keys: Array<{
+      key: StreamingPunctuationCustomPathKey;
+      required: boolean;
+    }> = [];
+    for (const key of schema.required) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({
+          key: key as StreamingPunctuationCustomPathKey,
+          required: true,
+        });
+      }
+    }
+    for (const key of schema.optional) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({
+          key: key as StreamingPunctuationCustomPathKey,
+          required: requiredSet.has(key),
+        });
+      }
+    }
+    return keys;
+  }, [schema]);
+
+  const setFileSource = (
+    key: StreamingPunctuationCustomPathKey,
+    source: FileSource | undefined
+  ) => {
+    const next = { ...value.fileSources };
+    if (source) {
+      next[key] = source;
+    } else {
+      delete next[key];
+    }
+    onChange({ fileSources: next });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.subheading}>Custom paths (cnn_bilstm)</Text>
+      {schemaLoading ? (
+        <ActivityIndicator style={styles.loader} />
+      ) : (
+        slotKeys.map(({ key, required }) => (
+          <FileSourceSlotPicker
+            key={key}
+            label={labelForStreamingPunctuationCustomPathKey(key)}
+            value={value.fileSources[key]}
+            onChange={(source) => setFileSource(key, source)}
+            disabled={disabled}
+            required={required}
+          />
+        ))
+      )}
+      <View style={styles.actions}>
+        <TouchableOpacity
+          style={[
+            styles.actionButton,
+            (!selectedCatalogModelId || fillLoading || disabled) &&
+              styles.actionDisabled,
+          ]}
+          disabled={!selectedCatalogModelId || fillLoading || disabled}
+          onPress={onFillFromSelectedModel}
+        >
+          {fillLoading ? (
+            <ActivityIndicator color="#fff" size="small" />
+          ) : (
+            <Text style={styles.actionText}>Fill from selected catalog</Text>
+          )}
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.actionButton, disabled && styles.actionDisabled]}
+          disabled={disabled}
+          onPress={onPrepareScatteredTest}
+        >
+          <Text style={styles.actionText}>Scattered test</Text>
+        </TouchableOpacity>
+      </View>
+      {fillHint ? <Text style={styles.fillHint}>{fillHint}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { marginTop: 12, gap: 8 },
+  subheading: { fontSize: 14, fontWeight: '600', color: '#333' },
+  loader: { marginVertical: 8 },
+  actions: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 8 },
+  actionButton: {
+    backgroundColor: '#555',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  actionDisabled: { opacity: 0.45 },
+  actionText: { color: '#fff', fontSize: 13 },
+  fillHint: { fontSize: 12, color: '#666', marginTop: 4 },
+});

--- a/example/src/components/modelInit/SpeechVadSegmentationCustomInitForm.tsx
+++ b/example/src/components/modelInit/SpeechVadSegmentationCustomInitForm.tsx
@@ -1,0 +1,4 @@
+export {
+  VadCustomInitForm as SpeechVadSegmentationCustomInitForm,
+  type VadCustomInitFormState as SpeechVadSegmentationCustomInitFormState,
+} from './VadCustomInitForm';

--- a/example/src/components/modelInit/StreamingSttCustomInitForm.tsx
+++ b/example/src/components/modelInit/StreamingSttCustomInitForm.tsx
@@ -20,9 +20,7 @@ import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 import { FileSourceSlotPicker } from './FileSourceSlotPicker';
 import { labelForStreamingSttCustomPathKey } from '../../utils/streamingCustomInitLabels';
 
-const STREAMING_CUSTOM_MODEL_TYPES = ONLINE_STT_MODEL_TYPES.filter(
-  (type): type is OnlineSTTModelType => type !== 'wenet_ctc'
-);
+const STREAMING_CUSTOM_MODEL_TYPES = ONLINE_STT_MODEL_TYPES;
 
 export type StreamingSttCustomInitFormState = {
   modelType: OnlineSTTModelType;

--- a/example/src/components/modelInit/StreamingSttCustomInitForm.tsx
+++ b/example/src/components/modelInit/StreamingSttCustomInitForm.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  ONLINE_STT_MODEL_TYPES,
+  type OnlineSTTModelType,
+  type StreamingSttCustomPathKey,
+} from 'react-native-sherpa-onnx/stt';
+import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import { FileSourceSlotPicker } from './FileSourceSlotPicker';
+import { labelForStreamingSttCustomPathKey } from '../../utils/streamingCustomInitLabels';
+
+const STREAMING_CUSTOM_MODEL_TYPES = ONLINE_STT_MODEL_TYPES.filter(
+  (type): type is OnlineSTTModelType => type !== 'wenet_ctc'
+);
+
+export type StreamingSttCustomInitFormState = {
+  modelType: OnlineSTTModelType;
+  fileSources: Partial<Record<StreamingSttCustomPathKey, FileSource>>;
+};
+
+type StreamingSttCustomInitFormProps = {
+  value: StreamingSttCustomInitFormState;
+  onChange: (next: StreamingSttCustomInitFormState) => void;
+  selectedCatalogModelId: string | null;
+  onFillFromSelectedModel: () => void;
+  fillLoading?: boolean;
+  disabled?: boolean;
+  fillHint?: string | null;
+};
+
+export function StreamingSttCustomInitForm({
+  value,
+  onChange,
+  selectedCatalogModelId,
+  onFillFromSelectedModel,
+  fillLoading = false,
+  disabled = false,
+  fillHint = null,
+}: StreamingSttCustomInitFormProps) {
+  const [schema, setSchema] = useState<{
+    required: string[];
+    optional: string[];
+  }>({ required: [], optional: [] });
+  const [schemaLoading, setSchemaLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSchemaLoading(true);
+    getCustomModelPathRequirements('stt_streaming', value.modelType)
+      .then((requirements) => {
+        if (!cancelled) {
+          setSchema(requirements);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setSchemaLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value.modelType]);
+
+  const slotKeys = useMemo(() => {
+    const requiredSet = new Set(schema.required);
+    const seen = new Set<string>();
+    const keys: Array<{ key: StreamingSttCustomPathKey; required: boolean }> =
+      [];
+    for (const key of schema.required) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({ key: key as StreamingSttCustomPathKey, required: true });
+      }
+    }
+    for (const key of schema.optional) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({
+          key: key as StreamingSttCustomPathKey,
+          required: requiredSet.has(key),
+        });
+      }
+    }
+    return keys;
+  }, [schema]);
+
+  const setModelType = (modelType: OnlineSTTModelType) => {
+    onChange({ modelType, fileSources: {} });
+  };
+
+  const setFileSource = (
+    key: StreamingSttCustomPathKey,
+    source: FileSource | undefined
+  ) => {
+    const next = { ...value.fileSources };
+    if (source) {
+      next[key] = source;
+    } else {
+      delete next[key];
+    }
+    onChange({ ...value, fileSources: next });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.subheading}>Streaming model type</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.typeRow}
+      >
+        {STREAMING_CUSTOM_MODEL_TYPES.map((type) => (
+          <TouchableOpacity
+            key={type}
+            style={[
+              styles.typeChip,
+              value.modelType === type && styles.typeChipActive,
+            ]}
+            onPress={() => setModelType(type)}
+            disabled={disabled || fillLoading}
+          >
+            <Text
+              style={[
+                styles.typeChipText,
+                value.modelType === type && styles.typeChipTextActive,
+              ]}
+            >
+              {type}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+
+      <View style={styles.fillRow}>
+        <TouchableOpacity
+          style={[
+            styles.fillButton,
+            (!selectedCatalogModelId || disabled || fillLoading) &&
+              styles.fillButtonDisabled,
+          ]}
+          onPress={onFillFromSelectedModel}
+          disabled={!selectedCatalogModelId || disabled || fillLoading}
+        >
+          {fillLoading ? (
+            <ActivityIndicator size="small" color="#fff" />
+          ) : (
+            <Text style={styles.fillButtonText}>Fill from selected model</Text>
+          )}
+        </TouchableOpacity>
+      </View>
+      {fillHint ? <Text style={styles.fillHint}>{fillHint}</Text> : null}
+
+      <Text style={styles.subheading}>Model files</Text>
+      {schemaLoading ? (
+        <ActivityIndicator size="small" />
+      ) : (
+        slotKeys.map(({ key, required }) => (
+          <FileSourceSlotPicker
+            key={key}
+            label={labelForStreamingSttCustomPathKey(key)}
+            required={required}
+            value={value.fileSources[key]}
+            onChange={(source) => setFileSource(key, source)}
+            disabled={disabled || fillLoading}
+          />
+        ))
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 12,
+  },
+  subheading: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#161616',
+  },
+  typeRow: {
+    gap: 8,
+    paddingVertical: 4,
+  },
+  typeChip: {
+    borderWidth: 1,
+    borderColor: '#c6c6c6',
+    borderRadius: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    backgroundColor: '#fff',
+  },
+  typeChipActive: {
+    borderColor: '#0F62FE',
+    backgroundColor: '#edf5ff',
+  },
+  typeChipText: {
+    fontSize: 13,
+    color: '#525252',
+  },
+  typeChipTextActive: {
+    color: '#0F62FE',
+    fontWeight: '600',
+  },
+  fillRow: {
+    flexDirection: 'row',
+  },
+  fillButton: {
+    backgroundColor: '#393939',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    minHeight: 40,
+    justifyContent: 'center',
+  },
+  fillButtonDisabled: {
+    opacity: 0.5,
+  },
+  fillButtonText: {
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  fillHint: {
+    fontSize: 12,
+    color: '#525252',
+  },
+});

--- a/example/src/components/modelInit/StreamingSttCustomInitForm.tsx
+++ b/example/src/components/modelInit/StreamingSttCustomInitForm.tsx
@@ -12,7 +12,10 @@ import {
   type OnlineSTTModelType,
   type StreamingSttCustomPathKey,
 } from 'react-native-sherpa-onnx/stt';
-import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import {
+  getCustomModelPathRequirements,
+  type CustomModelPathRequirements,
+} from 'react-native-sherpa-onnx/detect';
 import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 import { FileSourceSlotPicker } from './FileSourceSlotPicker';
 import { labelForStreamingSttCustomPathKey } from '../../utils/streamingCustomInitLabels';
@@ -45,10 +48,9 @@ export function StreamingSttCustomInitForm({
   disabled = false,
   fillHint = null,
 }: StreamingSttCustomInitFormProps) {
-  const [schema, setSchema] = useState<{
-    required: string[];
-    optional: string[];
-  }>({ required: [], optional: [] });
+  const [schema, setSchema] = useState<CustomModelPathRequirements>({
+    fields: [],
+  });
   const [schemaLoading, setSchemaLoading] = useState(false);
 
   useEffect(() => {
@@ -70,28 +72,14 @@ export function StreamingSttCustomInitForm({
     };
   }, [value.modelType]);
 
-  const slotKeys = useMemo(() => {
-    const requiredSet = new Set(schema.required);
-    const seen = new Set<string>();
-    const keys: Array<{ key: StreamingSttCustomPathKey; required: boolean }> =
-      [];
-    for (const key of schema.required) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({ key: key as StreamingSttCustomPathKey, required: true });
-      }
-    }
-    for (const key of schema.optional) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({
-          key: key as StreamingSttCustomPathKey,
-          required: requiredSet.has(key),
-        });
-      }
-    }
-    return keys;
-  }, [schema]);
+  const slotKeys = useMemo(
+    () =>
+      schema.fields.map((field) => ({
+        key: field.key as StreamingSttCustomPathKey,
+        required: field.required,
+      })),
+    [schema.fields]
+  );
 
   const setModelType = (modelType: OnlineSTTModelType) => {
     onChange({ modelType, fileSources: {} });

--- a/example/src/components/modelInit/SttCustomInitForm.tsx
+++ b/example/src/components/modelInit/SttCustomInitForm.tsx
@@ -12,7 +12,10 @@ import {
   type STTConcreteModelType,
   type SttCustomPathKey,
 } from 'react-native-sherpa-onnx/stt';
-import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import {
+  getCustomModelPathRequirements,
+  type CustomModelPathRequirements,
+} from 'react-native-sherpa-onnx/detect';
 import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 import { FileSourceSlotPicker } from './FileSourceSlotPicker';
 import { labelForSttCustomPathKey } from '../../utils/sttCustomInitLabels';
@@ -47,10 +50,9 @@ export function SttCustomInitForm({
   disabled = false,
   fillHint = null,
 }: SttCustomInitFormProps) {
-  const [schema, setSchema] = useState<{
-    required: string[];
-    optional: string[];
-  }>({ required: [], optional: [] });
+  const [schema, setSchema] = useState<CustomModelPathRequirements>({
+    fields: [],
+  });
   const [schemaLoading, setSchemaLoading] = useState(false);
 
   useEffect(() => {
@@ -72,27 +74,14 @@ export function SttCustomInitForm({
     };
   }, [value.modelType]);
 
-  const slotKeys = useMemo(() => {
-    const requiredSet = new Set(schema.required);
-    const seen = new Set<string>();
-    const keys: Array<{ key: SttCustomPathKey; required: boolean }> = [];
-    for (const key of schema.required) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({ key: key as SttCustomPathKey, required: true });
-      }
-    }
-    for (const key of schema.optional) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({
-          key: key as SttCustomPathKey,
-          required: requiredSet.has(key),
-        });
-      }
-    }
-    return keys;
-  }, [schema]);
+  const slotKeys = useMemo(
+    () =>
+      schema.fields.map((field) => ({
+        key: field.key as SttCustomPathKey,
+        required: field.required,
+      })),
+    [schema.fields]
+  );
 
   const setModelType = (modelType: STTConcreteModelType) => {
     onChange({ modelType, fileSources: {} });

--- a/example/src/components/modelInit/SttCustomInitForm.tsx
+++ b/example/src/components/modelInit/SttCustomInitForm.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  STT_MODEL_TYPES,
+  type STTConcreteModelType,
+  type SttCustomPathKey,
+} from 'react-native-sherpa-onnx/stt';
+import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import { FileSourceSlotPicker } from './FileSourceSlotPicker';
+import { labelForSttCustomPathKey } from '../../utils/sttCustomInitLabels';
+
+const OFFLINE_STT_MODEL_TYPES = STT_MODEL_TYPES.filter(
+  (type): type is STTConcreteModelType => type !== 'auto'
+);
+
+export type SttCustomInitFormState = {
+  modelType: STTConcreteModelType;
+  fileSources: Partial<Record<SttCustomPathKey, FileSource>>;
+};
+
+type SttCustomInitFormProps = {
+  value: SttCustomInitFormState;
+  onChange: (next: SttCustomInitFormState) => void;
+  selectedCatalogModelId: string | null;
+  onFillFromSelectedModel: () => void;
+  onPrepareScatteredTest: () => void;
+  fillLoading?: boolean;
+  disabled?: boolean;
+  fillHint?: string | null;
+};
+
+export function SttCustomInitForm({
+  value,
+  onChange,
+  selectedCatalogModelId,
+  onFillFromSelectedModel,
+  onPrepareScatteredTest,
+  fillLoading = false,
+  disabled = false,
+  fillHint = null,
+}: SttCustomInitFormProps) {
+  const [schema, setSchema] = useState<{
+    required: string[];
+    optional: string[];
+  }>({ required: [], optional: [] });
+  const [schemaLoading, setSchemaLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSchemaLoading(true);
+    getCustomModelPathRequirements('stt', value.modelType)
+      .then((requirements) => {
+        if (!cancelled) {
+          setSchema(requirements);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setSchemaLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value.modelType]);
+
+  const slotKeys = useMemo(() => {
+    const requiredSet = new Set(schema.required);
+    const seen = new Set<string>();
+    const keys: Array<{ key: SttCustomPathKey; required: boolean }> = [];
+    for (const key of schema.required) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({ key: key as SttCustomPathKey, required: true });
+      }
+    }
+    for (const key of schema.optional) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({
+          key: key as SttCustomPathKey,
+          required: requiredSet.has(key),
+        });
+      }
+    }
+    return keys;
+  }, [schema]);
+
+  const setModelType = (modelType: STTConcreteModelType) => {
+    onChange({ modelType, fileSources: {} });
+  };
+
+  const setFileSource = (
+    key: SttCustomPathKey,
+    source: FileSource | undefined
+  ) => {
+    const next = { ...value.fileSources };
+    if (source) {
+      next[key] = source;
+    } else {
+      delete next[key];
+    }
+    onChange({ ...value, fileSources: next });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.subheading}>Model type</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.typeRow}
+      >
+        {OFFLINE_STT_MODEL_TYPES.map((type) => {
+          const active = value.modelType === type;
+          return (
+            <TouchableOpacity
+              key={type}
+              style={[styles.typeChip, active && styles.typeChipActive]}
+              onPress={() => setModelType(type)}
+              disabled={disabled || fillLoading}
+            >
+              <Text
+                style={[
+                  styles.typeChipText,
+                  active && styles.typeChipTextActive,
+                ]}
+              >
+                {type}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+
+      <View style={styles.helperRow}>
+        <TouchableOpacity
+          style={[
+            styles.helperButton,
+            (!selectedCatalogModelId || fillLoading || disabled) &&
+              styles.helperButtonDisabled,
+          ]}
+          onPress={onFillFromSelectedModel}
+          disabled={!selectedCatalogModelId || fillLoading || disabled}
+        >
+          {fillLoading ? (
+            <ActivityIndicator size="small" color="#FFFFFF" />
+          ) : (
+            <Text style={styles.helperButtonText}>
+              Fill from selected model
+            </Text>
+          )}
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[
+            styles.helperButtonSecondary,
+            disabled && styles.helperButtonDisabled,
+          ]}
+          onPress={onPrepareScatteredTest}
+          disabled={disabled || fillLoading}
+        >
+          <Text style={styles.helperButtonSecondaryText}>
+            Scattered test (clear slots)
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {fillHint ? <Text style={styles.fillHint}>{fillHint}</Text> : null}
+
+      <Text style={styles.subheading}>Model files</Text>
+      <Text style={styles.hint}>
+        Pick each required file individually. Use Fill to pre-populate from the
+        catalog selection, then override paths for scattered layouts.
+      </Text>
+
+      {schemaLoading ? (
+        <ActivityIndicator
+          size="small"
+          color="#5856D6"
+          style={styles.schemaLoader}
+        />
+      ) : null}
+
+      {slotKeys.map(({ key, required }) => (
+        <FileSourceSlotPicker
+          key={key}
+          label={labelForSttCustomPathKey(key)}
+          value={value.fileSources[key]}
+          onChange={(source) => setFileSource(key, source)}
+          disabled={disabled || fillLoading}
+          required={required}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 4,
+  },
+  subheading: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#000000',
+    marginBottom: 8,
+    marginTop: 8,
+  },
+  hint: {
+    fontSize: 13,
+    color: '#8E8E93',
+    marginBottom: 8,
+  },
+  schemaLoader: {
+    marginVertical: 8,
+  },
+  typeRow: {
+    gap: 8,
+    paddingBottom: 4,
+  },
+  typeChip: {
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#C7C7CC',
+    backgroundColor: '#F2F2F7',
+  },
+  typeChipActive: {
+    borderColor: '#007AFF',
+    backgroundColor: '#E3F2FD',
+  },
+  typeChipText: {
+    fontSize: 12,
+    color: '#3A3A3C',
+  },
+  typeChipTextActive: {
+    color: '#007AFF',
+    fontWeight: '600',
+  },
+  helperRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginVertical: 8,
+  },
+  helperButton: {
+    backgroundColor: '#5856D6',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    minWidth: 160,
+    alignItems: 'center',
+  },
+  helperButtonSecondary: {
+    backgroundColor: '#F2F2F7',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#C7C7CC',
+  },
+  helperButtonDisabled: {
+    opacity: 0.5,
+  },
+  helperButtonText: {
+    color: '#FFFFFF',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  helperButtonSecondaryText: {
+    color: '#3A3A3C',
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  fillHint: {
+    fontSize: 12,
+    color: '#5856D6',
+    marginBottom: 4,
+  },
+});

--- a/example/src/components/modelInit/TtsCustomInitForm.tsx
+++ b/example/src/components/modelInit/TtsCustomInitForm.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  TTS_MODEL_TYPES,
+  type TTSConcreteModelType,
+  type TtsCustomPathKey,
+} from 'react-native-sherpa-onnx/tts';
+import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import { FileSourceSlotPicker } from './FileSourceSlotPicker';
+import { labelForTtsCustomPathKey } from '../../utils/ttsCustomInitLabels';
+
+const TTS_CUSTOM_MODEL_TYPES = TTS_MODEL_TYPES.filter(
+  (type): type is TTSConcreteModelType => type !== 'auto'
+);
+
+export type TtsCustomInitFormState = {
+  modelType: TTSConcreteModelType;
+  fileSources: Partial<Record<TtsCustomPathKey, FileSource>>;
+};
+
+type TtsCustomInitFormProps = {
+  value: TtsCustomInitFormState;
+  onChange: (next: TtsCustomInitFormState) => void;
+  selectedCatalogModelId: string | null;
+  onFillFromSelectedModel: () => void;
+  onPrepareScatteredTest: () => void;
+  fillLoading?: boolean;
+  disabled?: boolean;
+  fillHint?: string | null;
+};
+
+export function TtsCustomInitForm({
+  value,
+  onChange,
+  selectedCatalogModelId,
+  onFillFromSelectedModel,
+  onPrepareScatteredTest,
+  fillLoading = false,
+  disabled = false,
+  fillHint = null,
+}: TtsCustomInitFormProps) {
+  const [schema, setSchema] = useState<{
+    required: string[];
+    optional: string[];
+  }>({ required: [], optional: [] });
+  const [schemaLoading, setSchemaLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSchemaLoading(true);
+    getCustomModelPathRequirements('tts', value.modelType)
+      .then((requirements) => {
+        if (!cancelled) {
+          setSchema(requirements);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setSchemaLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value.modelType]);
+
+  const slotKeys = useMemo(() => {
+    const requiredSet = new Set(schema.required);
+    const seen = new Set<string>();
+    const keys: Array<{ key: TtsCustomPathKey; required: boolean }> = [];
+    for (const key of schema.required) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({ key: key as TtsCustomPathKey, required: true });
+      }
+    }
+    for (const key of schema.optional) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({
+          key: key as TtsCustomPathKey,
+          required: requiredSet.has(key),
+        });
+      }
+    }
+    return keys;
+  }, [schema]);
+
+  const setModelType = (modelType: TTSConcreteModelType) => {
+    onChange({ modelType, fileSources: {} });
+  };
+
+  const setFileSource = (
+    key: TtsCustomPathKey,
+    source: FileSource | undefined
+  ) => {
+    const next = { ...value.fileSources };
+    if (source) {
+      next[key] = source;
+    } else {
+      delete next[key];
+    }
+    onChange({ ...value, fileSources: next });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.subheading}>TTS model type</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.typeRow}
+      >
+        {TTS_CUSTOM_MODEL_TYPES.map((type) => {
+          const active = value.modelType === type;
+          return (
+            <TouchableOpacity
+              key={type}
+              style={[styles.typeChip, active && styles.typeChipActive]}
+              onPress={() => setModelType(type)}
+              disabled={disabled || fillLoading}
+            >
+              <Text
+                style={[
+                  styles.typeChipText,
+                  active && styles.typeChipTextActive,
+                ]}
+              >
+                {type}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+
+      <View style={styles.helperRow}>
+        <TouchableOpacity
+          style={[
+            styles.helperButton,
+            (!selectedCatalogModelId || fillLoading || disabled) &&
+              styles.helperButtonDisabled,
+          ]}
+          onPress={onFillFromSelectedModel}
+          disabled={!selectedCatalogModelId || fillLoading || disabled}
+        >
+          {fillLoading ? (
+            <ActivityIndicator size="small" color="#FFFFFF" />
+          ) : (
+            <Text style={styles.helperButtonText}>
+              Fill from selected model
+            </Text>
+          )}
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[
+            styles.helperButtonSecondary,
+            disabled && styles.helperButtonDisabled,
+          ]}
+          onPress={onPrepareScatteredTest}
+          disabled={disabled || fillLoading}
+        >
+          <Text style={styles.helperButtonSecondaryText}>
+            Scattered test (clear slots)
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {fillHint ? <Text style={styles.fillHint}>{fillHint}</Text> : null}
+
+      <Text style={styles.subheading}>Model files</Text>
+      <Text style={styles.hint}>
+        Pick each required file individually. Use Fill to pre-populate from the
+        catalog selection, then override paths for scattered layouts.
+      </Text>
+
+      {schemaLoading ? (
+        <ActivityIndicator
+          size="small"
+          color="#5856D6"
+          style={styles.schemaLoader}
+        />
+      ) : null}
+
+      {slotKeys.map(({ key, required }) => (
+        <FileSourceSlotPicker
+          key={key}
+          label={labelForTtsCustomPathKey(key)}
+          value={value.fileSources[key]}
+          onChange={(source) => setFileSource(key, source)}
+          disabled={disabled || fillLoading}
+          required={required}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 4,
+  },
+  subheading: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#000000',
+    marginBottom: 8,
+    marginTop: 8,
+  },
+  hint: {
+    fontSize: 13,
+    color: '#8E8E93',
+    marginBottom: 8,
+  },
+  schemaLoader: {
+    marginVertical: 8,
+  },
+  typeRow: {
+    gap: 8,
+    paddingBottom: 4,
+  },
+  typeChip: {
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#C7C7CC',
+    backgroundColor: '#F2F2F7',
+  },
+  typeChipActive: {
+    borderColor: '#007AFF',
+    backgroundColor: '#E3F2FD',
+  },
+  typeChipText: {
+    fontSize: 12,
+    color: '#3A3A3C',
+  },
+  typeChipTextActive: {
+    color: '#007AFF',
+    fontWeight: '600',
+  },
+  helperRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginVertical: 8,
+  },
+  helperButton: {
+    backgroundColor: '#5856D6',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    minWidth: 160,
+    alignItems: 'center',
+  },
+  helperButtonSecondary: {
+    backgroundColor: '#F2F2F7',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#C7C7CC',
+  },
+  helperButtonDisabled: {
+    opacity: 0.5,
+  },
+  helperButtonText: {
+    color: '#FFFFFF',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  helperButtonSecondaryText: {
+    color: '#3A3A3C',
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  fillHint: {
+    fontSize: 12,
+    color: '#5856D6',
+    marginBottom: 4,
+  },
+});

--- a/example/src/components/modelInit/TtsCustomInitForm.tsx
+++ b/example/src/components/modelInit/TtsCustomInitForm.tsx
@@ -12,7 +12,10 @@ import {
   type TTSConcreteModelType,
   type TtsCustomPathKey,
 } from 'react-native-sherpa-onnx/tts';
-import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import {
+  getCustomModelPathRequirements,
+  type CustomModelPathRequirements,
+} from 'react-native-sherpa-onnx/detect';
 import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 import { FileSourceSlotPicker } from './FileSourceSlotPicker';
 import { labelForTtsCustomPathKey } from '../../utils/ttsCustomInitLabels';
@@ -47,10 +50,9 @@ export function TtsCustomInitForm({
   disabled = false,
   fillHint = null,
 }: TtsCustomInitFormProps) {
-  const [schema, setSchema] = useState<{
-    required: string[];
-    optional: string[];
-  }>({ required: [], optional: [] });
+  const [schema, setSchema] = useState<CustomModelPathRequirements>({
+    fields: [],
+  });
   const [schemaLoading, setSchemaLoading] = useState(false);
 
   useEffect(() => {
@@ -72,27 +74,14 @@ export function TtsCustomInitForm({
     };
   }, [value.modelType]);
 
-  const slotKeys = useMemo(() => {
-    const requiredSet = new Set(schema.required);
-    const seen = new Set<string>();
-    const keys: Array<{ key: TtsCustomPathKey; required: boolean }> = [];
-    for (const key of schema.required) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({ key: key as TtsCustomPathKey, required: true });
-      }
-    }
-    for (const key of schema.optional) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({
-          key: key as TtsCustomPathKey,
-          required: requiredSet.has(key),
-        });
-      }
-    }
-    return keys;
-  }, [schema]);
+  const slotKeys = useMemo(
+    () =>
+      schema.fields.map((field) => ({
+        key: field.key as TtsCustomPathKey,
+        required: field.required,
+      })),
+    [schema.fields]
+  );
 
   const setModelType = (modelType: TTSConcreteModelType) => {
     onChange({ modelType, fileSources: {} });

--- a/example/src/components/modelInit/VadCustomInitForm.tsx
+++ b/example/src/components/modelInit/VadCustomInitForm.tsx
@@ -12,7 +12,10 @@ import {
   type VADConcreteModelType,
   type VadCustomPathKey,
 } from 'react-native-sherpa-onnx/vad';
-import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import {
+  getCustomModelPathRequirements,
+  type CustomModelPathRequirements,
+} from 'react-native-sherpa-onnx/detect';
 import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 import { FileSourceSlotPicker } from './FileSourceSlotPicker';
 import { labelForVadCustomPathKey } from '../../utils/vadCustomInitLabels';
@@ -43,10 +46,9 @@ export function VadCustomInitForm({
   disabled = false,
   fillHint = null,
 }: VadCustomInitFormProps) {
-  const [schema, setSchema] = useState<{
-    required: string[];
-    optional: string[];
-  }>({ required: [], optional: [] });
+  const [schema, setSchema] = useState<CustomModelPathRequirements>({
+    fields: [],
+  });
   const [schemaLoading, setSchemaLoading] = useState(false);
 
   useEffect(() => {
@@ -68,27 +70,14 @@ export function VadCustomInitForm({
     };
   }, [value.modelType]);
 
-  const slotKeys = useMemo(() => {
-    const requiredSet = new Set(schema.required);
-    const seen = new Set<string>();
-    const keys: Array<{ key: VadCustomPathKey; required: boolean }> = [];
-    for (const key of schema.required) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({ key: key as VadCustomPathKey, required: true });
-      }
-    }
-    for (const key of schema.optional) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        keys.push({
-          key: key as VadCustomPathKey,
-          required: requiredSet.has(key),
-        });
-      }
-    }
-    return keys;
-  }, [schema]);
+  const slotKeys = useMemo(
+    () =>
+      schema.fields.map((field) => ({
+        key: field.key as VadCustomPathKey,
+        required: field.required,
+      })),
+    [schema.fields]
+  );
 
   const setModelType = (modelType: VADConcreteModelType) => {
     onChange({ modelType, fileSources: {} });

--- a/example/src/components/modelInit/VadCustomInitForm.tsx
+++ b/example/src/components/modelInit/VadCustomInitForm.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  VAD_MODEL_TYPES,
+  type VADConcreteModelType,
+  type VadCustomPathKey,
+} from 'react-native-sherpa-onnx/vad';
+import { getCustomModelPathRequirements } from 'react-native-sherpa-onnx/detect';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import { FileSourceSlotPicker } from './FileSourceSlotPicker';
+import { labelForVadCustomPathKey } from '../../utils/vadCustomInitLabels';
+
+export type VadCustomInitFormState = {
+  modelType: VADConcreteModelType;
+  fileSources: Partial<Record<VadCustomPathKey, FileSource>>;
+};
+
+type VadCustomInitFormProps = {
+  value: VadCustomInitFormState;
+  onChange: (next: VadCustomInitFormState) => void;
+  selectedCatalogModelId: string | null;
+  onFillFromSelectedModel: () => void;
+  onPrepareScatteredTest: () => void;
+  fillLoading?: boolean;
+  disabled?: boolean;
+  fillHint?: string | null;
+};
+
+export function VadCustomInitForm({
+  value,
+  onChange,
+  selectedCatalogModelId,
+  onFillFromSelectedModel,
+  onPrepareScatteredTest,
+  fillLoading = false,
+  disabled = false,
+  fillHint = null,
+}: VadCustomInitFormProps) {
+  const [schema, setSchema] = useState<{
+    required: string[];
+    optional: string[];
+  }>({ required: [], optional: [] });
+  const [schemaLoading, setSchemaLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSchemaLoading(true);
+    getCustomModelPathRequirements('vad', value.modelType)
+      .then((requirements) => {
+        if (!cancelled) {
+          setSchema(requirements);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setSchemaLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value.modelType]);
+
+  const slotKeys = useMemo(() => {
+    const requiredSet = new Set(schema.required);
+    const seen = new Set<string>();
+    const keys: Array<{ key: VadCustomPathKey; required: boolean }> = [];
+    for (const key of schema.required) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({ key: key as VadCustomPathKey, required: true });
+      }
+    }
+    for (const key of schema.optional) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push({
+          key: key as VadCustomPathKey,
+          required: requiredSet.has(key),
+        });
+      }
+    }
+    return keys;
+  }, [schema]);
+
+  const setModelType = (modelType: VADConcreteModelType) => {
+    onChange({ modelType, fileSources: {} });
+  };
+
+  const setFileSource = (
+    key: VadCustomPathKey,
+    source: FileSource | undefined
+  ) => {
+    const next = { ...value.fileSources };
+    if (source) {
+      next[key] = source;
+    } else {
+      delete next[key];
+    }
+    onChange({ ...value, fileSources: next });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.subheading}>VAD model type</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.typeRow}
+      >
+        {VAD_MODEL_TYPES.map((type) => {
+          const active = value.modelType === type;
+          return (
+            <TouchableOpacity
+              key={type}
+              style={[styles.typeChip, active && styles.typeChipActive]}
+              onPress={() => setModelType(type)}
+              disabled={disabled || fillLoading}
+            >
+              <Text
+                style={[
+                  styles.typeChipText,
+                  active && styles.typeChipTextActive,
+                ]}
+              >
+                {type}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+
+      <View style={styles.helperRow}>
+        <TouchableOpacity
+          style={[
+            styles.helperButton,
+            (!selectedCatalogModelId || fillLoading || disabled) &&
+              styles.helperButtonDisabled,
+          ]}
+          onPress={onFillFromSelectedModel}
+          disabled={!selectedCatalogModelId || fillLoading || disabled}
+        >
+          {fillLoading ? (
+            <ActivityIndicator size="small" color="#FFFFFF" />
+          ) : (
+            <Text style={styles.helperButtonText}>
+              Fill from selected model
+            </Text>
+          )}
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[
+            styles.helperButtonSecondary,
+            disabled && styles.helperButtonDisabled,
+          ]}
+          onPress={onPrepareScatteredTest}
+          disabled={disabled || fillLoading}
+        >
+          <Text style={styles.helperButtonSecondaryText}>
+            Scattered test (clear slots)
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {fillHint ? <Text style={styles.fillHint}>{fillHint}</Text> : null}
+
+      <Text style={styles.subheading}>Model file</Text>
+      <Text style={styles.hint}>
+        Pick the VAD ONNX file. Use Fill to pre-populate from the catalog
+        selection, then override for scattered layouts.
+      </Text>
+
+      {schemaLoading ? (
+        <ActivityIndicator
+          size="small"
+          color="#5856D6"
+          style={styles.schemaLoader}
+        />
+      ) : null}
+
+      {slotKeys.map(({ key, required }) => (
+        <FileSourceSlotPicker
+          key={key}
+          label={labelForVadCustomPathKey(key)}
+          value={value.fileSources[key]}
+          onChange={(source) => setFileSource(key, source)}
+          disabled={disabled || fillLoading}
+          required={required}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 4,
+  },
+  subheading: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#000000',
+    marginBottom: 8,
+    marginTop: 8,
+  },
+  hint: {
+    fontSize: 13,
+    color: '#8E8E93',
+    marginBottom: 8,
+  },
+  schemaLoader: {
+    marginVertical: 8,
+  },
+  typeRow: {
+    gap: 8,
+    paddingBottom: 4,
+  },
+  typeChip: {
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#C7C7CC',
+    backgroundColor: '#F2F2F7',
+  },
+  typeChipActive: {
+    borderColor: '#007AFF',
+    backgroundColor: '#E3F2FD',
+  },
+  typeChipText: {
+    fontSize: 12,
+    color: '#3A3A3C',
+  },
+  typeChipTextActive: {
+    color: '#007AFF',
+    fontWeight: '600',
+  },
+  helperRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginVertical: 8,
+  },
+  helperButton: {
+    backgroundColor: '#5856D6',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    minWidth: 160,
+    alignItems: 'center',
+  },
+  helperButtonSecondary: {
+    backgroundColor: '#F2F2F7',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#C7C7CC',
+  },
+  helperButtonDisabled: {
+    opacity: 0.5,
+  },
+  helperButtonText: {
+    color: '#FFFFFF',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  helperButtonSecondaryText: {
+    color: '#3A3A3C',
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  fillHint: {
+    fontSize: 12,
+    color: '#5856D6',
+    marginBottom: 4,
+  },
+});

--- a/example/src/components/modelInit/index.ts
+++ b/example/src/components/modelInit/index.ts
@@ -29,3 +29,7 @@ export {
   PunctuationStreamingCustomInitForm,
   type PunctuationStreamingCustomInitFormState,
 } from './PunctuationStreamingCustomInitForm';
+export {
+  AlignmentCustomInitForm,
+  type AlignmentCustomInitFormState,
+} from './AlignmentCustomInitForm';

--- a/example/src/components/modelInit/index.ts
+++ b/example/src/components/modelInit/index.ts
@@ -13,3 +13,7 @@ export {
   TtsCustomInitForm,
   type TtsCustomInitFormState,
 } from './TtsCustomInitForm';
+export {
+  VadCustomInitForm,
+  type VadCustomInitFormState,
+} from './VadCustomInitForm';

--- a/example/src/components/modelInit/index.ts
+++ b/example/src/components/modelInit/index.ts
@@ -21,3 +21,11 @@ export {
   EnhancementCustomInitForm,
   type EnhancementCustomInitFormState,
 } from './EnhancementCustomInitForm';
+export {
+  PunctuationOfflineCustomInitForm,
+  type PunctuationOfflineCustomInitFormState,
+} from './PunctuationOfflineCustomInitForm';
+export {
+  PunctuationStreamingCustomInitForm,
+  type PunctuationStreamingCustomInitFormState,
+} from './PunctuationStreamingCustomInitForm';

--- a/example/src/components/modelInit/index.ts
+++ b/example/src/components/modelInit/index.ts
@@ -33,3 +33,7 @@ export {
   AlignmentCustomInitForm,
   type AlignmentCustomInitFormState,
 } from './AlignmentCustomInitForm';
+export {
+  SpeechVadSegmentationCustomInitForm,
+  type SpeechVadSegmentationCustomInitFormState,
+} from './SpeechVadSegmentationCustomInitForm';

--- a/example/src/components/modelInit/index.ts
+++ b/example/src/components/modelInit/index.ts
@@ -1,0 +1,7 @@
+export { InitModeSelector, type ModelInitMode } from './InitModeSelector';
+export { ModelFolderGrid, type ModelFolderGridEntry } from './ModelFolderGrid';
+export { FileSourceSlotPicker } from './FileSourceSlotPicker';
+export {
+  SttCustomInitForm,
+  type SttCustomInitFormState,
+} from './SttCustomInitForm';

--- a/example/src/components/modelInit/index.ts
+++ b/example/src/components/modelInit/index.ts
@@ -5,3 +5,7 @@ export {
   SttCustomInitForm,
   type SttCustomInitFormState,
 } from './SttCustomInitForm';
+export {
+  StreamingSttCustomInitForm,
+  type StreamingSttCustomInitFormState,
+} from './StreamingSttCustomInitForm';

--- a/example/src/components/modelInit/index.ts
+++ b/example/src/components/modelInit/index.ts
@@ -17,3 +17,7 @@ export {
   VadCustomInitForm,
   type VadCustomInitFormState,
 } from './VadCustomInitForm';
+export {
+  EnhancementCustomInitForm,
+  type EnhancementCustomInitFormState,
+} from './EnhancementCustomInitForm';

--- a/example/src/components/modelInit/index.ts
+++ b/example/src/components/modelInit/index.ts
@@ -9,3 +9,7 @@ export {
   StreamingSttCustomInitForm,
   type StreamingSttCustomInitFormState,
 } from './StreamingSttCustomInitForm';
+export {
+  TtsCustomInitForm,
+  type TtsCustomInitFormState,
+} from './TtsCustomInitForm';

--- a/example/src/hooks/useSttModelCatalog.ts
+++ b/example/src/hooks/useSttModelCatalog.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ModelCategory,
+  onModelsListUpdated,
+} from 'react-native-sherpa-onnx/download';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import {
+  createSttModelPathContext,
+  getSttModelPathConfig,
+  loadSttModelCatalog,
+  type SttCatalogSnapshot,
+  type SttModelEntry,
+} from '../utils/sttModelCatalog';
+
+export type UseSttModelCatalogResult = {
+  entries: SttModelEntry[];
+  modelIds: string[];
+  padModelIds: string[];
+  padModelsPath: string | null;
+  loading: boolean;
+  error: string | null;
+  reload: () => Promise<void>;
+  resolveModelPath: (modelId: string) => FileSource;
+};
+
+export function useSttModelCatalog(): UseSttModelCatalogResult {
+  const [snapshot, setSnapshot] = useState<SttCatalogSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await loadSttModelCatalog();
+      setSnapshot(next);
+      if (next.entries.length === 0) {
+        setError(
+          'No STT models found. Use bundled assets, downloaded models, or PAD models.'
+        );
+      }
+    } catch (err) {
+      setSnapshot(null);
+      setError(
+        err instanceof Error ? err.message : 'Failed to load STT model catalog'
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    reload().catch(() => {});
+  }, [reload]);
+
+  useEffect(() => {
+    const unsubscribe = onModelsListUpdated((category) => {
+      if (category !== ModelCategory.Stt) {
+        return;
+      }
+      reload().catch(() => {});
+    });
+    return unsubscribe;
+  }, [reload]);
+
+  const pathContext = useMemo(
+    () => (snapshot ? createSttModelPathContext(snapshot) : null),
+    [snapshot]
+  );
+
+  const resolveModelPath = useCallback(
+    (modelId: string): FileSource => {
+      if (!pathContext) {
+        throw new Error('STT model catalog is not loaded yet');
+      }
+      return getSttModelPathConfig(modelId, pathContext);
+    },
+    [pathContext]
+  );
+
+  return {
+    entries: snapshot?.entries ?? [],
+    modelIds: snapshot?.entries.map((entry) => entry.id) ?? [],
+    padModelIds: snapshot?.padModelIds ?? [],
+    padModelsPath: snapshot?.padModelsPath ?? null,
+    loading,
+    error,
+    reload,
+    resolveModelPath,
+  };
+}

--- a/example/src/screens/enhancement-streaming/EnhancementStreamingScreen.tsx
+++ b/example/src/screens/enhancement-streaming/EnhancementStreamingScreen.tsx
@@ -26,6 +26,7 @@ import {
 import {
   createStreamingEnhancement,
   detectEnhancementModel,
+  assertEnhancementCustomConfig,
   type StreamingEnhancementEngine,
   type EnhancementPipelineHandle,
   type EnhancementModelType,
@@ -74,9 +75,21 @@ import {
   buildSegmentationOption,
   type SegmentationControlConfig,
 } from '../../components/SegmentationPolicyControls';
+import {
+  InitModeSelector,
+  EnhancementCustomInitForm,
+  type ModelInitMode,
+  type EnhancementCustomInitFormState,
+} from '../../components/modelInit';
+import { fillEnhancementCustomConfigFromModelFolder } from '../../utils/enhancementCustomInitFill';
 
 const PAD_PACK_NAME = 'sherpa_models';
 const NUM_THREADS = 2;
+
+const DEFAULT_ENHANCEMENT_CUSTOM_INIT: EnhancementCustomInitFormState = {
+  modelType: 'gtcrn',
+  fileSources: {},
+};
 
 const ENHANCEMENT_STREAMING_MODE_HINT =
   'Streaming mode lists models with isStreaming=true from detectEnhancementModel. Live Overload lists all detected enhancement models and runs mandatory audio segmentation (continuous_frames by default) on the same streaming pipeline.';
@@ -119,6 +132,14 @@ const PIPELINE_WAIT_TIMEOUT_MS = 10 * 60 * 1000;
 
 export default function EnhancementStreamingScreen() {
   const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [initMode, setInitMode] = useState<ModelInitMode>('auto');
+  const [customInitForm, setCustomInitForm] =
+    useState<EnhancementCustomInitFormState>(DEFAULT_ENHANCEMENT_CUSTOM_INIT);
+  const [customFillLoading, setCustomFillLoading] = useState(false);
+  const [customFillHint, setCustomFillHint] = useState<string | null>(null);
+  const [initializedSummary, setInitializedSummary] = useState<string | null>(
+    null
+  );
   const [streamingEnhancementModelIds, setStreamingEnhancementModelIds] =
     useState<Set<string>>(new Set());
   const [offlineEnhancementModelIds, setOfflineEnhancementModelIds] = useState<
@@ -403,20 +424,140 @@ export default function EnhancementStreamingScreen() {
     };
   }, []);
 
-  const resolveEnhancementModelPath = (modelFolder: string) => {
-    if (padModelIds.includes(modelFolder)) {
-      return padModelsPath
-        ? getFileModelPath(
-            modelFolder,
-            ModelCategory.Enhancement,
-            padModelsPath
-          )
-        : getFileModelPath(modelFolder, ModelCategory.Enhancement);
+  const resolveEnhancementModelPath = useCallback(
+    (modelFolder: string) => {
+      if (padModelIds.includes(modelFolder)) {
+        return padModelsPath
+          ? getFileModelPath(
+              modelFolder,
+              ModelCategory.Enhancement,
+              padModelsPath
+            )
+          : getFileModelPath(modelFolder, ModelCategory.Enhancement);
+      }
+      if (downloadedModelIds.includes(modelFolder)) {
+        return getFileModelPath(modelFolder, ModelCategory.Enhancement);
+      }
+      return getAssetModelPath(modelFolder);
+    },
+    [downloadedModelIds, padModelIds, padModelsPath]
+  );
+
+  const handleFillFromSelectedModel = useCallback(async () => {
+    const modelFolder = selectedModelForInit;
+    if (!modelFolder) {
+      Alert.alert('Select a model', 'Pick a catalog model folder first.');
+      return;
     }
-    if (downloadedModelIds.includes(modelFolder)) {
-      return getFileModelPath(modelFolder, ModelCategory.Enhancement);
+
+    setCustomFillLoading(true);
+    setCustomFillHint(null);
+    setError(null);
+    setErrorSource(null);
+    try {
+      const modelPath = resolveEnhancementModelPath(modelFolder);
+      const fillResult = await fillEnhancementCustomConfigFromModelFolder(
+        await toDetectSource(modelPath),
+        { modelTypeOverride: customInitForm.modelType }
+      );
+      setCustomInitForm({
+        modelType: fillResult.modelType,
+        fileSources: fillResult.customConfig,
+      });
+      const missing =
+        fillResult.missingKeys.length > 0
+          ? ` Missing: ${fillResult.missingKeys.join(', ')}`
+          : '';
+      setCustomFillHint(
+        `Filled from ${getModelDisplayName(modelFolder)} (${
+          fillResult.modelDir
+        }).${missing}`
+      );
+    } catch (fillErr) {
+      setCustomFillHint(null);
+      const message =
+        fillErr instanceof Error ? fillErr.message : String(fillErr);
+      setErrorSource('init');
+      setError(message);
+    } finally {
+      setCustomFillLoading(false);
     }
-    return getAssetModelPath(modelFolder);
+  }, [
+    customInitForm.modelType,
+    resolveEnhancementModelPath,
+    selectedModelForInit,
+  ]);
+
+  const handlePrepareScatteredTest = useCallback(() => {
+    setCustomInitForm((prev) => ({ ...prev, fileSources: {} }));
+    setCustomFillHint(
+      'Scattered test: pick the model file from a different location, then Initialize.'
+    );
+  }, []);
+
+  const handleInitializeCustom = async () => {
+    setLoading(true);
+    setError(null);
+    setErrorSource(null);
+    setInitResult(null);
+    setDetectedModels([]);
+    setSelectedModelKind(null);
+    setInitializedSummary(null);
+
+    try {
+      const previous = engineRef.current;
+      if (previous) {
+        await previous.destroy();
+        engineRef.current = null;
+      }
+
+      const customConfig = {
+        ...customInitForm.fileSources,
+      };
+      assertEnhancementCustomConfig(
+        customConfig as unknown as Record<string, unknown>
+      );
+
+      const engine = await createStreamingEnhancement({
+        initMode: 'custom',
+        modelType: customInitForm.modelType,
+        customConfig: customConfig as { model: FileSource },
+        numThreads: NUM_THREADS,
+      });
+
+      engineRef.current = engine;
+      setCurrentModelFolder(null);
+      setSelectedModelKind(customInitForm.modelType);
+      setDetectedModels([
+        { type: customInitForm.modelType, modelDir: 'custom' },
+      ]);
+      setInitializedSummary(`custom:${customInitForm.modelType}`);
+      setInitResult(
+        `Initialized streaming (custom): ${customInitForm.modelType}\nFile: model`
+      );
+
+      setAudioSourceType(null);
+      setSelectedAudio(null);
+      setCustomAudioPath(null);
+      setCustomAudioName(null);
+      setEnhanceResult(null);
+      setLastInputPath(null);
+      await clearFinalizedOutput();
+    } catch (err) {
+      console.error('EnhancementStreaming custom init error:', err);
+      let errorMessage = 'Unknown error';
+      if (err instanceof Error) {
+        errorMessage = err.message;
+        if ('code' in err) {
+          errorMessage = `[${(err as { code?: string }).code}] ${errorMessage}`;
+        }
+      }
+      setErrorSource('init');
+      setError(errorMessage);
+      setInitResult(`Custom initialization failed: ${errorMessage}`);
+    } finally {
+      setLoading(false);
+    }
   };
 
   const loadAvailableModels = useCallback(async () => {
@@ -597,6 +738,7 @@ export default function EnhancementStreamingScreen() {
       engineRef.current = engine;
       setDetectedModels(normalized);
       setCurrentModelFolder(modelFolder);
+      setInitializedSummary(null);
       setSelectedModelForInit(modelFolder);
 
       if (loadedKind === 'gtcrn' || loadedKind === 'dpdfnet') {
@@ -1043,6 +1185,7 @@ export default function EnhancementStreamingScreen() {
     engineRef.current = null;
 
     setCurrentModelFolder(null);
+    setInitializedSummary(null);
     setSelectedModelForInit(null);
     setDetectedModels([]);
     setSelectedModelKind(null);
@@ -1056,7 +1199,9 @@ export default function EnhancementStreamingScreen() {
     setLastInputPath(null);
   };
 
-  const engineReady = currentModelFolder != null && engineRef.current != null;
+  const engineReady =
+    (currentModelFolder != null || initializedSummary != null) &&
+    engineRef.current != null;
   const showKindPicker =
     detectedModels.length > 1 &&
     detectedModels.some((m) => m.type === 'gtcrn') &&
@@ -1071,7 +1216,7 @@ export default function EnhancementStreamingScreen() {
           style={styles.scrollView}
           keyboardShouldPersistTaps="handled"
         >
-          {currentModelFolder != null && (
+          {currentModelFolder != null || initializedSummary != null ? (
             <TouchableOpacity
               style={styles.freeButton}
               onPress={handleFree}
@@ -1079,15 +1224,29 @@ export default function EnhancementStreamingScreen() {
             >
               <Text style={styles.freeButtonText}>Release model</Text>
             </TouchableOpacity>
-          )}
+          ) : null}
 
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>1. Initialize model</Text>
+            <InitModeSelector
+              value={initMode}
+              onChange={setInitMode}
+              disabled={loading || enhancing || customFillLoading}
+            />
+            <Text style={styles.hint}>
+              {initMode === 'auto'
+                ? 'Select a streaming-capable folder, then tap "Use model".'
+                : 'Choose model type, pick the ONNX file (or Fill from catalog), then Initialize custom.'}
+            </Text>
 
-            {(currentModelFolder || selectedModelForInit) && (
+            {(initializedSummary ||
+              currentModelFolder ||
+              selectedModelForInit) && (
               <View style={styles.currentModelContainer}>
                 <Text style={styles.currentModelText}>
-                  {currentModelFolder
+                  {initializedSummary
+                    ? `Initialized: ${initializedSummary}`
+                    : currentModelFolder
                     ? `Loaded: ${getModelDisplayName(currentModelFolder)}`
                     : `Selected: ${
                         selectedModelForInit
@@ -1115,21 +1274,44 @@ export default function EnhancementStreamingScreen() {
               mandatorySegmentationHint="Live Overload uses mandatory segmentation to split audio into enhancement chunks."
             />
 
+            {initMode === 'custom' ? (
+              <EnhancementCustomInitForm
+                value={customInitForm}
+                onChange={setCustomInitForm}
+                selectedCatalogModelId={selectedModelForInit}
+                onFillFromSelectedModel={() => {
+                  handleFillFromSelectedModel().catch(() => {});
+                }}
+                onPrepareScatteredTest={handlePrepareScatteredTest}
+                fillLoading={customFillLoading}
+                disabled={loading || enhancing}
+                fillHint={customFillHint}
+              />
+            ) : null}
+
             <TouchableOpacity
               style={[
                 styles.button,
                 styles.applyButton,
-                (loading || enhancing) && styles.buttonDisabled,
+                (loading || enhancing || customFillLoading) &&
+                  styles.buttonDisabled,
               ]}
-              onPress={() =>
+              onPress={() => {
+                if (initMode === 'custom') {
+                  handleInitializeCustom();
+                  return;
+                }
                 handleInitialize(
                   selectedModelForInit ?? currentModelFolder ?? ''
-                )
-              }
+                );
+              }}
               disabled={
                 loading ||
                 enhancing ||
-                (!selectedModelForInit && !currentModelFolder)
+                customFillLoading ||
+                (initMode === 'auto'
+                  ? !selectedModelForInit && !currentModelFolder
+                  : false)
               }
             >
               {loading ? (
@@ -1142,7 +1324,9 @@ export default function EnhancementStreamingScreen() {
                   <Text style={styles.buttonText}>Initializing...</Text>
                 </View>
               ) : (
-                <Text style={styles.buttonText}>Use model</Text>
+                <Text style={styles.buttonText}>
+                  {initMode === 'custom' ? 'Initialize custom' : 'Use model'}
+                </Text>
               )}
             </TouchableOpacity>
 

--- a/example/src/screens/enhancement/EnhancementScreen.tsx
+++ b/example/src/screens/enhancement/EnhancementScreen.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import {
   Text,
   View,
@@ -24,6 +24,7 @@ import {
 import {
   createEnhancement,
   detectEnhancementModel,
+  assertEnhancementCustomConfig,
   type EnhancementEngine,
   type EnhancementModelType,
 } from 'react-native-sherpa-onnx/enhancement';
@@ -55,9 +56,22 @@ import {
   buildSegmentationOption,
   type SegmentationControlConfig,
 } from '../../components/SegmentationPolicyControls';
+import {
+  InitModeSelector,
+  ModelFolderGrid,
+  EnhancementCustomInitForm,
+  type ModelInitMode,
+  type EnhancementCustomInitFormState,
+} from '../../components/modelInit';
+import { fillEnhancementCustomConfigFromModelFolder } from '../../utils/enhancementCustomInitFill';
 
 const PAD_PACK_NAME = 'sherpa_models';
 const NUM_THREADS = 2;
+
+const DEFAULT_ENHANCEMENT_CUSTOM_INIT: EnhancementCustomInitFormState = {
+  modelType: 'gtcrn',
+  fileSources: {},
+};
 
 function isEnhancementHint(folder: string, hint: string): boolean {
   if (hint === 'enhancement') return true;
@@ -97,6 +111,14 @@ const localStyles = StyleSheet.create({
 
 export default function EnhancementScreen() {
   const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [initMode, setInitMode] = useState<ModelInitMode>('auto');
+  const [customInitForm, setCustomInitForm] =
+    useState<EnhancementCustomInitFormState>(DEFAULT_ENHANCEMENT_CUSTOM_INIT);
+  const [customFillLoading, setCustomFillLoading] = useState(false);
+  const [customFillHint, setCustomFillHint] = useState<string | null>(null);
+  const [initializedSummary, setInitializedSummary] = useState<string | null>(
+    null
+  );
   const [padModelIds, setPadModelIds] = useState<string[]>([]);
   const [downloadedModelIds, setDownloadedModelIds] = useState<string[]>([]);
   const [padModelsPath, setPadModelsPath] = useState<string | null>(null);
@@ -242,20 +264,145 @@ export default function EnhancementScreen() {
     }
   };
 
-  const resolveEnhancementModelPath = (modelFolder: string) => {
-    if (padModelIds.includes(modelFolder)) {
-      return padModelsPath
-        ? getFileModelPath(
-            modelFolder,
-            ModelCategory.Enhancement,
-            padModelsPath
-          )
-        : getFileModelPath(modelFolder, ModelCategory.Enhancement);
+  const resolveEnhancementModelPath = useCallback(
+    (modelFolder: string) => {
+      if (padModelIds.includes(modelFolder)) {
+        return padModelsPath
+          ? getFileModelPath(
+              modelFolder,
+              ModelCategory.Enhancement,
+              padModelsPath
+            )
+          : getFileModelPath(modelFolder, ModelCategory.Enhancement);
+      }
+      if (downloadedModelIds.includes(modelFolder)) {
+        return getFileModelPath(modelFolder, ModelCategory.Enhancement);
+      }
+      return getAssetModelPath(modelFolder);
+    },
+    [downloadedModelIds, padModelIds, padModelsPath]
+  );
+
+  const catalogEntries = useMemo(
+    () =>
+      availableModels.map((id) => ({
+        id,
+        label: getModelDisplayName(id),
+      })),
+    [availableModels]
+  );
+
+  const handleFillFromSelectedModel = useCallback(async () => {
+    const modelFolder = selectedModelForInit;
+    if (!modelFolder) {
+      Alert.alert('Select a model', 'Pick a catalog model folder first.');
+      return;
     }
-    if (downloadedModelIds.includes(modelFolder)) {
-      return getFileModelPath(modelFolder, ModelCategory.Enhancement);
+
+    setCustomFillLoading(true);
+    setCustomFillHint(null);
+    setError(null);
+    setErrorSource(null);
+    try {
+      const modelPath = resolveEnhancementModelPath(modelFolder);
+      const fillResult = await fillEnhancementCustomConfigFromModelFolder(
+        await toDetectSource(modelPath),
+        { modelTypeOverride: customInitForm.modelType }
+      );
+      setCustomInitForm({
+        modelType: fillResult.modelType,
+        fileSources: fillResult.customConfig,
+      });
+      const missing =
+        fillResult.missingKeys.length > 0
+          ? ` Missing: ${fillResult.missingKeys.join(', ')}`
+          : '';
+      setCustomFillHint(
+        `Filled from ${getModelDisplayName(modelFolder)} (${
+          fillResult.modelDir
+        }).${missing}`
+      );
+    } catch (fillErr) {
+      setCustomFillHint(null);
+      const message =
+        fillErr instanceof Error ? fillErr.message : String(fillErr);
+      setErrorSource('init');
+      setError(message);
+    } finally {
+      setCustomFillLoading(false);
     }
-    return getAssetModelPath(modelFolder);
+  }, [
+    customInitForm.modelType,
+    resolveEnhancementModelPath,
+    selectedModelForInit,
+  ]);
+
+  const handlePrepareScatteredTest = useCallback(() => {
+    setCustomInitForm((prev) => ({ ...prev, fileSources: {} }));
+    setCustomFillHint(
+      'Scattered test: pick the model file from a different location, then Initialize.'
+    );
+  }, []);
+
+  const handleInitializeCustom = async () => {
+    setLoading(true);
+    setError(null);
+    setErrorSource(null);
+    setInitResult(null);
+    setDetectedModels([]);
+    setSelectedModelKind(null);
+    setInitializedSummary(null);
+
+    try {
+      const previous = engineRef.current;
+      if (previous) {
+        await previous.destroy();
+        engineRef.current = null;
+      }
+
+      const customConfig = {
+        ...customInitForm.fileSources,
+      };
+      assertEnhancementCustomConfig(
+        customConfig as unknown as Record<string, unknown>
+      );
+
+      const engine = await createEnhancement({
+        initMode: 'custom',
+        modelType: customInitForm.modelType,
+        customConfig: customConfig as {
+          model: import('react-native-sherpa-onnx/fileio').FileSource;
+        },
+        numThreads: NUM_THREADS,
+      });
+
+      engineRef.current = engine;
+      setCurrentModelFolder(null);
+      setSelectedModelKind(customInitForm.modelType);
+      setDetectedModels([
+        { type: customInitForm.modelType, modelDir: 'custom' },
+      ]);
+      setInitializedSummary(`custom:${customInitForm.modelType}`);
+      setInitResult(
+        `Initialized (custom): ${customInitForm.modelType}\nFile: model`
+      );
+      setEnhanceResult(null);
+      setLastEnhancedAudio(null);
+    } catch (err) {
+      console.error('Enhancement custom init error:', err);
+      let errorMessage = 'Unknown error';
+      if (err instanceof Error) {
+        errorMessage = err.message;
+        if ('code' in err) {
+          errorMessage = `[${(err as { code?: string }).code}] ${errorMessage}`;
+        }
+      }
+      setErrorSource('init');
+      setError(errorMessage);
+      setInitResult(`Custom initialization failed: ${errorMessage}`);
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleInitialize = async (modelFolder: string) => {
@@ -307,6 +454,7 @@ export default function EnhancementScreen() {
       engineRef.current = engine;
       setDetectedModels(normalized);
       setCurrentModelFolder(modelFolder);
+      setInitializedSummary(null);
       setSelectedModelForInit(modelFolder);
       if (loadedKind === 'gtcrn' || loadedKind === 'dpdfnet') {
         setSelectedModelKind(loadedKind);
@@ -500,6 +648,7 @@ export default function EnhancementScreen() {
     }
     engineRef.current = null;
     setCurrentModelFolder(null);
+    setInitializedSummary(null);
     setSelectedModelForInit(null);
     setDetectedModels([]);
     setSelectedModelKind(null);
@@ -569,7 +718,9 @@ export default function EnhancementScreen() {
     }
   };
 
-  const engineReady = currentModelFolder != null && engineRef.current != null;
+  const engineReady =
+    (currentModelFolder != null || initializedSummary != null) &&
+    engineRef.current != null;
   const showKindPicker =
     detectedModels.length > 1 &&
     detectedModels.some((m) => m.type === 'gtcrn') &&
@@ -584,7 +735,7 @@ export default function EnhancementScreen() {
           style={styles.scrollView}
           keyboardShouldPersistTaps="handled"
         >
-          {currentModelFolder != null && (
+          {currentModelFolder != null || initializedSummary != null ? (
             <TouchableOpacity
               style={styles.freeButton}
               onPress={handleFree}
@@ -592,19 +743,29 @@ export default function EnhancementScreen() {
             >
               <Text style={styles.freeButtonText}>Release model</Text>
             </TouchableOpacity>
-          )}
+          ) : null}
 
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>1. Initialize model</Text>
+            <InitModeSelector
+              value={initMode}
+              onChange={setInitMode}
+              disabled={loading || customFillLoading}
+            />
             <Text style={styles.hint}>
-              Offline denoising (GTCRN / DPDFNet). Select a folder, then tap
-              &quot;Use model&quot;.
+              {initMode === 'auto'
+                ? 'Offline denoising (GTCRN / DPDFNet). Select a folder, then tap "Use model".'
+                : 'Choose model type, pick the ONNX file (or Fill from catalog), then Initialize custom.'}
             </Text>
 
-            {(currentModelFolder || selectedModelForInit) && (
+            {(initializedSummary ||
+              currentModelFolder ||
+              selectedModelForInit) && (
               <View style={styles.currentModelContainer}>
                 <Text style={styles.currentModelText}>
-                  {currentModelFolder
+                  {initializedSummary
+                    ? `Initialized: ${initializedSummary}`
+                    : currentModelFolder
                     ? `Loaded: ${getModelDisplayName(currentModelFolder)}`
                     : `Selected: ${
                         selectedModelForInit
@@ -630,50 +791,53 @@ export default function EnhancementScreen() {
                 </Text>
               </View>
             ) : (
-              <View style={styles.modelButtons}>
-                {availableModels.map((modelFolder) => {
-                  const isSelected = selectedModelForInit === modelFolder;
-                  const isInitialized = currentModelFolder === modelFolder;
-                  return (
-                    <TouchableOpacity
-                      key={modelFolder}
-                      style={[
-                        styles.modelButton,
-                        isSelected && styles.modelButtonActive,
-                        isInitialized && styles.modelButtonInitialized,
-                        loading && styles.buttonDisabled,
-                      ]}
-                      onPress={() => setSelectedModelForInit(modelFolder)}
-                      disabled={loading}
-                    >
-                      <Text
-                        style={[
-                          styles.modelButtonText,
-                          isSelected && styles.modelButtonTextActive,
-                        ]}
-                      >
-                        {getModelDisplayName(modelFolder)}
-                      </Text>
-                      <Text style={styles.modelFolderText}>{modelFolder}</Text>
-                    </TouchableOpacity>
-                  );
-                })}
-              </View>
+              <ModelFolderGrid
+                entries={catalogEntries}
+                selectedId={selectedModelForInit}
+                initializedId={currentModelFolder}
+                onSelect={setSelectedModelForInit}
+                loading={loadingModels}
+                disabled={loading || customFillLoading}
+                emptyMessage="No enhancement models found."
+              />
             )}
+
+            {initMode === 'custom' ? (
+              <EnhancementCustomInitForm
+                value={customInitForm}
+                onChange={setCustomInitForm}
+                selectedCatalogModelId={selectedModelForInit}
+                onFillFromSelectedModel={() => {
+                  handleFillFromSelectedModel().catch(() => {});
+                }}
+                onPrepareScatteredTest={handlePrepareScatteredTest}
+                fillLoading={customFillLoading}
+                disabled={loading}
+                fillHint={customFillHint}
+              />
+            ) : null}
 
             <TouchableOpacity
               style={[
                 styles.button,
                 styles.applyButton,
-                loading && styles.buttonDisabled,
+                (loading || customFillLoading) && styles.buttonDisabled,
               ]}
-              onPress={() =>
+              onPress={() => {
+                if (initMode === 'custom') {
+                  handleInitializeCustom();
+                  return;
+                }
                 handleInitialize(
                   selectedModelForInit ?? currentModelFolder ?? ''
-                )
-              }
+                );
+              }}
               disabled={
-                loading || (!selectedModelForInit && !currentModelFolder)
+                loading ||
+                customFillLoading ||
+                (initMode === 'auto'
+                  ? !selectedModelForInit && !currentModelFolder
+                  : false)
               }
             >
               {loading ? (
@@ -686,7 +850,9 @@ export default function EnhancementScreen() {
                   <Text style={styles.buttonText}>Initializing…</Text>
                 </View>
               ) : (
-                <Text style={styles.buttonText}>Use model</Text>
+                <Text style={styles.buttonText}>
+                  {initMode === 'custom' ? 'Initialize custom' : 'Use model'}
+                </Text>
               )}
             </TouchableOpacity>
 
@@ -866,8 +1032,8 @@ export default function EnhancementScreen() {
                         const location = formatResolvedLocation(result);
                         Alert.alert('Saved', `Audio saved to:\n${location}`);
                       }}
-                      onError={(error) => {
-                        Alert.alert('Save failed', error.message);
+                      onError={(saveError) => {
+                        Alert.alert('Save failed', saveError.message);
                       }}
                     />
                   </View>

--- a/example/src/screens/generate-timestamp/GenerateTimestampScreen.tsx
+++ b/example/src/screens/generate-timestamp/GenerateTimestampScreen.tsx
@@ -67,6 +67,13 @@ import { AUDIO_FILES } from '../../audioConfig';
 import { RECOMMENDED_MODEL_IDS } from '../../utils/recommendedModels';
 import { ScreenIntroModal } from '../../components/ScreenIntroModal';
 import {
+  AlignmentCustomInitForm,
+  InitModeSelector,
+  type AlignmentCustomInitFormState,
+  type ModelInitMode,
+} from '../../components/modelInit';
+import { fillAlignmentCustomConfigFromModelFolder } from '../../utils/alignmentCustomInitFill';
+import {
   OfflineAudioBufferWidget,
   type OfflineAudioBufferInfo,
   type OfflineAudioBufferWidgetHandle,
@@ -481,6 +488,9 @@ function ModelPreparationCard(props: {
   preparedSummary: string | null;
   onSelect: (id: string) => void;
   onPrepare: () => void;
+  showPrepareButton?: boolean;
+  leadingExtra?: ReactNode;
+  footerExtra?: ReactNode;
 }) {
   return (
     <SectionCard
@@ -488,6 +498,7 @@ function ModelPreparationCard(props: {
       title={props.title}
       description={props.description}
     >
+      {props.leadingExtra}
       {props.preparedId ? (
         <View style={styles.currentModelContainer}>
           <Text style={styles.currentModelText}>
@@ -550,24 +561,29 @@ function ModelPreparationCard(props: {
         </View>
       )}
 
-      <Pressable
-        style={[
-          styles.button,
-          styles.applyButton,
-          (props.preparing || !props.selectedId || props.models.length === 0) &&
-            styles.buttonDisabled,
-        ]}
-        onPress={props.onPrepare}
-        disabled={
-          props.preparing || !props.selectedId || props.models.length === 0
-        }
-      >
-        {props.preparing ? (
-          <ActivityIndicator color="#FFFFFF" />
-        ) : (
-          <Text style={styles.buttonText}>{props.prepareLabel}</Text>
-        )}
-      </Pressable>
+      {props.showPrepareButton !== false ? (
+        <Pressable
+          style={[
+            styles.button,
+            styles.applyButton,
+            (props.preparing ||
+              !props.selectedId ||
+              props.models.length === 0) &&
+              styles.buttonDisabled,
+          ]}
+          onPress={props.onPrepare}
+          disabled={
+            props.preparing || !props.selectedId || props.models.length === 0
+          }
+        >
+          {props.preparing ? (
+            <ActivityIndicator color="#FFFFFF" />
+          ) : (
+            <Text style={styles.buttonText}>{props.prepareLabel}</Text>
+          )}
+        </Pressable>
+      ) : null}
+      {props.footerExtra}
     </SectionCard>
   );
 }
@@ -610,6 +626,15 @@ export default function GenerateTimestampScreen() {
   >(null);
   const [preparingAlignmentModel, setPreparingAlignmentModel] = useState(false);
   const [alignmentPrepareSummary, setAlignmentPrepareSummary] = useState<
+    string | null
+  >(null);
+  const [alignmentInitMode, setAlignmentInitMode] =
+    useState<ModelInitMode>('auto');
+  const [alignmentCustomInitForm, setAlignmentCustomInitForm] =
+    useState<AlignmentCustomInitFormState>({ fileSources: {} });
+  const [alignmentCustomFillLoading, setAlignmentCustomFillLoading] =
+    useState(false);
+  const [alignmentCustomFillHint, setAlignmentCustomFillHint] = useState<
     string | null
   >(null);
 
@@ -866,10 +891,18 @@ export default function GenerateTimestampScreen() {
     }
     if (
       activeMode.requiresAlignmentModel &&
+      alignmentInitMode === 'auto' &&
       (!selectedAlignmentModelId ||
         preparedAlignmentModelId !== selectedAlignmentModelId)
     ) {
       issues.push('Prepare the selected alignment model with Use model.');
+    }
+    if (
+      activeMode.requiresAlignmentModel &&
+      alignmentInitMode === 'custom' &&
+      alignmentCustomInitForm.fileSources.model == null
+    ) {
+      issues.push('Set the custom alignment model path (model slot).');
     }
     if (
       activeMode.requiresVadModel &&
@@ -896,6 +929,8 @@ export default function GenerateTimestampScreen() {
     preparedAudioBuffer,
     selectedSttModelId,
     selectedVadModelId,
+    alignmentInitMode,
+    alignmentCustomInitForm.fileSources.model,
   ]);
 
   const handlePrepareAlignmentModel = useCallback(async () => {
@@ -948,6 +983,57 @@ export default function GenerateTimestampScreen() {
       setPreparingAlignmentModel(false);
     }
   }, [alignmentCatalog, selectedAlignmentModelId]);
+
+  const handleFillAlignmentCustomFromCatalog = useCallback(async () => {
+    if (!selectedAlignmentModelId) {
+      setError('Select an alignment model folder first.');
+      return;
+    }
+
+    setAlignmentCustomFillLoading(true);
+    setAlignmentCustomFillHint(null);
+    setError(null);
+    setErrorCode(null);
+
+    try {
+      const modelSource = resolveModelPathForCatalog(
+        selectedAlignmentModelId,
+        ModelCategory.Alignment,
+        alignmentCatalog
+      );
+      const fillResult = await fillAlignmentCustomConfigFromModelFolder(
+        await toDetectSource(modelSource)
+      );
+      setAlignmentCustomInitForm({ fileSources: fillResult.customConfig });
+      const missing =
+        fillResult.missingKeys.length > 0
+          ? ` Missing: ${fillResult.missingKeys.join(', ')}`
+          : '';
+      setAlignmentCustomFillHint(
+        `Filled from ${getModelDisplayName(selectedAlignmentModelId)} (${
+          fillResult.modelDir
+        }).${missing}`
+      );
+      setResult(null);
+    } catch (err) {
+      setAlignmentCustomFillHint(null);
+      const message =
+        err instanceof Error
+          ? err.message
+          : 'Failed to fill custom alignment paths.';
+      setError(message);
+      setErrorCode(extractErrorCode(message));
+    } finally {
+      setAlignmentCustomFillLoading(false);
+    }
+  }, [alignmentCatalog, selectedAlignmentModelId]);
+
+  const handleAlignmentCustomScatteredTest = useCallback(() => {
+    setAlignmentCustomInitForm({ fileSources: {} });
+    setAlignmentCustomFillHint(
+      'Scattered test: pick the wav2vec2 ONNX from a different location, then run alignment.'
+    );
+  }, []);
 
   const handlePrepareVadModel = useCallback(async () => {
     if (!selectedVadModelId) {
@@ -1083,12 +1169,22 @@ export default function GenerateTimestampScreen() {
       });
       outputSegmentBufferId = outputBuffer.bufferId;
 
-      const alignmentModelPath = activeMode.requiresAlignmentModel
-        ? resolveModelPathForCatalog(
-            preparedAlignmentModelId!,
-            ModelCategory.Alignment,
-            alignmentCatalog
-          )
+      const accurateAlignmentModel = activeMode.requiresAlignmentModel
+        ? alignmentInitMode === 'custom'
+          ? {
+              initMode: 'custom' as const,
+              modelType: 'wav2vec2' as const,
+              customConfig: {
+                model: alignmentCustomInitForm.fileSources.model!,
+              },
+            }
+          : {
+              modelSource: resolveModelPathForCatalog(
+                preparedAlignmentModelId!,
+                ModelCategory.Alignment,
+                alignmentCatalog
+              ),
+            }
         : null;
       const vadModelPath = activeMode.requiresVadModel
         ? await toDetectSource(
@@ -1168,7 +1264,7 @@ export default function GenerateTimestampScreen() {
               {
                 mode: 'accurate',
                 granularity,
-                modelSource: alignmentModelPath!,
+                ...accurateAlignmentModel!,
               }
             )
           : mode === 'vad'
@@ -1193,7 +1289,7 @@ export default function GenerateTimestampScreen() {
               {
                 mode: 'accurate',
                 granularity: textGranularity,
-                modelSource: alignmentModelPath!,
+                ...accurateAlignmentModel!,
                 segmentation: {
                   mode: 'auto',
                   anchorSegmentBuffer: anchorSegmentBufferId!,
@@ -1211,7 +1307,7 @@ export default function GenerateTimestampScreen() {
               {
                 mode: 'accurate',
                 granularity: textGranularity,
-                modelSource: alignmentModelPath!,
+                ...accurateAlignmentModel!,
                 segmentation: {
                   mode: 'auto',
                   anchorSegmentBuffer: anchorSegmentBufferId!,
@@ -1274,6 +1370,8 @@ export default function GenerateTimestampScreen() {
   }, [
     activeMode,
     alignmentCatalog,
+    alignmentCustomInitForm.fileSources.model,
+    alignmentInitMode,
     estimatedTimeline.counts,
     estimatedTimeline.sampleRate,
     granularity,
@@ -1494,17 +1592,49 @@ export default function GenerateTimestampScreen() {
             <ModelPreparationCard
               stepLabel={stepLabels.alignment!}
               title="Prepare wav2vec2 alignment model"
-              description="Plain accurate and both anchor-constrained accurate modes require a wav2vec2 alignment model. Use model runs autodetect and stores the prepared selection for the next run."
+              description="Plain accurate and both anchor-constrained accurate modes require a wav2vec2 alignment model. Auto: detect from catalog folder per call. Custom: explicit ONNX path per accurate call (no engine init)."
               loading={loadingModelCatalogs}
               emptyMessage="No alignment models found. Add a wav2vec2 model under assets/models, PAD/documents/models, or downloads (category: alignment)."
               models={alignmentCatalog.entries}
               selectedId={selectedAlignmentModelId}
-              preparedId={preparedAlignmentModelId}
+              preparedId={
+                alignmentInitMode === 'auto' ? preparedAlignmentModelId : null
+              }
               preparing={preparingAlignmentModel}
               prepareLabel="Use alignment model"
-              preparedSummary={alignmentPrepareSummary}
+              preparedSummary={
+                alignmentInitMode === 'auto' ? alignmentPrepareSummary : null
+              }
               onSelect={setSelectedAlignmentModelId}
               onPrepare={handlePrepareAlignmentModel}
+              showPrepareButton={alignmentInitMode === 'auto'}
+              leadingExtra={
+                <InitModeSelector
+                  value={alignmentInitMode}
+                  onChange={setAlignmentInitMode}
+                  disabled={
+                    running ||
+                    preparingAlignmentModel ||
+                    alignmentCustomFillLoading
+                  }
+                />
+              }
+              footerExtra={
+                alignmentInitMode === 'custom' ? (
+                  <AlignmentCustomInitForm
+                    value={alignmentCustomInitForm}
+                    onChange={setAlignmentCustomInitForm}
+                    selectedCatalogModelId={selectedAlignmentModelId}
+                    onFillFromSelectedModel={() => {
+                      handleFillAlignmentCustomFromCatalog().catch(() => {});
+                    }}
+                    onPrepareScatteredTest={handleAlignmentCustomScatteredTest}
+                    fillLoading={alignmentCustomFillLoading}
+                    disabled={running || preparingAlignmentModel}
+                    fillHint={alignmentCustomFillHint}
+                  />
+                ) : null
+              }
             />
           ) : null}
 
@@ -1561,12 +1691,23 @@ export default function GenerateTimestampScreen() {
                 granularity: {granularity}
               </Text>
               <Text style={styles.resultCodeText}>
-                alignment model:{' '}
+                alignment init:{' '}
                 {activeMode.requiresAlignmentModel
-                  ? preparedAlignmentModelId ?? 'missing'
+                  ? alignmentInitMode
                   : 'not required'}
               </Text>
-              {activeMode.requiresAlignmentModel ? (
+              <Text style={styles.resultCodeText}>
+                alignment model:{' '}
+                {activeMode.requiresAlignmentModel
+                  ? alignmentInitMode === 'auto'
+                    ? preparedAlignmentModelId ?? 'missing'
+                    : alignmentCustomInitForm.fileSources.model
+                    ? 'custom path set'
+                    : 'missing'
+                  : 'not required'}
+              </Text>
+              {activeMode.requiresAlignmentModel &&
+              alignmentInitMode === 'auto' ? (
                 <Text style={styles.resultCodeText}>
                   alignment detect: {preparedAlignmentModelType ?? 'unknown'} ·{' '}
                   {preparedAlignmentModelPath ?? 'path unavailable'}

--- a/example/src/screens/punctuation-streaming/PunctuationStreamingScreen.tsx
+++ b/example/src/screens/punctuation-streaming/PunctuationStreamingScreen.tsx
@@ -32,9 +32,17 @@ import {
 import {
   createStreamingPunctuation,
   detectPunctuationModel,
+  assertStreamingPunctuationCustomConfig,
   type PunctuationPipelineHandle,
   type StreamingPunctuationEngine,
 } from 'react-native-sherpa-onnx/punctuation';
+import {
+  InitModeSelector,
+  PunctuationStreamingCustomInitForm,
+  type ModelInitMode,
+  type PunctuationStreamingCustomInitFormState,
+} from '../../components/modelInit';
+import { fillStreamingPunctuationCustomConfigFromModelFolder } from '../../utils/punctuationCustomInitFill';
 import {
   getFileModelPath,
   getAssetModelPath,
@@ -52,6 +60,11 @@ import {
 const PAD_PACK_NAME = 'sherpa_models';
 const DEFAULT_STREAMING_TEXT =
   'hello world\nthis is streaming punctuation\nit writes live text segments';
+
+const DEFAULT_STREAMING_PUNCTUATION_CUSTOM_INIT: PunctuationStreamingCustomInitFormState =
+  {
+    fileSources: {},
+  };
 
 function isPunctuationNameCandidate(folder: string): boolean {
   const f = folder.toLowerCase();
@@ -116,6 +129,13 @@ export default function PunctuationStreamingScreen() {
   const [outputText, setOutputText] = useState('');
   const [statusText, setStatusText] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [initMode, setInitMode] = useState<ModelInitMode>('auto');
+  const [customInitForm, setCustomInitForm] =
+    useState<PunctuationStreamingCustomInitFormState>(
+      DEFAULT_STREAMING_PUNCTUATION_CUSTOM_INIT
+    );
+  const [customFillLoading, setCustomFillLoading] = useState(false);
+  const [customFillHint, setCustomFillHint] = useState<string | null>(null);
 
   const engineRef = useRef<StreamingPunctuationEngine | null>(null);
   const handleRef = useRef<PunctuationPipelineHandle | null>(null);
@@ -218,6 +238,45 @@ export default function PunctuationStreamingScreen() {
     });
   }, [loadAvailableModels]);
 
+  const handleFillFromSelectedModel = useCallback(async () => {
+    if (!selectedFolder) {
+      Alert.alert('Select a model', 'Pick a catalog model folder first.');
+      return;
+    }
+    setCustomFillLoading(true);
+    setCustomFillHint(null);
+    setError(null);
+    try {
+      const modelPath = resolvePunctuationModelPath(selectedFolder);
+      const fillResult =
+        await fillStreamingPunctuationCustomConfigFromModelFolder(
+          await toDetectSource(modelPath)
+        );
+      setCustomInitForm({ fileSources: fillResult.customConfig });
+      const missing =
+        fillResult.missingKeys.length > 0
+          ? ` Missing: ${fillResult.missingKeys.join(', ')}`
+          : '';
+      setCustomFillHint(
+        `Filled from ${getModelDisplayName(selectedFolder)} (${
+          fillResult.modelDir
+        }).${missing}`
+      );
+    } catch (fillErr) {
+      setCustomFillHint(null);
+      setError(fillErr instanceof Error ? fillErr.message : String(fillErr));
+    } finally {
+      setCustomFillLoading(false);
+    }
+  }, [resolvePunctuationModelPath, selectedFolder]);
+
+  const handlePrepareScatteredTest = useCallback(() => {
+    setCustomInitForm({ fileSources: {} });
+    setCustomFillHint(
+      'Scattered test: pick CNN-BiLSTM ONNX and BPE vocab separately, then Run.'
+    );
+  }, []);
+
   const cleanup = async () => {
     if (handleRef.current) {
       await handleRef.current.stop().catch(() => {});
@@ -244,7 +303,7 @@ export default function PunctuationStreamingScreen() {
   }, []);
 
   const runStreamingPunctuation = async () => {
-    if (!selectedFolder) {
+    if (initMode === 'auto' && !selectedFolder) {
       Alert.alert('Model', 'Select a streaming CNN-BiLSTM punctuation model.');
       return;
     }
@@ -261,12 +320,30 @@ export default function PunctuationStreamingScreen() {
 
     try {
       await cleanup();
-      const modelPath = resolvePunctuationModelPath(selectedFolder);
-      const engine = await createStreamingPunctuation({
-        modelSource: modelPath,
-        modelType: 'cnn_bilstm',
-        provider: 'cpu',
-      });
+      const nt = 2;
+      const engine =
+        initMode === 'custom'
+          ? await (async () => {
+              const customConfig = { ...customInitForm.fileSources };
+              assertStreamingPunctuationCustomConfig(
+                customConfig as unknown as Record<string, unknown>
+              );
+              return createStreamingPunctuation({
+                initMode: 'custom',
+                modelType: 'cnn_bilstm',
+                customConfig: customConfig as {
+                  cnn_bilstm: FileSource;
+                  bpe_vocab: FileSource;
+                },
+                numThreads: nt,
+                provider: 'cpu',
+              });
+            })()
+          : await createStreamingPunctuation({
+              modelSource: resolvePunctuationModelPath(selectedFolder!),
+              modelType: 'cnn_bilstm',
+              provider: 'cpu',
+            });
       engineRef.current = engine;
 
       const input = await createLiveTextBuffer();
@@ -331,6 +408,16 @@ export default function PunctuationStreamingScreen() {
           <Text style={styles.sectionTitle}>
             1) Model{loadingModels ? ' (loading…)' : ''}
           </Text>
+          <InitModeSelector
+            value={initMode}
+            onChange={setInitMode}
+            disabled={busy || customFillLoading}
+          />
+          <Text style={styles.hint}>
+            {initMode === 'auto'
+              ? 'Select a streaming CNN-BiLSTM catalog folder, then Run.'
+              : 'Pick CNN-BiLSTM ONNX + BPE vocab (or Fill from catalog), then Run custom.'}
+          </Text>
           {loadingModels ? (
             <View style={styles.loadingContainer}>
               <ActivityIndicator size="large" />
@@ -374,6 +461,20 @@ export default function PunctuationStreamingScreen() {
               })}
             </View>
           )}
+          {initMode === 'custom' && canShowWorkflow ? (
+            <PunctuationStreamingCustomInitForm
+              value={customInitForm}
+              onChange={setCustomInitForm}
+              selectedCatalogModelId={selectedFolder}
+              onFillFromSelectedModel={() => {
+                handleFillFromSelectedModel().catch(() => {});
+              }}
+              onPrepareScatteredTest={handlePrepareScatteredTest}
+              fillLoading={customFillLoading}
+              disabled={busy}
+              fillHint={customFillHint}
+            />
+          ) : null}
         </View>
 
         {canShowWorkflow && (
@@ -397,15 +498,24 @@ export default function PunctuationStreamingScreen() {
 
             <View style={styles.section}>
               <TouchableOpacity
-                style={[styles.button, busy && styles.buttonDisabled]}
-                disabled={busy || !selectedFolder}
+                style={[
+                  styles.button,
+                  (busy || customFillLoading) && styles.buttonDisabled,
+                ]}
+                disabled={
+                  busy ||
+                  customFillLoading ||
+                  (initMode === 'auto' ? !selectedFolder : false)
+                }
                 onPress={runStreamingPunctuation}
               >
                 {busy ? (
                   <ActivityIndicator color="#fff" />
                 ) : (
                   <Text style={styles.buttonText}>
-                    Run streaming punctuation
+                    {initMode === 'custom'
+                      ? 'Run streaming (custom init)'
+                      : 'Run streaming punctuation'}
                   </Text>
                 )}
               </TouchableOpacity>

--- a/example/src/screens/punctuation/PunctuationScreen.tsx
+++ b/example/src/screens/punctuation/PunctuationScreen.tsx
@@ -37,8 +37,16 @@ import type {
 import {
   createOfflinePunctuation,
   detectPunctuationModel,
+  assertOfflinePunctuationCustomConfig,
   type OfflinePunctuationEngine,
 } from 'react-native-sherpa-onnx/punctuation';
+import {
+  InitModeSelector,
+  PunctuationOfflineCustomInitForm,
+  type ModelInitMode,
+  type PunctuationOfflineCustomInitFormState,
+} from '../../components/modelInit';
+import { fillOfflinePunctuationCustomConfigFromModelFolder } from '../../utils/punctuationCustomInitFill';
 import {
   getFileModelPath,
   getAssetModelPath,
@@ -57,6 +65,11 @@ import {
 const PAD_PACK_NAME = 'sherpa_models';
 const DEFAULT_INPUT =
   'this is a sample line without capitals or commas it shows offline ct punctuation on device';
+
+const DEFAULT_OFFLINE_PUNCTUATION_CUSTOM_INIT: PunctuationOfflineCustomInitFormState =
+  {
+    fileSources: {},
+  };
 
 function isPunctuationNameCandidate(folder: string): boolean {
   const f = folder.toLowerCase();
@@ -128,6 +141,16 @@ export default function PunctuationScreen() {
   const [offlineSegConfig, setOfflineSegConfig] =
     useState<SegmentationControlConfig>({ mode: 'off' });
   const [engineReady, setEngineReady] = useState(false);
+  const [initMode, setInitMode] = useState<ModelInitMode>('auto');
+  const [customInitForm, setCustomInitForm] =
+    useState<PunctuationOfflineCustomInitFormState>(
+      DEFAULT_OFFLINE_PUNCTUATION_CUSTOM_INIT
+    );
+  const [customFillLoading, setCustomFillLoading] = useState(false);
+  const [customFillHint, setCustomFillHint] = useState<string | null>(null);
+  const [initializedSummary, setInitializedSummary] = useState<string | null>(
+    null
+  );
 
   const engineRef = useRef<OfflinePunctuationEngine | null>(null);
   const textInRef = useRef<OfflineTextBufferRef | null>(null);
@@ -253,6 +276,87 @@ export default function PunctuationScreen() {
     };
   }, [releaseTextBuffers]);
 
+  const handleFillFromSelectedModel = useCallback(async () => {
+    if (!selectedFolder) {
+      Alert.alert('Select a model', 'Pick a catalog model folder first.');
+      return;
+    }
+    setCustomFillLoading(true);
+    setCustomFillHint(null);
+    setError(null);
+    try {
+      const modelPath = resolvePunctuationModelPath(selectedFolder);
+      const fillResult =
+        await fillOfflinePunctuationCustomConfigFromModelFolder(
+          await toDetectSource(modelPath)
+        );
+      setCustomInitForm({ fileSources: fillResult.customConfig });
+      const missing =
+        fillResult.missingKeys.length > 0
+          ? ` Missing: ${fillResult.missingKeys.join(', ')}`
+          : '';
+      setCustomFillHint(
+        `Filled from ${getModelDisplayName(selectedFolder)} (${
+          fillResult.modelDir
+        }).${missing}`
+      );
+    } catch (fillErr) {
+      setCustomFillHint(null);
+      setError(fillErr instanceof Error ? fillErr.message : String(fillErr));
+    } finally {
+      setCustomFillLoading(false);
+    }
+  }, [resolvePunctuationModelPath, selectedFolder]);
+
+  const handlePrepareScatteredTest = useCallback(() => {
+    setCustomInitForm({ fileSources: {} });
+    setCustomFillHint(
+      'Scattered test: pick the CT-Transformer ONNX from a different location, then Initialize.'
+    );
+  }, []);
+
+  const handleInitEngineCustom = async () => {
+    setInitBusy(true);
+    setError(null);
+    setInitMessage(null);
+    setOutputText('');
+    setLastProcessingMs(null);
+    setLastSegmentStatus(null);
+    setEngineReady(false);
+    setInitializedSummary(null);
+    try {
+      await releaseTextBuffers();
+      if (engineRef.current) {
+        await engineRef.current.destroy();
+        engineRef.current = null;
+      }
+      const customConfig = { ...customInitForm.fileSources };
+      assertOfflinePunctuationCustomConfig(
+        customConfig as unknown as Record<string, unknown>
+      );
+      const nt = Math.max(1, parseInt(numThreads, 10) || 1);
+      const eng = await createOfflinePunctuation({
+        initMode: 'custom',
+        modelType: 'ct_transformer',
+        customConfig: customConfig as { ct_transformer: FileSource },
+        numThreads: nt,
+        provider: provider.trim() || 'cpu',
+        debug: debugPunct,
+      });
+      engineRef.current = eng;
+      setEngineReady(true);
+      setInitializedSummary('custom:ct_transformer');
+      setInitMessage(
+        `Ready: custom ct_transformer (instance ${eng.instanceId})`
+      );
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(`Init failed: ${msg}`);
+    } finally {
+      setInitBusy(false);
+    }
+  };
+
   const handleInitEngine = async () => {
     if (!selectedFolder) {
       Alert.alert('Model', 'Select a punctuation model first.');
@@ -265,6 +369,7 @@ export default function PunctuationScreen() {
     setLastProcessingMs(null);
     setLastSegmentStatus(null);
     setEngineReady(false);
+    setInitializedSummary(null);
     try {
       await releaseTextBuffers();
       if (engineRef.current) {
@@ -282,6 +387,9 @@ export default function PunctuationScreen() {
       });
       engineRef.current = eng;
       setEngineReady(true);
+      setInitializedSummary(
+        selectedFolder ? getModelDisplayName(selectedFolder) : null
+      );
       setInitMessage(
         `Ready: ${getModelDisplayName(selectedFolder)} (instance ${
           eng.instanceId
@@ -387,6 +495,25 @@ export default function PunctuationScreen() {
           <Text style={styles.sectionTitle}>
             1) Model{loadingModels ? ' (loading…)' : ''}
           </Text>
+          <InitModeSelector
+            value={initMode}
+            onChange={setInitMode}
+            disabled={initBusy || punctuateBusy || customFillLoading}
+          />
+          <Text style={styles.hint}>
+            {initMode === 'auto'
+              ? 'Select an offline CT-Transformer catalog folder, then Initialize.'
+              : 'Pick the CT-Transformer ONNX (or Fill from catalog), then Initialize custom.'}
+          </Text>
+          {(initializedSummary || selectedFolder) && (
+            <Text style={[styles.hint, puncStyles.hintAfterAction]}>
+              {initializedSummary
+                ? `Initialized: ${initializedSummary}`
+                : selectedFolder
+                ? `Selected: ${getModelDisplayName(selectedFolder)}`
+                : ''}
+            </Text>
+          )}
           {loadingModels ? (
             <View style={styles.loadingContainer}>
               <ActivityIndicator size="large" />
@@ -430,6 +557,20 @@ export default function PunctuationScreen() {
               })}
             </View>
           )}
+          {initMode === 'custom' && canShowWorkflow ? (
+            <PunctuationOfflineCustomInitForm
+              value={customInitForm}
+              onChange={setCustomInitForm}
+              selectedCatalogModelId={selectedFolder}
+              onFillFromSelectedModel={() => {
+                handleFillFromSelectedModel().catch(() => {});
+              }}
+              onPrepareScatteredTest={handlePrepareScatteredTest}
+              fillLoading={customFillLoading}
+              disabled={initBusy || punctuateBusy}
+              fillHint={customFillHint}
+            />
+          ) : null}
         </View>
 
         {canShowWorkflow && (
@@ -483,14 +624,31 @@ export default function PunctuationScreen() {
                 </TouchableOpacity>
               </View>
               <TouchableOpacity
-                style={[styles.button, initBusy && styles.buttonDisabled]}
-                disabled={initBusy || !selectedFolder}
-                onPress={handleInitEngine}
+                style={[
+                  styles.button,
+                  (initBusy || customFillLoading) && styles.buttonDisabled,
+                ]}
+                disabled={
+                  initBusy ||
+                  customFillLoading ||
+                  (initMode === 'auto' ? !selectedFolder : false)
+                }
+                onPress={() => {
+                  if (initMode === 'custom') {
+                    handleInitEngineCustom();
+                    return;
+                  }
+                  handleInitEngine();
+                }}
               >
                 {initBusy ? (
                   <ActivityIndicator color="#fff" />
                 ) : (
-                  <Text style={styles.buttonText}>Initialize engine</Text>
+                  <Text style={styles.buttonText}>
+                    {initMode === 'custom'
+                      ? 'Initialize custom'
+                      : 'Initialize engine'}
+                  </Text>
                 )}
               </TouchableOpacity>
               {initMessage ? (

--- a/example/src/screens/segmentation-showcase/SegmentationShowcaseScreen.tsx
+++ b/example/src/screens/segmentation-showcase/SegmentationShowcaseScreen.tsx
@@ -8,6 +8,7 @@ import {
   TextInput,
   FlatList,
   Switch,
+  Alert,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
@@ -54,6 +55,13 @@ import {
 import { AUDIO_FILES } from '../../audioConfig';
 import { RECOMMENDED_MODEL_IDS } from '../../utils/recommendedModels';
 import { ScreenIntroModal } from '../../components/ScreenIntroModal';
+import {
+  InitModeSelector,
+  SpeechVadSegmentationCustomInitForm,
+  type ModelInitMode,
+  type SpeechVadSegmentationCustomInitFormState,
+} from '../../components/modelInit';
+import { fillSegmentSpeechVadCustomConfigFromModelFolder } from '../../utils/segmentSpeechVadCustomInitFill';
 import {
   OfflineAudioBufferWidget,
   type OfflineAudioBufferInfo,
@@ -118,6 +126,12 @@ type AudioSegmentationState = {
 const EXAMPLE_TEXT =
   'Hello world. This is a longer example text that will be segmented. The segmentation engine cuts text at sentence boundaries and respects length limits. You can adjust parameters to see how segments change.';
 const SEGMENT_PAGE_SIZE = 128;
+
+const DEFAULT_SPEECH_VAD_CUSTOM_INIT: SpeechVadSegmentationCustomInitFormState =
+  {
+    modelType: 'silero_vad',
+    fileSources: {},
+  };
 
 const PAD_PACK_NAME = 'sherpa_models';
 const RECOMMENDED_VAD_MODEL_IDS =
@@ -272,6 +286,15 @@ export default function SegmentationShowcaseScreen() {
   const [loadingVadModels, setLoadingVadModels] = useState(false);
   const [initializingPunctuation, setInitializingPunctuation] = useState(false);
   const [initializingVadModel, setInitializingVadModel] = useState(false);
+  const [vadInitMode, setVadInitMode] = useState<ModelInitMode>('auto');
+  const [vadCustomInitForm, setVadCustomInitForm] =
+    useState<SpeechVadSegmentationCustomInitFormState>(
+      DEFAULT_SPEECH_VAD_CUSTOM_INIT
+    );
+  const [vadCustomFillLoading, setVadCustomFillLoading] = useState(false);
+  const [vadCustomFillHint, setVadCustomFillHint] = useState<string | null>(
+    null
+  );
   const [punctuationStatus, setPunctuationStatus] = useState<string | null>(
     null
   );
@@ -725,6 +748,65 @@ export default function SegmentationShowcaseScreen() {
     padVadModelIds,
   ]);
 
+  const resolveVadModelPath = useCallback(
+    (modelId: string): FileSource =>
+      getVadModelPathConfig(modelId, {
+        padModelIds: padVadModelIds,
+        padModelsPath,
+        bundledFolders: bundledVadFolders,
+        downloadedIds: new Set(downloadedVadIds),
+      }),
+    [bundledVadFolders, downloadedVadIds, padModelsPath, padVadModelIds]
+  );
+
+  const handleFillVadCustomFromCatalog = useCallback(async () => {
+    const modelId = audioState.selectedVadModelId;
+    if (!modelId) {
+      Alert.alert('Select a model', 'Pick a catalog VAD model first.');
+      return;
+    }
+
+    setVadCustomFillLoading(true);
+    setVadCustomFillHint(null);
+    setError(null);
+    try {
+      const modelPath = resolveVadModelPath(modelId);
+      const fillResult = await fillSegmentSpeechVadCustomConfigFromModelFolder(
+        modelPath,
+        { modelTypeOverride: vadCustomInitForm.modelType }
+      );
+      setVadCustomInitForm({
+        modelType: fillResult.modelType,
+        fileSources: fillResult.customConfig,
+      });
+      const missing =
+        fillResult.missingKeys.length > 0
+          ? ` Missing: ${fillResult.missingKeys.join(', ')}`
+          : '';
+      setVadCustomFillHint(
+        `Filled from ${getModelDisplayName(modelId)} (${
+          fillResult.modelDir
+        }).${missing}`
+      );
+    } catch (fillErr) {
+      setVadCustomFillHint(null);
+      setError(normalizeErrorMessage(fillErr));
+    } finally {
+      setVadCustomFillLoading(false);
+    }
+  }, [
+    audioState.selectedVadModelId,
+    resolveVadModelPath,
+    vadCustomInitForm.modelType,
+  ]);
+
+  const handleVadCustomScatteredTest = useCallback(() => {
+    setVadCustomInitForm((prev) => ({ ...prev, fileSources: {} }));
+    setVadCustomFillHint(
+      'Scattered test: pick the model file from a different location, then run segmentation.'
+    );
+  }, []);
+
   const handleRunTextSegmentation = useCallback(async () => {
     if (!textState.inputText.trim()) {
       setError('Please enter some text');
@@ -822,16 +904,24 @@ export default function SegmentationShowcaseScreen() {
       return;
     }
 
-    if (
-      audioState.evaluator === 'speech_vad_model' &&
-      (!audioState.selectedVadModelId ||
-        !audioState.initializedVadFileSource ||
-        audioState.initializedVadModelId !== audioState.selectedVadModelId)
-    ) {
-      setError(
-        'Initialize a VAD model first. This evaluator requires policy.modelPath.'
-      );
-      return;
+    if (audioState.evaluator === 'speech_vad_model') {
+      if (vadInitMode === 'auto') {
+        if (
+          !audioState.selectedVadModelId ||
+          !audioState.initializedVadFileSource ||
+          audioState.initializedVadModelId !== audioState.selectedVadModelId
+        ) {
+          setError(
+            'Initialize a VAD model first. Auto mode requires policy.modelPath.'
+          );
+          return;
+        }
+      } else if (!vadCustomInitForm.fileSources.model) {
+        setError(
+          'Custom mode requires customConfig.model (pick the VAD ONNX file).'
+        );
+        return;
+      }
     }
 
     setLoading(true);
@@ -843,6 +933,10 @@ export default function SegmentationShowcaseScreen() {
 
       const energyDb = parseOptionalFloat(audioState.energyThresholdDb, -40);
       const vadTh = parseOptionalFloat(audioState.vadThreshold, 0.5);
+      const vadCustomModelSource =
+        vadInitMode === 'custom'
+          ? vadCustomInitForm.fileSources.model
+          : undefined;
 
       await segmentOfflineBuffer(
         audioBufferId,
@@ -854,6 +948,18 @@ export default function SegmentationShowcaseScreen() {
               minSegmentMs: audioState.minSegmentMs,
               maxSegmentMs: audioState.maxSegmentMs,
               hangoverMs: audioState.hangoverMs,
+            }
+          : vadInitMode === 'custom'
+          ? {
+              evaluator: 'speech_vad_model',
+              initMode: 'custom',
+              modelType: vadCustomInitForm.modelType,
+              customConfig: { model: vadCustomModelSource! },
+              vadThreshold: vadTh,
+              vadMinSpeechMs: audioState.vadMinSpeechMs,
+              vadMinSilenceMs: audioState.vadMinSilenceMs,
+              minSegmentMs: audioState.minSegmentMs,
+              maxSegmentMs: audioState.maxSegmentMs,
             }
           : {
               evaluator: 'speech_vad_model',
@@ -892,6 +998,9 @@ export default function SegmentationShowcaseScreen() {
     audioState.vadMinSilenceMs,
     audioState.vadMinSpeechMs,
     audioState.vadThreshold,
+    vadCustomInitForm.fileSources,
+    vadCustomInitForm.modelType,
+    vadInitMode,
   ]);
 
   const handleLoadMoreTextSegments = useCallback(async () => {
@@ -967,9 +1076,13 @@ export default function SegmentationShowcaseScreen() {
     !loading &&
     !!preparedAudioBuffer &&
     (audioState.evaluator === 'speech_energy_silence' ||
-      (!!audioState.selectedVadModelId &&
-        !!audioState.initializedVadFileSource &&
-        audioState.initializedVadModelId === audioState.selectedVadModelId));
+      (audioState.evaluator === 'speech_vad_model' &&
+        (vadInitMode === 'custom'
+          ? !!vadCustomInitForm.fileSources.model
+          : !!audioState.selectedVadModelId &&
+            !!audioState.initializedVadFileSource &&
+            audioState.initializedVadModelId ===
+              audioState.selectedVadModelId)));
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
@@ -1496,8 +1609,9 @@ export default function SegmentationShowcaseScreen() {
                     speech_vad_model
                   </Text>
                   <Text style={styles.optionDescription}>
-                    Segment with a VAD bundle via policy.modelPath (FileSource;
-                    same detect path as streaming VAD).
+                    Segment with a VAD ONNX via policy — auto: detect from a
+                    folder (`modelPath`); custom: explicit `model` path (no
+                    detect).
                   </Text>
                 </Pressable>
               </View>
@@ -1635,9 +1749,18 @@ export default function SegmentationShowcaseScreen() {
               <View>
                 <Text style={styles.sectionTitle}>VAD Model</Text>
                 <Text style={styles.sectionDescription}>
-                  Choose an available VAD model, detect its concrete files once,
-                  then use it for offline speech segmentation.
+                  Choose auto (detect from catalog folder) or custom (explicit
+                  ONNX path). Custom reuses VAD validation keys — single slot
+                  `model`.
                 </Text>
+
+                <InitModeSelector
+                  value={vadInitMode}
+                  onChange={setVadInitMode}
+                  disabled={
+                    loading || initializingVadModel || vadCustomFillLoading
+                  }
+                />
 
                 {loadingVadModels ? (
                   <View style={styles.loadingContainer}>
@@ -1706,38 +1829,53 @@ export default function SegmentationShowcaseScreen() {
                   </View>
                 )}
 
-                <Pressable
-                  style={[
-                    styles.button,
-                    styles.secondaryButton,
-                    (initializingVadModel ||
+                {vadInitMode === 'auto' ? (
+                  <Pressable
+                    style={[
+                      styles.button,
+                      styles.secondaryButton,
+                      (initializingVadModel ||
+                        !audioState.selectedVadModelId ||
+                        availableVadModels.length === 0) &&
+                        styles.buttonDisabled,
+                    ]}
+                    onPress={handleInitializeVadModel}
+                    disabled={
+                      initializingVadModel ||
                       !audioState.selectedVadModelId ||
-                      availableVadModels.length === 0) &&
-                      styles.buttonDisabled,
-                  ]}
-                  onPress={handleInitializeVadModel}
-                  disabled={
-                    initializingVadModel ||
-                    !audioState.selectedVadModelId ||
-                    availableVadModels.length === 0
-                  }
-                >
-                  {initializingVadModel ? (
-                    <ActivityIndicator size="small" color="#FFF" />
-                  ) : (
-                    <>
-                      <Ionicons
-                        name="hardware-chip"
-                        size={18}
-                        color="#FFF"
-                        style={styles.buttonIcon}
-                      />
-                      <Text style={styles.buttonText}>Use VAD Model</Text>
-                    </>
-                  )}
-                </Pressable>
+                      availableVadModels.length === 0
+                    }
+                  >
+                    {initializingVadModel ? (
+                      <ActivityIndicator size="small" color="#FFF" />
+                    ) : (
+                      <>
+                        <Ionicons
+                          name="hardware-chip"
+                          size={18}
+                          color="#FFF"
+                          style={styles.buttonIcon}
+                        />
+                        <Text style={styles.buttonText}>Use VAD Model</Text>
+                      </>
+                    )}
+                  </Pressable>
+                ) : (
+                  <SpeechVadSegmentationCustomInitForm
+                    value={vadCustomInitForm}
+                    onChange={setVadCustomInitForm}
+                    selectedCatalogModelId={audioState.selectedVadModelId}
+                    onFillFromSelectedModel={() => {
+                      handleFillVadCustomFromCatalog().catch(() => {});
+                    }}
+                    onPrepareScatteredTest={handleVadCustomScatteredTest}
+                    fillLoading={vadCustomFillLoading}
+                    disabled={loading || initializingVadModel}
+                    fillHint={vadCustomFillHint}
+                  />
+                )}
 
-                {vadStatus && (
+                {vadInitMode === 'auto' && vadStatus && (
                   <View style={styles.statusCard}>
                     <Text style={styles.statusTitle}>Loaded model</Text>
                     <Text style={styles.statusText}>{vadStatus}</Text>

--- a/example/src/screens/stt-streaming/STTStreamingScreen.tsx
+++ b/example/src/screens/stt-streaming/STTStreamingScreen.tsx
@@ -14,7 +14,9 @@ import { Ionicons } from '@react-native-vector-icons/ionicons';
 import {
   createStreamingSTT,
   detectSttModel,
+  assertStreamingSttCustomConfig,
   type LiveSttEngine,
+  type StreamingSttCustomConfig,
   type SttPipelineHandle,
 } from 'react-native-sherpa-onnx/stt';
 import {
@@ -51,6 +53,13 @@ import {
 import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 import { ScreenIntroModal } from '../../components/ScreenIntroModal';
 import {
+  InitModeSelector,
+  StreamingSttCustomInitForm,
+  type ModelInitMode,
+  type StreamingSttCustomInitFormState,
+} from '../../components/modelInit';
+import { fillStreamingCustomConfigFromFolder } from '../../utils/streamingCustomInitFill';
+import {
   SegmentationPolicyControls,
   buildSegmentationOption,
   type SegmentationControlConfig,
@@ -64,6 +73,11 @@ import { styles as lpStyles } from '../live-pipeline-showcase/LivePipelineShowca
 
 const STT_INPUT_SAMPLE_RATE = 16000;
 const PAD_PACK_NAME = 'sherpa_models';
+
+const DEFAULT_STREAMING_CUSTOM_INIT: StreamingSttCustomInitFormState = {
+  modelType: 'transducer',
+  fileSources: {},
+};
 
 function normalizeErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -103,6 +117,11 @@ export default function STTStreamingScreen() {
     null
   );
   const [engineMode, setEngineMode] = useState<EngineMode>('streaming');
+  const [initMode, setInitMode] = useState<ModelInitMode>('auto');
+  const [customInitForm, setCustomInitForm] =
+    useState<StreamingSttCustomInitFormState>(DEFAULT_STREAMING_CUSTOM_INIT);
+  const [customFillLoading, setCustomFillLoading] = useState(false);
+  const [customFillHint, setCustomFillHint] = useState<string | null>(null);
   const [streamingModelIds, setStreamingModelIds] = useState<Set<string>>(
     new Set()
   );
@@ -373,11 +392,46 @@ export default function STTStreamingScreen() {
     }
   }, [stopPolling]);
 
+  const fillCustomFromSelectedModel = useCallback(async () => {
+    if (!selectedModelFolder) {
+      setCustomFillHint('Select a catalog model first.');
+      return;
+    }
+    setCustomFillLoading(true);
+    setCustomFillHint(null);
+    try {
+      const modelPath = resolveModelPath(selectedModelFolder);
+      const fillResult = await fillStreamingCustomConfigFromFolder({
+        modelSource: modelPath,
+        modelType: customInitForm.modelType,
+      });
+      setCustomInitForm({
+        modelType: fillResult.modelType,
+        fileSources: fillResult.customConfig,
+      });
+      if (fillResult.missingKeys.length > 0) {
+        setCustomFillHint(
+          `Filled from ${
+            fillResult.modelDir
+          }; still missing: ${fillResult.missingKeys.join(', ')}`
+        );
+      } else {
+        setCustomFillHint(`Filled all slots from ${fillResult.modelDir}`);
+      }
+    } catch (err) {
+      setCustomFillHint(normalizeErrorMessage(err));
+    } finally {
+      setCustomFillLoading(false);
+    }
+  }, [customInitForm.modelType, resolveModelPath, selectedModelFolder]);
+
   const startStreaming = useCallback(async () => {
     if (streamingState !== 'idle') {
       return;
     }
-    if (!selectedModelFolder) {
+    const isStreamingCustom =
+      engineMode === 'streaming' && initMode === 'custom';
+    if (!isStreamingCustom && !selectedModelFolder) {
       setError('Select an STT model first.');
       return;
     }
@@ -394,40 +448,56 @@ export default function STTStreamingScreen() {
     setStreamingState('starting');
 
     try {
-      const modelPath = resolveModelPath(selectedModelFolder);
-      const detectSource = await toDetectSource(modelPath);
-      const detection = await detectSttModel(detectSource, {
-        modelType: 'auto',
-      });
-      if (!detection.success) {
-        throw new Error(detection.error ?? 'STT model detection failed');
-      }
-      if (engineMode === 'streaming' && !detection.isStreaming) {
-        throw new Error(
-          'This STT model is offline-only. Switch to "Live Overload" mode to use it.'
+      if (engineMode === 'streaming' && initMode === 'custom') {
+        const customConfig = {
+          ...customInitForm.fileSources,
+        } as StreamingSttCustomConfig;
+        assertStreamingSttCustomConfig(
+          customConfig as unknown as Record<string, unknown>
         );
-      }
-      if (engineMode === 'offline' && detection.isStreaming) {
-        throw new Error(
-          'This STT model is streaming-only (incremental encoder). Live Overload needs offline weights — pick another model or use ⚡ Streaming.'
-        );
-      }
-
-      if (engineMode === 'streaming') {
         const engine = await createStreamingSTT({
-          modelSource: modelPath,
-          modelType: 'auto',
+          initMode: 'custom',
+          modelType: customInitForm.modelType,
+          customConfig,
           numThreads: 2,
         });
         engineRef.current = engine;
       } else {
-        const { createSTT } = require('react-native-sherpa-onnx/stt');
-        const engine = await createSTT({
-          modelSource: modelPath,
+        const modelPath = resolveModelPath(selectedModelFolder!);
+        const detectSource = await toDetectSource(modelPath);
+        const detection = await detectSttModel(detectSource, {
           modelType: 'auto',
-          numThreads: 2,
         });
-        engineRef.current = engine;
+        if (!detection.success) {
+          throw new Error(detection.error ?? 'STT model detection failed');
+        }
+        if (engineMode === 'streaming' && !detection.isStreaming) {
+          throw new Error(
+            'This STT model is offline-only. Switch to "Live Overload" mode to use it.'
+          );
+        }
+        if (engineMode === 'offline' && detection.isStreaming) {
+          throw new Error(
+            'This STT model is streaming-only (incremental encoder). Live Overload needs offline weights — pick another model or use ⚡ Streaming.'
+          );
+        }
+
+        if (engineMode === 'streaming') {
+          const engine = await createStreamingSTT({
+            modelSource: modelPath,
+            modelType: 'auto',
+            numThreads: 2,
+          });
+          engineRef.current = engine;
+        } else {
+          const { createSTT } = require('react-native-sherpa-onnx/stt');
+          const engine = await createSTT({
+            modelSource: modelPath,
+            modelType: 'auto',
+            numThreads: 2,
+          });
+          engineRef.current = engine;
+        }
       }
 
       const liveAudio = await createEmptyLiveAudioBuffer({
@@ -526,7 +596,9 @@ export default function STTStreamingScreen() {
     }
   }, [
     cleanupStream,
+    customInitForm,
     engineMode,
+    initMode,
     resolveModelPath,
     segConfig,
     selectedFileUri,
@@ -588,10 +660,15 @@ export default function STTStreamingScreen() {
     setStatus('Audio file removed. Choose another file to continue.');
   }, [streamingState]);
 
+  const canStartCustomStreaming =
+    engineMode === 'streaming' &&
+    initMode === 'custom' &&
+    Object.keys(customInitForm.fileSources).length > 0;
+
   const canStart =
-    !!selectedModelFolder &&
     streamingState === 'idle' &&
-    (sourceMode === 'mic' || !!selectedFileUri);
+    (sourceMode === 'mic' || !!selectedFileUri) &&
+    (canStartCustomStreaming || !!selectedModelFolder);
 
   return (
     <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
@@ -615,6 +692,33 @@ export default function STTStreamingScreen() {
           loading={loadingModels}
           disabled={streamingState !== 'idle'}
         />
+
+        {engineMode === 'streaming' && (
+          <View style={styles.card}>
+            <Text style={styles.cardTitle}>Initialization</Text>
+            <InitModeSelector
+              value={initMode}
+              onChange={setInitMode}
+              disabled={streamingState !== 'idle' || customFillLoading}
+            />
+            {initMode === 'custom' ? (
+              <StreamingSttCustomInitForm
+                value={customInitForm}
+                onChange={setCustomInitForm}
+                selectedCatalogModelId={selectedModelFolder}
+                onFillFromSelectedModel={fillCustomFromSelectedModel}
+                fillLoading={customFillLoading}
+                disabled={streamingState !== 'idle'}
+                fillHint={customFillHint}
+              />
+            ) : (
+              <Text style={styles.bodyText}>
+                Auto mode scans the selected model folder for streaming ONNX
+                files.
+              </Text>
+            )}
+          </View>
+        )}
 
         {engineMode === 'offline' && (
           <View style={styles.card}>

--- a/example/src/screens/stt/STTScreen.tsx
+++ b/example/src/screens/stt/STTScreen.tsx
@@ -12,30 +12,15 @@ import { styles } from './STTScreen.styles';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
-  getAssetPackPath,
-  listAssetModels,
-  listModelsAtPath,
-} from 'react-native-sherpa-onnx/utils';
-import { DocumentDirectoryPath } from '@dr.pogodin/react-native-fs';
-import {
-  listDownloadedModels,
-  ModelCategory,
-  onModelsListUpdated,
-} from 'react-native-sherpa-onnx/download';
-import { getSizeHint, getQualityHint } from '../../utils/recommendedModels';
-import {
+  assertSttCustomConfig,
   createSTT,
   detectSttModel,
+  type SttCustomConfig,
   type STTModelType,
 } from 'react-native-sherpa-onnx/stt';
 import type { SttEngine } from 'react-native-sherpa-onnx/stt';
 import { getSttCache, setSttCache, clearSttCache } from '../../engineCache';
-import {
-  getAssetModelPath,
-  getFileModelPath,
-  getModelDisplayName,
-  toDetectSource,
-} from '../../modelConfig';
+import { getModelDisplayName, toDetectSource } from '../../modelConfig';
 import { getAudioFilesForModel } from '../../audioConfig';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
 import { releasePipelineAudioBuffer } from 'react-native-sherpa-onnx/audiobuffer';
@@ -62,8 +47,20 @@ import {
   buildSegmentationOption,
   type SegmentationControlConfig,
 } from '../../components/SegmentationPolicyControls';
+import {
+  InitModeSelector,
+  ModelFolderGrid,
+  SttCustomInitForm,
+  type ModelInitMode,
+  type SttCustomInitFormState,
+} from '../../components/modelInit';
+import { useSttModelCatalog } from '../../hooks/useSttModelCatalog';
+import { fillSttCustomConfigFromModelFolder } from '../../utils/sttCustomInitFill';
 
-const PAD_PACK_NAME = 'sherpa_models';
+const DEFAULT_CUSTOM_INIT: SttCustomInitFormState = {
+  modelType: 'transducer',
+  fileSources: {},
+};
 
 type SttTranscriptionResult = {
   text: string;
@@ -85,12 +82,22 @@ let gSttOfflineInputBuffer: OfflineAudioBufferInfo | null = null;
 let gSttOfflineTextBuffers: SttOfflineTextBufferState[] = [];
 
 export default function STTScreen() {
-  const [availableModels, setAvailableModels] = useState<string[]>([]);
-  const [padModelIds, setPadModelIds] = useState<string[]>([]);
-  const [downloadedModelIds, setDownloadedModelIds] = useState<string[]>([]);
-  const [padModelsPath, setPadModelsPath] = useState<string | null>(null);
-  const [loadingModels, setLoadingModels] = useState(false);
+  const {
+    entries: catalogEntries,
+    loading: loadingModels,
+    error: catalogError,
+    resolveModelPath,
+  } = useSttModelCatalog();
+
+  const [initMode, setInitMode] = useState<ModelInitMode>('auto');
+  const [customInitForm, setCustomInitForm] =
+    useState<SttCustomInitFormState>(DEFAULT_CUSTOM_INIT);
+  const [customFillLoading, setCustomFillLoading] = useState(false);
+  const [customFillHint, setCustomFillHint] = useState<string | null>(null);
   const [initResult, setInitResult] = useState<string | null>(null);
+  const [initializedSummary, setInitializedSummary] = useState<string | null>(
+    null
+  );
   const [currentModelFolder, setCurrentModelFolder] = useState<string | null>(
     null
   );
@@ -125,25 +132,20 @@ export default function STTScreen() {
   const sttEngineRef = useRef<SttEngine | null>(null);
   const STT_NUM_THREADS = 2;
 
+  const isEngineInitialized = initializedSummary != null;
+
   const availableAudioFiles = useMemo(
     () => (currentModelFolder ? getAudioFilesForModel(currentModelFolder) : []),
     [currentModelFolder]
   );
 
-  // Load available models on mount
   useEffect(() => {
-    loadAvailableModels();
-  }, []);
-
-  useEffect(() => {
-    const unsubscribe = onModelsListUpdated((category) => {
-      if (category !== ModelCategory.Stt) return;
-      loadAvailableModels().catch(() => {
-        // ignore refresh errors
-      });
-    });
-    return unsubscribe;
-  }, []);
+    if (!catalogError) {
+      return;
+    }
+    setErrorSource('init');
+    setError(catalogError);
+  }, [catalogError]);
 
   // Restore persisted instance state when entering the screen (no cleanup on unmount)
   useEffect(() => {
@@ -154,6 +156,11 @@ export default function STTScreen() {
       setSelectedModelForInit(cached.modelFolder);
       setDetectedModels(cached.detectedModels);
       setSelectedModelType(cached.selectedModelType);
+      setInitializedSummary(
+        cached.modelFolder === 'custom'
+          ? `custom:${cached.selectedModelType ?? 'unknown'}`
+          : `auto:${getModelDisplayName(cached.modelFolder)}`
+      );
       setInitResult(
         `Initialized: ${getModelDisplayName(
           cached.modelFolder
@@ -164,86 +171,42 @@ export default function STTScreen() {
     }
   }, []);
 
-  const loadAvailableModels = async () => {
-    setLoadingModels(true);
-    setError(null);
-    setErrorSource(null);
-    try {
-      const assetModels = await listAssetModels();
-      const sttFolders = assetModels
-        .filter((model) => model.hint === 'stt')
-        .map((model) => model.folder);
-      const downloadedModels = await listDownloadedModels(ModelCategory.Stt);
-      const downloadedFolders = downloadedModels.map((model) => model.id);
-
-      // PAD (Play Asset Delivery) or filesystem models: prefer real PAD path, fallback to DocumentDirectoryPath/models
-      let padFolders: string[] = [];
-      let resolvedPadPath: string | null = null;
-      try {
-        const padPathFromNative = await getAssetPackPath(PAD_PACK_NAME);
-        const fallbackPath = `${DocumentDirectoryPath}/models`;
-        const padPath = padPathFromNative ?? fallbackPath;
-        const padResults = await listModelsAtPath(padPath);
-        padFolders = (padResults || [])
-          .filter((m) => m.hint === 'stt')
-          .map((m) => m.folder);
-        if (padFolders.length > 0) {
-          resolvedPadPath = padPath;
-          console.log(
-            'STTScreen: Found PAD/filesystem STT models:',
-            padFolders,
-            'at',
-            padPath
-          );
-        }
-      } catch (e) {
-        console.warn('STTScreen: PAD/listModelsAtPath failed', e);
-        padFolders = [];
+  const formatInitError = (err: unknown): string => {
+    if (err instanceof Error) {
+      let errorMessage = err.message;
+      if ('code' in err) {
+        errorMessage = `[${String(err.code)}] ${errorMessage}`;
       }
-      setPadModelsPath(resolvedPadPath);
-
-      // Merge: PAD folders, then bundled asset folders (no duplicates)
-      const combined = [
-        ...padFolders,
-        ...sttFolders.filter((f) => !padFolders.includes(f)),
-        ...downloadedFolders.filter(
-          (f) => !padFolders.includes(f) && !sttFolders.includes(f)
-        ),
-      ];
-
-      setPadModelIds(padFolders);
-      setDownloadedModelIds(downloadedFolders);
-      if (sttFolders.length > 0) {
-        console.log('STTScreen: Found asset models:', sttFolders);
+      if (err.stack) {
+        console.error('Stack trace:', err.stack);
       }
-      setAvailableModels(combined);
-
-      if (combined.length === 0) {
-        setErrorSource('init');
-        setError(
-          'No STT models found. Use bundled assets, downloaded models, or PAD models. See STT_MODEL_SETUP.md'
-        );
-      }
-    } catch (err) {
-      console.error('STTScreen: Failed to load models:', err);
-      setErrorSource('init');
-      setError('Failed to load available models');
-      setAvailableModels([]);
-    } finally {
-      setLoadingModels(false);
+      return errorMessage;
     }
+    if (typeof err === 'object' && err !== null) {
+      const errorObj = err as {
+        message?: string;
+        code?: string;
+        userInfo?: { NSLocalizedDescription?: string };
+      };
+      let errorMessage =
+        errorObj.message ||
+        errorObj.userInfo?.NSLocalizedDescription ||
+        JSON.stringify(err);
+      if (errorObj.code) {
+        errorMessage = `[${errorObj.code}] ${errorMessage}`;
+      }
+      return errorMessage;
+    }
+    return String(err);
   };
 
-  const resolveSttModelPath = (modelFolder: string) => {
-    if (padModelIds.includes(modelFolder)) {
-      return padModelsPath
-        ? getFileModelPath(modelFolder, ModelCategory.Stt, padModelsPath)
-        : getFileModelPath(modelFolder, ModelCategory.Stt);
+  const releaseCurrentEngine = async () => {
+    const previous = sttEngineRef.current;
+    if (previous) {
+      await previous.destroy();
+      sttEngineRef.current = null;
+      clearSttCache();
     }
-    if (downloadedModelIds.includes(modelFolder)) {
-      return getFileModelPath(modelFolder, ModelCategory.Stt);
-    }
-    return getAssetModelPath(modelFolder);
   };
 
   const appendOfflineTextBuffer = useCallback(
@@ -283,17 +246,12 @@ export default function STTScreen() {
     setInitResult(null);
     setDetectedModels([]);
     setSelectedModelType(null);
+    setInitializedSummary(null);
 
     try {
-      // Release previous engine if switching to another model
-      const previous = sttEngineRef.current;
-      if (previous) {
-        await previous.destroy();
-        sttEngineRef.current = null;
-        clearSttCache();
-      }
+      await releaseCurrentEngine();
 
-      const modelPath = resolveSttModelPath(modelFolder);
+      const modelPath = resolveModelPath(modelFolder);
 
       const engine = await createSTT({
         modelSource: modelPath,
@@ -329,8 +287,9 @@ export default function STTScreen() {
       }
 
       const detectedTypes = normalizedDetected.map((m) => m.type).join(', ');
+      setInitializedSummary(`auto:${getModelDisplayName(modelFolder)}`);
       setInitResult(
-        `Initialized: ${getModelDisplayName(
+        `Initialized (auto): ${getModelDisplayName(
           modelFolder
         )}\nDetected models: ${detectedTypes}`
       );
@@ -344,32 +303,8 @@ export default function STTScreen() {
 
       setTranscriptionResult(null);
     } catch (err) {
-      // Log full error details for debugging
       console.error('Initialization error:', err);
-
-      let errorMessage = 'Unknown error';
-      if (err instanceof Error) {
-        errorMessage = err.message;
-        // Include error code if available (React Native error objects)
-        if ('code' in err) {
-          errorMessage = `[${err.code}] ${errorMessage}`;
-        }
-        // Include stack trace in console
-        if (err.stack) {
-          console.error('Stack trace:', err.stack);
-        }
-      } else if (typeof err === 'object' && err !== null) {
-        // Handle React Native error objects
-        const errorObj = err as any;
-        errorMessage =
-          errorObj.message ||
-          errorObj.userInfo?.NSLocalizedDescription ||
-          JSON.stringify(err);
-        if (errorObj.code) {
-          errorMessage = `[${errorObj.code}] ${errorMessage}`;
-        }
-      }
-
+      const errorMessage = formatInitError(err);
       setErrorSource('init');
       setError(errorMessage);
       setInitResult(
@@ -380,10 +315,104 @@ export default function STTScreen() {
     }
   };
 
+  const handleFillFromSelectedModel = async () => {
+    const modelFolder = selectedModelForInit;
+    if (!modelFolder) {
+      Alert.alert('Select a model', 'Pick a catalog model folder first.');
+      return;
+    }
+
+    setCustomFillLoading(true);
+    setCustomFillHint(null);
+    setError(null);
+    setErrorSource(null);
+    try {
+      const modelPath = resolveModelPath(modelFolder);
+      const fillResult = await fillSttCustomConfigFromModelFolder(modelPath, {
+        preferInt8: true,
+        modelTypeOverride: customInitForm.modelType,
+      });
+      setCustomInitForm({
+        modelType: fillResult.modelType,
+        fileSources: fillResult.customConfig,
+      });
+      const missing =
+        fillResult.missingKeys.length > 0
+          ? ` Missing: ${fillResult.missingKeys.join(', ')}`
+          : '';
+      setCustomFillHint(
+        `Filled from ${getModelDisplayName(modelFolder)} (${
+          fillResult.modelDir
+        }).${missing}`
+      );
+    } catch (err) {
+      const message = formatInitError(err);
+      setCustomFillHint(null);
+      setErrorSource('init');
+      setError(message);
+    } finally {
+      setCustomFillLoading(false);
+    }
+  };
+
+  const handlePrepareScatteredTest = () => {
+    setCustomInitForm((prev) => ({ ...prev, fileSources: {} }));
+    setCustomFillHint(
+      'Scattered test: pick each file from different locations, then Initialize.'
+    );
+  };
+
+  const handleInitializeCustom = async () => {
+    setLoading(true);
+    setError(null);
+    setErrorSource(null);
+    setInitResult(null);
+    setDetectedModels([]);
+    setInitializedSummary(null);
+
+    try {
+      await releaseCurrentEngine();
+
+      const customConfig = {
+        ...customInitForm.fileSources,
+      } as SttCustomConfig;
+      assertSttCustomConfig(customConfig as unknown as Record<string, unknown>);
+
+      const engine = await createSTT({
+        initMode: 'custom',
+        modelType: customInitForm.modelType,
+        customConfig,
+        numThreads: STT_NUM_THREADS,
+      });
+
+      sttEngineRef.current = engine;
+      setCurrentModelFolder(null);
+      setSelectedModelType(customInitForm.modelType);
+      setInitializedSummary(`custom:${customInitForm.modelType}`);
+      setInitResult(
+        `Initialized (custom): ${
+          customInitForm.modelType
+        }\nFiles: ${Object.keys(customConfig).join(', ')}`
+      );
+
+      setSttCache(engine, 'custom', [], customInitForm.modelType);
+
+      setTranscriptionResult(null);
+    } catch (err) {
+      console.error('Custom initialization error:', err);
+      const errorMessage = formatInitError(err);
+      setErrorSource('init');
+      setError(errorMessage);
+      setInitResult(`Custom initialization failed: ${errorMessage}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const handleTranscribe = async () => {
-    if (!currentModelFolder) {
+    if (!selectedModelType) {
       setErrorSource('transcribe');
-      setError('Please select a model first');
+      setError('Please initialize a model first');
       return;
     }
 
@@ -526,6 +555,8 @@ export default function STTScreen() {
     setDetectedModels([]);
     setSelectedModelType(null);
     setInitResult(null);
+    setInitializedSummary(null);
+    setCustomFillHint(null);
     const prevBuf = gSttOfflineInputBuffer;
     gSttOfflineInputBuffer = null;
     setOfflineInputBuffer(null);
@@ -552,7 +583,7 @@ export default function STTScreen() {
           style={styles.scrollView}
           keyboardShouldPersistTaps="handled"
         >
-          {currentModelFolder != null && (
+          {isEngineInitialized && (
             <TouchableOpacity
               style={styles.freeButton}
               onPress={handleFree}
@@ -563,15 +594,22 @@ export default function STTScreen() {
           )}
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>1. Initialize Model</Text>
+            <InitModeSelector
+              value={initMode}
+              onChange={setInitMode}
+              disabled={loading || customFillLoading}
+            />
             <Text style={styles.hint}>
-              Select a model, then tap "Use model".
+              {initMode === 'auto'
+                ? 'Select a model folder, then tap "Use model" for auto-detection.'
+                : 'Choose model type and pick files (or Fill from a catalog folder), then Initialize.'}
             </Text>
 
-            {(currentModelFolder || selectedModelForInit) && (
+            {(initializedSummary || selectedModelForInit) && (
               <View style={styles.currentModelContainer}>
                 <Text style={styles.currentModelText}>
-                  {currentModelFolder
-                    ? `Initialized: ${getModelDisplayName(currentModelFolder)}`
+                  {initializedSummary
+                    ? `Initialized: ${initializedSummary}`
                     : `Selected: ${
                         selectedModelForInit
                           ? getModelDisplayName(selectedModelForInit)
@@ -581,113 +619,67 @@ export default function STTScreen() {
               </View>
             )}
 
-            {loadingModels ? (
-              <View style={styles.loadingContainer}>
-                <ActivityIndicator size="large" color="#007AFF" />
-                <Text style={styles.loadingText}>
-                  Discovering available models...
-                </Text>
-              </View>
-            ) : availableModels.length === 0 ? (
-              <View style={styles.warningContainer}>
-                <Text style={styles.warningText}>
-                  No models found. Please add STT models as bundled assets,
-                  downloaded models, or PAD models. See STT_MODEL_SETUP.md for
-                  details.
-                </Text>
-              </View>
-            ) : (
-              <View style={styles.modelButtons}>
-                {availableModels.map((modelFolder) => {
-                  const isSelected = selectedModelForInit === modelFolder;
-                  const isInitialized = currentModelFolder === modelFolder;
-                  return (
-                    <TouchableOpacity
-                      key={modelFolder}
-                      style={[
-                        styles.modelButton,
-                        isSelected && styles.modelButtonActive,
-                        isInitialized && styles.modelButtonInitialized,
-                        loading && styles.buttonDisabled,
-                      ]}
-                      onPress={() => setSelectedModelForInit(modelFolder)}
-                      disabled={loading}
-                    >
-                      <Text
-                        style={[
-                          styles.modelButtonText,
-                          isSelected && styles.modelButtonTextActive,
-                        ]}
-                      >
-                        {getModelDisplayName(modelFolder)}
-                      </Text>
-                      {(() => {
-                        const sizeHintInfo = getSizeHint(modelFolder);
-                        const qualityHintInfo = getQualityHint(modelFolder);
+            <ModelFolderGrid
+              entries={catalogEntries}
+              selectedId={selectedModelForInit}
+              initializedId={currentModelFolder}
+              onSelect={setSelectedModelForInit}
+              loading={loadingModels}
+              disabled={loading || customFillLoading}
+              emptyMessage="No models found. Add bundled, downloaded, or PAD STT models."
+            />
 
-                        return (
-                          <View style={styles.modelHintRow}>
-                            <View style={styles.modelHintGroup}>
-                              <Ionicons
-                                name={sizeHintInfo.iconName as any}
-                                size={12}
-                                color={sizeHintInfo.iconColor}
-                              />
-                              <Text style={styles.modelHintText}>
-                                {sizeHintInfo.tier}
-                              </Text>
-                            </View>
+            {initMode === 'custom' ? (
+              <SttCustomInitForm
+                value={customInitForm}
+                onChange={setCustomInitForm}
+                selectedCatalogModelId={selectedModelForInit}
+                onFillFromSelectedModel={handleFillFromSelectedModel}
+                onPrepareScatteredTest={handlePrepareScatteredTest}
+                fillLoading={customFillLoading}
+                disabled={loading}
+                fillHint={customFillHint}
+              />
+            ) : null}
 
-                            <View style={styles.modelHintGroup}>
-                              <Ionicons
-                                name={qualityHintInfo.iconName as any}
-                                size={12}
-                                color={qualityHintInfo.iconColor}
-                              />
-                              <Text style={styles.modelHintText}>
-                                {qualityHintInfo.text.split(',')[0]}
-                              </Text>
-                            </View>
-                          </View>
-                        );
-                      })()}
-                      <Text style={styles.modelFolderText}>{modelFolder}</Text>
-                    </TouchableOpacity>
-                  );
-                })}
-              </View>
-            )}
-
-            <>
-              <TouchableOpacity
-                style={[
-                  styles.button,
-                  styles.applyButton,
-                  loading && styles.buttonDisabled,
-                ]}
-                onPress={() =>
-                  handleInitialize(
-                    selectedModelForInit ?? currentModelFolder ?? ''
-                  )
+            <TouchableOpacity
+              style={[
+                styles.button,
+                styles.applyButton,
+                loading && styles.buttonDisabled,
+              ]}
+              onPress={() => {
+                if (initMode === 'custom') {
+                  handleInitializeCustom();
+                  return;
                 }
-                disabled={
-                  loading || (!selectedModelForInit && !currentModelFolder)
-                }
-              >
-                {loading ? (
-                  <View style={styles.applyButtonContent}>
-                    <ActivityIndicator
-                      size="small"
-                      color="#FFFFFF"
-                      style={styles.applyButtonSpinner}
-                    />
-                    <Text style={styles.buttonText}>Initializing…</Text>
-                  </View>
-                ) : (
-                  <Text style={styles.buttonText}>Use model</Text>
-                )}
-              </TouchableOpacity>
-            </>
+                handleInitialize(
+                  selectedModelForInit ?? currentModelFolder ?? ''
+                );
+              }}
+              disabled={
+                loading ||
+                customFillLoading ||
+                (initMode === 'auto'
+                  ? !selectedModelForInit && !currentModelFolder
+                  : false)
+              }
+            >
+              {loading ? (
+                <View style={styles.applyButtonContent}>
+                  <ActivityIndicator
+                    size="small"
+                    color="#FFFFFF"
+                    style={styles.applyButtonSpinner}
+                  />
+                  <Text style={styles.buttonText}>Initializing…</Text>
+                </View>
+              ) : (
+                <Text style={styles.buttonText}>
+                  {initMode === 'custom' ? 'Initialize custom' : 'Use model'}
+                </Text>
+              )}
+            </TouchableOpacity>
 
             {initResult && !(error && errorSource === 'init') && (
               <View style={styles.resultContainer}>
@@ -769,9 +761,7 @@ export default function STTScreen() {
             {!selectedModelType && (
               <View style={styles.warningContainer}>
                 <Text style={styles.warningText}>
-                  {!currentModelFolder
-                    ? 'Please initialize a model directory first'
-                    : 'Please select a model type first'}
+                  Please initialize a model first
                 </Text>
               </View>
             )}

--- a/example/src/screens/tts-streaming/StreamingTTSScreen.tsx
+++ b/example/src/screens/tts-streaming/StreamingTTSScreen.tsx
@@ -16,6 +16,7 @@ import {
   type TtsEngine,
   type TtsLivePipelineOptions,
   type TtsPipelineHandle,
+  type TTSInitializeOptions,
   type TTSModelType,
 } from 'react-native-sherpa-onnx/tts';
 import {
@@ -106,11 +107,11 @@ type StreamingSessionEngine = {
 
 async function createStreamingSessionEngine(options: {
   modelSource: FileSource;
-  modelType: TTSModelType;
+  modelType?: TTSModelType;
   numThreads: number;
   debug: boolean;
 }): Promise<StreamingSessionEngine> {
-  const ttsEngine: TtsEngine = await createTTS(options);
+  const ttsEngine: TtsEngine = await createTTS(options as TTSInitializeOptions);
   let activePipeline: TtsPipelineHandle | null = null;
   let activeTextBufferId: string | null = null;
 
@@ -483,7 +484,7 @@ export default function StreamingTTSScreen() {
 
       const engine = await createStreamingSessionEngine({
         modelSource: modelPath,
-        modelType: 'auto' as TTSModelType,
+        modelType: 'auto',
         numThreads: 2,
         debug: false,
       });

--- a/example/src/screens/tts/OfflineTTSScreen.styles.ts
+++ b/example/src/screens/tts/OfflineTTSScreen.styles.ts
@@ -49,6 +49,41 @@ export const styles = StyleSheet.create({
     color: '#8E8E93',
     marginBottom: 12,
   },
+  currentModelContainer: {
+    backgroundColor: '#F2F2F7',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 12,
+  },
+  currentModelText: {
+    fontSize: 14,
+    color: '#3A3A3C',
+    fontWeight: '500',
+  },
+  primaryButton: {
+    backgroundColor: '#007AFF',
+    paddingHorizontal: 30,
+    paddingVertical: 15,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  applyButton: {
+    marginTop: 16,
+  },
+  applyButtonContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  applyButtonSpinner: {
+    marginRight: 2,
+  },
+  primaryButtonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
   labelText: {
     fontSize: 14,
     color: '#8E8E93',

--- a/example/src/screens/tts/OfflineTTSScreen.tsx
+++ b/example/src/screens/tts/OfflineTTSScreen.tsx
@@ -12,6 +12,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   createTTS,
   detectTtsModel,
+  assertTtsCustomConfig,
+  type TtsCustomConfig,
   type TTSModelType,
   type TtsSynthesisOptions,
   type TtsSynthesisResult,
@@ -49,7 +51,6 @@ import {
   getModelDisplayName,
   toDetectSource,
 } from '../../modelConfig';
-import { getSizeHint, getQualityHint } from '../../utils/recommendedModels';
 import {
   DocumentDirectoryPath,
   unlink,
@@ -73,8 +74,21 @@ import {
   buildSegmentationOption,
   type SegmentationControlConfig,
 } from '../../components/SegmentationPolicyControls';
+import {
+  InitModeSelector,
+  ModelFolderGrid,
+  TtsCustomInitForm,
+  type ModelInitMode,
+  type TtsCustomInitFormState,
+} from '../../components/modelInit';
+import { fillTtsCustomConfigFromModelFolder } from '../../utils/ttsCustomInitFill';
 
 const PAD_PACK_NAME = 'sherpa_models';
+
+const DEFAULT_TTS_CUSTOM_INIT: TtsCustomInitFormState = {
+  modelType: 'vits',
+  fileSources: {},
+};
 
 /** Readable placeholder on gray `synthesisOptionInput` / `textInput` backgrounds. */
 const INPUT_PLACEHOLDER_COLOR = '#8E8E93';
@@ -96,6 +110,18 @@ type ReferenceAudioState = {
 
 export default function OfflineTTSScreen() {
   const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [initMode, setInitMode] = useState<ModelInitMode>('auto');
+  const [customInitForm, setCustomInitForm] = useState<TtsCustomInitFormState>(
+    DEFAULT_TTS_CUSTOM_INIT
+  );
+  const [customFillLoading, setCustomFillLoading] = useState(false);
+  const [customFillHint, setCustomFillHint] = useState<string | null>(null);
+  const [selectedModelForInit, setSelectedModelForInit] = useState<
+    string | null
+  >(null);
+  const [initializedSummary, setInitializedSummary] = useState<string | null>(
+    null
+  );
   const [padModelIds, setPadModelIds] = useState<string[]>([]);
   const [downloadedModelIds, setDownloadedModelIds] = useState<string[]>([]);
   const [padModelsPath, setPadModelsPath] = useState<string | null>(null);
@@ -110,9 +136,7 @@ export default function OfflineTTSScreen() {
   const [selectedModelType, setSelectedModelType] =
     useState<TTSModelType | null>(null);
   const [loading, setLoading] = useState(false);
-  const [initializingModel, setInitializingModel] = useState<string | null>(
-    null
-  );
+  const [, setInitializingModel] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [inputText, setInputText] = useState<string>('Hello, world!');
   const [generatedAudio, setGeneratedAudio] = useState<GeneratedResult | null>(
@@ -235,7 +259,7 @@ export default function OfflineTTSScreen() {
   }, [currentModelFolder]);
 
   useEffect(() => {
-    if (!currentModelFolder) {
+    if (!selectedModelType) {
       return;
     }
     if (paramsDebounceRef.current) {
@@ -333,6 +357,7 @@ export default function OfflineTTSScreen() {
     };
   }, [
     currentModelFolder,
+    initializedSummary,
     lengthScale,
     noiseScale,
     noiseScaleW,
@@ -344,7 +369,14 @@ export default function OfflineTTSScreen() {
     const cached = getTtsCache();
     if (cached.engine != null && cached.modelFolder != null) {
       ttsEngineRef.current = cached.engine;
-      setCurrentModelFolder(cached.modelFolder);
+      setCurrentModelFolder(
+        cached.modelFolder === 'custom' ? null : cached.modelFolder
+      );
+      setInitializedSummary(
+        cached.modelFolder === 'custom'
+          ? `custom:${cached.selectedModelType ?? 'unknown'}`
+          : getModelDisplayName(cached.modelFolder)
+      );
       setDetectedModels(cached.detectedModels);
       setSelectedModelType(cached.selectedModelType);
       setModelInfo(cached.modelInfo);
@@ -551,6 +583,41 @@ export default function OfflineTTSScreen() {
     }
   };
 
+  const catalogEntries = useMemo(
+    () =>
+      availableModels.map((id) => ({
+        id,
+        label: getModelDisplayName(id),
+      })),
+    [availableModels]
+  );
+
+  const isEngineInitialized =
+    currentModelFolder != null || initializedSummary != null;
+
+  const formatInitError = (err: unknown): string => {
+    if (err instanceof Error) {
+      let message = err.message;
+      if ('code' in err && typeof err.code === 'string') {
+        message = `[${err.code}] ${message}`;
+      }
+      return message;
+    }
+    if (typeof err === 'object' && err !== null) {
+      const errorObj = err as {
+        message?: string;
+        code?: string;
+        userInfo?: { NSLocalizedDescription?: string };
+      };
+      const message =
+        errorObj.message ??
+        errorObj.userInfo?.NSLocalizedDescription ??
+        JSON.stringify(err);
+      return errorObj.code ? `[${errorObj.code}] ${message}` : message;
+    }
+    return 'Unknown error';
+  };
+
   const resolveTtsModelPath = (modelFolder: string) => {
     if (padModelIds.includes(modelFolder)) {
       return padModelsPath
@@ -564,12 +631,17 @@ export default function OfflineTTSScreen() {
   };
 
   const handleInitialize = async (modelFolder: string) => {
+    if (!modelFolder) {
+      Alert.alert('Select a model', 'Pick a catalog model folder first.');
+      return;
+    }
     setLoading(true);
     setInitializingModel(modelFolder);
     setError(null);
     setInitResult(null);
     setDetectedModels([]);
     setSelectedModelType(null);
+    setInitializedSummary(null);
     setModelInfo(null);
     setGeneratedAudio(null);
     setSavedAudioPath(null);
@@ -662,6 +734,7 @@ export default function OfflineTTSScreen() {
       setDetectedModels(normalizedDetected);
       setCurrentModelFolder(modelFolder);
       setSelectedModelType(firstType);
+      setInitializedSummary(getModelDisplayName(modelFolder));
       setModelInfo(modelInfoValue);
       setInitResult(
         `Initialized: ${getModelDisplayName(
@@ -712,14 +785,152 @@ export default function OfflineTTSScreen() {
     }
   };
 
-  const handleGenerate = async () => {
-    if (!currentModelFolder) {
-      setError('Please initialize a model first');
+  const handleFillFromSelectedModel = async () => {
+    const modelFolder = selectedModelForInit;
+    if (!modelFolder) {
+      Alert.alert('Select a model', 'Pick a catalog model folder first.');
       return;
     }
 
+    setCustomFillLoading(true);
+    setCustomFillHint(null);
+    setError(null);
+    try {
+      const modelPath = resolveTtsModelPath(modelFolder);
+      const fillResult = await fillTtsCustomConfigFromModelFolder(modelPath, {
+        modelTypeOverride: customInitForm.modelType,
+      });
+      setCustomInitForm({
+        modelType: fillResult.modelType,
+        fileSources: fillResult.customConfig,
+      });
+      const missing =
+        fillResult.missingKeys.length > 0
+          ? ` Missing: ${fillResult.missingKeys.join(', ')}`
+          : '';
+      setCustomFillHint(
+        `Filled from ${getModelDisplayName(modelFolder)} (${
+          fillResult.modelDir
+        }).${missing}`
+      );
+    } catch (err) {
+      setCustomFillHint(null);
+      setError(formatInitError(err));
+    } finally {
+      setCustomFillLoading(false);
+    }
+  };
+
+  const handlePrepareScatteredTest = () => {
+    setCustomInitForm((prev) => ({ ...prev, fileSources: {} }));
+    setCustomFillHint(
+      'Scattered test: pick each file from different locations, then Initialize.'
+    );
+  };
+
+  const handleInitializeCustom = async () => {
+    setLoading(true);
+    setError(null);
+    setInitResult(null);
+    setDetectedModels([]);
+    setSelectedModelType(null);
+    setInitializedSummary(null);
+    setModelInfo(null);
+    setGeneratedAudio(null);
+    setSavedAudioPath(null);
+    setSavedAudioBufferId(null);
+    stopTtsSavedAudioPlayback();
+
+    try {
+      const previous = ttsEngineRef.current;
+      if (previous) {
+        await previous.destroy();
+        ttsEngineRef.current = null;
+        clearTtsCache();
+      }
+
+      const customConfig = {
+        ...customInitForm.fileSources,
+      } as TtsCustomConfig;
+      assertTtsCustomConfig(customConfig as unknown as Record<string, unknown>);
+
+      let engine: TtsEngine;
+      try {
+        engine = await createTTS({
+          initMode: 'custom',
+          modelType: customInitForm.modelType,
+          customConfig,
+          numThreads: TTS_NUM_THREADS,
+          debug: false,
+        });
+      } catch (initErr) {
+        console.warn(
+          'Custom createTTS failed, retrying with 1 thread',
+          initErr
+        );
+        engine = await createTTS({
+          initMode: 'custom',
+          modelType: customInitForm.modelType,
+          customConfig,
+          numThreads: 1,
+          debug: false,
+        });
+      }
+
+      let modelInfoValue: { sampleRate: number; numSpeakers: number } | null =
+        null;
+      try {
+        const info = await engine.getModelInfo();
+        if (
+          info &&
+          typeof info.sampleRate === 'number' &&
+          typeof info.numSpeakers === 'number'
+        ) {
+          modelInfoValue = {
+            sampleRate: info.sampleRate,
+            numSpeakers: info.numSpeakers,
+          };
+        }
+      } catch {
+        // leave modelInfoValue null
+      }
+
+      const detected = [
+        { type: customInitForm.modelType, modelDir: 'custom' },
+      ] as Array<{ type: TTSModelType; modelDir: string }>;
+
+      ttsEngineRef.current = engine;
+      setCurrentModelFolder(null);
+      setDetectedModels(detected);
+      setSelectedModelType(customInitForm.modelType);
+      setInitializedSummary(`custom:${customInitForm.modelType}`);
+      setModelInfo(modelInfoValue);
+      setInitResult(
+        `Initialized (custom): ${
+          customInitForm.modelType
+        }\nFiles: ${Object.keys(customConfig).join(', ')}`
+      );
+      setTtsCache(
+        engine,
+        'custom',
+        detected,
+        customInitForm.modelType,
+        modelInfoValue
+      );
+    } catch (err) {
+      console.error('TTS custom initialization error:', err);
+      const errorMessage = formatInitError(err);
+      setError(errorMessage);
+      setInitResult(`Custom initialization failed: ${errorMessage}`);
+    } finally {
+      setLoading(false);
+      setInitializingModel(null);
+    }
+  };
+
+  const handleGenerate = async () => {
     if (!selectedModelType) {
-      setError('Please select a model type first');
+      setError('Please initialize a model first');
       return;
     }
 
@@ -973,6 +1184,8 @@ export default function OfflineTTSScreen() {
       }
       clearTtsCache();
       setCurrentModelFolder(null);
+      setInitializedSummary(null);
+      setSelectedModelForInit(null);
       setInitResult(null);
       setDetectedModels([]);
       setSelectedModelType(null);
@@ -1012,7 +1225,7 @@ export default function OfflineTTSScreen() {
           style={styles.scrollView}
           contentContainerStyle={styles.scrollContent}
         >
-          {currentModelFolder != null && (
+          {isEngineInitialized && (
             <TouchableOpacity
               style={styles.cleanupButton}
               onPress={handleFree}
@@ -1034,92 +1247,88 @@ export default function OfflineTTSScreen() {
           {/* Section 1: Initialize Model */}
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>1. Initialize TTS Model</Text>
+            <InitModeSelector
+              value={initMode}
+              onChange={setInitMode}
+              disabled={loading || customFillLoading}
+            />
             <Text style={styles.sectionDescription}>
-              Select a TTS model to load:
+              {initMode === 'auto'
+                ? 'Select a model folder, then tap "Use model" for auto-detection.'
+                : 'Choose model type and pick files (or Fill from a catalog folder), then Initialize.'}
             </Text>
-            {loadingModels ? (
-              <View style={styles.loadingContainer}>
-                <ActivityIndicator size="small" color="#007AFF" />
-                <Text style={styles.loadingText}>Loading models...</Text>
-              </View>
-            ) : availableModels.length === 0 ? (
-              <View style={styles.resultContainer}>
-                <Text style={styles.errorText}>
-                  No TTS models found. See TTS_MODEL_SETUP.md
+
+            {(initializedSummary || selectedModelForInit) && (
+              <View style={styles.currentModelContainer}>
+                <Text style={styles.currentModelText}>
+                  {initializedSummary
+                    ? `Initialized: ${initializedSummary}`
+                    : `Selected: ${
+                        selectedModelForInit
+                          ? getModelDisplayName(selectedModelForInit)
+                          : ''
+                      }`}
                 </Text>
               </View>
-            ) : (
-              <View style={styles.buttonGroup}>
-                {availableModels.map((modelFolder) => {
-                  const isInitializingOther =
-                    initializingModel !== null &&
-                    initializingModel !== modelFolder;
-                  const isDisabled =
-                    isInitializingOther ||
-                    (loading && initializingModel !== modelFolder);
-                  return (
-                    <TouchableOpacity
-                      key={modelFolder}
-                      style={[
-                        styles.modelButton,
-                        currentModelFolder === modelFolder &&
-                          styles.modelButtonActive,
-                        isDisabled && styles.modelButtonDisabled,
-                      ]}
-                      onPress={() => {
-                        if (isDisabled) return;
-                        handleInitialize(modelFolder);
-                      }}
-                      disabled={isDisabled}
-                    >
-                      <Text
-                        style={[
-                          styles.modelButtonText,
-                          currentModelFolder === modelFolder &&
-                            styles.modelButtonTextActive,
-                          isDisabled && styles.modelButtonTextDisabled,
-                        ]}
-                      >
-                        {getModelDisplayName(modelFolder)}
-                      </Text>
-                      {(() => {
-                        const sizeHintInfo = getSizeHint(modelFolder);
-                        const qualityHintInfo = getQualityHint(modelFolder);
-
-                        return (
-                          <View style={styles.modelHintRow}>
-                            <View style={styles.modelHintGroup}>
-                              <Ionicons
-                                name={sizeHintInfo.iconName as any}
-                                size={12}
-                                color={sizeHintInfo.iconColor}
-                              />
-                              <Text style={styles.modelHintText}>
-                                {sizeHintInfo.tier}
-                              </Text>
-                            </View>
-
-                            <View style={styles.modelHintGroup}>
-                              <Ionicons
-                                name={qualityHintInfo.iconName as any}
-                                size={12}
-                                color={qualityHintInfo.iconColor}
-                              />
-                              <Text style={styles.modelHintText}>
-                                {qualityHintInfo.text.split(',')[0]}
-                              </Text>
-                            </View>
-                          </View>
-                        );
-                      })()}
-                      <Text style={styles.modelButtonSubtext}>
-                        {modelFolder}
-                      </Text>
-                    </TouchableOpacity>
-                  );
-                })}
-              </View>
             )}
+
+            <ModelFolderGrid
+              entries={catalogEntries}
+              selectedId={selectedModelForInit}
+              initializedId={currentModelFolder}
+              onSelect={setSelectedModelForInit}
+              loading={loadingModels}
+              disabled={loading || customFillLoading}
+              emptyMessage="No TTS models found. See TTS_MODEL_SETUP.md"
+            />
+
+            {initMode === 'custom' ? (
+              <TtsCustomInitForm
+                value={customInitForm}
+                onChange={setCustomInitForm}
+                selectedCatalogModelId={selectedModelForInit}
+                onFillFromSelectedModel={handleFillFromSelectedModel}
+                onPrepareScatteredTest={handlePrepareScatteredTest}
+                fillLoading={customFillLoading}
+                disabled={loading}
+                fillHint={customFillHint}
+              />
+            ) : null}
+
+            <TouchableOpacity
+              style={[
+                styles.primaryButton,
+                styles.applyButton,
+                (loading || customFillLoading) && styles.buttonDisabled,
+              ]}
+              onPress={() => {
+                if (initMode === 'custom') {
+                  handleInitializeCustom();
+                  return;
+                }
+                handleInitialize(selectedModelForInit ?? '');
+              }}
+              disabled={
+                loading ||
+                customFillLoading ||
+                (initMode === 'auto'
+                  ? !selectedModelForInit && !currentModelFolder
+                  : false)
+              }
+            >
+              <View style={styles.applyButtonContent}>
+                {loading ? (
+                  <ActivityIndicator
+                    size="small"
+                    color="#FFFFFF"
+                    style={styles.applyButtonSpinner}
+                  />
+                ) : null}
+                <Text style={styles.primaryButtonText}>
+                  {initMode === 'custom' ? 'Initialize custom' : 'Use model'}
+                </Text>
+              </View>
+            </TouchableOpacity>
 
             {loading && (
               <View style={styles.loadingContainer}>
@@ -1199,7 +1408,7 @@ export default function OfflineTTSScreen() {
             </View>
           )}
 
-          {currentModelFolder != null && selectedModelType != null && (
+          {selectedModelType != null && (
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>Synthesis options</Text>
               <Text style={styles.sectionDescription}>

--- a/example/src/screens/vad/VADScreen.tsx
+++ b/example/src/screens/vad/VADScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -40,11 +40,13 @@ import {
 import {
   createStreamingVAD,
   detectVadModel,
+  assertVadCustomConfig,
   type VADEngine,
   type VADModelType,
   type VADOfflineRunOptions,
   type VADPipelineHandle,
   type VADPipelineStatus,
+  type VADRuntimeOptions,
   type VADSummary,
 } from 'react-native-sherpa-onnx/vad';
 import {
@@ -56,6 +58,14 @@ import {
   SegmentationPolicyControls,
   type SegmentationControlConfig,
 } from '../../components/SegmentationPolicyControls';
+import {
+  InitModeSelector,
+  ModelFolderGrid,
+  VadCustomInitForm,
+  type ModelInitMode,
+  type VadCustomInitFormState,
+} from '../../components/modelInit';
+import { fillVadCustomConfigFromModelFolder } from '../../utils/vadCustomInitFill';
 import { ScreenIntroModal } from '../../components/ScreenIntroModal';
 import {
   OfflineAudioBufferWidget,
@@ -83,6 +93,28 @@ type TimelineEntry = {
 
 const TIMELINE_LIMIT = 200;
 const SEGMENT_PREVIEW_LIMIT = 200;
+
+const DEFAULT_VAD_CUSTOM_INIT: VadCustomInitFormState = {
+  modelType: 'silero_vad',
+  fileSources: {},
+};
+
+function buildVadRuntimeOptions(
+  modelType: VADModelType,
+  threshold: number
+): VADRuntimeOptions {
+  return modelType === 'ten_vad'
+    ? {
+        tenVad: {
+          scoreThreshold: Number.isFinite(threshold) ? threshold : undefined,
+        },
+      }
+    : {
+        sileroVad: {
+          scoreThreshold: Number.isFinite(threshold) ? threshold : undefined,
+        },
+      };
+}
 
 function normalizeErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -120,6 +152,12 @@ export default function VADScreen() {
   const [streamState, setStreamState] = useState<StreamState>('idle');
   const [busyOffline, setBusyOffline] = useState(false);
   const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [initMode, setInitMode] = useState<ModelInitMode>('auto');
+  const [customInitForm, setCustomInitForm] = useState<VadCustomInitFormState>(
+    DEFAULT_VAD_CUSTOM_INIT
+  );
+  const [customFillLoading, setCustomFillLoading] = useState(false);
+  const [customFillHint, setCustomFillHint] = useState<string | null>(null);
   const [downloadedModelIds, setDownloadedModelIds] = useState<string[]>([]);
   const [selectedModelFolder, setSelectedModelFolder] = useState<string | null>(
     null
@@ -166,7 +204,10 @@ export default function VADScreen() {
   const canStartLive =
     streamState === 'idle' &&
     !busyOffline &&
-    !!selectedModelFolder &&
+    !customFillLoading &&
+    (initMode === 'custom'
+      ? !!customInitForm.fileSources.model
+      : !!selectedModelFolder) &&
     (liveSource === 'mic' || !!selectedLiveFileUri);
 
   const offlineSegReady =
@@ -175,12 +216,24 @@ export default function VADScreen() {
 
   const canStartOffline =
     !busyOffline &&
+    !customFillLoading &&
     streamState === 'idle' &&
-    !!selectedModelFolder &&
+    (initMode === 'custom'
+      ? !!customInitForm.fileSources.model
+      : !!selectedModelFolder) &&
     preparedOfflineInputBuffer != null &&
     offlineSegReady;
 
-  const isBusy = streamState !== 'idle' || busyOffline;
+  const isBusy = streamState !== 'idle' || busyOffline || customFillLoading;
+
+  const catalogEntries = useMemo(
+    () =>
+      availableModels.map((id) => ({
+        id,
+        label: getModelDisplayName(id),
+      })),
+    [availableModels]
+  );
 
   const pushTimeline = useCallback((type: string, detail: string) => {
     const now = new Date();
@@ -252,6 +305,94 @@ export default function VADScreen() {
     },
     []
   );
+
+  const createVadEngine = useCallback(
+    async (sampleRate: number, threshold: number): Promise<VADEngine> => {
+      if (initMode === 'custom') {
+        const modelSource = customInitForm.fileSources.model;
+        if (!modelSource) {
+          throw new Error('Pick a VAD model file for custom init.');
+        }
+        const customConfig = { model: modelSource };
+        assertVadCustomConfig(
+          customConfig as unknown as Record<string, unknown>
+        );
+        return createStreamingVAD({
+          initMode: 'custom',
+          modelType: customInitForm.modelType,
+          customConfig,
+          sampleRate,
+          runtimeOptions: buildVadRuntimeOptions(
+            customInitForm.modelType,
+            threshold
+          ),
+        });
+      }
+
+      if (!selectedModelFolder) {
+        throw new Error('Select a VAD model folder first.');
+      }
+      const modelPath = resolveModelPath(selectedModelFolder);
+      const resolvedModelType = await detectResolvedModelType(modelPath);
+      return createStreamingVAD({
+        modelSource: modelPath,
+        modelType: resolvedModelType,
+        sampleRate,
+        runtimeOptions: buildVadRuntimeOptions(resolvedModelType, threshold),
+      });
+    },
+    [
+      customInitForm.fileSources.model,
+      customInitForm.modelType,
+      detectResolvedModelType,
+      initMode,
+      resolveModelPath,
+      selectedModelFolder,
+    ]
+  );
+
+  const handleFillFromSelectedModel = useCallback(async () => {
+    const modelFolder = selectedModelFolder;
+    if (!modelFolder) {
+      Alert.alert('Select a model', 'Pick a catalog model folder first.');
+      return;
+    }
+
+    setCustomFillLoading(true);
+    setCustomFillHint(null);
+    setError(null);
+    try {
+      const modelPath = resolveModelPath(modelFolder);
+      const fillResult = await fillVadCustomConfigFromModelFolder(modelPath, {
+        modelTypeOverride: customInitForm.modelType,
+      });
+      setCustomInitForm({
+        modelType: fillResult.modelType,
+        fileSources: fillResult.customConfig,
+      });
+      const missing =
+        fillResult.missingKeys.length > 0
+          ? ` Missing: ${fillResult.missingKeys.join(', ')}`
+          : '';
+      setCustomFillHint(
+        `Filled from ${getModelDisplayName(modelFolder)} (${
+          fillResult.modelDir
+        }).${missing}`
+      );
+    } catch (fillErr) {
+      setCustomFillHint(null);
+      setError(normalizeErrorMessage(fillErr));
+    } finally {
+      setCustomFillLoading(false);
+    }
+  }, [customInitForm.modelType, resolveModelPath, selectedModelFolder]);
+
+  const handlePrepareScatteredTest = useCallback(() => {
+    setCustomInitForm((prev) => ({ ...prev, fileSources: {} }));
+    setCustomFillHint(
+      'Scattered test: pick the model file from a different location, then run VAD.'
+    );
+  }, []);
 
   const loadModels = useCallback(async () => {
     setLoadingModels(true);
@@ -433,7 +574,11 @@ export default function VADScreen() {
   }, []);
 
   const startLive = useCallback(async () => {
-    if (!selectedModelFolder) return;
+    if (initMode === 'auto' && !selectedModelFolder) return;
+    if (initMode === 'custom' && !customInitForm.fileSources.model) {
+      setError('Pick a VAD model file for custom init.');
+      return;
+    }
     if (liveSource === 'file' && !selectedLiveFileUri) {
       setError('Select an audio file for live file-ingest mode.');
       return;
@@ -468,25 +613,6 @@ export default function VADScreen() {
         Number.parseInt(speechEventMinInput, 10) || 0
       );
 
-      const modelPath = resolveModelPath(selectedModelFolder);
-      const resolvedModelType = await detectResolvedModelType(modelPath);
-      logLiveLifecycle('model.detected', resolvedModelType);
-      const runtimeOptions =
-        resolvedModelType === 'ten_vad'
-          ? {
-              tenVad: {
-                scoreThreshold: Number.isFinite(threshold)
-                  ? threshold
-                  : undefined,
-              },
-            }
-          : {
-              sileroVad: {
-                scoreThreshold: Number.isFinite(threshold)
-                  ? threshold
-                  : undefined,
-              },
-            };
       const liveAudio = await createEmptyLiveAudioBuffer({
         sampleRate,
         channelCount: 1,
@@ -548,12 +674,7 @@ export default function VADScreen() {
       liveSegmentRef.current = liveSegment;
       logLiveLifecycle('segment.created', `bufferId=${liveSegment.bufferId}`);
 
-      const engine = await createStreamingVAD({
-        modelSource: modelPath,
-        modelType: resolvedModelType,
-        sampleRate,
-        runtimeOptions,
-      });
+      const engine = await createVadEngine(sampleRate, threshold);
       liveEngineRef.current = engine;
       setEngineInstanceId(engine.instanceId);
       logLiveLifecycle('engine.created', `instanceId=${engine.instanceId}`);
@@ -690,8 +811,9 @@ export default function VADScreen() {
     liveSource,
     logLiveLifecycle,
     pushTimeline,
-    resolveModelPath,
-    detectResolvedModelType,
+    createVadEngine,
+    customInitForm.fileSources.model,
+    initMode,
     sampleRateInput,
     selectedLiveFileName,
     selectedLiveFileUri,
@@ -862,8 +984,12 @@ export default function VADScreen() {
   }, [logLiveLifecycle, pushTimeline, streamState, teardownLiveResources]);
 
   const runOffline = useCallback(async () => {
-    if (!selectedModelFolder) {
+    if (initMode === 'auto' && !selectedModelFolder) {
       setError('Select a VAD model first.');
+      return;
+    }
+    if (initMode === 'custom' && !customInitForm.fileSources.model) {
+      setError('Pick a VAD model file for custom init.');
       return;
     }
     if (!preparedOfflineInputBuffer) {
@@ -897,25 +1023,6 @@ export default function VADScreen() {
         Number.parseInt(sampleRateInput, 10) || 16000
       );
       const threshold = Number.parseFloat(thresholdInput);
-      const modelPath = resolveModelPath(selectedModelFolder);
-      const resolvedModelType = await detectResolvedModelType(modelPath);
-      logOfflineLifecycle('model.detected', resolvedModelType);
-      const runtimeOptions =
-        resolvedModelType === 'ten_vad'
-          ? {
-              tenVad: {
-                scoreThreshold: Number.isFinite(threshold)
-                  ? threshold
-                  : undefined,
-              },
-            }
-          : {
-              sileroVad: {
-                scoreThreshold: Number.isFinite(threshold)
-                  ? threshold
-                  : undefined,
-              },
-            };
       const segment = await createEmptyOfflineSegmentBuffer({
         sourceAudioBufferId: preparedOfflineInputBuffer.bufferId,
       });
@@ -930,12 +1037,7 @@ export default function VADScreen() {
         }`
       );
 
-      const engine = await createStreamingVAD({
-        modelSource: modelPath,
-        modelType: resolvedModelType,
-        sampleRate,
-        runtimeOptions,
-      });
+      const engine = await createVadEngine(sampleRate, threshold);
       createdEngine = engine;
 
       const builtSeg = buildSegmentationOption(offlineSegConfig);
@@ -1029,8 +1131,9 @@ export default function VADScreen() {
     offlineSegConfig,
     preparedOfflineInputBuffer,
     pushTimeline,
-    resolveModelPath,
-    detectResolvedModelType,
+    createVadEngine,
+    customInitForm.fileSources.model,
+    initMode,
     sampleRateInput,
     selectedModelFolder,
     thresholdInput,
@@ -1114,6 +1217,16 @@ export default function VADScreen() {
 
         <View style={styles.card}>
           <Text style={styles.cardTitle}>Engine config</Text>
+          <InitModeSelector
+            value={initMode}
+            onChange={setInitMode}
+            disabled={isBusy}
+          />
+          <Text style={styles.mutedText}>
+            {initMode === 'auto'
+              ? 'Select a model folder; type is detected when you start live or offline VAD.'
+              : 'Choose silero_vad or ten_vad, pick the ONNX file (or Fill from catalog), then run VAD.'}
+          </Text>
           {loadingModels ? (
             <View style={styles.inlineRow}>
               <ActivityIndicator />
@@ -1127,32 +1240,30 @@ export default function VADScreen() {
               first.
             </Text>
           ) : (
-            <View style={styles.modelList}>
-              {availableModels.map((model) => {
-                const selected = selectedModelFolder === model;
-                return (
-                  <Pressable
-                    key={model}
-                    style={[
-                      styles.modelChip,
-                      selected && styles.modelChipActive,
-                    ]}
-                    onPress={() => setSelectedModelFolder(model)}
-                    disabled={isBusy}
-                  >
-                    <Text
-                      style={[
-                        styles.modelChipText,
-                        selected && styles.modelChipTextActive,
-                      ]}
-                    >
-                      {getModelDisplayName(model)}
-                    </Text>
-                  </Pressable>
-                );
-              })}
-            </View>
+            <ModelFolderGrid
+              entries={catalogEntries}
+              selectedId={selectedModelFolder}
+              initializedId={null}
+              onSelect={setSelectedModelFolder}
+              loading={loadingModels}
+              disabled={isBusy}
+              emptyMessage="No streaming VAD models found."
+            />
           )}
+          {initMode === 'custom' ? (
+            <VadCustomInitForm
+              value={customInitForm}
+              onChange={setCustomInitForm}
+              selectedCatalogModelId={selectedModelFolder}
+              onFillFromSelectedModel={() => {
+                handleFillFromSelectedModel().catch(() => {});
+              }}
+              onPrepareScatteredTest={handlePrepareScatteredTest}
+              fillLoading={customFillLoading}
+              disabled={isBusy}
+              fillHint={customFillHint}
+            />
+          ) : null}
           <View style={styles.inlineRowWrap}>
             <Text style={styles.inputLabel}>sampleRate: {sampleRateInput}</Text>
             <Pressable

--- a/example/src/utils/alignmentCustomInitFill.ts
+++ b/example/src/utils/alignmentCustomInitFill.ts
@@ -1,6 +1,7 @@
 import { exists, readDir } from '@dr.pogodin/react-native-fs';
 import {
   getCustomModelPathRequirements,
+  requiredCustomModelPathFieldKeys,
   resolveFileSourceForModelInit,
 } from 'react-native-sherpa-onnx/detect';
 import {
@@ -80,14 +81,14 @@ export async function fillAlignmentCustomConfigFromModelFolder(
 
   const schema = await getCustomModelPathRequirements('alignment', 'wav2vec2');
   const customConfig: Partial<Record<AlignmentCustomPathKey, FileSource>> = {};
-  for (const key of [...schema.required, ...schema.optional]) {
-    const source = key === 'model' ? toFsSource(modelPath) : undefined;
+  for (const field of schema.fields) {
+    const source = field.key === 'model' ? toFsSource(modelPath) : undefined;
     if (source) {
-      customConfig[key as AlignmentCustomPathKey] = source;
+      customConfig[field.key as AlignmentCustomPathKey] = source;
     }
   }
 
-  const missingKeys = schema.required.filter(
+  const missingKeys = requiredCustomModelPathFieldKeys(schema).filter(
     (key) => customConfig[key as AlignmentCustomPathKey] == null
   );
 

--- a/example/src/utils/alignmentCustomInitFill.ts
+++ b/example/src/utils/alignmentCustomInitFill.ts
@@ -1,0 +1,95 @@
+import { exists, readDir } from '@dr.pogodin/react-native-fs';
+import {
+  getCustomModelPathRequirements,
+  resolveFileSourceForModelInit,
+} from 'react-native-sherpa-onnx/detect';
+import {
+  detectAlignmentModel,
+  type AlignmentCustomPathKey,
+} from 'react-native-sherpa-onnx/alignment';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+
+export type FillAlignmentCustomConfigResult = {
+  customConfig: Partial<Record<AlignmentCustomPathKey, FileSource>>;
+  missingKeys: readonly string[];
+  modelDir: string;
+};
+
+function basename(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1] ?? path;
+}
+
+async function listFilesRecursive(dir: string): Promise<string[]> {
+  if (!(await exists(dir))) {
+    return [];
+  }
+  const entries = await readDir(dir);
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      files.push(...(await listFilesRecursive(entry.path)));
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(entry.path);
+    }
+  }
+  return files;
+}
+
+function findOnnxByTokens(files: string[], tokens: string[]): string {
+  const onnxFiles = files.filter((file) =>
+    file.toLowerCase().endsWith('.onnx')
+  );
+  const matches = onnxFiles.filter((file) => {
+    const lower = basename(file).toLowerCase();
+    return tokens.some((token) => lower.includes(token.toLowerCase()));
+  });
+  return matches[0] ?? '';
+}
+
+function toFsSource(path: string): FileSource | undefined {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return { kind: 'fs', path: trimmed };
+}
+
+export async function fillAlignmentCustomConfigFromModelFolder(
+  modelSource: FileSource
+): Promise<FillAlignmentCustomConfigResult> {
+  const detectResult = await detectAlignmentModel(modelSource, {
+    modelType: 'wav2vec2',
+  });
+  if (!detectResult.success || detectResult.modelType !== 'wav2vec2') {
+    throw new Error(
+      detectResult.error?.trim() ||
+        'Alignment wav2vec2 detection failed for fill helper'
+    );
+  }
+
+  const modelDir = await resolveFileSourceForModelInit(modelSource);
+  const files = await listFilesRecursive(modelDir);
+  const modelPath =
+    detectResult.paths?.model?.trim() ||
+    findOnnxByTokens(files, ['wav2vec', 'align']) ||
+    files.find((file) => file.toLowerCase().endsWith('.onnx')) ||
+    '';
+
+  const schema = await getCustomModelPathRequirements('alignment', 'wav2vec2');
+  const customConfig: Partial<Record<AlignmentCustomPathKey, FileSource>> = {};
+  for (const key of [...schema.required, ...schema.optional]) {
+    const source = key === 'model' ? toFsSource(modelPath) : undefined;
+    if (source) {
+      customConfig[key as AlignmentCustomPathKey] = source;
+    }
+  }
+
+  const missingKeys = schema.required.filter(
+    (key) => customConfig[key as AlignmentCustomPathKey] == null
+  );
+
+  return { customConfig, missingKeys, modelDir };
+}

--- a/example/src/utils/alignmentCustomInitLabels.ts
+++ b/example/src/utils/alignmentCustomInitLabels.ts
@@ -1,0 +1,15 @@
+import type { AlignmentCustomPathKey } from 'react-native-sherpa-onnx/alignment';
+
+/** Human-readable labels for alignment custom path keys (example app UI). */
+export const ALIGNMENT_CUSTOM_PATH_LABELS: Record<
+  AlignmentCustomPathKey,
+  string
+> = {
+  model: 'Wav2vec2 alignment model (.onnx)',
+};
+
+export function labelForAlignmentCustomPathKey(
+  key: AlignmentCustomPathKey
+): string {
+  return ALIGNMENT_CUSTOM_PATH_LABELS[key] ?? key;
+}

--- a/example/src/utils/enhancementCustomInitFill.ts
+++ b/example/src/utils/enhancementCustomInitFill.ts
@@ -1,0 +1,134 @@
+import { exists, readDir } from '@dr.pogodin/react-native-fs';
+import {
+  getCustomModelPathRequirements,
+  resolveFileSourceForModelInit,
+} from 'react-native-sherpa-onnx/detect';
+import {
+  detectEnhancementModel,
+  type EnhancementConcreteModelType,
+  type EnhancementCustomPathKey,
+} from 'react-native-sherpa-onnx/enhancement';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+
+export type FillEnhancementCustomConfigResult = {
+  modelType: EnhancementConcreteModelType;
+  customConfig: Partial<Record<EnhancementCustomPathKey, FileSource>>;
+  missingKeys: readonly string[];
+  modelDir: string;
+};
+
+function basename(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1] ?? path;
+}
+
+async function listFilesRecursive(dir: string): Promise<string[]> {
+  if (!(await exists(dir))) {
+    return [];
+  }
+  const entries = await readDir(dir);
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      files.push(...(await listFilesRecursive(entry.path)));
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(entry.path);
+    }
+  }
+  return files;
+}
+
+function findOnnxByTokens(files: string[], tokens: string[]): string {
+  const onnxFiles = files.filter((file) =>
+    file.toLowerCase().endsWith('.onnx')
+  );
+  const matches = onnxFiles.filter((file) => {
+    const lower = basename(file).toLowerCase();
+    return tokens.some((token) => lower.includes(token.toLowerCase()));
+  });
+  return matches[0] ?? '';
+}
+
+function scanEnhancementModelPath(
+  files: string[],
+  modelType: EnhancementConcreteModelType
+): string {
+  const tokens =
+    modelType === 'dpdfnet'
+      ? ['dpdf', 'dpdfnet']
+      : ['gtcrn', 'enhancement', 'denois'];
+  return (
+    findOnnxByTokens(files, tokens) ||
+    files.find((file) => file.toLowerCase().endsWith('.onnx')) ||
+    ''
+  );
+}
+
+function toFsSource(path: string): FileSource | undefined {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return { kind: 'fs', path: trimmed };
+}
+
+function isConcreteEnhancementModelType(
+  value: string
+): value is EnhancementConcreteModelType {
+  return value === 'gtcrn' || value === 'dpdfnet';
+}
+
+export async function fillEnhancementCustomConfigFromModelFolder(
+  modelSource: FileSource,
+  options?: { modelTypeOverride?: EnhancementConcreteModelType }
+): Promise<FillEnhancementCustomConfigResult> {
+  const detectResult = await detectEnhancementModel(modelSource, {
+    modelType: options?.modelTypeOverride ?? 'auto',
+  });
+  if (!detectResult.success) {
+    throw new Error(
+      detectResult.error?.trim() || 'Model detection failed for fill helper'
+    );
+  }
+
+  const rawType =
+    options?.modelTypeOverride ??
+    (detectResult.modelType &&
+    isConcreteEnhancementModelType(detectResult.modelType)
+      ? detectResult.modelType
+      : detectResult.detectedModels[0]?.type);
+
+  if (!rawType || !isConcreteEnhancementModelType(rawType)) {
+    throw new Error(
+      'Could not determine a concrete enhancement model type for fill'
+    );
+  }
+
+  const modelType = rawType;
+  const modelDir = await resolveFileSourceForModelInit(modelSource);
+  const files = await listFilesRecursive(modelDir);
+  const modelPath = scanEnhancementModelPath(files, modelType);
+
+  const schema = await getCustomModelPathRequirements('enhancement', modelType);
+  const customConfig: Partial<Record<EnhancementCustomPathKey, FileSource>> =
+    {};
+  for (const key of [...schema.required, ...schema.optional]) {
+    const source = key === 'model' ? toFsSource(modelPath) : undefined;
+    if (source) {
+      customConfig[key as EnhancementCustomPathKey] = source;
+    }
+  }
+
+  const missingKeys = schema.required.filter(
+    (key) => customConfig[key as EnhancementCustomPathKey] == null
+  );
+
+  return {
+    modelType,
+    customConfig,
+    missingKeys,
+    modelDir,
+  };
+}

--- a/example/src/utils/enhancementCustomInitFill.ts
+++ b/example/src/utils/enhancementCustomInitFill.ts
@@ -1,6 +1,7 @@
 import { exists, readDir } from '@dr.pogodin/react-native-fs';
 import {
   getCustomModelPathRequirements,
+  requiredCustomModelPathFieldKeys,
   resolveFileSourceForModelInit,
 } from 'react-native-sherpa-onnx/detect';
 import {
@@ -114,14 +115,14 @@ export async function fillEnhancementCustomConfigFromModelFolder(
   const schema = await getCustomModelPathRequirements('enhancement', modelType);
   const customConfig: Partial<Record<EnhancementCustomPathKey, FileSource>> =
     {};
-  for (const key of [...schema.required, ...schema.optional]) {
-    const source = key === 'model' ? toFsSource(modelPath) : undefined;
+  for (const field of schema.fields) {
+    const source = field.key === 'model' ? toFsSource(modelPath) : undefined;
     if (source) {
-      customConfig[key as EnhancementCustomPathKey] = source;
+      customConfig[field.key as EnhancementCustomPathKey] = source;
     }
   }
 
-  const missingKeys = schema.required.filter(
+  const missingKeys = requiredCustomModelPathFieldKeys(schema).filter(
     (key) => customConfig[key as EnhancementCustomPathKey] == null
   );
 

--- a/example/src/utils/enhancementCustomInitLabels.ts
+++ b/example/src/utils/enhancementCustomInitLabels.ts
@@ -1,0 +1,15 @@
+import type { EnhancementCustomPathKey } from 'react-native-sherpa-onnx/enhancement';
+
+/** Human-readable labels for enhancement custom init path keys (example app UI). */
+export const ENHANCEMENT_CUSTOM_PATH_LABELS: Record<
+  EnhancementCustomPathKey,
+  string
+> = {
+  model: 'Enhancement model (.onnx)',
+};
+
+export function labelForEnhancementCustomPathKey(
+  key: EnhancementCustomPathKey
+): string {
+  return ENHANCEMENT_CUSTOM_PATH_LABELS[key] ?? key;
+}

--- a/example/src/utils/punctuationCustomInitFill.ts
+++ b/example/src/utils/punctuationCustomInitFill.ts
@@ -1,0 +1,167 @@
+import { exists, readDir } from '@dr.pogodin/react-native-fs';
+import {
+  getCustomModelPathRequirements,
+  resolveFileSourceForModelInit,
+} from 'react-native-sherpa-onnx/detect';
+import {
+  detectPunctuationModel,
+  type OfflinePunctuationCustomPathKey,
+  type StreamingPunctuationCustomPathKey,
+} from 'react-native-sherpa-onnx/punctuation';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+
+export type FillOfflinePunctuationCustomConfigResult = {
+  customConfig: Partial<Record<OfflinePunctuationCustomPathKey, FileSource>>;
+  missingKeys: readonly string[];
+  modelDir: string;
+};
+
+export type FillStreamingPunctuationCustomConfigResult = {
+  customConfig: Partial<Record<StreamingPunctuationCustomPathKey, FileSource>>;
+  missingKeys: readonly string[];
+  modelDir: string;
+};
+
+function basename(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1] ?? path;
+}
+
+async function listFilesRecursive(dir: string): Promise<string[]> {
+  if (!(await exists(dir))) {
+    return [];
+  }
+  const entries = await readDir(dir);
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      files.push(...(await listFilesRecursive(entry.path)));
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(entry.path);
+    }
+  }
+  return files;
+}
+
+function findOnnxByTokens(files: string[], tokens: string[]): string {
+  const onnxFiles = files.filter((file) =>
+    file.toLowerCase().endsWith('.onnx')
+  );
+  const matches = onnxFiles.filter((file) => {
+    const lower = basename(file).toLowerCase();
+    return tokens.some((token) => lower.includes(token.toLowerCase()));
+  });
+  return matches[0] ?? '';
+}
+
+function findVocabFile(files: string[]): string {
+  const vocabCandidates = files.filter((file) => {
+    const lower = basename(file).toLowerCase();
+    return lower.endsWith('.vocab') || lower.includes('bpe');
+  });
+  return vocabCandidates[0] ?? '';
+}
+
+function toFsSource(path: string): FileSource | undefined {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return { kind: 'fs', path: trimmed };
+}
+
+export async function fillOfflinePunctuationCustomConfigFromModelFolder(
+  modelSource: FileSource
+): Promise<FillOfflinePunctuationCustomConfigResult> {
+  const detectResult = await detectPunctuationModel(modelSource, {
+    modelType: 'ct_transformer',
+  });
+  if (!detectResult.success || detectResult.modelType !== 'ct_transformer') {
+    throw new Error(
+      detectResult.error?.trim() ||
+        'Offline CT-Transformer detection failed for fill helper'
+    );
+  }
+
+  const modelDir = await resolveFileSourceForModelInit(modelSource);
+  const files = await listFilesRecursive(modelDir);
+  const ctPath =
+    detectResult.paths?.ct_transformer?.trim() ||
+    findOnnxByTokens(files, ['ct', 'punct', 'transformer']) ||
+    files.find((file) => file.toLowerCase().endsWith('.onnx')) ||
+    '';
+
+  const schema = await getCustomModelPathRequirements(
+    'punctuation',
+    'ct_transformer'
+  );
+  const customConfig: Partial<
+    Record<OfflinePunctuationCustomPathKey, FileSource>
+  > = {};
+  for (const key of [...schema.required, ...schema.optional]) {
+    const source = key === 'ct_transformer' ? toFsSource(ctPath) : undefined;
+    if (source) {
+      customConfig[key as OfflinePunctuationCustomPathKey] = source;
+    }
+  }
+
+  const missingKeys = schema.required.filter(
+    (key) => customConfig[key as OfflinePunctuationCustomPathKey] == null
+  );
+
+  return { customConfig, missingKeys, modelDir };
+}
+
+export async function fillStreamingPunctuationCustomConfigFromModelFolder(
+  modelSource: FileSource
+): Promise<FillStreamingPunctuationCustomConfigResult> {
+  const detectResult = await detectPunctuationModel(modelSource, {
+    modelType: 'cnn_bilstm',
+  });
+  if (
+    !detectResult.success ||
+    detectResult.modelType !== 'cnn_bilstm' ||
+    !detectResult.isStreaming
+  ) {
+    throw new Error(
+      detectResult.error?.trim() ||
+        'Streaming CNN-BiLSTM detection failed for fill helper'
+    );
+  }
+
+  const modelDir = await resolveFileSourceForModelInit(modelSource);
+  const files = await listFilesRecursive(modelDir);
+  const cnnPath =
+    detectResult.paths?.cnn_bilstm?.trim() ||
+    findOnnxByTokens(files, ['cnn', 'bilstm', 'punct']) ||
+    '';
+  const vocabPath =
+    detectResult.paths?.bpe_vocab?.trim() || findVocabFile(files) || '';
+
+  const schema = await getCustomModelPathRequirements(
+    'punctuation',
+    'cnn_bilstm'
+  );
+  const customConfig: Partial<
+    Record<StreamingPunctuationCustomPathKey, FileSource>
+  > = {};
+  for (const key of [...schema.required, ...schema.optional]) {
+    let source: FileSource | undefined;
+    if (key === 'cnn_bilstm') {
+      source = toFsSource(cnnPath);
+    } else if (key === 'bpe_vocab') {
+      source = toFsSource(vocabPath);
+    }
+    if (source) {
+      customConfig[key as StreamingPunctuationCustomPathKey] = source;
+    }
+  }
+
+  const missingKeys = schema.required.filter(
+    (key) => customConfig[key as StreamingPunctuationCustomPathKey] == null
+  );
+
+  return { customConfig, missingKeys, modelDir };
+}

--- a/example/src/utils/punctuationCustomInitFill.ts
+++ b/example/src/utils/punctuationCustomInitFill.ts
@@ -1,6 +1,7 @@
 import { exists, readDir } from '@dr.pogodin/react-native-fs';
 import {
   getCustomModelPathRequirements,
+  requiredCustomModelPathFieldKeys,
   resolveFileSourceForModelInit,
 } from 'react-native-sherpa-onnx/detect';
 import {
@@ -100,14 +101,15 @@ export async function fillOfflinePunctuationCustomConfigFromModelFolder(
   const customConfig: Partial<
     Record<OfflinePunctuationCustomPathKey, FileSource>
   > = {};
-  for (const key of [...schema.required, ...schema.optional]) {
-    const source = key === 'ct_transformer' ? toFsSource(ctPath) : undefined;
+  for (const field of schema.fields) {
+    const source =
+      field.key === 'ct_transformer' ? toFsSource(ctPath) : undefined;
     if (source) {
-      customConfig[key as OfflinePunctuationCustomPathKey] = source;
+      customConfig[field.key as OfflinePunctuationCustomPathKey] = source;
     }
   }
 
-  const missingKeys = schema.required.filter(
+  const missingKeys = requiredCustomModelPathFieldKeys(schema).filter(
     (key) => customConfig[key as OfflinePunctuationCustomPathKey] == null
   );
 
@@ -147,19 +149,19 @@ export async function fillStreamingPunctuationCustomConfigFromModelFolder(
   const customConfig: Partial<
     Record<StreamingPunctuationCustomPathKey, FileSource>
   > = {};
-  for (const key of [...schema.required, ...schema.optional]) {
+  for (const field of schema.fields) {
     let source: FileSource | undefined;
-    if (key === 'cnn_bilstm') {
+    if (field.key === 'cnn_bilstm') {
       source = toFsSource(cnnPath);
-    } else if (key === 'bpe_vocab') {
+    } else if (field.key === 'bpe_vocab') {
       source = toFsSource(vocabPath);
     }
     if (source) {
-      customConfig[key as StreamingPunctuationCustomPathKey] = source;
+      customConfig[field.key as StreamingPunctuationCustomPathKey] = source;
     }
   }
 
-  const missingKeys = schema.required.filter(
+  const missingKeys = requiredCustomModelPathFieldKeys(schema).filter(
     (key) => customConfig[key as StreamingPunctuationCustomPathKey] == null
   );
 

--- a/example/src/utils/punctuationCustomInitLabels.ts
+++ b/example/src/utils/punctuationCustomInitLabels.ts
@@ -1,0 +1,25 @@
+import type {
+  OfflinePunctuationCustomPathKey,
+  StreamingPunctuationCustomPathKey,
+} from 'react-native-sherpa-onnx/punctuation';
+
+const OFFLINE_LABELS: Record<OfflinePunctuationCustomPathKey, string> = {
+  ct_transformer: 'CT-Transformer ONNX',
+};
+
+const STREAMING_LABELS: Record<StreamingPunctuationCustomPathKey, string> = {
+  cnn_bilstm: 'CNN-BiLSTM ONNX',
+  bpe_vocab: 'BPE vocabulary',
+};
+
+export function labelForOfflinePunctuationCustomPathKey(
+  key: OfflinePunctuationCustomPathKey
+): string {
+  return OFFLINE_LABELS[key] ?? key;
+}
+
+export function labelForStreamingPunctuationCustomPathKey(
+  key: StreamingPunctuationCustomPathKey
+): string {
+  return STREAMING_LABELS[key] ?? key;
+}

--- a/example/src/utils/segmentSpeechVadCustomInitFill.ts
+++ b/example/src/utils/segmentSpeechVadCustomInitFill.ts
@@ -1,0 +1,4 @@
+export {
+  fillVadCustomConfigFromModelFolder as fillSegmentSpeechVadCustomConfigFromModelFolder,
+  type FillVadCustomConfigResult as FillSegmentSpeechVadCustomConfigResult,
+} from './vadCustomInitFill';

--- a/example/src/utils/streamingCustomInitFill.ts
+++ b/example/src/utils/streamingCustomInitFill.ts
@@ -77,7 +77,6 @@ function scanOnlinePaths(
     case 'zipformer2_ctc':
     case 'nemo_ctc':
     case 'tone_ctc':
-    case 'wenet_ctc':
       return {
         model: findOnnxByToken(files, 'model'),
         tokens,

--- a/example/src/utils/streamingCustomInitFill.ts
+++ b/example/src/utils/streamingCustomInitFill.ts
@@ -1,6 +1,7 @@
 import { exists, readDir } from '@dr.pogodin/react-native-fs';
 import {
   getCustomModelPathRequirements,
+  requiredCustomModelPathFieldKeys,
   resolveFileSourceForModelInit,
 } from 'react-native-sherpa-onnx/detect';
 import type {
@@ -104,14 +105,14 @@ export async function fillStreamingCustomConfigFromFolder(args: {
 
   const customConfig: Partial<Record<StreamingSttCustomPathKey, FileSource>> =
     {};
-  for (const key of [...schema.required, ...schema.optional]) {
-    const path = scanned[key as StreamingSttCustomPathKey];
+  for (const field of schema.fields) {
+    const path = scanned[field.key as StreamingSttCustomPathKey];
     if (path) {
-      customConfig[key as StreamingSttCustomPathKey] = toFileSource(path);
+      customConfig[field.key as StreamingSttCustomPathKey] = toFileSource(path);
     }
   }
 
-  const missingKeys = schema.required.filter(
+  const missingKeys = requiredCustomModelPathFieldKeys(schema).filter(
     (key) => customConfig[key as StreamingSttCustomPathKey] == null
   );
 

--- a/example/src/utils/streamingCustomInitFill.ts
+++ b/example/src/utils/streamingCustomInitFill.ts
@@ -1,0 +1,124 @@
+import { exists, readDir } from '@dr.pogodin/react-native-fs';
+import {
+  getCustomModelPathRequirements,
+  resolveFileSourceForModelInit,
+} from 'react-native-sherpa-onnx/detect';
+import type {
+  OnlineSTTModelType,
+  StreamingSttCustomPathKey,
+} from 'react-native-sherpa-onnx/stt';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+
+export type FillStreamingCustomConfigResult = {
+  modelType: OnlineSTTModelType;
+  customConfig: Partial<Record<StreamingSttCustomPathKey, FileSource>>;
+  missingKeys: readonly string[];
+  modelDir: string;
+};
+
+function basename(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1] ?? path;
+}
+
+async function listFilesRecursive(dir: string): Promise<string[]> {
+  if (!(await exists(dir))) {
+    return [];
+  }
+  const entries = await readDir(dir);
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      files.push(...(await listFilesRecursive(entry.path)));
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(entry.path);
+    }
+  }
+  return files;
+}
+
+function findOnnxByToken(files: string[], token: string): string {
+  const lowerToken = token.toLowerCase();
+  return (
+    files.find((file) => {
+      const name = basename(file).toLowerCase();
+      return name.endsWith('.onnx') && name.includes(lowerToken);
+    }) ?? ''
+  );
+}
+
+function findTokens(files: string[]): string {
+  return files.find((file) => basename(file) === 'tokens.txt') ?? '';
+}
+
+function scanOnlinePaths(
+  files: string[],
+  modelType: OnlineSTTModelType
+): Partial<Record<StreamingSttCustomPathKey, string>> {
+  const tokens = findTokens(files);
+  switch (modelType) {
+    case 'transducer':
+    case 'nemo_transducer':
+      return {
+        encoder: findOnnxByToken(files, 'encoder'),
+        decoder: findOnnxByToken(files, 'decoder'),
+        joiner: findOnnxByToken(files, 'joiner'),
+        tokens,
+      };
+    case 'paraformer':
+      return {
+        encoder: findOnnxByToken(files, 'encoder'),
+        decoder: findOnnxByToken(files, 'decoder'),
+        tokens,
+      };
+    case 'zipformer2_ctc':
+    case 'nemo_ctc':
+    case 'tone_ctc':
+    case 'wenet_ctc':
+      return {
+        model: findOnnxByToken(files, 'model'),
+        tokens,
+      };
+    default:
+      return {};
+  }
+}
+
+function toFileSource(path: string): FileSource {
+  return { kind: 'fs', path };
+}
+
+export async function fillStreamingCustomConfigFromFolder(args: {
+  modelSource: FileSource;
+  modelType: OnlineSTTModelType;
+}): Promise<FillStreamingCustomConfigResult> {
+  const modelDir = await resolveFileSourceForModelInit(args.modelSource);
+  const files = await listFilesRecursive(modelDir);
+  const scanned = scanOnlinePaths(files, args.modelType);
+  const schema = await getCustomModelPathRequirements(
+    'stt_streaming',
+    args.modelType
+  );
+
+  const customConfig: Partial<Record<StreamingSttCustomPathKey, FileSource>> =
+    {};
+  for (const key of [...schema.required, ...schema.optional]) {
+    const path = scanned[key as StreamingSttCustomPathKey];
+    if (path) {
+      customConfig[key as StreamingSttCustomPathKey] = toFileSource(path);
+    }
+  }
+
+  const missingKeys = schema.required.filter(
+    (key) => customConfig[key as StreamingSttCustomPathKey] == null
+  );
+
+  return {
+    modelType: args.modelType,
+    customConfig,
+    missingKeys,
+    modelDir,
+  };
+}

--- a/example/src/utils/streamingCustomInitLabels.ts
+++ b/example/src/utils/streamingCustomInitLabels.ts
@@ -1,0 +1,15 @@
+import type { StreamingSttCustomPathKey } from 'react-native-sherpa-onnx/stt';
+
+const LABELS: Record<StreamingSttCustomPathKey, string> = {
+  encoder: 'Encoder (.onnx)',
+  decoder: 'Decoder (.onnx)',
+  joiner: 'Joiner (.onnx)',
+  tokens: 'Tokens (tokens.txt)',
+  model: 'Model (.onnx)',
+};
+
+export function labelForStreamingSttCustomPathKey(
+  key: StreamingSttCustomPathKey
+): string {
+  return LABELS[key] ?? key;
+}

--- a/example/src/utils/sttCustomInitFill.ts
+++ b/example/src/utils/sttCustomInitFill.ts
@@ -6,6 +6,7 @@
 import { exists, readDir } from '@dr.pogodin/react-native-fs';
 import {
   getCustomModelPathRequirements,
+  requiredCustomModelPathFieldKeys,
   resolveFileSourceForModelInit,
 } from 'react-native-sherpa-onnx/detect';
 import {
@@ -329,9 +330,9 @@ export async function fillSttCustomConfigFromModelFolder(
   const candidate = buildCandidatePaths(files, preferInt8);
   const customConfig = mapCandidatesToCustomConfig(modelType, candidate);
 
-  const required = (await getCustomModelPathRequirements('stt', modelType))
-    .required;
-  const missingKeys = required.filter(
+  const missingKeys = requiredCustomModelPathFieldKeys(
+    await getCustomModelPathRequirements('stt', modelType)
+  ).filter(
     (key) =>
       (customConfig as Record<string, FileSource | undefined>)[key] == null
   );

--- a/example/src/utils/sttCustomInitFill.ts
+++ b/example/src/utils/sttCustomInitFill.ts
@@ -1,0 +1,345 @@
+/**
+ * Example-app helper: scan a model folder and pre-fill customConfig slots.
+ * Uses detectSttModel for modelType + filename heuristics aligned with native detection.
+ */
+
+import { exists, readDir } from '@dr.pogodin/react-native-fs';
+import {
+  getCustomModelPathRequirements,
+  resolveFileSourceForModelInit,
+} from 'react-native-sherpa-onnx/detect';
+import {
+  detectSttModel,
+  type STTConcreteModelType,
+  type SttCustomPathKey,
+} from 'react-native-sherpa-onnx/stt';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+
+type CandidatePaths = {
+  encoder: string;
+  decoder: string;
+  joiner: string;
+  paraformerModel: string;
+  ctcModel: string;
+  tokens: string;
+  funasrEncoderAdaptor: string;
+  funasrLLM: string;
+  funasrEmbedding: string;
+  funasrTokenizer: string;
+  qwen3ConvFrontend: string;
+  qwen3Encoder: string;
+  qwen3Decoder: string;
+  qwen3Tokenizer: string;
+  moonshinePreprocessor: string;
+  moonshineEncoder: string;
+  moonshineUncachedDecoder: string;
+  moonshineCachedDecoder: string;
+  moonshineMergedDecoder: string;
+  encoderForV2: string;
+};
+
+export type FillSttCustomConfigResult = {
+  modelType: STTConcreteModelType;
+  customConfig: Partial<Record<SttCustomPathKey, FileSource>>;
+  missingKeys: readonly string[];
+  modelDir: string;
+};
+
+function basename(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1] ?? path;
+}
+
+async function listFilesRecursive(dir: string): Promise<string[]> {
+  const existsDir = await exists(dir);
+  if (!existsDir) {
+    return [];
+  }
+  const entries = await readDir(dir);
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      files.push(...(await listFilesRecursive(entry.path)));
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(entry.path);
+    }
+  }
+  return files;
+}
+
+function findOnnxByTokens(
+  files: string[],
+  tokens: string[],
+  preferInt8: boolean
+): string {
+  const onnxFiles = files.filter((file) =>
+    file.toLowerCase().endsWith('.onnx')
+  );
+  const matches = onnxFiles.filter((file) => {
+    const lower = basename(file).toLowerCase();
+    return tokens.some((token) => lower.includes(token.toLowerCase()));
+  });
+  if (matches.length === 0) {
+    return '';
+  }
+  if (preferInt8) {
+    const int8Match = matches.find((file) => /int8/i.test(basename(file)));
+    if (int8Match) {
+      return int8Match;
+    }
+  }
+  const nonInt8 = matches.find((file) => !/int8/i.test(basename(file)));
+  return nonInt8 ?? matches[0] ?? '';
+}
+
+function findFileEndingWith(files: string[], suffix: string): string {
+  const lowerSuffix = suffix.toLowerCase();
+  return files.find((file) => file.toLowerCase().endsWith(lowerSuffix)) ?? '';
+}
+
+function findDirByToken(files: string[], token: string): string {
+  const dirs = new Set<string>();
+  for (const file of files) {
+    const normalized = file.replace(/\\/g, '/');
+    const idx = normalized.toLowerCase().indexOf(`/${token.toLowerCase()}/`);
+    if (idx >= 0) {
+      dirs.add(normalized.slice(0, idx + token.length + 1));
+    }
+  }
+  return dirs.values().next().value ?? '';
+}
+
+function buildCandidatePaths(
+  files: string[],
+  preferInt8: boolean
+): CandidatePaths {
+  return {
+    encoder: findOnnxByTokens(files, ['encoder'], preferInt8),
+    decoder: findOnnxByTokens(files, ['decoder'], preferInt8),
+    joiner: findOnnxByTokens(files, ['joiner'], preferInt8),
+    paraformerModel: findOnnxByTokens(files, ['model'], preferInt8),
+    ctcModel: findOnnxByTokens(files, ['model', 'ctc'], preferInt8),
+    tokens: findFileEndingWith(files, 'tokens.txt'),
+    funasrEncoderAdaptor: findOnnxByTokens(
+      files,
+      ['encoder_adaptor', 'encoder-adaptor'],
+      preferInt8
+    ),
+    funasrLLM: findOnnxByTokens(files, ['llm'], preferInt8),
+    funasrEmbedding: findOnnxByTokens(files, ['embedding'], preferInt8),
+    funasrTokenizer: findDirByToken(files, 'tokenizer'),
+    qwen3ConvFrontend: findOnnxByTokens(
+      files,
+      ['conv_frontend', 'conv-frontend'],
+      preferInt8
+    ),
+    qwen3Encoder: findOnnxByTokens(files, ['encoder'], preferInt8),
+    qwen3Decoder: findOnnxByTokens(files, ['decoder'], preferInt8),
+    qwen3Tokenizer: findDirByToken(files, 'tokenizer'),
+    moonshinePreprocessor: findOnnxByTokens(
+      files,
+      ['preprocessor', 'preprocess'],
+      preferInt8
+    ),
+    moonshineEncoder: findOnnxByTokens(
+      files,
+      ['encode', 'encoder_model', 'encoder'],
+      preferInt8
+    ),
+    moonshineUncachedDecoder: findOnnxByTokens(
+      files,
+      ['uncached', 'decode'],
+      preferInt8
+    ),
+    moonshineCachedDecoder: findOnnxByTokens(
+      files,
+      ['cached', 'cache'],
+      preferInt8
+    ),
+    moonshineMergedDecoder: findOnnxByTokens(
+      files,
+      ['merged', 'decode'],
+      preferInt8
+    ),
+    encoderForV2: findOnnxByTokens(
+      files,
+      ['encoder', 'encoder_model'],
+      preferInt8
+    ),
+  };
+}
+
+function toFsSource(path: string): FileSource | undefined {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return { kind: 'fs', path: trimmed };
+}
+
+function mapCandidatesToCustomConfig(
+  modelType: STTConcreteModelType,
+  candidate: CandidatePaths
+): Partial<Record<SttCustomPathKey, FileSource>> {
+  const out: Partial<Record<SttCustomPathKey, FileSource>> = {};
+  const set = (key: SttCustomPathKey, path: string) => {
+    const source = toFsSource(path);
+    if (source) {
+      out[key] = source;
+    }
+  };
+
+  switch (modelType) {
+    case 'transducer':
+    case 'nemo_transducer':
+      set('encoder', candidate.encoder);
+      set('decoder', candidate.decoder);
+      set('joiner', candidate.joiner);
+      set('tokens', candidate.tokens);
+      break;
+    case 'paraformer':
+      set('tokens', candidate.tokens);
+      if (candidate.paraformerModel) {
+        set('paraformerModel', candidate.paraformerModel);
+      } else {
+        set('encoder', candidate.encoder);
+        set('decoder', candidate.decoder);
+      }
+      break;
+    case 'nemo_ctc':
+    case 'wenet_ctc':
+    case 'sense_voice':
+    case 'zipformer_ctc':
+    case 'ctc':
+      set('ctcModel', candidate.ctcModel);
+      set('tokens', candidate.tokens);
+      break;
+    case 'whisper':
+      set('whisperEncoder', candidate.encoder);
+      set('whisperDecoder', candidate.decoder);
+      set('tokens', candidate.tokens);
+      break;
+    case 'funasr_nano':
+      set('funasrEncoderAdaptor', candidate.funasrEncoderAdaptor);
+      set('funasrLLM', candidate.funasrLLM);
+      set('funasrEmbedding', candidate.funasrEmbedding);
+      set('funasrTokenizer', candidate.funasrTokenizer);
+      break;
+    case 'qwen3_asr':
+      set('qwen3ConvFrontend', candidate.qwen3ConvFrontend);
+      set('qwen3Encoder', candidate.qwen3Encoder);
+      set('qwen3Decoder', candidate.qwen3Decoder);
+      set('qwen3Tokenizer', candidate.qwen3Tokenizer);
+      break;
+    case 'cohere_transcribe':
+      set('cohereEncoder', candidate.encoder);
+      set('cohereDecoder', candidate.decoder);
+      set('tokens', candidate.tokens);
+      break;
+    case 'moonshine':
+      if (candidate.moonshineMergedDecoder) {
+        set('moonshineEncoder', candidate.encoderForV2);
+        set('moonshineUncachedDecoder', candidate.moonshineMergedDecoder);
+        set('moonshineCachedDecoder', candidate.moonshineMergedDecoder);
+        set('moonshinePreprocessor', candidate.moonshinePreprocessor);
+      } else {
+        set('moonshinePreprocessor', candidate.moonshinePreprocessor);
+        set('moonshineEncoder', candidate.moonshineEncoder);
+        set('moonshineUncachedDecoder', candidate.moonshineUncachedDecoder);
+        set('moonshineCachedDecoder', candidate.moonshineCachedDecoder);
+      }
+      set('tokens', candidate.tokens);
+      break;
+    case 'fire_red_asr': {
+      const single =
+        candidate.paraformerModel || candidate.ctcModel || candidate.encoder;
+      set('fireRedEncoder', candidate.encoder || single);
+      set('fireRedDecoder', candidate.decoder || single);
+      set('tokens', candidate.tokens);
+      break;
+    }
+    case 'dolphin':
+      set(
+        'dolphinModel',
+        candidate.ctcModel || candidate.paraformerModel || candidate.ctcModel
+      );
+      set('tokens', candidate.tokens);
+      break;
+    case 'canary':
+      set('canaryEncoder', candidate.encoder);
+      set('canaryDecoder', candidate.decoder);
+      set('tokens', candidate.tokens);
+      break;
+    case 'omnilingual':
+      set('omnilingualModel', candidate.ctcModel);
+      set('tokens', candidate.tokens);
+      break;
+    case 'medasr':
+      set('medasrModel', candidate.ctcModel);
+      set('tokens', candidate.tokens);
+      break;
+    case 'telespeech_ctc':
+      set('telespeechCtcModel', candidate.ctcModel);
+      set('tokens', candidate.tokens);
+      break;
+    default:
+      break;
+  }
+
+  return out;
+}
+
+function isConcreteSttModelType(value: string): value is STTConcreteModelType {
+  return value !== 'auto';
+}
+
+export async function fillSttCustomConfigFromModelFolder(
+  modelSource: FileSource,
+  options?: {
+    preferInt8?: boolean;
+    modelTypeOverride?: STTConcreteModelType;
+  }
+): Promise<FillSttCustomConfigResult> {
+  const preferInt8 = options?.preferInt8 ?? true;
+  const detectResult = await detectSttModel(modelSource, {
+    preferInt8,
+    modelType: options?.modelTypeOverride,
+  });
+  if (!detectResult.success) {
+    throw new Error(
+      detectResult.error?.trim() || 'Model detection failed for fill helper'
+    );
+  }
+
+  const rawType =
+    options?.modelTypeOverride ??
+    (detectResult.modelType && isConcreteSttModelType(detectResult.modelType)
+      ? detectResult.modelType
+      : detectResult.detectedModels[0]?.type);
+
+  if (!rawType || !isConcreteSttModelType(rawType)) {
+    throw new Error('Could not determine a concrete STT model type for fill');
+  }
+
+  const modelType = rawType;
+  const modelDir = await resolveFileSourceForModelInit(modelSource);
+  const files = await listFilesRecursive(modelDir);
+  const candidate = buildCandidatePaths(files, preferInt8);
+  const customConfig = mapCandidatesToCustomConfig(modelType, candidate);
+
+  const required = (await getCustomModelPathRequirements('stt', modelType))
+    .required;
+  const missingKeys = required.filter(
+    (key) =>
+      (customConfig as Record<string, FileSource | undefined>)[key] == null
+  );
+
+  return {
+    modelType,
+    customConfig,
+    missingKeys,
+    modelDir,
+  };
+}

--- a/example/src/utils/sttCustomInitLabels.ts
+++ b/example/src/utils/sttCustomInitLabels.ts
@@ -1,0 +1,41 @@
+import type { SttCustomPathKey } from 'react-native-sherpa-onnx/stt';
+
+/** Human-readable labels for custom init path keys (example app UI). */
+export const STT_CUSTOM_PATH_LABELS: Record<SttCustomPathKey, string> = {
+  encoder: 'Encoder (.onnx)',
+  decoder: 'Decoder (.onnx)',
+  joiner: 'Joiner (.onnx)',
+  tokens: 'Tokens (tokens.txt)',
+  bpeVocab: 'BPE vocab (optional)',
+  paraformerModel: 'Paraformer model (.onnx)',
+  ctcModel: 'CTC model (.onnx)',
+  whisperEncoder: 'Whisper encoder (.onnx)',
+  whisperDecoder: 'Whisper decoder (.onnx)',
+  funasrEncoderAdaptor: 'FunASR encoder adaptor',
+  funasrLLM: 'FunASR LLM',
+  funasrEmbedding: 'FunASR embedding',
+  funasrTokenizer: 'FunASR tokenizer',
+  qwen3ConvFrontend: 'Qwen3 conv frontend',
+  qwen3Encoder: 'Qwen3 encoder',
+  qwen3Decoder: 'Qwen3 decoder',
+  qwen3Tokenizer: 'Qwen3 tokenizer',
+  cohereEncoder: 'Cohere encoder',
+  cohereDecoder: 'Cohere decoder',
+  moonshinePreprocessor: 'Moonshine preprocessor',
+  moonshineEncoder: 'Moonshine encoder',
+  moonshineUncachedDecoder: 'Moonshine uncached decoder',
+  moonshineCachedDecoder: 'Moonshine cached decoder',
+  moonshineMergedDecoder: 'Moonshine v2 merged decoder',
+  fireRedEncoder: 'FireRed encoder',
+  fireRedDecoder: 'FireRed decoder',
+  canaryEncoder: 'Canary encoder',
+  canaryDecoder: 'Canary decoder',
+  dolphinModel: 'Dolphin model',
+  omnilingualModel: 'Omnilingual model',
+  medasrModel: 'MedASR model',
+  telespeechCtcModel: 'TeleSpeech CTC model',
+};
+
+export function labelForSttCustomPathKey(key: SttCustomPathKey): string {
+  return STT_CUSTOM_PATH_LABELS[key] ?? key;
+}

--- a/example/src/utils/sttModelCatalog.ts
+++ b/example/src/utils/sttModelCatalog.ts
@@ -1,0 +1,167 @@
+/**
+ * Shared STT model discovery + path resolution (same rules as STTScreen / pipeline screens).
+ */
+
+import { DocumentDirectoryPath } from '@dr.pogodin/react-native-fs';
+import {
+  getAssetPackPath,
+  listAssetModels,
+  listModelsAtPath,
+} from 'react-native-sherpa-onnx/utils';
+import {
+  listDownloadedModels,
+  ModelCategory,
+  type ModelMeta,
+} from 'react-native-sherpa-onnx/download';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import {
+  getAssetModelPath,
+  getFileModelPath,
+  getModelDisplayName,
+} from '../modelConfig';
+import { RECOMMENDED_MODEL_IDS } from './recommendedModels';
+
+const PAD_PACK_NAME = 'sherpa_models';
+
+const RECOMMENDED_STT_MODEL_IDS =
+  RECOMMENDED_MODEL_IDS[ModelCategory.Stt] ?? [];
+
+export type SttModelEntry = {
+  id: string;
+  label: string;
+  recommended?: boolean;
+};
+
+export type SttCatalogSnapshot = {
+  entries: SttModelEntry[];
+  padModelIds: string[];
+  padModelsPath: string | null;
+  bundledSttFolders: string[];
+  downloadedSttIds: string[];
+};
+
+function getModelLabel(model: ModelMeta): string {
+  const title = model.displayName?.trim();
+  if (title && title.length > 0) {
+    return title;
+  }
+  return getModelDisplayName(model.id);
+}
+
+function prioritizeEntries(
+  entries: SttModelEntry[],
+  recommendedIds: string[] = []
+): SttModelEntry[] {
+  const uniqueEntries = Array.from(
+    new Map(entries.map((entry) => [entry.id, entry])).values()
+  );
+  const recommendedSet = new Set(recommendedIds);
+  const recommended: SttModelEntry[] = [];
+  const remaining: SttModelEntry[] = [];
+
+  for (const entry of uniqueEntries) {
+    if (recommendedSet.has(entry.id)) {
+      recommended.push({ ...entry, recommended: true });
+      continue;
+    }
+    remaining.push(entry);
+  }
+
+  recommended.sort(
+    (left, right) =>
+      recommendedIds.indexOf(left.id) - recommendedIds.indexOf(right.id)
+  );
+  remaining.sort((left, right) => left.label.localeCompare(right.label));
+
+  return [...recommended, ...remaining];
+}
+
+export type SttModelPathContext = {
+  padModelIds: string[];
+  padModelsPath: string | null;
+  bundledFolders: string[];
+  downloadedIds: Set<string>;
+};
+
+/** Resolve a discovered folder id to the FileSource shape used by detectSttModel / createSTT. */
+export function getSttModelPathConfig(
+  modelId: string,
+  ctx: SttModelPathContext
+): FileSource {
+  if (ctx.padModelIds.includes(modelId)) {
+    return ctx.padModelsPath
+      ? getFileModelPath(modelId, ModelCategory.Stt, ctx.padModelsPath)
+      : getFileModelPath(modelId, ModelCategory.Stt);
+  }
+  if (ctx.downloadedIds.has(modelId)) {
+    return getFileModelPath(modelId, ModelCategory.Stt);
+  }
+  if (ctx.bundledFolders.includes(modelId)) {
+    return getAssetModelPath(modelId);
+  }
+  return getAssetModelPath(modelId);
+}
+
+export function createSttModelPathContext(
+  snapshot: SttCatalogSnapshot
+): SttModelPathContext {
+  return {
+    padModelIds: snapshot.padModelIds,
+    padModelsPath: snapshot.padModelsPath,
+    bundledFolders: snapshot.bundledSttFolders,
+    downloadedIds: new Set(snapshot.downloadedSttIds),
+  };
+}
+
+export async function loadSttModelCatalog(): Promise<SttCatalogSnapshot> {
+  const assetModels = await listAssetModels();
+  const bundledIds = assetModels
+    .filter((model) => model.hint === 'stt')
+    .map((model) => model.folder);
+  const downloadedModels = await listDownloadedModels(ModelCategory.Stt);
+  const downloadedIds = downloadedModels.map((model) => model.id);
+
+  let padIds: string[] = [];
+  let padModelsPath: string | null = null;
+  try {
+    const padPathFromNative = await getAssetPackPath(PAD_PACK_NAME);
+    const fallbackPath = `${DocumentDirectoryPath}/models`;
+    const padPath = padPathFromNative ?? fallbackPath;
+    const padResults = await listModelsAtPath(padPath);
+    padIds = (padResults || [])
+      .filter((model) => model.hint === 'stt')
+      .map((model) => model.folder);
+    if (padIds.length > 0) {
+      padModelsPath = padPath;
+    }
+  } catch {
+    padIds = [];
+  }
+
+  const mergedIds = [
+    ...padIds,
+    ...bundledIds.filter((id) => !padIds.includes(id)),
+    ...downloadedIds.filter(
+      (id) => !padIds.includes(id) && !bundledIds.includes(id)
+    ),
+  ];
+
+  const entries = prioritizeEntries(
+    mergedIds.map((id) => {
+      const downloaded = downloadedModels.find((model) => model.id === id);
+      return {
+        id,
+        label: downloaded ? getModelLabel(downloaded) : getModelDisplayName(id),
+      };
+    }),
+    RECOMMENDED_STT_MODEL_IDS
+  );
+
+  return {
+    entries,
+    padModelIds: padIds,
+    padModelsPath,
+    bundledSttFolders: bundledIds,
+    downloadedSttIds: downloadedIds,
+  };
+}

--- a/example/src/utils/ttsCustomInitFill.ts
+++ b/example/src/utils/ttsCustomInitFill.ts
@@ -1,6 +1,7 @@
 import { exists, readDir } from '@dr.pogodin/react-native-fs';
 import {
   getCustomModelPathRequirements,
+  requiredCustomModelPathFieldKeys,
   resolveFileSourceForModelInit,
 } from 'react-native-sherpa-onnx/detect';
 import {
@@ -188,15 +189,15 @@ export async function fillTtsCustomConfigFromModelFolder(
 
   const schema = await getCustomModelPathRequirements('tts', modelType);
   const customConfig: Partial<Record<TtsCustomPathKey, FileSource>> = {};
-  for (const key of [...schema.required, ...schema.optional]) {
-    const path = scanned[key as TtsCustomPathKey];
+  for (const field of schema.fields) {
+    const path = scanned[field.key as TtsCustomPathKey];
     const source = path ? toFsSource(path) : undefined;
     if (source) {
-      customConfig[key as TtsCustomPathKey] = source;
+      customConfig[field.key as TtsCustomPathKey] = source;
     }
   }
 
-  const missingKeys = schema.required.filter(
+  const missingKeys = requiredCustomModelPathFieldKeys(schema).filter(
     (key) => customConfig[key as TtsCustomPathKey] == null
   );
 

--- a/example/src/utils/ttsCustomInitFill.ts
+++ b/example/src/utils/ttsCustomInitFill.ts
@@ -1,0 +1,209 @@
+import { exists, readDir } from '@dr.pogodin/react-native-fs';
+import {
+  getCustomModelPathRequirements,
+  resolveFileSourceForModelInit,
+} from 'react-native-sherpa-onnx/detect';
+import {
+  detectTtsModel,
+  type TTSConcreteModelType,
+  type TtsCustomPathKey,
+} from 'react-native-sherpa-onnx/tts';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+
+export type FillTtsCustomConfigResult = {
+  modelType: TTSConcreteModelType;
+  customConfig: Partial<Record<TtsCustomPathKey, FileSource>>;
+  missingKeys: readonly string[];
+  modelDir: string;
+};
+
+function basename(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1] ?? path;
+}
+
+async function listFilesRecursive(dir: string): Promise<string[]> {
+  if (!(await exists(dir))) {
+    return [];
+  }
+  const entries = await readDir(dir);
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      files.push(...(await listFilesRecursive(entry.path)));
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(entry.path);
+    }
+  }
+  return files;
+}
+
+function findOnnxByTokens(files: string[], tokens: string[]): string {
+  const onnxFiles = files.filter((file) =>
+    file.toLowerCase().endsWith('.onnx')
+  );
+  const matches = onnxFiles.filter((file) => {
+    const lower = basename(file).toLowerCase();
+    return tokens.some((token) => lower.includes(token.toLowerCase()));
+  });
+  return matches[0] ?? '';
+}
+
+function findFileEndingWith(files: string[], suffix: string): string {
+  const lowerSuffix = suffix.toLowerCase();
+  return files.find((file) => file.toLowerCase().endsWith(lowerSuffix)) ?? '';
+}
+
+function findDirByToken(files: string[], token: string): string {
+  const dirs = new Set<string>();
+  for (const file of files) {
+    const normalized = file.replace(/\\/g, '/');
+    const idx = normalized.toLowerCase().indexOf(`/${token.toLowerCase()}/`);
+    if (idx >= 0) {
+      dirs.add(normalized.slice(0, idx + token.length + 1));
+    }
+  }
+  return dirs.values().next().value ?? '';
+}
+
+function scanTtsPaths(
+  files: string[],
+  modelType: TTSConcreteModelType
+): Partial<Record<TtsCustomPathKey, string>> {
+  const tokens = findFileEndingWith(files, 'tokens.txt');
+  switch (modelType) {
+    case 'vits':
+      return {
+        ttsModel:
+          findOnnxByTokens(files, ['vits', 'model']) ||
+          findOnnxByTokens(files, ['model']),
+        tokens,
+        dataDir: findDirByToken(files, 'espeak-ng-data'),
+        lexicon: findFileEndingWith(files, 'lexicon.txt'),
+      };
+    case 'matcha':
+      return {
+        acousticModel: findOnnxByTokens(files, ['acoustic', 'model']),
+        vocoder: findOnnxByTokens(files, ['vocoder', 'vocos']),
+        tokens,
+        dataDir: findDirByToken(files, 'espeak-ng-data'),
+        lexicon: findFileEndingWith(files, 'lexicon.txt'),
+      };
+    case 'kokoro':
+    case 'kitten':
+      return {
+        ttsModel: findOnnxByTokens(files, ['model', 'kokoro', 'kitten']),
+        tokens,
+        voices:
+          findFileEndingWith(files, 'voices.bin') ||
+          findFileEndingWith(files, 'voices.pt'),
+        dataDir: findDirByToken(files, 'espeak-ng-data'),
+        lexicon: findFileEndingWith(files, 'lexicon.txt'),
+      };
+    case 'pocket':
+      return {
+        lmFlow: findOnnxByTokens(files, ['lm_flow', 'lm-flow', 'flow']),
+        lmMain: findOnnxByTokens(files, ['lm_main', 'lm-main', 'main']),
+        encoder: findOnnxByTokens(files, ['encoder']),
+        decoder: findOnnxByTokens(files, ['decoder']),
+        textConditioner: findOnnxByTokens(files, [
+          'text_conditioner',
+          'text-conditioner',
+          'conditioner',
+        ]),
+        vocabJson: findFileEndingWith(files, 'vocab.json'),
+        tokenScoresJson: findFileEndingWith(files, 'token_scores.json'),
+      };
+    case 'zipvoice':
+      return {
+        encoder: findOnnxByTokens(files, ['encoder']),
+        decoder: findOnnxByTokens(files, ['decoder']),
+        vocoder: findOnnxByTokens(files, ['vocoder', 'vocos']),
+        tokens,
+        dataDir: findDirByToken(files, 'espeak-ng-data'),
+        lexicon: findFileEndingWith(files, 'lexicon.txt'),
+      };
+    case 'supertonic':
+      return {
+        durationPredictor: findOnnxByTokens(files, [
+          'duration',
+          'duration_predictor',
+        ]),
+        textEncoder: findOnnxByTokens(files, ['text_encoder', 'text-encoder']),
+        vectorEstimator: findOnnxByTokens(files, [
+          'vector_estimator',
+          'vector-estimator',
+        ]),
+        vocoder: findOnnxByTokens(files, ['vocoder']),
+        ttsJson: findFileEndingWith(files, 'tts.json'),
+        unicodeIndexer: findFileEndingWith(files, 'unicode_indexer.txt'),
+        voiceStyle: findFileEndingWith(files, 'voice_style.bin'),
+      };
+    default:
+      return {};
+  }
+}
+
+function toFsSource(path: string): FileSource | undefined {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return { kind: 'fs', path: trimmed };
+}
+
+function isConcreteTtsModelType(value: string): value is TTSConcreteModelType {
+  return value !== 'auto';
+}
+
+export async function fillTtsCustomConfigFromModelFolder(
+  modelSource: FileSource,
+  options?: { modelTypeOverride?: TTSConcreteModelType }
+): Promise<FillTtsCustomConfigResult> {
+  const detectResult = await detectTtsModel(modelSource, {
+    modelType: options?.modelTypeOverride,
+  });
+  if (!detectResult.success) {
+    throw new Error(
+      detectResult.error?.trim() || 'Model detection failed for fill helper'
+    );
+  }
+
+  const rawType =
+    options?.modelTypeOverride ??
+    (detectResult.modelType && isConcreteTtsModelType(detectResult.modelType)
+      ? detectResult.modelType
+      : detectResult.detectedModels[0]?.type);
+
+  if (!rawType || !isConcreteTtsModelType(rawType)) {
+    throw new Error('Could not determine a concrete TTS model type for fill');
+  }
+
+  const modelType = rawType;
+  const modelDir = await resolveFileSourceForModelInit(modelSource);
+  const files = await listFilesRecursive(modelDir);
+  const scanned = scanTtsPaths(files, modelType);
+
+  const schema = await getCustomModelPathRequirements('tts', modelType);
+  const customConfig: Partial<Record<TtsCustomPathKey, FileSource>> = {};
+  for (const key of [...schema.required, ...schema.optional]) {
+    const path = scanned[key as TtsCustomPathKey];
+    const source = path ? toFsSource(path) : undefined;
+    if (source) {
+      customConfig[key as TtsCustomPathKey] = source;
+    }
+  }
+
+  const missingKeys = schema.required.filter(
+    (key) => customConfig[key as TtsCustomPathKey] == null
+  );
+
+  return {
+    modelType,
+    customConfig,
+    missingKeys,
+    modelDir,
+  };
+}

--- a/example/src/utils/ttsCustomInitLabels.ts
+++ b/example/src/utils/ttsCustomInitLabels.ts
@@ -1,0 +1,29 @@
+import type { TtsCustomPathKey } from 'react-native-sherpa-onnx/tts';
+
+/** Human-readable labels for TTS custom init path keys (example app UI). */
+export const TTS_CUSTOM_PATH_LABELS: Record<TtsCustomPathKey, string> = {
+  ttsModel: 'TTS model (.onnx)',
+  tokens: 'Tokens (tokens.txt)',
+  lexicon: 'Lexicon (lexicon.txt, optional)',
+  dataDir: 'espeak-ng-data directory',
+  voices: 'Voices file (e.g. voices.bin)',
+  acousticModel: 'Acoustic model (.onnx)',
+  vocoder: 'Vocoder (.onnx)',
+  encoder: 'Encoder (.onnx)',
+  decoder: 'Decoder (.onnx)',
+  lmFlow: 'LM flow (.onnx)',
+  lmMain: 'LM main (.onnx)',
+  textConditioner: 'Text conditioner (.onnx)',
+  vocabJson: 'Vocab JSON',
+  tokenScoresJson: 'Token scores JSON',
+  durationPredictor: 'Duration predictor (.onnx)',
+  textEncoder: 'Text encoder (.onnx)',
+  vectorEstimator: 'Vector estimator (.onnx)',
+  ttsJson: 'TTS config JSON',
+  unicodeIndexer: 'Unicode indexer',
+  voiceStyle: 'Voice style file',
+};
+
+export function labelForTtsCustomPathKey(key: TtsCustomPathKey): string {
+  return TTS_CUSTOM_PATH_LABELS[key] ?? key;
+}

--- a/example/src/utils/vadCustomInitFill.ts
+++ b/example/src/utils/vadCustomInitFill.ts
@@ -1,6 +1,7 @@
 import { exists, readDir } from '@dr.pogodin/react-native-fs';
 import {
   getCustomModelPathRequirements,
+  requiredCustomModelPathFieldKeys,
   resolveFileSourceForModelInit,
 } from 'react-native-sherpa-onnx/detect';
 import {
@@ -108,14 +109,14 @@ export async function fillVadCustomConfigFromModelFolder(
 
   const schema = await getCustomModelPathRequirements('vad', modelType);
   const customConfig: Partial<Record<VadCustomPathKey, FileSource>> = {};
-  for (const key of [...schema.required, ...schema.optional]) {
-    const source = key === 'model' ? toFsSource(modelPath) : undefined;
+  for (const field of schema.fields) {
+    const source = field.key === 'model' ? toFsSource(modelPath) : undefined;
     if (source) {
-      customConfig[key as VadCustomPathKey] = source;
+      customConfig[field.key as VadCustomPathKey] = source;
     }
   }
 
-  const missingKeys = schema.required.filter(
+  const missingKeys = requiredCustomModelPathFieldKeys(schema).filter(
     (key) => customConfig[key as VadCustomPathKey] == null
   );
 

--- a/example/src/utils/vadCustomInitFill.ts
+++ b/example/src/utils/vadCustomInitFill.ts
@@ -1,0 +1,128 @@
+import { exists, readDir } from '@dr.pogodin/react-native-fs';
+import {
+  getCustomModelPathRequirements,
+  resolveFileSourceForModelInit,
+} from 'react-native-sherpa-onnx/detect';
+import {
+  detectVadModel,
+  type VADConcreteModelType,
+  type VadCustomPathKey,
+} from 'react-native-sherpa-onnx/vad';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+
+export type FillVadCustomConfigResult = {
+  modelType: VADConcreteModelType;
+  customConfig: Partial<Record<VadCustomPathKey, FileSource>>;
+  missingKeys: readonly string[];
+  modelDir: string;
+};
+
+function basename(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1] ?? path;
+}
+
+async function listFilesRecursive(dir: string): Promise<string[]> {
+  if (!(await exists(dir))) {
+    return [];
+  }
+  const entries = await readDir(dir);
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      files.push(...(await listFilesRecursive(entry.path)));
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(entry.path);
+    }
+  }
+  return files;
+}
+
+function findOnnxByTokens(files: string[], tokens: string[]): string {
+  const onnxFiles = files.filter((file) =>
+    file.toLowerCase().endsWith('.onnx')
+  );
+  const matches = onnxFiles.filter((file) => {
+    const lower = basename(file).toLowerCase();
+    return tokens.some((token) => lower.includes(token.toLowerCase()));
+  });
+  return matches[0] ?? '';
+}
+
+function scanVadModelPath(
+  files: string[],
+  modelType: VADConcreteModelType
+): string {
+  const tokens =
+    modelType === 'ten_vad'
+      ? ['ten', 'ten-vad', 'ten_vad']
+      : ['silero', 'silero_vad', 'silero-vad', 'vad'];
+  return (
+    findOnnxByTokens(files, tokens) ||
+    files.find((file) => file.toLowerCase().endsWith('.onnx')) ||
+    ''
+  );
+}
+
+function toFsSource(path: string): FileSource | undefined {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return { kind: 'fs', path: trimmed };
+}
+
+function isConcreteVadModelType(value: string): value is VADConcreteModelType {
+  return value === 'silero_vad' || value === 'ten_vad';
+}
+
+export async function fillVadCustomConfigFromModelFolder(
+  modelSource: FileSource,
+  options?: { modelTypeOverride?: VADConcreteModelType }
+): Promise<FillVadCustomConfigResult> {
+  const detectResult = await detectVadModel(modelSource, {
+    modelType: options?.modelTypeOverride ?? 'auto',
+  });
+  if (!detectResult.success) {
+    throw new Error(
+      detectResult.error?.trim() || 'Model detection failed for fill helper'
+    );
+  }
+
+  const rawType =
+    options?.modelTypeOverride ??
+    (detectResult.modelType && isConcreteVadModelType(detectResult.modelType)
+      ? detectResult.modelType
+      : detectResult.detectedModels[0]?.type);
+
+  if (!rawType || !isConcreteVadModelType(rawType)) {
+    throw new Error('Could not determine a concrete VAD model type for fill');
+  }
+
+  const modelType = rawType;
+  const modelDir = await resolveFileSourceForModelInit(modelSource);
+  const files = await listFilesRecursive(modelDir);
+  const modelPath = scanVadModelPath(files, modelType);
+
+  const schema = await getCustomModelPathRequirements('vad', modelType);
+  const customConfig: Partial<Record<VadCustomPathKey, FileSource>> = {};
+  for (const key of [...schema.required, ...schema.optional]) {
+    const source = key === 'model' ? toFsSource(modelPath) : undefined;
+    if (source) {
+      customConfig[key as VadCustomPathKey] = source;
+    }
+  }
+
+  const missingKeys = schema.required.filter(
+    (key) => customConfig[key as VadCustomPathKey] == null
+  );
+
+  return {
+    modelType,
+    customConfig,
+    missingKeys,
+    modelDir,
+  };
+}

--- a/example/src/utils/vadCustomInitLabels.ts
+++ b/example/src/utils/vadCustomInitLabels.ts
@@ -1,0 +1,10 @@
+import type { VadCustomPathKey } from 'react-native-sherpa-onnx/vad';
+
+/** Human-readable labels for VAD custom init path keys (example app UI). */
+export const VAD_CUSTOM_PATH_LABELS: Record<VadCustomPathKey, string> = {
+  model: 'VAD model (.onnx)',
+};
+
+export function labelForVadCustomPathKey(key: VadCustomPathKey): string {
+  return VAD_CUSTOM_PATH_LABELS[key] ?? key;
+}

--- a/ios/detect/bridge/SherpaOnnx+ModelDetect.mm
+++ b/ios/detect/bridge/SherpaOnnx+ModelDetect.mm
@@ -1,8 +1,11 @@
 #import "../../SherpaOnnx.h"
 
 #include "../native/sherpa-onnx-unified-detect-bridge.h"
+#include "../native/sherpa-onnx-validate-custom-bridge.h"
 #include "sherpa-onnx-model-detect-unified.h"
+#include "sherpa-onnx-validate-custom.h"
 
+#include <map>
 #include <optional>
 #include <string>
 #include <vector>
@@ -30,6 +33,20 @@ std::vector<sherpaonnx::UnifiedModelDetectInput> InputsFromNSArray(NSArray *inpu
         input.model_dir = OptionalUtf8String(entry[@"modelDir"]);
         input.asset_name = OptionalUtf8String(entry[@"assetName"]);
         out.push_back(std::move(input));
+    }
+    return out;
+}
+
+std::map<std::string, std::string> StringMapFromNSDictionary(NSDictionary *dict) {
+    std::map<std::string, std::string> out;
+    if (![dict isKindOfClass:[NSDictionary class]]) {
+        return out;
+    }
+    for (NSString *key in dict) {
+        id value = dict[key];
+        if ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) {
+            out[std::string([key UTF8String])] = std::string([(NSString *)value UTF8String]);
+        }
     }
     return out;
 }
@@ -70,6 +87,54 @@ std::vector<sherpaonnx::UnifiedModelDetectInput> InputsFromNSArray(NSArray *inpu
     } @catch (NSException *exception) {
         reject(@"DETECT_ERROR",
                [NSString stringWithFormat:@"Unified batch model detect failed: %@", exception.reason],
+               nil);
+    }
+}
+
+- (void)validateCustomModelPaths:(NSString *)category
+                       modelType:(NSString *)modelType
+                           paths:(NSDictionary *)paths
+                         resolve:(RCTPromiseResolveBlock)resolve
+                          reject:(RCTPromiseRejectBlock)reject
+{
+    @try {
+        if (category == nil || [category length] == 0 ||
+            modelType == nil || [modelType length] == 0) {
+            reject(@"VALIDATE_ERROR", @"category and modelType are required", nil);
+            return;
+        }
+        auto pathMap = StringMapFromNSDictionary(paths);
+        auto result = sherpaonnx::ValidateCustomModelPaths(
+            std::string([category UTF8String]),
+            std::string([modelType UTF8String]),
+            pathMap,
+            "custom");
+        resolve(sherpaonnx::detect::bridge::CustomValidationResultToDict(result));
+    } @catch (NSException *exception) {
+        reject(@"VALIDATE_ERROR",
+               [NSString stringWithFormat:@"Custom model path validation failed: %@", exception.reason],
+               nil);
+    }
+}
+
+- (void)getCustomModelPathRequirements:(NSString *)category
+                             modelType:(NSString *)modelType
+                               resolve:(RCTPromiseResolveBlock)resolve
+                                reject:(RCTPromiseRejectBlock)reject
+{
+    @try {
+        if (category == nil || [category length] == 0 ||
+            modelType == nil || [modelType length] == 0) {
+            reject(@"VALIDATE_ERROR", @"category and modelType are required", nil);
+            return;
+        }
+        auto requirements = sherpaonnx::GetCustomModelPathRequirements(
+            std::string([category UTF8String]),
+            std::string([modelType UTF8String]));
+        resolve(sherpaonnx::detect::bridge::CustomPathRequirementsToDict(requirements));
+    } @catch (NSException *exception) {
+        reject(@"VALIDATE_ERROR",
+               [NSString stringWithFormat:@"Custom model path requirements failed: %@", exception.reason],
                nil);
     }
 }

--- a/ios/detect/native/sherpa-onnx-unified-detect-bridge.mm
+++ b/ios/detect/native/sherpa-onnx-unified-detect-bridge.mm
@@ -57,6 +57,20 @@ NSDictionary *UnifiedDetectResultToDict(const UnifiedModelDetectResult &result) 
         dict[@"detectionSources"] = sources;
     }
 
+    if (!result.paths.empty()) {
+        NSMutableDictionary *paths = [NSMutableDictionary dictionary];
+        for (const auto &entry : result.paths) {
+            if (entry.second.empty()) {
+                continue;
+            }
+            paths[[NSString stringWithUTF8String:entry.first.c_str()] ?: @""] =
+                [NSString stringWithUTF8String:entry.second.c_str()] ?: @"";
+        }
+        if (paths.count > 0) {
+            dict[@"paths"] = paths;
+        }
+    }
+
     return dict;
 }
 

--- a/ios/detect/native/sherpa-onnx-validate-custom-bridge.h
+++ b/ios/detect/native/sherpa-onnx-validate-custom-bridge.h
@@ -1,0 +1,19 @@
+#ifndef SHERPA_ONNX_VALIDATE_CUSTOM_BRIDGE_H
+#define SHERPA_ONNX_VALIDATE_CUSTOM_BRIDGE_H
+
+#import <Foundation/Foundation.h>
+
+#include "sherpa-onnx-validate-custom-types.h"
+
+namespace sherpaonnx {
+namespace detect {
+namespace bridge {
+
+NSDictionary *CustomValidationResultToDict(const CustomModelValidationResult &result);
+NSDictionary *CustomPathRequirementsToDict(const CustomModelPathRequirements &requirements);
+
+}  // namespace bridge
+}  // namespace detect
+}  // namespace sherpaonnx
+
+#endif  // SHERPA_ONNX_VALIDATE_CUSTOM_BRIDGE_H

--- a/ios/detect/native/sherpa-onnx-validate-custom-bridge.mm
+++ b/ios/detect/native/sherpa-onnx-validate-custom-bridge.mm
@@ -1,0 +1,44 @@
+#import "sherpa-onnx-validate-custom-bridge.h"
+
+namespace sherpaonnx {
+namespace detect {
+namespace bridge {
+
+NSDictionary *CustomValidationResultToDict(const CustomModelValidationResult &result) {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    dict[@"ok"] = @(result.ok);
+    if (!result.error.empty()) {
+        dict[@"error"] = [NSString stringWithUTF8String:result.error.c_str()];
+    }
+    if (!result.missingRequired.empty()) {
+        NSMutableArray *missing = [NSMutableArray arrayWithCapacity:result.missingRequired.size()];
+        for (const auto &entry : result.missingRequired) {
+            [missing addObject:[NSString stringWithUTF8String:entry.c_str()]];
+        }
+        dict[@"missingRequired"] = missing;
+    }
+    return dict;
+}
+
+NSDictionary *CustomPathRequirementsToDict(const CustomModelPathRequirements &requirements) {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    if (!requirements.required.empty()) {
+        NSMutableArray *required = [NSMutableArray arrayWithCapacity:requirements.required.size()];
+        for (const auto &entry : requirements.required) {
+            [required addObject:[NSString stringWithUTF8String:entry.c_str()]];
+        }
+        dict[@"required"] = required;
+    }
+    if (!requirements.optional.empty()) {
+        NSMutableArray *optional = [NSMutableArray arrayWithCapacity:requirements.optional.size()];
+        for (const auto &entry : requirements.optional) {
+            [optional addObject:[NSString stringWithUTF8String:entry.c_str()]];
+        }
+        dict[@"optional"] = optional;
+    }
+    return dict;
+}
+
+}  // namespace bridge
+}  // namespace detect
+}  // namespace sherpaonnx

--- a/ios/detect/native/sherpa-onnx-validate-custom-bridge.mm
+++ b/ios/detect/native/sherpa-onnx-validate-custom-bridge.mm
@@ -22,19 +22,16 @@ NSDictionary *CustomValidationResultToDict(const CustomModelValidationResult &re
 
 NSDictionary *CustomPathRequirementsToDict(const CustomModelPathRequirements &requirements) {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-    if (!requirements.required.empty()) {
-        NSMutableArray *required = [NSMutableArray arrayWithCapacity:requirements.required.size()];
-        for (const auto &entry : requirements.required) {
-            [required addObject:[NSString stringWithUTF8String:entry.c_str()]];
+    if (!requirements.fields.empty()) {
+        NSMutableArray *fields = [NSMutableArray arrayWithCapacity:requirements.fields.size()];
+        for (const auto &field : requirements.fields) {
+            NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+            entry[@"key"] = [NSString stringWithUTF8String:field.key.c_str()];
+            entry[@"required"] = @(field.required);
+            entry[@"kind"] = field.isDirectory ? @"dir" : @"file";
+            [fields addObject:entry];
         }
-        dict[@"required"] = required;
-    }
-    if (!requirements.optional.empty()) {
-        NSMutableArray *optional = [NSMutableArray arrayWithCapacity:requirements.optional.size()];
-        for (const auto &entry : requirements.optional) {
-            [optional addObject:[NSString stringWithUTF8String:entry.c_str()]];
-        }
-        dict[@"optional"] = optional;
+        dict[@"fields"] = fields;
     }
     return dict;
 }

--- a/ios/enhancement/bridge/SherpaOnnx+EnhancementDetect.mm
+++ b/ios/enhancement/bridge/SherpaOnnx+EnhancementDetect.mm
@@ -4,6 +4,11 @@
 #include "../core/EnhancementBridgeState.h"
 #include "../core/EnhancementBridgeUtils.h"
 
+#include "sherpa-onnx-model-path-fill.h"
+#include "sherpa-onnx-validate-enhancement.h"
+
+#include <map>
+#include <mutex>
 #include <optional>
 #include <string>
 
@@ -14,6 +19,41 @@ std::optional<std::string> OptionalUtf8String(NSString *value) {
     return std::nullopt;
   }
   return std::string([value UTF8String]);
+}
+
+void FillEnhancementModelPathsFromDict(
+    NSDictionary *dict,
+    sherpaonnx::EnhancementModelPaths &paths
+) {
+  if (![dict isKindOfClass:[NSDictionary class]]) {
+    return;
+  }
+  std::map<std::string, std::string> pathMap;
+  for (NSString *key in dict) {
+    id value = dict[key];
+    if ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) {
+      pathMap[std::string([key UTF8String])] = std::string([(NSString *)value UTF8String]);
+    }
+  }
+  sherpaonnx::FillEnhancementModelPathsFromStringMap(pathMap, paths);
+}
+
+struct EnhancementInitScalars {
+  int32_t numThreads = 1;
+  bool debug = false;
+  std::optional<std::string> provider;
+};
+
+EnhancementInitScalars ParseEnhancementInitScalars(NSDictionary *options) {
+  EnhancementInitScalars scalars;
+  if ([options[@"numThreads"] respondsToSelector:@selector(intValue)]) {
+    scalars.numThreads = MAX(1, [options[@"numThreads"] intValue]);
+  }
+  if ([options[@"debug"] respondsToSelector:@selector(boolValue)]) {
+    scalars.debug = [options[@"debug"] boolValue];
+  }
+  scalars.provider = OptionalUtf8String(options[@"provider"]);
+  return scalars;
 }
 
 }  // namespace
@@ -41,29 +81,22 @@ std::optional<std::string> OptionalUtf8String(NSString *value) {
 }
 
 - (void)initializeEnhancement:(NSString *)instanceId
-                     modelDir:(NSString *)modelDir
-                    modelType:(NSString *)modelType
-                   numThreads:(NSNumber *)numThreads
-                     provider:(NSString *)provider
-                        debug:(NSNumber *)debug
-                      resolve:(RCTPromiseResolveBlock)resolve
-                       reject:(RCTPromiseRejectBlock)reject
+                    options:(NSDictionary *)options
+                    resolve:(RCTPromiseResolveBlock)resolve
+                     reject:(RCTPromiseRejectBlock)reject
 {
   if (instanceId == nil || [instanceId length] == 0) {
     reject(@"ENHANCEMENT_INIT_ERROR", @"instanceId is required", nil);
     return;
   }
-  if (modelDir == nil || [modelDir length] == 0) {
-    reject(@"ENHANCEMENT_INIT_ERROR", @"modelDir is required", nil);
-    return;
-  }
 
-  std::string instanceIdStr = [instanceId UTF8String];
-  std::string modelDirStr = [modelDir UTF8String];
-  std::string modelTypeStr = sherpaonnx::enhancement::bridge::ModelTypeOrAuto(modelType);
-  int32_t numThreadsVal = numThreads != nil ? [numThreads intValue] : 1;
-  bool debugVal = debug != nil && [debug boolValue];
-  std::optional<std::string> providerOpt = OptionalUtf8String(provider);
+  NSString *initMode = options[@"initMode"];
+  if (initMode == nil || [initMode length] == 0) {
+    initMode = @"auto";
+  }
+  const bool isCustomInit = [initMode isEqualToString:@"custom"];
+  const std::string instanceIdStr = [instanceId UTF8String];
+  const EnhancementInitScalars scalars = ParseEnhancementInitScalars(options);
 
   @try {
     std::lock_guard<std::mutex> lock(sherpaonnx::enhancement::bridge::g_enhancement_mutex);
@@ -78,12 +111,44 @@ std::optional<std::string> OptionalUtf8String(NSString *value) {
       inst->wrapper = std::make_unique<sherpaonnx::EnhancementWrapper>();
     }
 
-    auto result = inst->wrapper->initialize(
-        modelDirStr,
-        modelTypeStr,
-        numThreadsVal,
-        providerOpt,
-        debugVal);
+    sherpaonnx::EnhancementInitializeResult result;
+    if (isCustomInit) {
+      NSString *modelType = options[@"modelType"];
+      if (modelType == nil || [modelType length] == 0 || [modelType isEqualToString:@"auto"]) {
+        reject(@"ENHANCEMENT_INIT_ERROR", @"modelType is required for initMode custom", nil);
+        return;
+      }
+      id pathsRaw = options[@"modelPaths"];
+      NSDictionary *pathsDict =
+          [pathsRaw isKindOfClass:[NSDictionary class]] ? (NSDictionary *)pathsRaw : nil;
+      if (pathsDict == nil || pathsDict.count == 0) {
+        reject(@"ENHANCEMENT_INIT_ERROR", @"modelPaths is required for initMode custom", nil);
+        return;
+      }
+
+      sherpaonnx::EnhancementModelPaths paths;
+      FillEnhancementModelPathsFromDict(pathsDict, paths);
+      result = inst->wrapper->initializeCustom(
+          std::string([modelType UTF8String]),
+          paths,
+          scalars.numThreads,
+          scalars.provider,
+          scalars.debug);
+    } else {
+      NSString *modelDir = options[@"modelDir"];
+      if (modelDir == nil || [modelDir length] == 0) {
+        reject(@"ENHANCEMENT_INIT_ERROR", @"modelDir is required for initMode auto", nil);
+        return;
+      }
+      NSString *modelType = options[@"modelType"];
+      std::string modelTypeStr = sherpaonnx::enhancement::bridge::ModelTypeOrAuto(modelType);
+      result = inst->wrapper->initialize(
+          std::string([modelDir UTF8String]),
+          modelTypeStr,
+          scalars.numThreads,
+          scalars.provider,
+          scalars.debug);
+    }
 
     if (!result.success) {
       NSString *errorMsg = result.error.empty()
@@ -115,11 +180,7 @@ std::optional<std::string> OptionalUtf8String(NSString *value) {
 }
 
 - (void)initializeOnlineEnhancement:(NSString *)instanceId
-                           modelDir:(NSString *)modelDir
-                          modelType:(NSString *)modelType
-                         numThreads:(NSNumber *)numThreads
-                           provider:(NSString *)provider
-                              debug:(NSNumber *)debug
+                            options:(NSDictionary *)options
                             resolve:(RCTPromiseResolveBlock)resolve
                              reject:(RCTPromiseRejectBlock)reject
 {
@@ -127,17 +188,14 @@ std::optional<std::string> OptionalUtf8String(NSString *value) {
     reject(@"ONLINE_ENHANCEMENT_INIT_ERROR", @"instanceId is required", nil);
     return;
   }
-  if (modelDir == nil || [modelDir length] == 0) {
-    reject(@"ONLINE_ENHANCEMENT_INIT_ERROR", @"modelDir is required", nil);
-    return;
-  }
 
-  std::string instanceIdStr = [instanceId UTF8String];
-  std::string modelDirStr = [modelDir UTF8String];
-  std::string modelTypeStr = sherpaonnx::enhancement::bridge::ModelTypeOrAuto(modelType);
-  int32_t numThreadsVal = numThreads != nil ? [numThreads intValue] : 1;
-  bool debugVal = debug != nil && [debug boolValue];
-  std::optional<std::string> providerOpt = OptionalUtf8String(provider);
+  NSString *initMode = options[@"initMode"];
+  if (initMode == nil || [initMode length] == 0) {
+    initMode = @"auto";
+  }
+  const bool isCustomInit = [initMode isEqualToString:@"custom"];
+  const std::string instanceIdStr = [instanceId UTF8String];
+  const EnhancementInitScalars scalars = ParseEnhancementInitScalars(options);
 
   @try {
     std::lock_guard<std::mutex> lock(sherpaonnx::enhancement::bridge::g_enhancement_mutex);
@@ -152,12 +210,44 @@ std::optional<std::string> OptionalUtf8String(NSString *value) {
       inst->wrapper = std::make_shared<sherpaonnx::OnlineEnhancementWrapper>();
     }
 
-    auto result = inst->wrapper->initialize(
-        modelDirStr,
-        modelTypeStr,
-        numThreadsVal,
-        providerOpt,
-        debugVal);
+    sherpaonnx::EnhancementInitializeResult result;
+    if (isCustomInit) {
+      NSString *modelType = options[@"modelType"];
+      if (modelType == nil || [modelType length] == 0 || [modelType isEqualToString:@"auto"]) {
+        reject(@"ONLINE_ENHANCEMENT_INIT_ERROR", @"modelType is required for initMode custom", nil);
+        return;
+      }
+      id pathsRaw = options[@"modelPaths"];
+      NSDictionary *pathsDict =
+          [pathsRaw isKindOfClass:[NSDictionary class]] ? (NSDictionary *)pathsRaw : nil;
+      if (pathsDict == nil || pathsDict.count == 0) {
+        reject(@"ONLINE_ENHANCEMENT_INIT_ERROR", @"modelPaths is required for initMode custom", nil);
+        return;
+      }
+
+      sherpaonnx::EnhancementModelPaths paths;
+      FillEnhancementModelPathsFromDict(pathsDict, paths);
+      result = inst->wrapper->initializeCustom(
+          std::string([modelType UTF8String]),
+          paths,
+          scalars.numThreads,
+          scalars.provider,
+          scalars.debug);
+    } else {
+      NSString *modelDir = options[@"modelDir"];
+      if (modelDir == nil || [modelDir length] == 0) {
+        reject(@"ONLINE_ENHANCEMENT_INIT_ERROR", @"modelDir is required for initMode auto", nil);
+        return;
+      }
+      NSString *modelType = options[@"modelType"];
+      std::string modelTypeStr = sherpaonnx::enhancement::bridge::ModelTypeOrAuto(modelType);
+      result = inst->wrapper->initialize(
+          std::string([modelDir UTF8String]),
+          modelTypeStr,
+          scalars.numThreads,
+          scalars.provider,
+          scalars.debug);
+    }
 
     if (!result.success) {
       NSString *errorMsg = result.error.empty()

--- a/ios/enhancement/sherpa-onnx-enhancement-wrapper.h
+++ b/ios/enhancement/sherpa-onnx-enhancement-wrapper.h
@@ -38,6 +38,14 @@ public:
         bool debug = false
     );
 
+    EnhancementInitializeResult initializeCustom(
+        const std::string& modelType,
+        const EnhancementModelPaths& paths,
+        int32_t numThreads = 1,
+        const std::optional<std::string>& provider = std::nullopt,
+        bool debug = false
+    );
+
     EnhancedAudioResult runSamples(const std::vector<float>& samples, int32_t sampleRate);
 
     int32_t getSampleRate() const;
@@ -59,6 +67,14 @@ public:
     EnhancementInitializeResult initialize(
         const std::string& modelDir,
         const std::string& modelType = "auto",
+        int32_t numThreads = 1,
+        const std::optional<std::string>& provider = std::nullopt,
+        bool debug = false
+    );
+
+    EnhancementInitializeResult initializeCustom(
+        const std::string& modelType,
+        const EnhancementModelPaths& paths,
         int32_t numThreads = 1,
         const std::optional<std::string>& provider = std::nullopt,
         bool debug = false

--- a/ios/enhancement/sherpa-onnx-enhancement-wrapper.mm
+++ b/ios/enhancement/sherpa-onnx-enhancement-wrapper.mm
@@ -1,6 +1,7 @@
 #include "sherpa-onnx-enhancement-wrapper.h"
 
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-validate-enhancement.h"
 
 #include <optional>
 
@@ -18,6 +19,38 @@ std::string EnhancementKindToString(EnhancementModelKind kind) {
         default:
             return "unknown";
     }
+}
+
+EnhancementModelKind ParseEnhancementModelTypeFromString(const std::string& modelType) {
+    if (modelType == "gtcrn") return EnhancementModelKind::kGtcrn;
+    if (modelType == "dpdfnet") return EnhancementModelKind::kDpdfNet;
+    return EnhancementModelKind::kUnknown;
+}
+
+sherpa_onnx::cxx::OfflineSpeechDenoiserModelConfig BuildModelConfigFromPaths(
+    EnhancementModelKind kind,
+    const EnhancementModelPaths& paths,
+    int32_t numThreads,
+    const std::optional<std::string>& provider,
+    bool debug
+) {
+    sherpa_onnx::cxx::OfflineSpeechDenoiserModelConfig cfg;
+    cfg.num_threads = numThreads;
+    cfg.debug = debug;
+    if (provider.has_value() && !provider->empty()) {
+        cfg.provider = *provider;
+    }
+    switch (kind) {
+        case EnhancementModelKind::kGtcrn:
+            cfg.gtcrn.model = paths.model;
+            break;
+        case EnhancementModelKind::kDpdfNet:
+            cfg.dpdfnet.model = paths.model;
+            break;
+        default:
+            break;
+    }
+    return cfg;
 }
 
 sherpa_onnx::cxx::OfflineSpeechDenoiserModelConfig BuildModelConfig(
@@ -104,6 +137,43 @@ EnhancementInitializeResult EnhancementWrapper::initialize(
     return result;
 }
 
+EnhancementInitializeResult EnhancementWrapper::initializeCustom(
+    const std::string& modelType,
+    const EnhancementModelPaths& paths,
+    int32_t numThreads,
+    const std::optional<std::string>& provider,
+    bool debug
+) {
+    EnhancementInitializeResult result;
+    if (pImpl->initialized) {
+        release();
+    }
+
+    const EnhancementModelKind selectedKind = ParseEnhancementModelTypeFromString(modelType);
+    if (selectedKind == EnhancementModelKind::kUnknown) {
+        result.error = "Unsupported custom enhancement model type";
+        return result;
+    }
+
+    auto validation = ValidateEnhancementPaths(selectedKind, paths, "custom");
+    if (!validation.ok) {
+        result.error = validation.error;
+        return result;
+    }
+
+    result.modelType = EnhancementKindToString(selectedKind);
+    result.detectedModels.push_back({result.modelType, "custom"});
+
+    sherpa_onnx::cxx::OfflineSpeechDenoiserConfig config;
+    config.model = BuildModelConfigFromPaths(selectedKind, paths, numThreads, provider, debug);
+    pImpl->denoiser = sherpa_onnx::cxx::OfflineSpeechDenoiser::Create(config);
+    pImpl->initialized = true;
+
+    result.success = true;
+    result.sampleRate = pImpl->denoiser->GetSampleRate();
+    return result;
+}
+
 EnhancedAudioResult EnhancementWrapper::runSamples(
     const std::vector<float>& samples,
     int32_t sampleRate
@@ -171,6 +241,44 @@ EnhancementInitializeResult OnlineEnhancementWrapper::initialize(
 
     sherpa_onnx::cxx::OnlineSpeechDenoiserConfig config;
     config.model = BuildModelConfig(detect, numThreads, provider, debug);
+    pImpl->denoiser = sherpa_onnx::cxx::OnlineSpeechDenoiser::Create(config);
+    pImpl->initialized = true;
+
+    result.success = true;
+    result.sampleRate = pImpl->denoiser->GetSampleRate();
+    result.frameShiftInSamples = pImpl->denoiser->GetFrameShiftInSamples();
+    return result;
+}
+
+EnhancementInitializeResult OnlineEnhancementWrapper::initializeCustom(
+    const std::string& modelType,
+    const EnhancementModelPaths& paths,
+    int32_t numThreads,
+    const std::optional<std::string>& provider,
+    bool debug
+) {
+    EnhancementInitializeResult result;
+    if (pImpl->initialized) {
+        release();
+    }
+
+    const EnhancementModelKind selectedKind = ParseEnhancementModelTypeFromString(modelType);
+    if (selectedKind == EnhancementModelKind::kUnknown) {
+        result.error = "Unsupported custom enhancement model type";
+        return result;
+    }
+
+    auto validation = ValidateEnhancementPaths(selectedKind, paths, "custom");
+    if (!validation.ok) {
+        result.error = validation.error;
+        return result;
+    }
+
+    result.modelType = EnhancementKindToString(selectedKind);
+    result.detectedModels.push_back({result.modelType, "custom"});
+
+    sherpa_onnx::cxx::OnlineSpeechDenoiserConfig config;
+    config.model = BuildModelConfigFromPaths(selectedKind, paths, numThreads, provider, debug);
     pImpl->denoiser = sherpa_onnx::cxx::OnlineSpeechDenoiser::Create(config);
     pImpl->initialized = true;
 

--- a/ios/punctuation/bridge/SherpaOnnx+OfflinePunctuation.mm
+++ b/ios/punctuation/bridge/SherpaOnnx+OfflinePunctuation.mm
@@ -1,6 +1,8 @@
 #import "../../SherpaOnnx.h"
 
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-model-path-fill.h"
+#include "sherpa-onnx-validate-punctuation.h"
 #include "sherpa-onnx/c-api/cxx-api.h"
 #include "../../pipeline/bridge/SherpaOnnx+StreamingPipelineCompletion.h"
 #include "../../pipeline/core/SherpaOnnx+StreamingPipeline.h"
@@ -16,6 +18,7 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <vector>
 
 namespace {
 
@@ -30,6 +33,43 @@ static NSString *kTxtNotFound = @"TEXT_BUFFER_NOT_FOUND";
 static NSString *kTxtKind = @"TEXT_BUFFER_KIND_MISMATCH";
 static NSString *kTxtEmpty = @"TEXT_BUFFER_EMPTY";
 static NSString *kTxtPop = @"TEXT_ALREADY_POPULATED";
+
+static void FillPunctuationModelPathsFromDict(
+    NSDictionary *dict,
+    sherpaonnx::PunctuationModelPaths &paths) {
+  if (![dict isKindOfClass:[NSDictionary class]]) {
+    return;
+  }
+  std::map<std::string, std::string> pathMap;
+  for (NSString *key in dict) {
+    id value = dict[key];
+    if ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) {
+      pathMap[std::string([key UTF8String])] = std::string([(NSString *)value UTF8String]);
+    }
+  }
+  sherpaonnx::FillPunctuationModelPathsFromStringMap(pathMap, paths);
+}
+
+struct PunctuationInitScalars {
+  int32_t numThreads = 1;
+  bool debug = false;
+  std::string provider = "cpu";
+};
+
+static PunctuationInitScalars ParsePunctuationInitScalars(NSDictionary *options) {
+  PunctuationInitScalars scalars;
+  if ([options[@"numThreads"] respondsToSelector:@selector(intValue)]) {
+    scalars.numThreads = MAX(1, [options[@"numThreads"] intValue]);
+  }
+  if ([options[@"debug"] respondsToSelector:@selector(boolValue)]) {
+    scalars.debug = [options[@"debug"] boolValue];
+  }
+  NSString *provider = options[@"provider"];
+  if (provider != nil && provider.length > 0) {
+    scalars.provider = std::string([provider UTF8String]);
+  }
+  return scalars;
+}
 
 }  // namespace
 
@@ -68,71 +108,125 @@ extern "C" bool sherpaonnx_punct_offline_has_instance(
 @implementation SherpaOnnx (OfflinePunctuation)
 
 - (void)initializeOfflinePunctuation:(NSString *)instanceId
-                            modelDir:(NSString *)modelDir
-                           modelType:(NSString * _Nullable)modelType
-                          numThreads:(NSNumber *)numThreads
-                            provider:(NSString *)provider
-                               debug:(NSNumber *)debug
-                             resolve:(RCTPromiseResolveBlock)resolve
-                              reject:(RCTPromiseRejectBlock)reject
+                            options:(NSDictionary *)options
+                            resolve:(RCTPromiseResolveBlock)resolve
+                             reject:(RCTPromiseRejectBlock)reject
 {
   if (instanceId == nil || [instanceId length] == 0) {
     reject(kInitErr, @"instanceId is required", nil);
     return;
   }
-  if (modelDir == nil || [modelDir length] == 0) {
-    reject(kInitErr, @"modelDir is required", nil);
+  if (options == nil) {
+    reject(kInitErr, @"options is required", nil);
     return;
   }
-  if (modelType != nil) {
-    NSString *trimmed =
-        [modelType stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    NSString *req = [trimmed lowercaseString];
-    if (!([req isEqualToString:@"auto"] || [req isEqualToString:@"ct_transformer"])) {
-      reject(kInitErr,
-             [NSString stringWithFormat:@"Unsupported modelType for offline engine: %@", modelType],
-             nil);
-      return;
-    }
+
+  NSString *initMode = options[@"initMode"];
+  if (initMode == nil || [initMode length] == 0) {
+    initMode = @"auto";
   }
+  const bool isCustomInit = [initMode isEqualToString:@"custom"];
   std::string idStr = [instanceId UTF8String];
-  std::string dirStr = [modelDir UTF8String];
+  const PunctuationInitScalars scalars = ParsePunctuationInitScalars(options);
 
   @try {
-    auto det = sherpaonnx::DetectPunctuationModel(
-        std::optional<std::string>(dirStr),
-        std::nullopt,
-        "ct_transformer");
-    if (!det.ok) {
-      NSString *msg = det.error.empty()
-          ? @"Punctuation: model is not a valid offline CT-Transformer layout"
-          : [NSString stringWithUTF8String:det.error.c_str()];
-      reject(kInitErr, msg, nil);
-      return;
+    std::string ctPath;
+    NSMutableArray *models = [NSMutableArray array];
+
+    if (isCustomInit) {
+      NSString *modelType = options[@"modelType"];
+      if (modelType == nil || [modelType length] == 0 || [modelType isEqualToString:@"auto"]) {
+        reject(kInitErr, @"modelType is required for initMode custom", nil);
+        return;
+      }
+      NSString *req = [[modelType stringByTrimmingCharactersInSet:
+          [NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+      if (![req isEqualToString:@"ct_transformer"]) {
+        reject(kInitErr,
+               [NSString stringWithFormat:@"Unsupported modelType for offline engine: %@", modelType],
+               nil);
+        return;
+      }
+      id pathsRaw = options[@"modelPaths"];
+      NSDictionary *pathsDict =
+          [pathsRaw isKindOfClass:[NSDictionary class]] ? (NSDictionary *)pathsRaw : nil;
+      if (pathsDict == nil || pathsDict.count == 0) {
+        reject(kInitErr, @"modelPaths is required for initMode custom", nil);
+        return;
+      }
+
+      sherpaonnx::PunctuationModelPaths paths;
+      FillPunctuationModelPathsFromDict(pathsDict, paths);
+      auto validation = sherpaonnx::ValidatePunctuationPaths(
+          sherpaonnx::PunctuationModelKind::kCtTransformer,
+          paths,
+          "custom");
+      if (!validation.ok) {
+        NSString *msg = validation.error.empty()
+            ? @"Punctuation: custom path validation failed"
+            : [NSString stringWithUTF8String:validation.error.c_str()];
+        reject(kInitErr, msg, nil);
+        return;
+      }
+      ctPath = paths.ct_transformer;
+      [models addObject:@{@"type": @"ct_transformer", @"modelDir": @"custom"}];
+    } else {
+      NSString *modelDir = options[@"modelDir"];
+      if (modelDir == nil || [modelDir length] == 0) {
+        reject(kInitErr, @"modelDir is required for initMode auto", nil);
+        return;
+      }
+      NSString *modelType = options[@"modelType"];
+      if (modelType != nil) {
+        NSString *trimmed =
+            [modelType stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        NSString *req = [trimmed lowercaseString];
+        if (!([req isEqualToString:@"auto"] || [req isEqualToString:@"ct_transformer"])) {
+          reject(kInitErr,
+                 [NSString stringWithFormat:@"Unsupported modelType for offline engine: %@", modelType],
+                 nil);
+          return;
+        }
+      }
+      std::string dirStr = [modelDir UTF8String];
+      auto det = sherpaonnx::DetectPunctuationModel(
+          std::optional<std::string>(dirStr),
+          std::nullopt,
+          "ct_transformer");
+      if (!det.ok) {
+        NSString *msg = det.error.empty()
+            ? @"Punctuation: model is not a valid offline CT-Transformer layout"
+            : [NSString stringWithUTF8String:det.error.c_str()];
+        reject(kInitErr, msg, nil);
+        return;
+      }
+      if (det.selectedKind != sherpaonnx::PunctuationModelKind::kCtTransformer) {
+        reject(kInitErr, @"Offline punctuation requires ct_transformer (native detect mismatch)", nil);
+        return;
+      }
+      if (det.paths.ct_transformer.empty()) {
+        reject(kInitErr, @"Punctuation: missing ct_transformer onnx path", nil);
+        return;
+      }
+      ctPath = det.paths.ct_transformer;
+      for (const auto &m : det.detectedModels) {
+        [models addObject:@{
+          @"type": [NSString stringWithUTF8String:m.type.c_str()] ?: @"",
+          @"modelDir": [NSString stringWithUTF8String:m.modelDir.c_str()] ?: @""
+        }];
+      }
     }
-    if (det.selectedKind != sherpaonnx::PunctuationModelKind::kCtTransformer) {
-      reject(kInitErr, @"Offline punctuation requires ct_transformer (native detect mismatch)", nil);
-      return;
-    }
-    if (det.paths.ct_transformer.empty()) {
+
+    if (ctPath.empty()) {
       reject(kInitErr, @"Punctuation: missing ct_transformer onnx path", nil);
       return;
     }
-    int32_t nt = numThreads != nil ? (int32_t)[numThreads intValue] : 1;
-    if (nt < 1) {
-      nt = 1;
-    }
-    bool dbg = debug != nil && [debug boolValue];
-    std::string prov = "cpu";
-    if (provider != nil && [provider length] > 0) {
-      prov = std::string([provider UTF8String]);
-    }
 
     sherpa_onnx::cxx::OfflinePunctuationConfig cfg;
-    cfg.model.ct_transformer = det.paths.ct_transformer;
-    cfg.model.num_threads = nt;
-    cfg.model.debug = dbg;
-    cfg.model.provider = prov;
+    cfg.model.ct_transformer = ctPath;
+    cfg.model.num_threads = scalars.numThreads;
+    cfg.model.debug = scalars.debug;
+    cfg.model.provider = scalars.provider;
 
     auto created = sherpa_onnx::cxx::OfflinePunctuation::Create(cfg);
     {
@@ -141,17 +235,10 @@ extern "C" bool sherpaonnx_punct_offline_has_instance(
       g_punct_offline.emplace(idStr, std::move(created));
     }
 
-    NSMutableArray *models = [NSMutableArray array];
-    for (const auto &m : det.detectedModels) {
-      [models addObject:@ {
-        @"type" : [NSString stringWithUTF8String:m.type.c_str()] ?: @"",
-        @"modelDir" : [NSString stringWithUTF8String:m.modelDir.c_str()] ?: @""
-      }];
-    }
     resolve(@{
-      @"success" : @YES,
-      @"modelType" : @"ct_transformer",
-      @"detectedModels" : models
+      @"success": @YES,
+      @"modelType": @"ct_transformer",
+      @"detectedModels": models,
     });
   } @catch (NSException *exception) {
     reject(kInitErr, [NSString stringWithFormat:@"Offline punctuation init: %@", exception.reason], nil);

--- a/ios/punctuation/bridge/SherpaOnnx+OnlinePunctuation.mm
+++ b/ios/punctuation/bridge/SherpaOnnx+OnlinePunctuation.mm
@@ -1,6 +1,8 @@
 #import "../../SherpaOnnx.h"
 
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-model-path-fill.h"
+#include "sherpa-onnx-validate-punctuation.h"
 #include "sherpa-onnx/c-api/cxx-api.h"
 #include "../../pipeline/core/SherpaOnnx+StreamingPipeline.h"
 #include "../../pipeline/bridge/SherpaOnnx+StreamingPipelineCompletion.h"
@@ -29,6 +31,43 @@ static NSString *kPunctErr = @"PUNCTUATION_ERROR";
 static NSString *kNotFound = @"PUNCTUATION_INSTANCE_NOT_FOUND";
 static NSString *kTxtKind = @"TEXT_BUFFER_KIND_MISMATCH";
 static NSString *kTxtState = @"TEXT_INVALID_STATE";
+
+static void FillPunctuationModelPathsFromDict(
+    NSDictionary *dict,
+    sherpaonnx::PunctuationModelPaths &paths) {
+  if (![dict isKindOfClass:[NSDictionary class]]) {
+    return;
+  }
+  std::map<std::string, std::string> pathMap;
+  for (NSString *key in dict) {
+    id value = dict[key];
+    if ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) {
+      pathMap[std::string([key UTF8String])] = std::string([(NSString *)value UTF8String]);
+    }
+  }
+  sherpaonnx::FillPunctuationModelPathsFromStringMap(pathMap, paths);
+}
+
+struct PunctuationInitScalars {
+  int32_t numThreads = 1;
+  bool debug = false;
+  std::string provider = "cpu";
+};
+
+static PunctuationInitScalars ParsePunctuationInitScalars(NSDictionary *options) {
+  PunctuationInitScalars scalars;
+  if ([options[@"numThreads"] respondsToSelector:@selector(intValue)]) {
+    scalars.numThreads = MAX(1, [options[@"numThreads"] intValue]);
+  }
+  if ([options[@"debug"] respondsToSelector:@selector(boolValue)]) {
+    scalars.debug = [options[@"debug"] boolValue];
+  }
+  NSString *provider = options[@"provider"];
+  if (provider != nil && provider.length > 0) {
+    scalars.provider = std::string([provider UTF8String]);
+  }
+  return scalars;
+}
 
 static std::string punct_resolve_text_input_normalization(NSString *mode) {
   if (mode == nil || mode.length == 0) {
@@ -312,54 +351,121 @@ extern "C" bool sherpaonnx_punct_online_has_instance(
 @implementation SherpaOnnx (OnlinePunctuation)
 
 - (void)initializeOnlinePunctuation:(NSString *)instanceId
-                            modelDir:(NSString *)modelDir
-                           modelType:(NSString * _Nullable)modelType
-                          numThreads:(NSNumber *)numThreads
-                            provider:(NSString *)provider
-                               debug:(NSNumber *)debug
-                             resolve:(RCTPromiseResolveBlock)resolve
-                              reject:(RCTPromiseRejectBlock)reject
+                           options:(NSDictionary *)options
+                           resolve:(RCTPromiseResolveBlock)resolve
+                            reject:(RCTPromiseRejectBlock)reject
 {
   if (instanceId == nil || instanceId.length == 0) {
     reject(kInitErr, @"instanceId is required", nil);
     return;
   }
-  if (modelDir == nil || modelDir.length == 0) {
-    reject(kInitErr, @"modelDir is required", nil);
-    return;
-  }
-  NSString *req = modelType == nil ? @"auto" : [[modelType stringByTrimmingCharactersInSet:
-      [NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
-  if (!([req isEqualToString:@"auto"] || [req isEqualToString:@"cnn_bilstm"])) {
-    reject(kInitErr, @"Streaming punctuation requires cnn_bilstm or auto", nil);
+  if (options == nil) {
+    reject(kInitErr, @"options is required", nil);
     return;
   }
 
+  NSString *initMode = options[@"initMode"];
+  if (initMode == nil || initMode.length == 0) {
+    initMode = @"auto";
+  }
+  const bool isCustomInit = [initMode isEqualToString:@"custom"];
+  const PunctuationInitScalars scalars = ParsePunctuationInitScalars(options);
+
   @try {
-    std::string idStr = instanceId.UTF8String ?: "";
-    std::string dirStr = modelDir.UTF8String ?: "";
-    auto det = sherpaonnx::DetectPunctuationModel(
-        std::optional<std::string>(dirStr),
-        std::nullopt,
-        "cnn_bilstm");
-    if (!det.ok || det.selectedKind != sherpaonnx::PunctuationModelKind::kCnnBilstm || !det.isStreaming) {
-      NSString *msg = det.error.empty()
-          ? @"Punctuation: model is not a valid online CNN-BiLSTM layout"
-          : [NSString stringWithUTF8String:det.error.c_str()];
-      reject(kInitErr, msg, nil);
-      return;
+    std::string cnnPath;
+    std::string vocabPath;
+    NSMutableArray *models = [NSMutableArray array];
+
+    if (isCustomInit) {
+      NSString *modelType = options[@"modelType"];
+      if (modelType == nil || modelType.length == 0 || [modelType isEqualToString:@"auto"]) {
+        reject(kInitErr, @"modelType is required for initMode custom", nil);
+        return;
+      }
+      NSString *req = [[modelType stringByTrimmingCharactersInSet:
+          [NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+      if (![req isEqualToString:@"cnn_bilstm"]) {
+        reject(kInitErr, @"Streaming punctuation requires cnn_bilstm", nil);
+        return;
+      }
+      id pathsRaw = options[@"modelPaths"];
+      NSDictionary *pathsDict =
+          [pathsRaw isKindOfClass:[NSDictionary class]] ? (NSDictionary *)pathsRaw : nil;
+      if (pathsDict == nil || pathsDict.count == 0) {
+        reject(kInitErr, @"modelPaths is required for initMode custom", nil);
+        return;
+      }
+
+      sherpaonnx::PunctuationModelPaths paths;
+      FillPunctuationModelPathsFromDict(pathsDict, paths);
+      auto validation = sherpaonnx::ValidatePunctuationPaths(
+          sherpaonnx::PunctuationModelKind::kCnnBilstm,
+          paths,
+          "custom");
+      if (!validation.ok) {
+        NSString *msg = validation.error.empty()
+            ? @"Punctuation: custom path validation failed"
+            : [NSString stringWithUTF8String:validation.error.c_str()];
+        reject(kInitErr, msg, nil);
+        return;
+      }
+      cnnPath = paths.cnn_bilstm;
+      vocabPath = paths.bpe_vocab;
+      [models addObject:@{@"type": @"cnn_bilstm", @"modelDir": @"custom"}];
+    } else {
+      NSString *modelDir = options[@"modelDir"];
+      if (modelDir == nil || modelDir.length == 0) {
+        reject(kInitErr, @"modelDir is required for initMode auto", nil);
+        return;
+      }
+      NSString *modelType = options[@"modelType"];
+      NSString *req = modelType == nil ? @"auto" : [[modelType stringByTrimmingCharactersInSet:
+          [NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+      if (!([req isEqualToString:@"auto"] || [req isEqualToString:@"cnn_bilstm"])) {
+        reject(kInitErr, @"Streaming punctuation requires cnn_bilstm or auto", nil);
+        return;
+      }
+
+      std::string idStr = instanceId.UTF8String ?: "";
+      std::string dirStr = modelDir.UTF8String ?: "";
+      auto det = sherpaonnx::DetectPunctuationModel(
+          std::optional<std::string>(dirStr),
+          std::nullopt,
+          "cnn_bilstm");
+      if (!det.ok || det.selectedKind != sherpaonnx::PunctuationModelKind::kCnnBilstm || !det.isStreaming) {
+        NSString *msg = det.error.empty()
+            ? @"Punctuation: model is not a valid online CNN-BiLSTM layout"
+            : [NSString stringWithUTF8String:det.error.c_str()];
+        reject(kInitErr, msg, nil);
+        return;
+      }
+      if (det.paths.cnn_bilstm.empty() || det.paths.bpe_vocab.empty()) {
+        reject(kInitErr, @"Punctuation: missing cnn_bilstm or bpe.vocab path", nil);
+        return;
+      }
+      cnnPath = det.paths.cnn_bilstm;
+      vocabPath = det.paths.bpe_vocab;
+      for (const auto &m : det.detectedModels) {
+        [models addObject:@{
+          @"type": [NSString stringWithUTF8String:m.type.c_str()] ?: @"",
+          @"modelDir": [NSString stringWithUTF8String:m.modelDir.c_str()] ?: @""
+        }];
+      }
+      (void)idStr;
     }
-    if (det.paths.cnn_bilstm.empty() || det.paths.bpe_vocab.empty()) {
+
+    if (cnnPath.empty() || vocabPath.empty()) {
       reject(kInitErr, @"Punctuation: missing cnn_bilstm or bpe.vocab path", nil);
       return;
     }
 
+    std::string idStr = instanceId.UTF8String ?: "";
     sherpa_onnx::cxx::OnlinePunctuationConfig cfg;
-    cfg.model.cnn_bilstm = det.paths.cnn_bilstm;
-    cfg.model.bpe_vocab = det.paths.bpe_vocab;
-    cfg.model.num_threads = numThreads != nil ? std::max(1, numThreads.intValue) : 1;
-    cfg.model.debug = debug != nil && debug.boolValue;
-    cfg.model.provider = provider.length > 0 ? provider.UTF8String : "cpu";
+    cfg.model.cnn_bilstm = cnnPath;
+    cfg.model.bpe_vocab = vocabPath;
+    cfg.model.num_threads = scalars.numThreads;
+    cfg.model.debug = scalars.debug;
+    cfg.model.provider = scalars.provider;
     auto created = sherpa_onnx::cxx::OnlinePunctuation::Create(cfg);
     auto ptr = std::make_shared<sherpa_onnx::cxx::OnlinePunctuation>(std::move(created));
     {
@@ -367,13 +473,6 @@ extern "C" bool sherpaonnx_punct_online_has_instance(
       g_punct_online[idStr] = ptr;
     }
 
-    NSMutableArray *models = [NSMutableArray array];
-    for (const auto &m : det.detectedModels) {
-      [models addObject:@{
-        @"type": [NSString stringWithUTF8String:m.type.c_str()] ?: @"",
-        @"modelDir": [NSString stringWithUTF8String:m.modelDir.c_str()] ?: @""
-      }];
-    }
     resolve(@{
       @"success": @YES,
       @"modelType": @"cnn_bilstm",

--- a/ios/stt/bridge/SherpaOnnx+OnlineSTT.mm
+++ b/ios/stt/bridge/SherpaOnnx+OnlineSTT.mm
@@ -17,8 +17,10 @@
 #include "../../textbuffer/core/SherpaOnnx+TextBufferGlobals.h"
 #include "../pipeline/SttPipelineWorker.h"
 #include "../native/sherpa-onnx-online-stt-wrapper.h"
+#include "sherpa-onnx-model-path-fill.h"
 
 #include <chrono>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -27,6 +29,22 @@
 static std::unordered_map<std::string, std::unique_ptr<sherpaonnx::OnlineSttWrapper>> g_online_stt_instances;
 static std::unordered_map<std::string, std::string> g_online_stt_instance_to_pipeline;
 static std::mutex g_online_stt_mutex;
+
+static void FillOnlineSttModelPathsFromDict(
+    NSDictionary *dict,
+    sherpaonnx::OnlineSttModelPaths &out
+) {
+    if (dict == nil) return;
+    std::map<std::string, std::string> paths;
+    for (NSString *key in dict) {
+        id value = dict[key];
+        if (![value isKindOfClass:[NSString class]]) continue;
+        NSString *str = (NSString *)value;
+        if ([str length] == 0) continue;
+        paths[[key UTF8String]] = [str UTF8String];
+    }
+    sherpaonnx::FillOnlineSttModelPathsFromStringMap(paths, out);
+}
 
 static sherpaonnx::OnlineSttWrapper* getOnlineSttInstance(NSString* instanceId) {
     if (instanceId == nil || [instanceId length] == 0) return nullptr;
@@ -48,15 +66,21 @@ static sherpaonnx::OnlineSttWrapper* getOnlineSttInstance(NSString* instanceId) 
         return;
     }
 
+    NSString *initMode = options.initMode();
+    const bool isCustomInit = initMode.length > 0 && [initMode isEqualToString:@"custom"];
     NSString *modelDir = options.modelDir();
     NSString *modelType = options.modelType();
-    if (modelDir == nil || [modelDir length] == 0) {
-        reject(@"STT_INIT_FAILED", @"modelDir is required", nil);
+    if (!isCustomInit && (modelDir == nil || [modelDir length] == 0)) {
+        reject(@"STT_INIT_FAILED", @"modelDir is required for initMode auto", nil);
+        return;
+    }
+    if (isCustomInit && (modelType == nil || [modelType length] == 0)) {
+        reject(@"STT_INIT_FAILED", @"modelType is required for initMode custom", nil);
         return;
     }
 
     std::string instanceIdStr = [instanceId UTF8String];
-    std::string modelDirStr = [modelDir UTF8String];
+    std::string modelDirStr = modelDir != nil ? [modelDir UTF8String] : "";
     std::string modelTypeStr = (modelType != nil && [modelType length] > 0) ? [modelType UTF8String] : "transducer";
 
     auto enableEndpoint = options.enableEndpoint();
@@ -89,31 +113,69 @@ static sherpaonnx::OnlineSttWrapper* getOnlineSttInstance(NSString* instanceId) 
         }
 
         auto wrapper = std::make_unique<sherpaonnx::OnlineSttWrapper>();
-        sherpaonnx::OnlineSttInitResult result = wrapper->initialize(
-            modelDirStr,
-            modelTypeStr,
-            enableEndpoint.has_value() && enableEndpoint.value(),
-            decodingMethod != nil ? [decodingMethod UTF8String] : "greedy_search",
-            maxActivePaths.has_value() ? (int32_t)maxActivePaths.value() : 4,
-            hotwordsFile != nil ? [hotwordsFile UTF8String] : "",
-            hotwordsScore.has_value() ? (float)hotwordsScore.value() : 1.5f,
-            numThreads.has_value() ? (int32_t)numThreads.value() : 1,
-            provider != nil ? [provider UTF8String] : "cpu",
-            ruleFsts != nil ? [ruleFsts UTF8String] : "",
-            ruleFars != nil ? [ruleFars UTF8String] : "",
-            dither.has_value() ? (float)dither.value() : 0.f,
-            blankPenalty.has_value() ? (float)blankPenalty.value() : 0.f,
-            debug.has_value() && debug.value(),
-            rule1MustContainNonSilence.has_value() && rule1MustContainNonSilence.value(),
-            rule1MinTrailingSilence.has_value() ? (float)rule1MinTrailingSilence.value() : 2.4f,
-            rule1MinUtteranceLength.has_value() ? (float)rule1MinUtteranceLength.value() : 0.f,
-            rule2MustContainNonSilence.has_value() && rule2MustContainNonSilence.value(),
-            rule2MinTrailingSilence.has_value() ? (float)rule2MinTrailingSilence.value() : 1.2f,
-            rule2MinUtteranceLength.has_value() ? (float)rule2MinUtteranceLength.value() : 0.f,
-            rule3MustContainNonSilence.has_value() && rule3MustContainNonSilence.value(),
-            rule3MinTrailingSilence.has_value() ? (float)rule3MinTrailingSilence.value() : 0.f,
-            rule3MinUtteranceLength.has_value() ? (float)rule3MinUtteranceLength.value() : 20.f
-        );
+        sherpaonnx::OnlineSttInitResult result;
+        if (isCustomInit) {
+            id pathsRaw = options.modelPaths();
+            NSDictionary *pathsDict =
+                [pathsRaw isKindOfClass:[NSDictionary class]] ? (NSDictionary *)pathsRaw : nil;
+            if (pathsDict == nil || pathsDict.count == 0) {
+                reject(@"STT_INIT_FAILED", @"modelPaths is required for initMode custom", nil);
+                return;
+            }
+            sherpaonnx::OnlineSttModelPaths paths;
+            FillOnlineSttModelPathsFromDict(pathsDict, paths);
+            result = wrapper->initializeCustom(
+                modelTypeStr,
+                paths,
+                enableEndpoint.has_value() && enableEndpoint.value(),
+                decodingMethod != nil ? [decodingMethod UTF8String] : "greedy_search",
+                maxActivePaths.has_value() ? (int32_t)maxActivePaths.value() : 4,
+                hotwordsFile != nil ? [hotwordsFile UTF8String] : "",
+                hotwordsScore.has_value() ? (float)hotwordsScore.value() : 1.5f,
+                numThreads.has_value() ? (int32_t)numThreads.value() : 1,
+                provider != nil ? [provider UTF8String] : "cpu",
+                ruleFsts != nil ? [ruleFsts UTF8String] : "",
+                ruleFars != nil ? [ruleFars UTF8String] : "",
+                dither.has_value() ? (float)dither.value() : 0.f,
+                blankPenalty.has_value() ? (float)blankPenalty.value() : 0.f,
+                debug.has_value() && debug.value(),
+                rule1MustContainNonSilence.has_value() && rule1MustContainNonSilence.value(),
+                rule1MinTrailingSilence.has_value() ? (float)rule1MinTrailingSilence.value() : 2.4f,
+                rule1MinUtteranceLength.has_value() ? (float)rule1MinUtteranceLength.value() : 0.f,
+                rule2MustContainNonSilence.has_value() && rule2MustContainNonSilence.value(),
+                rule2MinTrailingSilence.has_value() ? (float)rule2MinTrailingSilence.value() : 1.2f,
+                rule2MinUtteranceLength.has_value() ? (float)rule2MinUtteranceLength.value() : 0.f,
+                rule3MustContainNonSilence.has_value() && rule3MustContainNonSilence.value(),
+                rule3MinTrailingSilence.has_value() ? (float)rule3MinTrailingSilence.value() : 0.f,
+                rule3MinUtteranceLength.has_value() ? (float)rule3MinUtteranceLength.value() : 20.f
+            );
+        } else {
+            result = wrapper->initialize(
+                modelDirStr,
+                modelTypeStr,
+                enableEndpoint.has_value() && enableEndpoint.value(),
+                decodingMethod != nil ? [decodingMethod UTF8String] : "greedy_search",
+                maxActivePaths.has_value() ? (int32_t)maxActivePaths.value() : 4,
+                hotwordsFile != nil ? [hotwordsFile UTF8String] : "",
+                hotwordsScore.has_value() ? (float)hotwordsScore.value() : 1.5f,
+                numThreads.has_value() ? (int32_t)numThreads.value() : 1,
+                provider != nil ? [provider UTF8String] : "cpu",
+                ruleFsts != nil ? [ruleFsts UTF8String] : "",
+                ruleFars != nil ? [ruleFars UTF8String] : "",
+                dither.has_value() ? (float)dither.value() : 0.f,
+                blankPenalty.has_value() ? (float)blankPenalty.value() : 0.f,
+                debug.has_value() && debug.value(),
+                rule1MustContainNonSilence.has_value() && rule1MustContainNonSilence.value(),
+                rule1MinTrailingSilence.has_value() ? (float)rule1MinTrailingSilence.value() : 2.4f,
+                rule1MinUtteranceLength.has_value() ? (float)rule1MinUtteranceLength.value() : 0.f,
+                rule2MustContainNonSilence.has_value() && rule2MustContainNonSilence.value(),
+                rule2MinTrailingSilence.has_value() ? (float)rule2MinTrailingSilence.value() : 1.2f,
+                rule2MinUtteranceLength.has_value() ? (float)rule2MinUtteranceLength.value() : 0.f,
+                rule3MustContainNonSilence.has_value() && rule3MustContainNonSilence.value(),
+                rule3MinTrailingSilence.has_value() ? (float)rule3MinTrailingSilence.value() : 0.f,
+                rule3MinUtteranceLength.has_value() ? (float)rule3MinUtteranceLength.value() : 20.f
+            );
+        }
 
         if (!result.success) {
             reject(@"STT_INIT_FAILED", [NSString stringWithUTF8String:result.error.c_str()], nil);

--- a/ios/stt/bridge/SherpaOnnx+STT.mm
+++ b/ios/stt/bridge/SherpaOnnx+STT.mm
@@ -16,9 +16,11 @@
 #include "../pipeline/SttOfflineLivePipelineWorker.h"
 #include "../native/sherpa-onnx-stt-wrapper.h"
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-model-path-fill.h"
 #include "sherpa-onnx/c-api/cxx-api.h"
 #include <atomic>
 #include <chrono>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -78,6 +80,23 @@ static NSString *sttModelKindToNSString(sherpaonnx::SttModelKind kind) {
     }
 }
 
+static void FillSttModelPathsFromDict(
+    NSDictionary *dict,
+    sherpaonnx::SttModelPaths &paths
+) {
+    if (![dict isKindOfClass:[NSDictionary class]]) {
+        return;
+    }
+    std::map<std::string, std::string> pathMap;
+    for (NSString *key in dict) {
+        id value = dict[key];
+        if ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) {
+            pathMap[std::string([key UTF8String])] = std::string([(NSString *)value UTF8String]);
+        }
+    }
+    sherpaonnx::FillSttModelPathsFromStringMap(pathMap, paths);
+}
+
 @implementation SherpaOnnx (STT)
 
 - (void)initializeStt:(NSString *)instanceId
@@ -89,12 +108,12 @@ static NSString *sttModelKindToNSString(sherpaonnx::SttModelKind kind) {
         reject(kSttErrInitFailed, @"instanceId is required", nil);
         return;
     }
-    NSString *modelDir = options.modelDir();
-    if (modelDir == nil || [modelDir length] == 0) {
-        reject(kSttErrInitFailed, @"modelDir is required", nil);
-        return;
+
+    NSString *initMode = @"auto";
+    if (options.initMode().has_value()) {
+        initMode = [NSString stringWithUTF8String:options.initMode()->c_str()];
     }
-    auto preferInt8 = options.preferInt8();
+
     NSString *modelType = options.modelType();
     auto debug = options.debug();
     NSString *hotwordsFile = options.hotwordsFile();
@@ -108,7 +127,19 @@ static NSString *sttModelKindToNSString(sherpaonnx::SttModelKind kind) {
     NSDictionary *modelOptions =
         [modelOptionsRaw isKindOfClass:[NSDictionary class]] ? (NSDictionary *)modelOptionsRaw : nil;
     std::string instanceIdStr = [instanceId UTF8String];
-    RCTLogInfo(@"Initializing STT instance %@ with modelDir: %@", instanceId, modelDir);
+
+    const bool isCustomInit = initMode.length > 0 && [initMode isEqualToString:@"custom"];
+    NSString *modelDir = options.modelDir();
+    if (!isCustomInit && (modelDir == nil || [modelDir length] == 0)) {
+        reject(kSttErrInitFailed, @"modelDir is required for initMode auto", nil);
+        return;
+    }
+    if (isCustomInit && (modelType == nil || [modelType length] == 0)) {
+        reject(kSttErrInitFailed, @"modelType is required for initMode custom", nil);
+        return;
+    }
+
+    RCTLogInfo(@"Initializing STT instance %@ initMode=%@ modelDir=%@", instanceId, initMode, modelDir);
 
     @try {
         std::lock_guard<std::mutex> lock(g_stt_mutex);
@@ -121,11 +152,14 @@ static NSString *sttModelKindToNSString(sherpaonnx::SttModelKind kind) {
             inst->wrapper = std::make_unique<sherpaonnx::SttWrapper>();
         }
 
-        std::string modelDirStr = [modelDir UTF8String];
+        std::string modelDirStr = modelDir != nil ? [modelDir UTF8String] : "";
 
         std::optional<bool> preferInt8Opt = std::nullopt;
-        if (preferInt8.has_value()) {
-            preferInt8Opt = preferInt8.value();
+        if (!isCustomInit) {
+            auto preferInt8 = options.preferInt8();
+            if (preferInt8.has_value()) {
+                preferInt8Opt = preferInt8.value();
+            }
         }
 
         std::optional<std::string> modelTypeOpt = std::nullopt;
@@ -242,11 +276,42 @@ static NSString *sttModelKindToNSString(sherpaonnx::SttModelKind kind) {
             }
         }
 
-        sherpaonnx::SttInitializeResult result = inst->wrapper->initialize(
-            modelDirStr, preferInt8Opt, modelTypeOpt, debugVal, hotwordsFileOpt, hotwordsScoreOpt,
-            numThreadsOpt, providerOpt, ruleFstsOpt, ruleFarsOpt, ditherOpt,
-            whisperOptsPtr, senseVoiceOptsPtr, canaryOptsPtr, funasrNanoOptsPtr, qwen3AsrOptsPtr,
-            cohereTranscribeOptsPtr);
+        sherpaonnx::SttInitializeResult result;
+        if (isCustomInit) {
+            id pathsRaw = options.modelPaths();
+            NSDictionary *pathsDict =
+                [pathsRaw isKindOfClass:[NSDictionary class]] ? (NSDictionary *)pathsRaw : nil;
+            if (pathsDict == nil || pathsDict.count == 0) {
+                reject(kSttErrInitFailed, @"modelPaths is required for initMode custom", nil);
+                return;
+            }
+            sherpaonnx::SttModelPaths paths;
+            FillSttModelPathsFromDict(pathsDict, paths);
+            result = inst->wrapper->initializeCustom(
+                modelTypeOpt.value_or(""),
+                paths,
+                debugVal,
+                hotwordsFileOpt,
+                hotwordsScoreOpt,
+                numThreadsOpt,
+                providerOpt,
+                ruleFstsOpt,
+                ruleFarsOpt,
+                ditherOpt,
+                whisperOptsPtr,
+                senseVoiceOptsPtr,
+                canaryOptsPtr,
+                funasrNanoOptsPtr,
+                qwen3AsrOptsPtr,
+                cohereTranscribeOptsPtr
+            );
+        } else {
+            result = inst->wrapper->initialize(
+                modelDirStr, preferInt8Opt, modelTypeOpt, debugVal, hotwordsFileOpt, hotwordsScoreOpt,
+                numThreadsOpt, providerOpt, ruleFstsOpt, ruleFarsOpt, ditherOpt,
+                whisperOptsPtr, senseVoiceOptsPtr, canaryOptsPtr, funasrNanoOptsPtr, qwen3AsrOptsPtr,
+                cohereTranscribeOptsPtr);
+        }
 
         if (result.success) {
             RCTLogInfo(@"Sherpa-onnx initialized successfully");

--- a/ios/stt/bridge/SherpaOnnx+STT.mm
+++ b/ios/stt/bridge/SherpaOnnx+STT.mm
@@ -109,9 +109,9 @@ static void FillSttModelPathsFromDict(
         return;
     }
 
-    NSString *initMode = @"auto";
-    if (options.initMode().has_value()) {
-        initMode = [NSString stringWithUTF8String:options.initMode()->c_str()];
+    NSString *initMode = options.initMode();
+    if (initMode == nil || [initMode length] == 0) {
+        initMode = @"auto";
     }
 
     NSString *modelType = options.modelType();

--- a/ios/stt/native/sherpa-onnx-online-stt-wrapper.h
+++ b/ios/stt/native/sherpa-onnx-online-stt-wrapper.h
@@ -9,6 +9,8 @@
 #ifndef SHERPA_ONNX_ONLINE_STT_WRAPPER_H
 #define SHERPA_ONNX_ONLINE_STT_WRAPPER_H
 
+#include "sherpa-onnx-validate-online-stt.h"
+
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -40,6 +42,32 @@ public:
     OnlineSttInitResult initialize(
         const std::string& modelDir,
         const std::string& modelType,
+        bool enableEndpoint,
+        const std::string& decodingMethod,
+        int32_t maxActivePaths,
+        const std::string& hotwordsFile,
+        float hotwordsScore,
+        int32_t numThreads,
+        const std::string& provider,
+        const std::string& ruleFsts,
+        const std::string& ruleFars,
+        float dither,
+        float blankPenalty,
+        bool debug,
+        bool rule1MustContainNonSilence,
+        float rule1MinTrailingSilence,
+        float rule1MinUtteranceLength,
+        bool rule2MustContainNonSilence,
+        float rule2MinTrailingSilence,
+        float rule2MinUtteranceLength,
+        bool rule3MustContainNonSilence,
+        float rule3MinTrailingSilence,
+        float rule3MinUtteranceLength
+    );
+
+    OnlineSttInitResult initializeCustom(
+        const std::string& modelType,
+        const OnlineSttModelPaths& paths,
         bool enableEndpoint,
         const std::string& decodingMethod,
         int32_t maxActivePaths,

--- a/ios/stt/native/sherpa-onnx-online-stt-wrapper.mm
+++ b/ios/stt/native/sherpa-onnx-online-stt-wrapper.mm
@@ -7,6 +7,7 @@
 
 #include "sherpa-onnx-online-stt-wrapper.h"
 #include "sherpa-onnx-model-detect-helper.h"
+#include "sherpa-onnx-validate-online-stt.h"
 
 #include "sherpa-onnx/c-api/cxx-api.h"
 
@@ -77,6 +78,115 @@ std::unordered_map<std::string, std::string> scanOnlineModelPaths(const std::str
     return {};
 }
 
+static std::unordered_map<std::string, std::string> onlinePathsToMap(
+    const OnlineSttModelPaths& paths
+) {
+    return {
+        {"encoder", paths.encoder},
+        {"decoder", paths.decoder},
+        {"joiner", paths.joiner},
+        {"tokens", paths.tokens},
+        {"model", paths.model},
+    };
+}
+
+static bool applyOnlineModelPathsToConfig(
+    const std::unordered_map<std::string, std::string>& paths,
+    const std::string& modelType,
+    sherpa_onnx::cxx::OnlineRecognizerConfig& config,
+    std::string& error
+) {
+    if (modelType == "transducer") {
+        config.model_config.transducer.encoder = paths.at("encoder");
+        config.model_config.transducer.decoder = paths.at("decoder");
+        config.model_config.transducer.joiner = paths.at("joiner");
+        config.model_config.model_type = "zipformer";
+    } else if (modelType == "nemo_transducer") {
+        config.model_config.transducer.encoder = paths.at("encoder");
+        config.model_config.transducer.decoder = paths.at("decoder");
+        config.model_config.transducer.joiner = paths.at("joiner");
+        config.model_config.model_type = "";
+    } else if (modelType == "paraformer") {
+        config.model_config.paraformer.encoder = paths.at("encoder");
+        config.model_config.paraformer.decoder = paths.at("decoder");
+        config.model_config.model_type = "paraformer";
+    } else if (modelType == "zipformer2_ctc") {
+        config.model_config.zipformer2_ctc.model = paths.at("model");
+        config.model_config.model_type = "zipformer2";
+    } else if (modelType == "nemo_ctc") {
+        config.model_config.nemo_ctc.model = paths.at("model");
+        config.model_config.model_type = "nemo_ctc";
+    } else if (modelType == "tone_ctc") {
+        config.model_config.t_one_ctc.model = paths.at("model");
+        config.model_config.model_type = "t_one";
+    } else {
+        error = "Unsupported online STT model type: " + modelType;
+        return false;
+    }
+    return true;
+}
+
+static OnlineSttInitResult createOnlineRecognizerFromPaths(
+    const std::unordered_map<std::string, std::string>& paths,
+    const std::string& modelType,
+    bool enableEndpoint,
+    const std::string& decodingMethod,
+    int32_t maxActivePaths,
+    const std::string& hotwordsFile,
+    float hotwordsScore,
+    int32_t numThreads,
+    const std::string& provider,
+    const std::string& ruleFsts,
+    const std::string& ruleFars,
+    float dither,
+    float blankPenalty,
+    bool debug,
+    float rule1MinTrailingSilence,
+    float rule2MinTrailingSilence,
+    float rule3MinUtteranceLength,
+    std::unique_ptr<sherpa_onnx::cxx::OnlineRecognizer>& recognizerOut,
+    int32_t& sampleRateOut
+) {
+    OnlineSttInitResult result;
+    sherpa_onnx::cxx::OnlineRecognizerConfig config;
+    config.feat_config.sample_rate = 16000;
+    config.feat_config.feature_dim = 80;
+    (void)dither;
+    config.decoding_method = decodingMethod.empty() ? "greedy_search" : decodingMethod;
+    config.max_active_paths = maxActivePaths;
+    config.enable_endpoint = enableEndpoint;
+    config.rule1_min_trailing_silence = rule1MinTrailingSilence > 0 ? rule1MinTrailingSilence : 2.4f;
+    config.rule2_min_trailing_silence = rule2MinTrailingSilence > 0 ? rule2MinTrailingSilence : 1.4f;
+    config.rule3_min_utterance_length = rule3MinUtteranceLength > 0 ? rule3MinUtteranceLength : 20.f;
+    config.hotwords_file = hotwordsFile;
+    config.hotwords_score = hotwordsScore;
+    config.rule_fsts = ruleFsts;
+    config.rule_fars = ruleFars;
+    config.blank_penalty = blankPenalty;
+    config.model_config.num_threads = numThreads <= 0 ? 1 : numThreads;
+    config.model_config.provider = provider.empty() ? "cpu" : provider;
+    config.model_config.debug = debug;
+    config.model_config.tokens = paths.count("tokens") ? paths.at("tokens") : "";
+
+    if (!applyOnlineModelPathsToConfig(paths, modelType, config, result.error)) {
+        return result;
+    }
+
+    try {
+        sherpa_onnx::cxx::OnlineRecognizer rec = sherpa_onnx::cxx::OnlineRecognizer::Create(config);
+        recognizerOut = std::make_unique<sherpa_onnx::cxx::OnlineRecognizer>(std::move(rec));
+        sampleRateOut = config.feat_config.sample_rate;
+        result.success = true;
+    } catch (const std::exception& e) {
+        result.error = std::string("OnlineRecognizer Create failed: ") + e.what();
+        LOGE("%s", result.error.c_str());
+    } catch (...) {
+        result.error = "OnlineRecognizer Create failed: unknown error";
+        LOGE("%s", result.error.c_str());
+    }
+    return result;
+}
+
 } // namespace
 
 struct OnlineSttWrapper::Impl {
@@ -137,70 +247,101 @@ OnlineSttInitResult OnlineSttWrapper::initialize(
         return result;
     }
 
-    sherpa_onnx::cxx::OnlineRecognizerConfig config;
-    config.feat_config.sample_rate = 16000;
-    config.feat_config.feature_dim = 80;
-    // Dither is not exposed on cxx::FeatureConfig in the bundled sherpa-onnx headers;
-    // Android applies it via JNI. iOS uses the library default (no dither from JS).
-    (void)dither;
-    config.decoding_method = decodingMethod.empty() ? "greedy_search" : decodingMethod;
-    config.max_active_paths = maxActivePaths;
-    config.enable_endpoint = enableEndpoint;
-    config.rule1_min_trailing_silence = rule1MinTrailingSilence > 0 ? rule1MinTrailingSilence : 2.4f;
-    config.rule2_min_trailing_silence = rule2MinTrailingSilence > 0 ? rule2MinTrailingSilence : 1.4f;
-    config.rule3_min_utterance_length = rule3MinUtteranceLength > 0 ? rule3MinUtteranceLength : 20.f;
-    config.hotwords_file = hotwordsFile;
-    config.hotwords_score = hotwordsScore;
-    config.rule_fsts = ruleFsts;
-    config.rule_fars = ruleFars;
-    config.blank_penalty = blankPenalty;
-    config.model_config.num_threads = numThreads <= 0 ? 1 : numThreads;
-    config.model_config.provider = provider.empty() ? "cpu" : provider;
-    config.model_config.debug = debug;
-    config.model_config.tokens = paths.count("tokens") ? paths["tokens"] : "";
+    auto initResult = createOnlineRecognizerFromPaths(
+        paths,
+        modelType,
+        enableEndpoint,
+        decodingMethod,
+        maxActivePaths,
+        hotwordsFile,
+        hotwordsScore,
+        numThreads,
+        provider,
+        ruleFsts,
+        ruleFars,
+        dither,
+        blankPenalty,
+        debug,
+        rule1MinTrailingSilence,
+        rule2MinTrailingSilence,
+        rule3MinUtteranceLength,
+        pImpl->recognizer,
+        pImpl->sampleRate
+    );
+    if (initResult.success) {
+        pImpl->initialized = true;
+    }
+    return initResult;
+}
 
-    if (modelType == "transducer") {
-        config.model_config.transducer.encoder = paths["encoder"];
-        config.model_config.transducer.decoder = paths["decoder"];
-        config.model_config.transducer.joiner = paths["joiner"];
-        config.model_config.model_type = "zipformer";
-    } else if (modelType == "nemo_transducer") {
-        config.model_config.transducer.encoder = paths["encoder"];
-        config.model_config.transducer.decoder = paths["decoder"];
-        config.model_config.transducer.joiner = paths["joiner"];
-        config.model_config.model_type = "";
-    } else if (modelType == "paraformer") {
-        config.model_config.paraformer.encoder = paths["encoder"];
-        config.model_config.paraformer.decoder = paths["decoder"];
-        config.model_config.model_type = "paraformer";
-    } else if (modelType == "zipformer2_ctc") {
-        config.model_config.zipformer2_ctc.model = paths["model"];
-        config.model_config.model_type = "zipformer2";
-    } else if (modelType == "nemo_ctc") {
-        config.model_config.nemo_ctc.model = paths["model"];
-        config.model_config.model_type = "nemo_ctc";
-    } else if (modelType == "tone_ctc") {
-        config.model_config.t_one_ctc.model = paths["model"];
-        config.model_config.model_type = "t_one";
-    } else {
-        result.error = "Unsupported online STT model type: " + modelType;
+OnlineSttInitResult OnlineSttWrapper::initializeCustom(
+    const std::string& modelType,
+    const OnlineSttModelPaths& paths,
+    bool enableEndpoint,
+    const std::string& decodingMethod,
+    int32_t maxActivePaths,
+    const std::string& hotwordsFile,
+    float hotwordsScore,
+    int32_t numThreads,
+    const std::string& provider,
+    const std::string& ruleFsts,
+    const std::string& ruleFars,
+    float dither,
+    float blankPenalty,
+    bool debug,
+    bool /* rule1MustContainNonSilence */,
+    float rule1MinTrailingSilence,
+    float /* rule1MinUtteranceLength */,
+    bool /* rule2MustContainNonSilence */,
+    float rule2MinTrailingSilence,
+    float /* rule2MinUtteranceLength */,
+    bool /* rule3MustContainNonSilence */,
+    float /* rule3MinTrailingSilence */,
+    float rule3MinUtteranceLength
+) {
+    OnlineSttInitResult result;
+    if (pImpl->initialized) {
+        result.error = "Already initialized";
         return result;
     }
 
-    try {
-        sherpa_onnx::cxx::OnlineRecognizer rec = sherpa_onnx::cxx::OnlineRecognizer::Create(config);
-        pImpl->recognizer = std::make_unique<sherpa_onnx::cxx::OnlineRecognizer>(std::move(rec));
-        pImpl->sampleRate = config.feat_config.sample_rate;
-        pImpl->initialized = true;
-        result.success = true;
-    } catch (const std::exception& e) {
-        result.error = std::string("OnlineRecognizer Create failed: ") + e.what();
-        LOGE("%s", result.error.c_str());
-    } catch (...) {
-        result.error = "OnlineRecognizer Create failed: unknown error";
-        LOGE("%s", result.error.c_str());
+    const OnlineSttModelKind kind = ParseOnlineSttModelType(modelType);
+    if (kind == OnlineSttModelKind::kUnknown) {
+        result.error = "Unsupported custom streaming STT model type: " + modelType;
+        return result;
     }
-    return result;
+
+    const auto validation = ValidateOnlineSttPaths(kind, paths, "custom");
+    if (!validation.ok) {
+        result.error = validation.error;
+        return result;
+    }
+
+    auto initResult = createOnlineRecognizerFromPaths(
+        onlinePathsToMap(paths),
+        modelType,
+        enableEndpoint,
+        decodingMethod,
+        maxActivePaths,
+        hotwordsFile,
+        hotwordsScore,
+        numThreads,
+        provider,
+        ruleFsts,
+        ruleFars,
+        dither,
+        blankPenalty,
+        debug,
+        rule1MinTrailingSilence,
+        rule2MinTrailingSilence,
+        rule3MinUtteranceLength,
+        pImpl->recognizer,
+        pImpl->sampleRate
+    );
+    if (initResult.success) {
+        pImpl->initialized = true;
+    }
+    return initResult;
 }
 
 bool OnlineSttWrapper::createStream(const std::string& streamId, const std::string& hotwords) {

--- a/ios/stt/native/sherpa-onnx-stt-wrapper.h
+++ b/ios/stt/native/sherpa-onnx-stt-wrapper.h
@@ -1,7 +1,8 @@
-#ifndef SHERPA_ONNX_STT_WRAPPER_H
-#define SHERPA_ONNX_STT_WRAPPER_H
+#ifndef SHERPA_ONNX_IOS_STT_WRAPPER_H
+#define SHERPA_ONNX_IOS_STT_WRAPPER_H
 
 #include "sherpa-onnx-common.h"
+#include "sherpa-onnx-model-detect.h"
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -131,6 +132,26 @@ public:
         const SttCohereTranscribeOptions* cohereTranscribeOpts = nullptr
     );
 
+    /** Skip auto-detection; use explicit resolved model file paths. */
+    SttInitializeResult initializeCustom(
+        const std::string& modelType,
+        const SttModelPaths& paths,
+        bool debug = false,
+        const std::optional<std::string>& hotwordsFile = std::nullopt,
+        const std::optional<float>& hotwordsScore = std::nullopt,
+        const std::optional<int32_t>& numThreads = std::nullopt,
+        const std::optional<std::string>& provider = std::nullopt,
+        const std::optional<std::string>& ruleFsts = std::nullopt,
+        const std::optional<std::string>& ruleFars = std::nullopt,
+        const std::optional<float>& dither = std::nullopt,
+        const SttWhisperOptions* whisperOpts = nullptr,
+        const SttSenseVoiceOptions* senseVoiceOpts = nullptr,
+        const SttCanaryOptions* canaryOpts = nullptr,
+        const SttFunAsrNanoOptions* funasrNanoOpts = nullptr,
+        const SttQwen3AsrOptions* qwen3AsrOpts = nullptr,
+        const SttCohereTranscribeOptions* cohereTranscribeOpts = nullptr
+    );
+
     SttRecognitionResult transcribeFile(const std::string& filePath);
 
     SttRecognitionResult transcribeSamples(const std::vector<float>& samples, int32_t sampleRate);
@@ -155,4 +176,4 @@ private:
 
 } // namespace sherpaonnx
 
-#endif // SHERPA_ONNX_STT_WRAPPER_H
+#endif // SHERPA_ONNX_IOS_STT_WRAPPER_H

--- a/ios/stt/native/sherpa-onnx-stt-wrapper.mm
+++ b/ios/stt/native/sherpa-onnx-stt-wrapper.mm
@@ -7,6 +7,7 @@
 
 #include "sherpa-onnx-stt-wrapper.h"
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-validate-stt.h"
 #include <algorithm>
 #include <cctype>
 #include <cstring>
@@ -469,6 +470,283 @@ SttInitializeResult SttWrapper::initialize(
     } catch (...) {
         result.error = "Unknown exception during initialization";
         LOGE("%s", result.error.c_str());
+        return result;
+    }
+}
+
+SttInitializeResult SttWrapper::initializeCustom(
+    const std::string& modelType,
+    const SttModelPaths& paths,
+    bool debug,
+    const std::optional<std::string>& hotwordsFile,
+    const std::optional<float>& hotwordsScore,
+    const std::optional<int32_t>& numThreads,
+    const std::optional<std::string>& provider,
+    const std::optional<std::string>& ruleFsts,
+    const std::optional<std::string>& ruleFars,
+    const std::optional<float>& dither,
+    const SttWhisperOptions* whisperOpts,
+    const SttSenseVoiceOptions* senseVoiceOpts,
+    const SttCanaryOptions* canaryOpts,
+    const SttFunAsrNanoOptions* funasrNanoOpts,
+    const SttQwen3AsrOptions* qwen3AsrOpts,
+    const SttCohereTranscribeOptions* cohereTranscribeOpts
+) {
+    SttInitializeResult result;
+    result.success = false;
+    (void)debug;
+
+    if (pImpl->initialized) {
+        release();
+    }
+
+    const SttModelKind selectedKind = ParseSttModelType(modelType);
+    if (selectedKind == SttModelKind::kUnknown) {
+        result.error = "Unsupported custom STT model type: " + modelType;
+        LOGE("%s", result.error.c_str());
+        return result;
+    }
+
+    auto validation = ValidateSttPaths(selectedKind, paths, "custom");
+    if (!validation.ok) {
+        result.error = validation.error;
+        LOGE("%s", result.error.c_str());
+        return result;
+    }
+
+    SttDetectResult detect;
+    detect.ok = true;
+    detect.selectedKind = selectedKind;
+    detect.paths = paths;
+    detect.detectedModels.push_back({modelType, "custom"});
+
+    try {
+        sherpa_onnx::cxx::OfflineRecognizerConfig config;
+        config.feat_config.sample_rate = 16000;
+        config.feat_config.feature_dim = 80;
+
+        switch (detect.selectedKind) {
+            case SttModelKind::kTransducer:
+            case SttModelKind::kNemoTransducer:
+                config.model_config.transducer.encoder = detect.paths.encoder;
+                config.model_config.transducer.decoder = detect.paths.decoder;
+                config.model_config.transducer.joiner = detect.paths.joiner;
+                break;
+            case SttModelKind::kParaformer:
+                config.model_config.paraformer.model = detect.paths.paraformerModel;
+                break;
+            case SttModelKind::kNemoCtc:
+                config.model_config.nemo_ctc.model = detect.paths.ctcModel;
+                break;
+            case SttModelKind::kWenetCtc:
+                config.model_config.wenet_ctc.model = detect.paths.ctcModel;
+                break;
+            case SttModelKind::kSenseVoice:
+                config.model_config.sense_voice.model = detect.paths.ctcModel;
+                break;
+            case SttModelKind::kZipformerCtc:
+                config.model_config.zipformer_ctc.model = detect.paths.ctcModel;
+                break;
+            case SttModelKind::kWhisper:
+                config.model_config.whisper.encoder = detect.paths.whisperEncoder;
+                config.model_config.whisper.decoder = detect.paths.whisperDecoder;
+                break;
+            case SttModelKind::kFunAsrNano:
+                config.model_config.funasr_nano.encoder_adaptor = detect.paths.funasrEncoderAdaptor;
+                config.model_config.funasr_nano.llm = detect.paths.funasrLLM;
+                config.model_config.funasr_nano.embedding = detect.paths.funasrEmbedding;
+                config.model_config.funasr_nano.tokenizer = detect.paths.funasrTokenizer;
+                break;
+            case SttModelKind::kQwen3Asr:
+                config.model_config.qwen3_asr.conv_frontend = detect.paths.qwen3ConvFrontend;
+                config.model_config.qwen3_asr.encoder = detect.paths.qwen3Encoder;
+                config.model_config.qwen3_asr.decoder = detect.paths.qwen3Decoder;
+                config.model_config.qwen3_asr.tokenizer = detect.paths.qwen3Tokenizer;
+                break;
+            case SttModelKind::kCohereTranscribe:
+                config.model_config.cohere_transcribe.encoder = detect.paths.cohereEncoder;
+                config.model_config.cohere_transcribe.decoder = detect.paths.cohereDecoder;
+                break;
+            case SttModelKind::kFireRedAsr:
+                config.model_config.fire_red_asr.encoder = detect.paths.fireRedEncoder;
+                config.model_config.fire_red_asr.decoder = detect.paths.fireRedDecoder;
+                break;
+            case SttModelKind::kMoonshine:
+                config.model_config.moonshine.preprocessor = detect.paths.moonshinePreprocessor;
+                config.model_config.moonshine.encoder = detect.paths.moonshineEncoder;
+                config.model_config.moonshine.uncached_decoder = detect.paths.moonshineUncachedDecoder;
+                config.model_config.moonshine.cached_decoder = detect.paths.moonshineCachedDecoder;
+                break;
+            case SttModelKind::kMoonshineV2:
+                config.model_config.moonshine.encoder = detect.paths.moonshineEncoder;
+                config.model_config.moonshine.merged_decoder = detect.paths.moonshineMergedDecoder;
+                break;
+            case SttModelKind::kDolphin:
+                config.model_config.dolphin.model = detect.paths.dolphinModel;
+                break;
+            case SttModelKind::kCanary:
+                config.model_config.canary.encoder = detect.paths.canaryEncoder;
+                config.model_config.canary.decoder = detect.paths.canaryDecoder;
+                break;
+            case SttModelKind::kOmnilingual:
+                config.model_config.omnilingual.model = detect.paths.omnilingualModel;
+                break;
+            case SttModelKind::kMedAsr:
+                config.model_config.medasr.model = detect.paths.medasrModel;
+                break;
+            case SttModelKind::kTeleSpeechCtc:
+                config.model_config.telespeech_ctc = detect.paths.telespeechCtcModel;
+                break;
+            default:
+                result.error = "Unsupported custom STT model kind";
+                return result;
+        }
+
+        if (!detect.paths.tokens.empty()) {
+            config.model_config.tokens = detect.paths.tokens;
+        }
+
+        switch (detect.selectedKind) {
+            case SttModelKind::kWhisper:
+                if (whisperOpts) {
+                    if (whisperOpts->language.has_value())
+                        config.model_config.whisper.language = *whisperOpts->language;
+                    if (whisperOpts->task.has_value())
+                        config.model_config.whisper.task = *whisperOpts->task;
+                    if (whisperOpts->tail_paddings.has_value())
+                        config.model_config.whisper.tail_paddings = *whisperOpts->tail_paddings;
+                    if (whisperOpts->enable_token_timestamps.has_value())
+                        config.model_config.whisper.enable_token_timestamps =
+                            *whisperOpts->enable_token_timestamps;
+                    if (whisperOpts->enable_segment_timestamps.has_value())
+                        config.model_config.whisper.enable_segment_timestamps =
+                            *whisperOpts->enable_segment_timestamps;
+                }
+                break;
+            case SttModelKind::kSenseVoice:
+                if (senseVoiceOpts) {
+                    if (senseVoiceOpts->language.has_value())
+                        config.model_config.sense_voice.language = *senseVoiceOpts->language;
+                    if (senseVoiceOpts->use_itn.has_value())
+                        config.model_config.sense_voice.use_itn = *senseVoiceOpts->use_itn;
+                }
+                break;
+            case SttModelKind::kCanary:
+                if (canaryOpts) {
+                    if (canaryOpts->src_lang.has_value())
+                        config.model_config.canary.src_lang = *canaryOpts->src_lang;
+                    if (canaryOpts->tgt_lang.has_value())
+                        config.model_config.canary.tgt_lang = *canaryOpts->tgt_lang;
+                    if (canaryOpts->use_pnc.has_value())
+                        config.model_config.canary.use_pnc = *canaryOpts->use_pnc;
+                }
+                break;
+            case SttModelKind::kFunAsrNano:
+                if (funasrNanoOpts) {
+                    if (funasrNanoOpts->system_prompt.has_value())
+                        config.model_config.funasr_nano.system_prompt = *funasrNanoOpts->system_prompt;
+                    if (funasrNanoOpts->user_prompt.has_value())
+                        config.model_config.funasr_nano.user_prompt = *funasrNanoOpts->user_prompt;
+                    if (funasrNanoOpts->max_new_tokens.has_value())
+                        config.model_config.funasr_nano.max_new_tokens = *funasrNanoOpts->max_new_tokens;
+                    if (funasrNanoOpts->temperature.has_value())
+                        config.model_config.funasr_nano.temperature = *funasrNanoOpts->temperature;
+                    if (funasrNanoOpts->top_p.has_value())
+                        config.model_config.funasr_nano.top_p = *funasrNanoOpts->top_p;
+                    if (funasrNanoOpts->seed.has_value())
+                        config.model_config.funasr_nano.seed = *funasrNanoOpts->seed;
+                    if (funasrNanoOpts->language.has_value())
+                        config.model_config.funasr_nano.language = *funasrNanoOpts->language;
+                    if (funasrNanoOpts->itn.has_value())
+                        config.model_config.funasr_nano.itn = *funasrNanoOpts->itn;
+                    if (funasrNanoOpts->hotwords.has_value())
+                        config.model_config.funasr_nano.hotwords = *funasrNanoOpts->hotwords;
+                }
+                break;
+            case SttModelKind::kQwen3Asr:
+                if (qwen3AsrOpts) {
+                    if (qwen3AsrOpts->max_total_len.has_value())
+                        config.model_config.qwen3_asr.max_total_len = *qwen3AsrOpts->max_total_len;
+                    if (qwen3AsrOpts->max_new_tokens.has_value())
+                        config.model_config.qwen3_asr.max_new_tokens = *qwen3AsrOpts->max_new_tokens;
+                    if (qwen3AsrOpts->temperature.has_value())
+                        config.model_config.qwen3_asr.temperature = *qwen3AsrOpts->temperature;
+                    if (qwen3AsrOpts->top_p.has_value())
+                        config.model_config.qwen3_asr.top_p = *qwen3AsrOpts->top_p;
+                    if (qwen3AsrOpts->seed.has_value())
+                        config.model_config.qwen3_asr.seed = *qwen3AsrOpts->seed;
+                }
+                break;
+            case SttModelKind::kCohereTranscribe:
+                if (cohereTranscribeOpts) {
+                    if (cohereTranscribeOpts->language.has_value())
+                        config.model_config.cohere_transcribe.language = *cohereTranscribeOpts->language;
+                    if (cohereTranscribeOpts->use_punct.has_value())
+                        config.model_config.cohere_transcribe.use_punct = *cohereTranscribeOpts->use_punct;
+                    if (cohereTranscribeOpts->use_itn.has_value())
+                        config.model_config.cohere_transcribe.use_itn = *cohereTranscribeOpts->use_itn;
+                }
+                break;
+            default:
+                break;
+        }
+
+        if (hotwordsFile.has_value() && !hotwordsFile->empty()) {
+            if (!SupportsHotwords(detect.selectedKind)) {
+                result.error = "HOTWORDS_NOT_SUPPORTED: Hotwords are only supported for transducer models (transducer, nemo_transducer).";
+                return result;
+            }
+            auto validateErr = ValidateHotwordsFile(*hotwordsFile);
+            if (validateErr.has_value()) {
+                result.error = "INVALID_HOTWORDS_FILE: " + *validateErr;
+                return result;
+            }
+        }
+
+        config.decoding_method = "greedy_search";
+        config.model_config.num_threads = numThreads.value_or(1);
+        config.model_config.provider = provider.value_or("cpu");
+        if (hotwordsFile.has_value() && !hotwordsFile->empty()) {
+            config.hotwords_file = *hotwordsFile;
+            config.decoding_method = "modified_beam_search";
+            config.max_active_paths = std::max(4, config.max_active_paths);
+        }
+        if (hotwordsScore.has_value()) {
+            config.hotwords_score = *hotwordsScore;
+        }
+        if (ruleFsts.has_value() && !ruleFsts->empty()) {
+            config.rule_fsts = *ruleFsts;
+        }
+        if (ruleFars.has_value() && !ruleFars->empty()) {
+            config.rule_fars = *ruleFars;
+        }
+        (void)dither;
+
+        pImpl->qwen3_hotwords_csv.clear();
+        if (detect.selectedKind == SttModelKind::kQwen3Asr && qwen3AsrOpts &&
+            qwen3AsrOpts->hotwords.has_value() && !qwen3AsrOpts->hotwords->empty()) {
+            pImpl->qwen3_hotwords_csv = NormalizeQwen3HotwordsCsv(*qwen3AsrOpts->hotwords);
+        }
+
+        try {
+            pImpl->recognizer = sherpa_onnx::cxx::OfflineRecognizer::Create(config);
+        } catch (const std::exception& e) {
+            result.error = std::string("INIT_ERROR: ") + e.what();
+            return result;
+        }
+
+        pImpl->lastConfig = config;
+        pImpl->modelDir = "custom";
+        pImpl->currentModelKind = detect.selectedKind;
+        pImpl->initialized = true;
+
+        result.success = true;
+        result.detectedModels = detect.detectedModels;
+        result.modelType = modelType;
+        result.decodingMethod = config.decoding_method;
+        return result;
+    } catch (const std::exception& e) {
+        result.error = std::string("Exception during custom initialization: ") + e.what();
         return result;
     }
 }

--- a/ios/tts/bridge/SherpaOnnx+TTSInit.mm
+++ b/ios/tts/bridge/SherpaOnnx+TTSInit.mm
@@ -9,11 +9,30 @@
 #include "engine/TtsEngineStore.h"
 #include "options/TtsGenerationOptionsHelpers.h"
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-model-path-fill.h"
 #include "native/sherpa-onnx-tts-wrapper.h"
 
 #include <memory>
+#include <map>
 #include <optional>
 #include <string>
+
+static void FillTtsModelPathsFromDict(
+    NSDictionary *dict,
+    sherpaonnx::TtsModelPaths &paths
+) {
+    if (![dict isKindOfClass:[NSDictionary class]]) {
+        return;
+    }
+    std::map<std::string, std::string> pathMap;
+    for (NSString *key in dict) {
+        id value = dict[key];
+        if ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) {
+            pathMap[std::string([key UTF8String])] = std::string([(NSString *)value UTF8String]);
+        }
+    }
+    sherpaonnx::FillTtsModelPathsFromStringMap(pathMap, paths);
+}
 
 @implementation SherpaOnnx (TTSInit)
 
@@ -32,12 +51,27 @@ static NSString *TtsTrimmedString(NSString *value) {
         reject(@"TTS_INIT_ERROR", @"instanceId is required", nil);
         return;
     }
+
+    NSString *initMode = options.initMode();
+    if (initMode == nil || [initMode length] == 0) {
+        initMode = @"auto";
+    }
+    const bool isCustomInit = initMode.length > 0 && [initMode isEqualToString:@"custom"];
+
     NSString *modelDir = TtsTrimmedString(options.modelDir());
-    if (modelDir == nil) {
-        reject(@"TTS_INIT_ERROR", @"modelDir is required", nil);
+    if (!isCustomInit && modelDir == nil) {
+        reject(@"TTS_INIT_ERROR", @"modelDir is required for initMode auto", nil);
         return;
     }
     NSString *modelType = TtsTrimmedString(options.modelType()) ?: @"auto";
+    if (isCustomInit && (modelType == nil || [modelType length] == 0 || [modelType isEqualToString:@"auto"])) {
+        reject(@"TTS_INIT_ERROR", @"modelType is required for initMode custom", nil);
+        return;
+    }
+    if (isCustomInit && TtsTrimmedString(options.lexiconLanguageId()) != nil) {
+        reject(@"TTS_INIT_ERROR", @"lexiconLanguageId is only supported for initMode auto", nil);
+        return;
+    }
     auto numThreadsOpt = options.numThreads();
     double numThreads = numThreadsOpt.has_value() ? numThreadsOpt.value() : 2.0;
     auto debugOpt = options.debug();
@@ -59,7 +93,7 @@ static NSString *TtsTrimmedString(NSString *value) {
     NSString *kokoroLang = TtsTrimmedString(options.kokoroLang());
 
     std::string instanceIdStr = [instanceId UTF8String];
-    RCTLogInfo(@"Initializing TTS instance %@ with modelDir: %@, modelType: %@", instanceId, modelDir, modelType);
+    RCTLogInfo(@"Initializing TTS instance %@ initMode=%@ modelDir=%@, modelType: %@", instanceId, initMode, modelDir, modelType);
 
     @try {
         std::lock_guard<std::mutex> lock(g_tts_mutex);
@@ -72,7 +106,7 @@ static NSString *TtsTrimmedString(NSString *value) {
             inst->wrapper = std::make_unique<sherpaonnx::TtsWrapper>();
         }
 
-        std::string modelDirStr = [modelDir UTF8String];
+        std::string modelDirStr = modelDir != nil ? [modelDir UTF8String] : "";
         std::string modelTypeStr = [modelType UTF8String];
 
         std::optional<float> noiseScaleOpt = std::nullopt;
@@ -117,27 +151,55 @@ static NSString *TtsTrimmedString(NSString *value) {
             kokoroLangOpt = std::string([kokoroLang UTF8String]);
         }
 
-        sherpaonnx::TtsInitializeResult result = inst->wrapper->initialize(
-            modelDirStr,
-            modelTypeStr,
-            static_cast<int32_t>(numThreads),
-            debug,
-            noiseScaleOpt,
-            noiseScaleWOpt,
-            lengthScaleOpt,
-            ruleFstsOpt,
-            ruleFarsOpt,
-            maxNumSentencesOpt,
-            silenceScaleOpt,
-            providerOpt,
-            lexiconLanguageIdOpt,
-            kokoroLangOpt
-        );
+        sherpaonnx::TtsInitializeResult result;
+        if (isCustomInit) {
+            id pathsRaw = options.modelPaths();
+            NSDictionary *pathsDict =
+                [pathsRaw isKindOfClass:[NSDictionary class]] ? (NSDictionary *)pathsRaw : nil;
+            if (pathsDict == nil || pathsDict.count == 0) {
+                reject(@"TTS_INIT_ERROR", @"modelPaths is required for initMode custom", nil);
+                return;
+            }
+            sherpaonnx::TtsModelPaths paths;
+            FillTtsModelPathsFromDict(pathsDict, paths);
+            result = inst->wrapper->initializeCustom(
+                modelTypeStr,
+                paths,
+                static_cast<int32_t>(numThreads),
+                debug,
+                noiseScaleOpt,
+                noiseScaleWOpt,
+                lengthScaleOpt,
+                ruleFstsOpt,
+                ruleFarsOpt,
+                maxNumSentencesOpt,
+                silenceScaleOpt,
+                providerOpt,
+                kokoroLangOpt
+            );
+        } else {
+            result = inst->wrapper->initialize(
+                modelDirStr,
+                modelTypeStr,
+                static_cast<int32_t>(numThreads),
+                debug,
+                noiseScaleOpt,
+                noiseScaleWOpt,
+                lengthScaleOpt,
+                ruleFstsOpt,
+                ruleFarsOpt,
+                maxNumSentencesOpt,
+                silenceScaleOpt,
+                providerOpt,
+                lexiconLanguageIdOpt,
+                kokoroLangOpt
+            );
+        }
 
         if (result.success) {
             RCTLogInfo(@"TTS initialization successful for instance %@", instanceId);
 
-            inst->modelDir = [modelDir copy];
+            inst->modelDir = isCustomInit ? [@"custom" copy] : [modelDir copy];
             inst->modelType = [modelType copy];
             inst->numThreads = static_cast<int32_t>(numThreads);
             inst->debug = debug;

--- a/ios/tts/native/sherpa-onnx-tts-wrapper.h
+++ b/ios/tts/native/sherpa-onnx-tts-wrapper.h
@@ -58,6 +58,22 @@ public:
         const std::optional<std::string>& kokoroLang = std::nullopt
     );
 
+    TtsInitializeResult initializeCustom(
+        const std::string& modelType,
+        const TtsModelPaths& paths,
+        int32_t numThreads = 2,
+        bool debug = false,
+        const std::optional<float>& noiseScale = std::nullopt,
+        const std::optional<float>& noiseScaleW = std::nullopt,
+        const std::optional<float>& lengthScale = std::nullopt,
+        const std::optional<std::string>& ruleFsts = std::nullopt,
+        const std::optional<std::string>& ruleFars = std::nullopt,
+        const std::optional<int32_t>& maxNumSentences = std::nullopt,
+        const std::optional<float>& silenceScale = std::nullopt,
+        const std::optional<std::string>& provider = std::nullopt,
+        const std::optional<std::string>& kokoroLang = std::nullopt
+    );
+
     struct AudioResult {
         std::vector<float> samples;  // Audio samples in range [-1.0, 1.0]
         int32_t sampleRate;          // Sample rate in Hz

--- a/ios/tts/native/sherpa-onnx-tts-wrapper.mm
+++ b/ios/tts/native/sherpa-onnx-tts-wrapper.mm
@@ -8,6 +8,8 @@
 #include "sherpa-onnx-tts-wrapper.h"
 #include "sherpa-onnx-model-detect.h"
 #include "sherpa-onnx-model-detect-helper.h"
+#include "sherpa-onnx-model-path-fill.h"
+#include "sherpa-onnx-validate-tts.h"
 #include <cctype>
 #include <cstring>
 #include <optional>
@@ -32,6 +34,21 @@ namespace fs = std::filesystem;
 #include "sherpa-onnx/c-api/cxx-api.h"
 
 namespace sherpaonnx {
+
+namespace {
+
+TtsModelKind ParseTtsModelTypeFromString(const std::string& modelType) {
+    if (modelType == "vits") return TtsModelKind::kVits;
+    if (modelType == "matcha") return TtsModelKind::kMatcha;
+    if (modelType == "kokoro") return TtsModelKind::kKokoro;
+    if (modelType == "kitten") return TtsModelKind::kKitten;
+    if (modelType == "pocket") return TtsModelKind::kPocket;
+    if (modelType == "zipvoice") return TtsModelKind::kZipvoice;
+    if (modelType == "supertonic") return TtsModelKind::kSupertonic;
+    return TtsModelKind::kUnknown;
+}
+
+}  // namespace
 
 class TtsWrapper::Impl {
 public:
@@ -266,6 +283,194 @@ TtsInitializeResult TtsWrapper::initialize(
     } catch (...) {
         result.error = "TTS: Unknown exception during initialization";
         LOGE("TTS: Unknown exception during initialization");
+        return result;
+    }
+}
+
+TtsInitializeResult TtsWrapper::initializeCustom(
+    const std::string& modelType,
+    const TtsModelPaths& paths,
+    int32_t numThreads,
+    bool debug,
+    const std::optional<float>& noiseScale,
+    const std::optional<float>& noiseScaleW,
+    const std::optional<float>& lengthScale,
+    const std::optional<std::string>& ruleFsts,
+    const std::optional<std::string>& ruleFars,
+    const std::optional<int32_t>& maxNumSentences,
+    const std::optional<float>& silenceScale,
+    const std::optional<std::string>& provider,
+    const std::optional<std::string>& kokoroLang
+) {
+    TtsInitializeResult result;
+    result.success = false;
+
+    if (pImpl->initialized) {
+        release();
+    }
+
+    const TtsModelKind selectedKind = ParseTtsModelTypeFromString(modelType);
+    if (selectedKind == TtsModelKind::kUnknown) {
+        result.error = "Unsupported custom TTS model type: " + modelType;
+        LOGE("%s", result.error.c_str());
+        return result;
+    }
+
+    auto validation = ValidateTtsPaths(selectedKind, paths, "custom");
+    if (!validation.ok) {
+        result.error = validation.error;
+        LOGE("%s", result.error.c_str());
+        return result;
+    }
+
+    try {
+        sherpa_onnx::cxx::OfflineTtsConfig config;
+        config.model.num_threads = numThreads;
+        config.model.debug = debug;
+        if (provider.has_value() && !provider->empty()) {
+            config.model.provider = *provider;
+        }
+
+        switch (selectedKind) {
+            case TtsModelKind::kVits:
+                config.model.vits.model = paths.ttsModel;
+                config.model.vits.tokens = paths.tokens;
+                config.model.vits.data_dir = paths.dataDir;
+                if (!paths.lexicon.empty()) {
+                    config.model.vits.lexicon = paths.lexicon;
+                }
+                if (noiseScale.has_value()) {
+                    config.model.vits.noise_scale = *noiseScale;
+                }
+                if (noiseScaleW.has_value()) {
+                    config.model.vits.noise_scale_w = *noiseScaleW;
+                }
+                if (lengthScale.has_value()) {
+                    config.model.vits.length_scale = *lengthScale;
+                }
+                break;
+            case TtsModelKind::kMatcha:
+                config.model.matcha.acoustic_model = paths.acousticModel;
+                config.model.matcha.vocoder = paths.vocoder;
+                config.model.matcha.tokens = paths.tokens;
+                config.model.matcha.data_dir = paths.dataDir;
+                if (!paths.lexicon.empty()) {
+                    config.model.matcha.lexicon = paths.lexicon;
+                }
+                if (noiseScale.has_value()) {
+                    config.model.matcha.noise_scale = *noiseScale;
+                }
+                if (lengthScale.has_value()) {
+                    config.model.matcha.length_scale = *lengthScale;
+                }
+                break;
+            case TtsModelKind::kKokoro:
+                config.model.kokoro.model = paths.ttsModel;
+                config.model.kokoro.tokens = paths.tokens;
+                config.model.kokoro.data_dir = paths.dataDir;
+                config.model.kokoro.voices = paths.voices;
+                if (!paths.lexicon.empty()) {
+                    config.model.kokoro.lexicon = paths.lexicon;
+                }
+                if (lengthScale.has_value()) {
+                    config.model.kokoro.length_scale = *lengthScale;
+                }
+                if (kokoroLang.has_value() && !kokoroLang->empty()) {
+                    config.model.kokoro.lang = *kokoroLang;
+                }
+                break;
+            case TtsModelKind::kKitten:
+                config.model.kitten.model = paths.ttsModel;
+                config.model.kitten.tokens = paths.tokens;
+                config.model.kitten.data_dir = paths.dataDir;
+                config.model.kitten.voices = paths.voices;
+                if (lengthScale.has_value()) {
+                    config.model.kitten.length_scale = *lengthScale;
+                }
+                break;
+            case TtsModelKind::kZipvoice:
+                config.model.zipvoice.encoder = paths.encoder;
+                config.model.zipvoice.decoder = paths.decoder;
+                config.model.zipvoice.vocoder = paths.vocoder;
+                config.model.zipvoice.tokens = paths.tokens;
+                config.model.zipvoice.data_dir = paths.dataDir;
+                if (!paths.lexicon.empty()) {
+                    config.model.zipvoice.lexicon = paths.lexicon;
+                }
+                config.model.num_threads = 1;
+                break;
+            case TtsModelKind::kPocket:
+                config.model.pocket.lm_flow = paths.lmFlow;
+                config.model.pocket.lm_main = paths.lmMain;
+                config.model.pocket.encoder = paths.encoder;
+                config.model.pocket.decoder = paths.decoder;
+                config.model.pocket.text_conditioner = paths.textConditioner;
+                config.model.pocket.vocab_json = paths.vocabJson;
+                config.model.pocket.token_scores_json = paths.tokenScoresJson;
+                break;
+            case TtsModelKind::kSupertonic:
+                config.model.supertonic.duration_predictor = paths.durationPredictor;
+                config.model.supertonic.text_encoder = paths.textEncoder;
+                config.model.supertonic.vector_estimator = paths.vectorEstimator;
+                config.model.supertonic.vocoder = paths.vocoder;
+                config.model.supertonic.tts_json = paths.ttsJson;
+                config.model.supertonic.unicode_indexer = paths.unicodeIndexer;
+                config.model.supertonic.voice_style = paths.voiceStyle;
+                break;
+            case TtsModelKind::kUnknown:
+            default:
+                result.error = "TTS: Unknown model type: " + modelType;
+                LOGE("TTS: Unknown model type: %s", modelType.c_str());
+                return result;
+        }
+
+        if (selectedKind == TtsModelKind::kVits &&
+            paths.dataDir.empty() &&
+            paths.lexicon.empty()) {
+            result.error =
+                "TTS VITS init blocked: missing both espeak-ng-data and lexicon. "
+                "Please add espeak-ng-data to the model folder or provide a lexicon.";
+            LOGE("%s", result.error.c_str());
+            return result;
+        }
+
+        if (ruleFsts.has_value() && !ruleFsts->empty()) {
+            config.rule_fsts = *ruleFsts;
+        }
+        if (ruleFars.has_value() && !ruleFars->empty()) {
+            config.rule_fars = *ruleFars;
+        }
+        if (maxNumSentences.has_value() && *maxNumSentences >= 1) {
+            config.max_num_sentences = *maxNumSentences;
+        }
+        if (silenceScale.has_value()) {
+            config.silence_scale = *silenceScale;
+        }
+
+        LOGI("TTS: Creating OfflineTts instance (custom init)...");
+        pImpl->tts = sherpa_onnx::cxx::OfflineTts::Create(config);
+
+        if (!pImpl->tts.has_value()) {
+            result.error = "TTS: Failed to create OfflineTts instance (e.g. missing espeak-ng data or invalid model)";
+            LOGE("%s", result.error.c_str());
+            return result;
+        }
+
+        pImpl->initialized = true;
+        pImpl->modelDir = "custom";
+        pImpl->modelKind = selectedKind;
+
+        LOGI("TTS: Custom initialization successful");
+        result.success = true;
+        result.detectedModels.push_back({modelType, "custom"});
+        return result;
+    } catch (const std::exception& e) {
+        result.error = std::string("TTS custom init exception: ") + e.what();
+        LOGE("TTS: Exception during custom initialization: %s", e.what());
+        return result;
+    } catch (...) {
+        result.error = "TTS: Unknown exception during custom initialization";
+        LOGE("TTS: Unknown exception during custom initialization");
         return result;
     }
 }

--- a/ios/vad/bridge/SherpaOnnx+VAD.mm
+++ b/ios/vad/bridge/SherpaOnnx+VAD.mm
@@ -57,6 +57,36 @@ void FillVadModelPathsFromDict(NSDictionary *dict, sherpaonnx::VadModelPaths &pa
   sherpaonnx::FillVadModelPathsFromStringMap(pathMap, paths);
 }
 
+struct VadInstanceState {
+  std::string modelType;
+  std::string modelPath;
+  int sampleRate = 16000;
+  int numThreads = 1;
+  std::string provider = "cpu";
+  bool debug = false;
+  double scoreThreshold = 0.5;
+  int minSpeechDurationMs = 250;
+  int minSilenceDurationMs = 250;
+  int maxSpeechDurationMs = 5000;
+  int windowSize = 512;
+  bool speechDetected = false;
+  std::shared_ptr<VadRuntime> runtime;
+};
+
+struct VadPipelineState {
+  std::string instanceId;
+  std::shared_ptr<VadPipelineWorker> worker;
+  bool running = true;
+  bool flushing = false;
+  int queueDepth = 0;
+  std::string error;
+};
+
+std::mutex g_vad_mutex;
+std::unordered_map<std::string, VadInstanceState> g_vad_instances;
+std::unordered_map<std::string, VadPipelineState> g_vad_pipelines;
+std::unordered_map<std::string, std::string> g_vad_instance_to_pipeline;
+
 void ApplyVadInitScalars(VadInstanceState &state, NSDictionary *options, NSString *resolvedModelType) {
   if ([options[@"sampleRate"] respondsToSelector:@selector(intValue)]) {
     state.sampleRate = MAX(1, [options[@"sampleRate"] intValue]);
@@ -126,36 +156,6 @@ bool FinishVadInitialize(
   resolve(nil);
   return true;
 }
-
-struct VadInstanceState {
-  std::string modelType;
-  std::string modelPath;
-  int sampleRate = 16000;
-  int numThreads = 1;
-  std::string provider = "cpu";
-  bool debug = false;
-  double scoreThreshold = 0.5;
-  int minSpeechDurationMs = 250;
-  int minSilenceDurationMs = 250;
-  int maxSpeechDurationMs = 5000;
-  int windowSize = 512;
-  bool speechDetected = false;
-  std::shared_ptr<VadRuntime> runtime;
-};
-
-struct VadPipelineState {
-  std::string instanceId;
-  std::shared_ptr<VadPipelineWorker> worker;
-  bool running = true;
-  bool flushing = false;
-  int queueDepth = 0;
-  std::string error;
-};
-
-std::mutex g_vad_mutex;
-std::unordered_map<std::string, VadInstanceState> g_vad_instances;
-std::unordered_map<std::string, VadPipelineState> g_vad_pipelines;
-std::unordered_map<std::string, std::string> g_vad_instance_to_pipeline;
 
 std::shared_ptr<VadPipelineWorker> DetachPipelineLocked(
   const std::string &pipelineId,

--- a/ios/vad/bridge/SherpaOnnx+VAD.mm
+++ b/ios/vad/bridge/SherpaOnnx+VAD.mm
@@ -14,6 +14,9 @@
 #include <algorithm>
 
 #include "sherpa-onnx-model-detect.h"
+#include "sherpa-onnx-model-path-fill.h"
+#include "sherpa-onnx-validate-vad.h"
+#include <map>
 
 namespace {
 std::optional<std::string> OptionalUtf8String(NSString *value) {
@@ -32,6 +35,96 @@ NSString *VadModelKindToNSString(sherpaonnx::VadModelKind kind) {
     default:
       return @"unknown";
   }
+}
+
+sherpaonnx::VadModelKind ParseVadModelTypeFromString(const std::string &modelType) {
+  if (modelType == "silero_vad") return sherpaonnx::VadModelKind::kSileroVad;
+  if (modelType == "ten_vad") return sherpaonnx::VadModelKind::kTenVad;
+  return sherpaonnx::VadModelKind::kUnknown;
+}
+
+void FillVadModelPathsFromDict(NSDictionary *dict, sherpaonnx::VadModelPaths &paths) {
+  if (![dict isKindOfClass:[NSDictionary class]]) {
+    return;
+  }
+  std::map<std::string, std::string> pathMap;
+  for (NSString *key in dict) {
+    id value = dict[key];
+    if ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) {
+      pathMap[std::string([key UTF8String])] = std::string([(NSString *)value UTF8String]);
+    }
+  }
+  sherpaonnx::FillVadModelPathsFromStringMap(pathMap, paths);
+}
+
+void ApplyVadInitScalars(VadInstanceState &state, NSDictionary *options, NSString *resolvedModelType) {
+  if ([options[@"sampleRate"] respondsToSelector:@selector(intValue)]) {
+    state.sampleRate = MAX(1, [options[@"sampleRate"] intValue]);
+  }
+  if ([options[@"numThreads"] respondsToSelector:@selector(intValue)]) {
+    state.numThreads = MAX(1, [options[@"numThreads"] intValue]);
+  }
+  if ([options[@"provider"] isKindOfClass:[NSString class]] &&
+      [options[@"provider"] length] > 0) {
+    state.provider = std::string([options[@"provider"] UTF8String]);
+  }
+  if ([options[@"debug"] respondsToSelector:@selector(boolValue)]) {
+    state.debug = [options[@"debug"] boolValue];
+  }
+  if ([options[@"threshold"] respondsToSelector:@selector(doubleValue)]) {
+    state.scoreThreshold = MAX(0.0, [options[@"threshold"] doubleValue]);
+  }
+  if ([options[@"minSpeechDurationMs"] respondsToSelector:@selector(intValue)]) {
+    state.minSpeechDurationMs = MAX(0, [options[@"minSpeechDurationMs"] intValue]);
+  } else if ([options[@"speechDurationMs"] respondsToSelector:@selector(intValue)]) {
+    state.minSpeechDurationMs = MAX(0, [options[@"speechDurationMs"] intValue]);
+  }
+  if ([options[@"silenceDurationMs"] respondsToSelector:@selector(intValue)]) {
+    state.minSilenceDurationMs = MAX(0, [options[@"silenceDurationMs"] intValue]);
+  }
+  if ([options[@"windowSize"] respondsToSelector:@selector(intValue)]) {
+    state.windowSize = MAX(1, [options[@"windowSize"] intValue]);
+  } else if ([resolvedModelType isEqualToString:@"ten_vad"]) {
+    state.windowSize = 256;
+  }
+  if ([options[@"maxSpeechDurationS"] respondsToSelector:@selector(doubleValue)]) {
+    state.maxSpeechDurationMs =
+        MAX(0, (int)llround([options[@"maxSpeechDurationS"] doubleValue] * 1000.0));
+  }
+}
+
+bool FinishVadInitialize(
+    const std::string &instanceIdStr,
+    VadInstanceState state,
+    RCTPromiseResolveBlock resolve,
+    RCTPromiseRejectBlock reject
+) {
+  VadRuntimeConfig runtimeCfg;
+  runtimeCfg.modelType = state.modelType;
+  runtimeCfg.modelPath = state.modelPath;
+  runtimeCfg.sampleRate = state.sampleRate;
+  runtimeCfg.numThreads = state.numThreads;
+  runtimeCfg.provider = state.provider;
+  runtimeCfg.debug = state.debug;
+  runtimeCfg.scoreThreshold = state.scoreThreshold;
+  runtimeCfg.minSpeechDurationMs = state.minSpeechDurationMs;
+  runtimeCfg.minSilenceDurationMs = state.minSilenceDurationMs;
+  runtimeCfg.maxSpeechDurationMs = state.maxSpeechDurationMs;
+  runtimeCfg.windowSize = state.windowSize;
+  std::string runtimeErr;
+  state.runtime = VadRuntime::Create(runtimeCfg, &runtimeErr);
+  if (!state.runtime) {
+    reject(
+      @"VAD_MODEL_INIT_FAILED",
+      [NSString stringWithUTF8String:(runtimeErr.empty() ? "Failed to create iOS VAD runtime" : runtimeErr.c_str())],
+      nil
+    );
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(g_vad_mutex);
+  g_vad_instances[instanceIdStr] = state;
+  resolve(nil);
+  return true;
 }
 
 struct VadInstanceState {
@@ -166,9 +259,54 @@ std::shared_ptr<VadPipelineWorker> DetachPipelineLocked(
     reject(@"VAD_INVALID_ARGUMENT", @"instanceId is required", nil);
     return;
   }
+
+  NSString *initMode = options[@"initMode"];
+  if (initMode == nil || [initMode length] == 0) {
+    initMode = @"auto";
+  }
+  const bool isCustomInit = [initMode isEqualToString:@"custom"];
+  const std::string instanceIdStr = [instanceId UTF8String];
+
+  if (isCustomInit) {
+    NSString *modelType = options[@"modelType"];
+    if (modelType == nil || [modelType length] == 0 || [modelType isEqualToString:@"auto"]) {
+      reject(@"VAD_MODEL_INIT_FAILED", @"modelType is required for initMode custom", nil);
+      return;
+    }
+    id pathsRaw = options[@"modelPaths"];
+    NSDictionary *pathsDict =
+        [pathsRaw isKindOfClass:[NSDictionary class]] ? (NSDictionary *)pathsRaw : nil;
+    if (pathsDict == nil || pathsDict.count == 0) {
+      reject(@"VAD_MODEL_INIT_FAILED", @"modelPaths is required for initMode custom", nil);
+      return;
+    }
+
+    const std::string modelTypeStr = [modelType UTF8String];
+    const sherpaonnx::VadModelKind selectedKind = ParseVadModelTypeFromString(modelTypeStr);
+    if (selectedKind == sherpaonnx::VadModelKind::kUnknown) {
+      reject(@"VAD_MODEL_INIT_FAILED", @"Unsupported custom VAD model type", nil);
+      return;
+    }
+
+    sherpaonnx::VadModelPaths paths;
+    FillVadModelPathsFromDict(pathsDict, paths);
+    auto validation = sherpaonnx::ValidateVadPaths(selectedKind, paths, "custom");
+    if (!validation.ok) {
+      reject(@"VAD_MODEL_INIT_FAILED", [NSString stringWithUTF8String:validation.error.c_str()], nil);
+      return;
+    }
+
+    VadInstanceState state;
+    state.modelType = modelTypeStr;
+    state.modelPath = paths.model;
+    ApplyVadInitScalars(state, options, modelType);
+    FinishVadInitialize(instanceIdStr, state, resolve, reject);
+    return;
+  }
+
   NSString *modelDir = options[@"modelDir"];
   if (modelDir == nil || [modelDir length] == 0) {
-    reject(@"VAD_MODEL_INIT_FAILED", @"modelDir is required for VAD initialization", nil);
+    reject(@"VAD_MODEL_INIT_FAILED", @"modelDir is required for initMode auto", nil);
     return;
   }
 
@@ -199,65 +337,8 @@ std::shared_ptr<VadPipelineWorker> DetachPipelineLocked(
   VadInstanceState state;
   state.modelType = [resolvedModelType UTF8String];
   state.modelPath = detect.paths.model;
-  if ([options[@"sampleRate"] respondsToSelector:@selector(intValue)]) {
-    state.sampleRate = MAX(1, [options[@"sampleRate"] intValue]);
-  }
-  if ([options[@"numThreads"] respondsToSelector:@selector(intValue)]) {
-    state.numThreads = MAX(1, [options[@"numThreads"] intValue]);
-  }
-  if ([options[@"provider"] isKindOfClass:[NSString class]] &&
-      [options[@"provider"] length] > 0) {
-    state.provider = std::string([options[@"provider"] UTF8String]);
-  }
-  if ([options[@"debug"] respondsToSelector:@selector(boolValue)]) {
-    state.debug = [options[@"debug"] boolValue];
-  }
-  if ([options[@"threshold"] respondsToSelector:@selector(doubleValue)]) {
-    state.scoreThreshold = MAX(0.0, [options[@"threshold"] doubleValue]);
-  }
-  if ([options[@"minSpeechDurationMs"] respondsToSelector:@selector(intValue)]) {
-    state.minSpeechDurationMs = MAX(0, [options[@"minSpeechDurationMs"] intValue]);
-  } else if ([options[@"speechDurationMs"] respondsToSelector:@selector(intValue)]) {
-    state.minSpeechDurationMs = MAX(0, [options[@"speechDurationMs"] intValue]);
-  }
-  if ([options[@"silenceDurationMs"] respondsToSelector:@selector(intValue)]) {
-    state.minSilenceDurationMs = MAX(0, [options[@"silenceDurationMs"] intValue]);
-  }
-  if ([options[@"windowSize"] respondsToSelector:@selector(intValue)]) {
-    state.windowSize = MAX(1, [options[@"windowSize"] intValue]);
-  } else if ([resolvedModelType isEqualToString:@"ten_vad"]) {
-    state.windowSize = 256;
-  }
-  if ([options[@"maxSpeechDurationS"] respondsToSelector:@selector(doubleValue)]) {
-    state.maxSpeechDurationMs =
-        MAX(0, (int)llround([options[@"maxSpeechDurationS"] doubleValue] * 1000.0));
-  }
-
-  VadRuntimeConfig runtimeCfg;
-  runtimeCfg.modelType = state.modelType;
-  runtimeCfg.modelPath = state.modelPath;
-  runtimeCfg.sampleRate = state.sampleRate;
-  runtimeCfg.numThreads = state.numThreads;
-  runtimeCfg.provider = state.provider;
-  runtimeCfg.debug = state.debug;
-  runtimeCfg.scoreThreshold = state.scoreThreshold;
-  runtimeCfg.minSpeechDurationMs = state.minSpeechDurationMs;
-  runtimeCfg.minSilenceDurationMs = state.minSilenceDurationMs;
-  runtimeCfg.maxSpeechDurationMs = state.maxSpeechDurationMs;
-  runtimeCfg.windowSize = state.windowSize;
-  std::string runtimeErr;
-  state.runtime = VadRuntime::Create(runtimeCfg, &runtimeErr);
-  if (!state.runtime) {
-    reject(
-      @"VAD_MODEL_INIT_FAILED",
-      [NSString stringWithUTF8String:(runtimeErr.empty() ? "Failed to create iOS VAD runtime" : runtimeErr.c_str())],
-      nil
-    );
-    return;
-  }
-  std::lock_guard<std::mutex> lock(g_vad_mutex);
-  g_vad_instances[[instanceId UTF8String]] = state;
-  resolve(nil);
+  ApplyVadInitScalars(state, options, resolvedModelType);
+  FinishVadInitialize(instanceIdStr, state, resolve, reject);
 }
 
 - (void)startVadPipeline:(NSString *)instanceId

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -61,7 +61,10 @@ export type OnlineSttInitBridgeOptions = {
 
 /** `initializeTts(instanceId, options)` — offline TTS. */
 export type TtsInitBridgeOptions = {
-  modelDir: string;
+  initMode?: string;
+  modelDir?: string;
+  /** Resolved path map (ttsModel, tokens, …); NSDictionary / ReadableMap at native boundary. */
+  modelPaths?: Object;
   modelType: string;
   numThreads?: number;
   debug?: boolean;

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -112,6 +112,18 @@ export type EnhancementInitBridgeOptions = {
   debug?: boolean;
 };
 
+/** `initializeOfflinePunctuation` / `initializeOnlinePunctuation(instanceId, options)`. */
+export type PunctuationInitBridgeOptions = {
+  initMode?: string;
+  modelDir?: string;
+  /** Resolved path map; NSDictionary / ReadableMap at native boundary. */
+  modelPaths?: Object;
+  modelType: string;
+  numThreads?: number;
+  provider?: string;
+  debug?: boolean;
+};
+
 /** Native unified detect bridge result (see `detectModel` in detectModel.ts). */
 export type UnifiedDetectNativeResult = {
   matched: boolean;
@@ -1511,11 +1523,7 @@ export interface Spec extends TurboModule {
    */
   initializeOfflinePunctuation(
     instanceId: string,
-    modelDir: string,
-    modelType?: string | null,
-    numThreads?: number,
-    provider?: string,
-    debug?: boolean
+    options: PunctuationInitBridgeOptions
   ): Promise<{
     success: boolean;
     error?: string;
@@ -1551,11 +1559,7 @@ export interface Spec extends TurboModule {
    */
   initializeOnlinePunctuation(
     instanceId: string,
-    modelDir: string,
-    modelType?: string | null,
-    numThreads?: number,
-    provider?: string,
-    debug?: boolean
+    options: PunctuationInitBridgeOptions
   ): Promise<{
     success: boolean;
     error?: string;

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -137,6 +137,7 @@ export type UnifiedDetectNativeResult = {
   isHardwareSpecificUnsupported?: boolean;
   detectedModels: Array<{ type: string; modelDir: string }>;
   detectionSources?: string[];
+  paths?: Record<string, string>;
   error?: string;
 };
 
@@ -216,6 +217,8 @@ export interface Spec extends TurboModule {
     quantization?: string;
     /** Optional trace strings from native (see DetectionSource in src/types/modelDetect.ts). */
     detectionSources?: string[];
+    /** Resolved non-empty path keys from native file-based detection. */
+    paths?: Record<string, string>;
   }>;
 
   // ==================== Offline STT (by-reference) ====================
@@ -1201,6 +1204,8 @@ export interface Spec extends TurboModule {
     sizeTier?: string;
     /** Optional trace strings from native (see DetectionSource in src/types/modelDetect.ts). */
     detectionSources?: string[];
+    /** Resolved non-empty path keys from native file-based detection. */
+    paths?: Record<string, string>;
   }>;
 
   /**
@@ -1436,6 +1441,9 @@ export interface Spec extends TurboModule {
     languages?: string[];
     quantization?: string;
     detectionSources?: string[];
+    paths?: {
+      model?: string;
+    };
   }>;
 
   detectVadModel(

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -32,7 +32,9 @@ export type SttInitBridgeOptions = {
 
 /** `initializeOnlineStt(instanceId, options)` — streaming STT (endpoint rules flattened). */
 export type OnlineSttInitBridgeOptions = {
-  modelDir: string;
+  initMode?: string;
+  modelDir?: string;
+  modelPaths?: Object;
   modelType: string;
   enableEndpoint?: boolean;
   decodingMethod?: string;

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -10,9 +10,10 @@ import type { ExtractArchiveResult } from './extraction/types';
 
 /** `initializeStt(instanceId, options)` — offline STT. */
 export type SttInitBridgeOptions = {
-  initMode: 'auto' | 'custom';
+  initMode?: string;
   modelDir?: string;
-  modelPaths?: Record<string, string>;
+  /** Resolved path map (encoder, tokens, …); NSDictionary / ReadableMap at native boundary. */
+  modelPaths?: Object;
   preferInt8?: boolean;
   modelType?: string;
   debug?: boolean;
@@ -1449,7 +1450,7 @@ export interface Spec extends TurboModule {
   validateCustomModelPaths(
     category: string,
     modelType: string,
-    paths: Readonly<Record<string, string>>
+    paths: Object
   ): Promise<{
     ok: boolean;
     error?: string;

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -100,6 +100,18 @@ export type VadInitBridgeOptions = {
   debug?: boolean;
 };
 
+/** `initializeEnhancement` / `initializeOnlineEnhancement(instanceId, options)`. */
+export type EnhancementInitBridgeOptions = {
+  initMode?: string;
+  modelDir?: string;
+  /** Resolved path map (`model`); NSDictionary / ReadableMap at native boundary. */
+  modelPaths?: Object;
+  modelType: string;
+  numThreads?: number;
+  provider?: string;
+  debug?: boolean;
+};
+
 /** Native unified detect bridge result (see `detectModel` in detectModel.ts). */
 export type UnifiedDetectNativeResult = {
   matched: boolean;
@@ -1609,11 +1621,7 @@ export interface Spec extends TurboModule {
 
   initializeEnhancement(
     instanceId: string,
-    modelDir: string,
-    modelType?: string,
-    numThreads?: number,
-    provider?: string,
-    debug?: boolean
+    options: EnhancementInitBridgeOptions
   ): Promise<{
     success: boolean;
     error?: string;
@@ -1634,11 +1642,7 @@ export interface Spec extends TurboModule {
 
   initializeOnlineEnhancement(
     instanceId: string,
-    modelDir: string,
-    modelType?: string,
-    numThreads?: number,
-    provider?: string,
-    debug?: boolean
+    options: EnhancementInitBridgeOptions
   ): Promise<{
     success: boolean;
     error?: string;

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -5,7 +5,7 @@ import type { ExtractArchiveResult } from './extraction/types';
 /**
  * TurboModule init bridge option shapes (flat ReadableMap / NSDictionary).
  * Must live in this file — React Native codegen does not resolve imported type aliases.
- * Builders: `buildSttInitBridgeOptions`, `buildOnlineSttInitBridgeOptions`, `buildTtsInitBridgeOptions`.
+ * Builders: `buildSttInitBridgeOptions`, `buildOnlineSttInitBridgeOptions`, `buildTtsInitBridgeOptions`, `buildVadInitBridgeOptions`.
  */
 
 /** `initializeStt(instanceId, options)` — offline STT. */
@@ -79,6 +79,25 @@ export type TtsInitBridgeOptions = {
   lexiconLanguageId?: string;
   /** Bridge-only: from public `modelOptions.kokoro.lang`. */
   kokoroLang?: string;
+};
+
+/** `initializeVad(instanceId, options)` — streaming VAD. */
+export type VadInitBridgeOptions = {
+  initMode?: string;
+  modelDir?: string;
+  /** Resolved path map (`model`); NSDictionary / ReadableMap at native boundary. */
+  modelPaths?: Object;
+  modelType: string;
+  sampleRate?: number;
+  threshold?: number;
+  silenceDurationMs?: number;
+  speechDurationMs?: number;
+  minSpeechDurationMs?: number;
+  maxSpeechDurationS?: number;
+  windowSize?: number;
+  provider?: string;
+  numThreads?: number;
+  debug?: boolean;
 };
 
 /** Native unified detect bridge result (see `detectModel` in detectModel.ts). */
@@ -1062,7 +1081,10 @@ export interface Spec extends TurboModule {
 
   // ==================== VAD Methods ====================
 
-  initializeVad(instanceId: string, options: Object): Promise<void>;
+  initializeVad(
+    instanceId: string,
+    options: VadInitBridgeOptions
+  ): Promise<void>;
 
   startVadPipeline(
     instanceId: string,

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -1508,13 +1508,16 @@ export interface Spec extends TurboModule {
     missingRequired?: string[];
   }>;
 
-  /** Schema for custom-init UI: required vs optional path keys from native C++. */
+  /** Schema for custom-init UI: path keys from native C++ requirement tables. */
   getCustomModelPathRequirements(
     category: string,
     modelType: string
   ): Promise<{
-    required: string[];
-    optional: string[];
+    fields: Array<{
+      key: string;
+      required: boolean;
+      kind: 'file' | 'dir';
+    }>;
   }>;
 
   /**

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -137,7 +137,7 @@ export type UnifiedDetectNativeResult = {
   isHardwareSpecificUnsupported?: boolean;
   detectedModels: Array<{ type: string; modelDir: string }>;
   detectionSources?: string[];
-  paths?: Record<string, string>;
+  paths?: Object;
   error?: string;
 };
 
@@ -218,7 +218,7 @@ export interface Spec extends TurboModule {
     /** Optional trace strings from native (see DetectionSource in src/types/modelDetect.ts). */
     detectionSources?: string[];
     /** Resolved non-empty path keys from native file-based detection. */
-    paths?: Record<string, string>;
+    paths?: Object;
   }>;
 
   // ==================== Offline STT (by-reference) ====================
@@ -1205,7 +1205,7 @@ export interface Spec extends TurboModule {
     /** Optional trace strings from native (see DetectionSource in src/types/modelDetect.ts). */
     detectionSources?: string[];
     /** Resolved non-empty path keys from native file-based detection. */
-    paths?: Record<string, string>;
+    paths?: Object;
   }>;
 
   /**

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -10,7 +10,9 @@ import type { ExtractArchiveResult } from './extraction/types';
 
 /** `initializeStt(instanceId, options)` — offline STT. */
 export type SttInitBridgeOptions = {
-  modelDir: string;
+  initMode: 'auto' | 'custom';
+  modelDir?: string;
+  modelPaths?: Record<string, string>;
   preferInt8?: boolean;
   modelType?: string;
   debug?: boolean;
@@ -1442,6 +1444,26 @@ export interface Spec extends TurboModule {
       assetName?: string | null;
     }>
   ): Promise<UnifiedDetectNativeResult[]>;
+
+  /** Runtime validation of resolved custom-init path maps (C++ validate-* tables). */
+  validateCustomModelPaths(
+    category: string,
+    modelType: string,
+    paths: Readonly<Record<string, string>>
+  ): Promise<{
+    ok: boolean;
+    error?: string;
+    missingRequired?: string[];
+  }>;
+
+  /** Schema for custom-init UI: required vs optional path keys from native C++. */
+  getCustomModelPathRequirements(
+    category: string,
+    modelType: string
+  ): Promise<{
+    required: string[];
+    optional: string[];
+  }>;
 
   /**
    * Load sherpa-onnx `OfflinePunctuation` (CT-Transformer). Uses native detect with

--- a/src/__tests__/detectModel.test.ts
+++ b/src/__tests__/detectModel.test.ts
@@ -38,7 +38,12 @@ describe('detectModel', () => {
       success: true,
       category: 'tts',
       modelType: 'vits',
-      detectedModels: [],
+      detectedModels: [{ type: 'vits', modelDir: '/models/vits' }],
+      detectionSources: ['fileListing'],
+      paths: {
+        ttsModel: '/models/vits/model.onnx',
+        tokens: '/models/vits/tokens.txt',
+      },
       languages: ['en'],
       quantization: 'int8',
       sizeTier: 'small',
@@ -53,6 +58,12 @@ describe('detectModel', () => {
         category: ModelCategory.Tts,
         modelType: 'vits',
         isStreaming: true,
+        paths: {
+          ttsModel: '/models/vits/model.onnx',
+          tokens: '/models/vits/tokens.txt',
+        },
+        detectionSources: ['fileListing'],
+        detectedModels: [{ type: 'vits', modelDir: '/models/vits' }],
       })
     );
     expect(mockSherpa.detectModel).toHaveBeenCalledWith('', 'vits-piper-en');
@@ -101,6 +112,7 @@ describe('detectModelsBatch', () => {
         modelType: 'vits',
         detectedModels: [],
         isStreaming: true,
+        paths: { ttsModel: '/x.onnx' },
       },
       {
         matched: false,
@@ -118,11 +130,37 @@ describe('detectModelsBatch', () => {
     expect(results[0]).toEqual(
       expect.objectContaining({ matched: true, category: ModelCategory.Tts })
     );
+    expect(results[0]).not.toHaveProperty('paths');
     expect(results[1]).toEqual({ matched: false });
     expect(mockSherpa.detectModelsBatch).toHaveBeenCalledWith([
       { modelDir: '', assetName: 'vits-en' },
       { modelDir: '', assetName: 'missing' },
     ]);
+  });
+
+  it('includes paths in batch results when includePaths is true', async () => {
+    mockSherpa.detectModelsBatch.mockResolvedValue([
+      {
+        matched: true,
+        success: true,
+        category: 'tts',
+        modelType: 'vits',
+        detectedModels: [],
+        isStreaming: true,
+        paths: { ttsModel: '/x.onnx', tokens: '/x/tokens.txt' },
+      },
+    ]);
+
+    const results = await detectModelsBatch([{ assetName: 'vits-en' }], {
+      includePaths: true,
+    });
+
+    expect(results[0]).toEqual(
+      expect.objectContaining({
+        matched: true,
+        paths: { ttsModel: '/x.onnx', tokens: '/x/tokens.txt' },
+      })
+    );
   });
 });
 

--- a/src/alignment/__tests__/customConfig.test.ts
+++ b/src/alignment/__tests__/customConfig.test.ts
@@ -1,0 +1,81 @@
+jest.mock('../../detect/validateCustomModelPaths', () => ({
+  getCustomModelPathRequirements: jest.fn(async () => ({
+    required: ['model'],
+    optional: [],
+  })),
+  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+}));
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveModelFileSources: jest.fn(async (sources: Record<string, unknown>) => {
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(sources)) {
+      const path = (value as { path?: string })?.path;
+      if (path) out[key] = path;
+    }
+    return out;
+  }),
+}));
+
+import {
+  assertAlignmentCustomConfig,
+  resolveAlignmentCustomConfigPaths,
+  AlignmentErrorCode,
+} from '../customConfig';
+import {
+  getCustomModelPathRequirements,
+  validateCustomModelPaths,
+} from '../../detect/validateCustomModelPaths';
+
+const mockGetRequirements = getCustomModelPathRequirements as jest.Mock;
+const mockValidate = validateCustomModelPaths as jest.Mock;
+
+describe('assertAlignmentCustomConfig', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  it('accepts FileSource values', () => {
+    expect(() =>
+      assertAlignmentCustomConfig({
+        model: fsPath('/wav2vec2.onnx'),
+      })
+    ).not.toThrow();
+  });
+
+  it('throws ALIGNMENT_INVALID_ARGUMENT when a value is not a FileSource', () => {
+    expect(() =>
+      assertAlignmentCustomConfig({
+        model: '/wav2vec2.onnx',
+      })
+    ).toThrow(AlignmentErrorCode.INVALID_ARGUMENT);
+  });
+});
+
+describe('resolveAlignmentCustomConfigPaths', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetRequirements.mockResolvedValue({
+      required: ['model'],
+      optional: [],
+    });
+    mockValidate.mockResolvedValue({ ok: true });
+  });
+
+  it('rejects unknown keys using native schema', async () => {
+    await expect(
+      resolveAlignmentCustomConfigPaths('wav2vec2', {
+        model: fsPath('/wav2vec2.onnx'),
+        unknownKey: fsPath('/x.onnx'),
+      } as never)
+    ).rejects.toThrow(AlignmentErrorCode.INVALID_ARGUMENT);
+  });
+
+  it('resolves paths via shared resolver', async () => {
+    const paths = await resolveAlignmentCustomConfigPaths('wav2vec2', {
+      model: fsPath('/wav2vec2.onnx'),
+    });
+    expect(paths).toEqual({ model: '/wav2vec2.onnx' });
+    expect(mockValidate).toHaveBeenCalled();
+  });
+});

--- a/src/alignment/__tests__/customConfig.test.ts
+++ b/src/alignment/__tests__/customConfig.test.ts
@@ -1,10 +1,15 @@
-jest.mock('../../detect/validateCustomModelPaths', () => ({
-  getCustomModelPathRequirements: jest.fn(async () => ({
-    required: ['model'],
-    optional: [],
-  })),
-  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
-}));
+jest.mock('../../detect/validateCustomModelPaths', () => {
+  const helpers = jest.requireActual(
+    '../../detect/customModelPathRequirements'
+  );
+  return {
+    ...helpers,
+    getCustomModelPathRequirements: jest.fn(async () => ({
+      fields: [{ key: 'model', required: true, kind: 'file' }],
+    })),
+    validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+  };
+});
 
 jest.mock('../../detect/resolveModelInput', () => ({
   resolveModelFileSources: jest.fn(async (sources: Record<string, unknown>) => {
@@ -56,8 +61,7 @@ describe('resolveAlignmentCustomConfigPaths', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetRequirements.mockResolvedValue({
-      required: ['model'],
-      optional: [],
+      fields: [{ key: 'model', required: true, kind: 'file' }],
     });
     mockValidate.mockResolvedValue({ ok: true });
   });

--- a/src/alignment/__tests__/engine-no-freestanding-export.test.ts
+++ b/src/alignment/__tests__/engine-no-freestanding-export.test.ts
@@ -30,8 +30,13 @@ describe('alignment public exports', () => {
 
   it('exports only runtime alignment APIs expected in P1', () => {
     expect(Object.keys(alignment).sort()).toEqual([
+      'AlignmentErrorCode',
+      'accurateOptionsToModelConfig',
+      'assertAlignmentCustomConfig',
       'createAlignment',
       'detectAlignmentModel',
+      'resolveAlignmentCustomConfigPaths',
+      'resolveAlignmentOnnxPath',
     ]);
   });
 });

--- a/src/alignment/__tests__/engine-options-validation.test.ts
+++ b/src/alignment/__tests__/engine-options-validation.test.ts
@@ -89,6 +89,36 @@ describe('AlignmentEngine options validation', () => {
     expect(native.alignOfflineTextToAudio).not.toHaveBeenCalled();
   });
 
+  it('emits ALIGNMENT_MODEL_PATH_INVALID for custom mode with invalid customConfig', async () => {
+    const engine = createAlignment();
+
+    await expect(
+      engine.alignTextToAudio('txt_off', 'off_audio', 'seg_off', {
+        mode: 'accurate',
+        initMode: 'custom',
+        modelType: 'wav2vec2',
+        customConfig: { model: '/tmp/model.onnx' },
+        segmentation: { mode: 'off' },
+      } as any)
+    ).rejects.toMatchObject({ code: 'ALIGNMENT_MODEL_PATH_INVALID' });
+    expect(native.alignOfflineTextToAudio).not.toHaveBeenCalled();
+  });
+
+  it('emits ALIGNMENT_MODEL_PATH_INVALID for custom mode with wrong modelType', async () => {
+    const engine = createAlignment();
+
+    await expect(
+      engine.alignTextToAudio('txt_off', 'off_audio', 'seg_off', {
+        mode: 'accurate',
+        initMode: 'custom',
+        modelType: 'other',
+        customConfig: { model: { kind: 'fs', path: '/tmp/model.onnx' } },
+        segmentation: { mode: 'off' },
+      } as any)
+    ).rejects.toMatchObject({ code: 'ALIGNMENT_MODEL_PATH_INVALID' });
+    expect(native.alignOfflineTextToAudio).not.toHaveBeenCalled();
+  });
+
   it('emits ALIGNMENT_GRANULARITY_INVALID for disallowed granularity', async () => {
     const engine = createAlignment();
 

--- a/src/alignment/__tests__/native-bridge-error-mapping.test.ts
+++ b/src/alignment/__tests__/native-bridge-error-mapping.test.ts
@@ -145,7 +145,7 @@ describe('alignment/native bridge error mapping', () => {
         segmentOut: 'seg_out',
         anchorSegmentBuffer: 'seg_anchor',
         hypothesisTextBuffer: 'txt_hyp',
-        modelSource: { kind: 'fs', path: '/m' },
+        model: { modelSource: { kind: 'fs', path: '/m' } },
         granularity: 'word',
       })
     ).rejects.toMatchObject({ code: 'ALIGNMENT_MODEL_LOAD_FAILED' });
@@ -167,7 +167,7 @@ describe('alignment/native bridge error mapping', () => {
         audioIn: 'off_audio',
         segmentOut: 'seg_out',
         anchorSegmentBuffer: 'seg_anchor',
-        modelSource: { kind: 'fs', path: '/m' },
+        model: { modelSource: { kind: 'fs', path: '/m' } },
         granularity: 'word',
       })
     ).rejects.toMatchObject({ code: 'OFFLINE_OOM' });
@@ -187,7 +187,7 @@ describe('alignment/native bridge error mapping', () => {
         audioIn: 'off_audio',
         segmentOut: 'seg_out',
         anchorSegmentBuffer: 'seg_anchor',
-        modelSource: { kind: 'fs', path: '/m' },
+        model: { modelSource: { kind: 'fs', path: '/m' } },
         granularity: 'word',
       })
     ).rejects.toMatchObject({ code: 'ALIGNMENT_NATIVE_UNKNOWN' });

--- a/src/alignment/__tests__/native-bridge-slice-call.test.ts
+++ b/src/alignment/__tests__/native-bridge-slice-call.test.ts
@@ -132,7 +132,7 @@ describe('alignment/native bridge slice calls', () => {
       segmentOut: 'seg_out',
       anchorSegmentBuffer: 'seg_anchor',
       hypothesisTextBuffer: 'txt_hyp',
-      modelSource: { kind: 'fs', path: '/m' },
+      model: { modelSource: { kind: 'fs', path: '/m' } },
       granularity: 'word',
       language: 'en',
     });
@@ -161,7 +161,7 @@ describe('alignment/native bridge slice calls', () => {
       audioIn: 'off_audio',
       segmentOut: 'seg_out',
       anchorSegmentBuffer: 'seg_anchor',
-      modelSource: { kind: 'fs', path: '/m' },
+      model: { modelSource: { kind: 'fs', path: '/m' } },
       granularity: 'word',
       language: 'en',
     });

--- a/src/alignment/__tests__/public-surface-snapshot.test.ts
+++ b/src/alignment/__tests__/public-surface-snapshot.test.ts
@@ -17,8 +17,13 @@ describe('alignment public surface snapshot', () => {
 
     expect(keys).toMatchInlineSnapshot(`
       [
+        "AlignmentErrorCode",
+        "accurateOptionsToModelConfig",
+        "assertAlignmentCustomConfig",
         "createAlignment",
         "detectAlignmentModel",
+        "resolveAlignmentCustomConfigPaths",
+        "resolveAlignmentOnnxPath",
       ]
     `);
   });

--- a/src/alignment/__tests__/resolveAlignmentOnnxPath.test.ts
+++ b/src/alignment/__tests__/resolveAlignmentOnnxPath.test.ts
@@ -1,0 +1,111 @@
+jest.mock('../../NativeSherpaOnnx', () => ({
+  __esModule: true,
+  default: {
+    detectAlignmentModel: jest.fn(),
+  },
+}));
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveFileSourceForModelInit: jest.fn(),
+}));
+
+jest.mock('../customConfig', () => ({
+  resolveAlignmentCustomConfigPaths: jest.fn(),
+}));
+
+import SherpaOnnx from '../../NativeSherpaOnnx';
+import { resolveFileSourceForModelInit } from '../../detect/resolveModelInput';
+import { resolveAlignmentCustomConfigPaths } from '../customConfig';
+import {
+  accurateOptionsToModelConfig,
+  resolveAlignmentOnnxPath,
+} from '../resolveAlignmentOnnxPath';
+
+const mockDetect = SherpaOnnx.detectAlignmentModel as jest.Mock;
+const mockResolveInit = resolveFileSourceForModelInit as jest.Mock;
+const mockResolveCustom = resolveAlignmentCustomConfigPaths as jest.Mock;
+
+describe('resolveAlignmentOnnxPath', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolveInit.mockResolvedValue('/models/alignment');
+    mockDetect.mockResolvedValue({
+      success: true,
+      paths: { model: '/models/alignment/model.onnx' },
+    });
+    mockResolveCustom.mockResolvedValue({ model: '/custom/wav2vec2.onnx' });
+  });
+
+  it('auto mode resolves modelSource via detectAlignmentModel', async () => {
+    const path = await resolveAlignmentOnnxPath({
+      modelSource: fsPath('/models/alignment'),
+    });
+    expect(path).toBe('/models/alignment/model.onnx');
+    expect(mockResolveInit).toHaveBeenCalledWith(fsPath('/models/alignment'));
+    expect(mockDetect).toHaveBeenCalledWith('/models/alignment', 'auto');
+    expect(mockResolveCustom).not.toHaveBeenCalled();
+  });
+
+  it('custom mode resolves customConfig without detectAlignmentModel', async () => {
+    const customConfig = { model: fsPath('/custom/wav2vec2.onnx') };
+    const path = await resolveAlignmentOnnxPath({
+      initMode: 'custom',
+      modelType: 'wav2vec2',
+      customConfig,
+    });
+    expect(path).toBe('/custom/wav2vec2.onnx');
+    expect(mockResolveCustom).toHaveBeenCalledWith('wav2vec2', customConfig);
+    expect(mockDetect).not.toHaveBeenCalled();
+    expect(mockResolveInit).not.toHaveBeenCalled();
+  });
+
+  it('throws ALIGNMENT_MODEL_MISSING when auto modelSource resolves empty', async () => {
+    mockResolveInit.mockResolvedValue('');
+    await expect(
+      resolveAlignmentOnnxPath({ modelSource: fsPath('/empty') })
+    ).rejects.toThrow('ALIGNMENT_MODEL_MISSING');
+  });
+
+  it('throws ALIGNMENT_MODEL_LOAD_FAILED when detect fails', async () => {
+    mockDetect.mockResolvedValue({ success: false, error: 'no model' });
+    await expect(
+      resolveAlignmentOnnxPath({ modelSource: fsPath('/bad') })
+    ).rejects.toThrow('ALIGNMENT_MODEL_LOAD_FAILED');
+  });
+});
+
+describe('accurateOptionsToModelConfig', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  it('maps auto accurate options', () => {
+    expect(
+      accurateOptionsToModelConfig({
+        mode: 'accurate',
+        modelSource: fsPath('/m'),
+        segmentation: { mode: 'off' },
+      })
+    ).toEqual({
+      initMode: 'auto',
+      modelSource: fsPath('/m'),
+    });
+  });
+
+  it('maps custom accurate options', () => {
+    const customConfig = { model: fsPath('/custom.onnx') };
+    expect(
+      accurateOptionsToModelConfig({
+        mode: 'accurate',
+        initMode: 'custom',
+        modelType: 'wav2vec2',
+        customConfig,
+        segmentation: { mode: 'off' },
+      })
+    ).toEqual({
+      initMode: 'custom',
+      modelType: 'wav2vec2',
+      customConfig,
+    });
+  });
+});

--- a/src/alignment/alignTextToAudio.ts
+++ b/src/alignment/alignTextToAudio.ts
@@ -1,6 +1,5 @@
 import SherpaOnnx from '../NativeSherpaOnnx';
 import { resolvePipelineAudioBufferId } from '../audiobuffer';
-import { resolveFileSourceForModelInit } from '../detect/resolveModelInput';
 import {
   getOfflineSegmentBufferSegments,
   resolveOfflineSegmentBufferId,
@@ -12,6 +11,10 @@ import {
   createAlignmentProgressSession,
   type AlignmentProgressSession,
 } from './progress';
+import {
+  accurateOptionsToModelConfig,
+  resolveAlignmentOnnxPath,
+} from './resolveAlignmentOnnxPath';
 import type {
   AlignTextToAudioFn,
   AlignTextToAudioOptions,
@@ -71,24 +74,9 @@ async function buildNativeOptions(
     typeof options.language === 'string' ? options.language.trim() : '';
 
   if (options.mode === 'accurate') {
-    const modelDir = (
-      await resolveFileSourceForModelInit(options.modelSource)
-    ).trim();
-    if (!modelDir) {
-      throw new Error(
-        'ALIGNMENT_MODEL_MISSING: Provide options.modelSource for accurate alignment.'
-      );
-    }
-    const det = await SherpaOnnx.detectAlignmentModel(modelDir, 'auto');
-    const onnxPath =
-      typeof det.paths?.model === 'string' ? det.paths.model.trim() : '';
-    if (!det.success || !onnxPath) {
-      const err =
-        typeof det.error === 'string' && det.error.trim().length > 0
-          ? det.error.trim()
-          : 'Alignment model detection failed: no ONNX path.';
-      throw new Error(`ALIGNMENT_MODEL_LOAD_FAILED: ${err}`);
-    }
+    const onnxPath = await resolveAlignmentOnnxPath(
+      accurateOptionsToModelConfig(options)
+    );
     const base: Record<string, unknown> = {
       modelPath: onnxPath,
       ...(language.length > 0 ? { language } : {}),
@@ -152,6 +140,7 @@ export const runAlignTextToAudio: AlignTextToAudioFn = async (
 ) => {
   if (options.mode === 'accurate' && options.segmentation?.mode === 'auto') {
     const onProgress = options.onProgress;
+    const model = accurateOptionsToModelConfig(options);
     if (options.segmentation.mappingStrategy === 'asr_mediated') {
       return runAccurateAsrMediated({
         textIn,
@@ -159,7 +148,7 @@ export const runAlignTextToAudio: AlignTextToAudioFn = async (
         segmentOut,
         anchorSegmentBuffer: options.segmentation.anchorSegmentBuffer,
         hypothesisTextBuffer: options.segmentation.asr.hypothesisTextBuffer,
-        modelSource: options.modelSource,
+        model,
         granularity: options.granularity === 'word' ? 'word' : 'sentence',
         ...(onProgress ? { onProgress } : {}),
         ...(typeof options.language === 'string'
@@ -173,7 +162,7 @@ export const runAlignTextToAudio: AlignTextToAudioFn = async (
       audioIn,
       segmentOut,
       anchorSegmentBuffer: options.segmentation.anchorSegmentBuffer,
-      modelSource: options.modelSource,
+      model,
       granularity: options.granularity === 'word' ? 'word' : 'sentence',
       ...(onProgress ? { onProgress } : {}),
       ...(typeof options.language === 'string'

--- a/src/alignment/asrMediated/__tests__/driver-coverage.test.ts
+++ b/src/alignment/asrMediated/__tests__/driver-coverage.test.ts
@@ -143,7 +143,7 @@ describe('asrMediated/driver coverage', () => {
       segmentOut: 'seg_out',
       anchorSegmentBuffer: 'seg_anchor',
       hypothesisTextBuffer: 'txt_hyp',
-      modelSource: { kind: 'fs', path: '/m' },
+      model: { modelSource: { kind: 'fs', path: '/m' } },
       granularity: 'word',
       language: 'en',
     });

--- a/src/alignment/asrMediated/__tests__/driver-offset.test.ts
+++ b/src/alignment/asrMediated/__tests__/driver-offset.test.ts
@@ -138,7 +138,7 @@ describe('asrMediated/driver offset', () => {
       segmentOut: 'seg_out',
       anchorSegmentBuffer: 'seg_anchor',
       hypothesisTextBuffer: 'txt_hyp',
-      modelSource: { kind: 'fs', path: '/m' },
+      model: { modelSource: { kind: 'fs', path: '/m' } },
       granularity: 'word',
     });
 

--- a/src/alignment/asrMediated/__tests__/driver-options.test.ts
+++ b/src/alignment/asrMediated/__tests__/driver-options.test.ts
@@ -151,7 +151,7 @@ describe('asrMediated/driver options', () => {
         segmentOut: 'seg_out',
         anchorSegmentBuffer: 'seg_anchor',
         hypothesisTextBuffer: 'txt_hyp',
-        modelSource: { kind: 'fs', path: '/m' },
+        model: { modelSource: { kind: 'fs', path: '/m' } },
         granularity: 'word',
       })
     ).rejects.toMatchObject({ code: 'ALIGNMENT_LINKER_INPUT_INVALID' });
@@ -174,7 +174,7 @@ describe('asrMediated/driver options', () => {
         segmentOut: 'seg_out',
         anchorSegmentBuffer: 'seg_anchor',
         hypothesisTextBuffer: 'txt_hyp',
-        modelSource: { kind: 'fs', path: '/m' },
+        model: { modelSource: { kind: 'fs', path: '/m' } },
         granularity: 'word',
       })
     ).rejects.toMatchObject({ code: 'ALIGNMENT_LINKER_NO_MAPPING' });
@@ -228,7 +228,7 @@ describe('asrMediated/driver options', () => {
         segmentOut: 'seg_out',
         anchorSegmentBuffer: 'seg_anchor',
         hypothesisTextBuffer: 'txt_hyp',
-        modelSource: { kind: 'fs', path: '/m' },
+        model: { modelSource: { kind: 'fs', path: '/m' } },
         granularity: 'word',
         onProgress,
       })

--- a/src/alignment/asrMediated/__tests__/driver-pipeline.test.ts
+++ b/src/alignment/asrMediated/__tests__/driver-pipeline.test.ts
@@ -190,7 +190,7 @@ describe('asrMediated/driver pipeline', () => {
       segmentOut: 'seg_out',
       anchorSegmentBuffer: 'seg_anchor',
       hypothesisTextBuffer: 'txt_hyp',
-      modelSource: { kind: 'fs', path: '/m' },
+      model: { modelSource: { kind: 'fs', path: '/m' } },
       granularity: 'word',
       language: 'en',
       onProgress,

--- a/src/alignment/asrMediated/__tests__/missing-timestamps.test.ts
+++ b/src/alignment/asrMediated/__tests__/missing-timestamps.test.ts
@@ -86,7 +86,7 @@ describe('asrMediated/missing-timestamps', () => {
         segmentOut: 'seg_out',
         anchorSegmentBuffer: 'seg_anchor',
         hypothesisTextBuffer: 'txt_hyp',
-        modelSource: { kind: 'fs', path: '/m' },
+        model: { modelSource: { kind: 'fs', path: '/m' } },
         granularity: 'word',
       })
     ).rejects.toMatchObject({

--- a/src/alignment/asrMediated/driver.ts
+++ b/src/alignment/asrMediated/driver.ts
@@ -31,10 +31,10 @@ import type {
   OfflineTextBufferIdSource,
   OfflineTextBufferInfo,
 } from '../../textbuffer/types';
-import type { FileSource } from '../../fileio/types';
-import { resolveFileSourceForModelInit } from '../../detect/resolveModelInput';
+import { resolveAlignmentOnnxPath } from '../resolveAlignmentOnnxPath';
 import { runLinker } from '../linker/linker';
 import type {
+  AlignmentAccurateModelConfig,
   AlignmentErrorCode,
   AlignmentWarning,
   AlignmentWarningCode,
@@ -404,7 +404,7 @@ interface RunAccurateAsrMediatedInput {
   segmentOut: OfflineSegmentBufferIdSource;
   anchorSegmentBuffer: OfflineSegmentBufferIdSource;
   hypothesisTextBuffer: OfflineTextBufferIdSource;
-  modelSource: FileSource;
+  model: AlignmentAccurateModelConfig;
   granularity?: 'sentence' | 'word';
   language?: string;
   onProgress?: (progress: OrchestrationProgress) => void;
@@ -440,28 +440,7 @@ export async function runAccurateAsrMediated(
     getPipelineSegmentBufferInfo(anchorSegmentBufferId),
     getPipelineSegmentBufferInfo(segmentOutBufferId),
     getOfflineTextBufferTextSlice(textInBufferId, 0, textInfo.utf16Length ?? 0),
-    (async () => {
-      const dir = (
-        await resolveFileSourceForModelInit(input.modelSource)
-      ).trim();
-      if (!dir) {
-        throw createAsrMediatedError(
-          'ALIGNMENT_MODEL_LOAD_FAILED',
-          'resolveFileSourceForModelInit returned empty for alignment modelSource.'
-        );
-      }
-      const det = await SherpaOnnx.detectAlignmentModel(dir, 'auto');
-      const onnx =
-        typeof det.paths?.model === 'string' ? det.paths.model.trim() : '';
-      if (!det.success || !onnx) {
-        const msg =
-          typeof det.error === 'string' && det.error.trim().length > 0
-            ? det.error.trim()
-            : 'Alignment model detection failed: no ONNX path.';
-        throw createAsrMediatedError('ALIGNMENT_MODEL_LOAD_FAILED', msg);
-      }
-      return onnx;
-    })(),
+    resolveAlignmentOnnxPath(input.model),
   ]);
 
   const audioInfo = asOfflineAudioBufferInfo(audioInfoRaw);

--- a/src/alignment/chunkedForcedCtc/__tests__/driver-options.test.ts
+++ b/src/alignment/chunkedForcedCtc/__tests__/driver-options.test.ts
@@ -131,7 +131,7 @@ describe('chunkedForcedCtc/driver options', () => {
         audioIn: 'off_audio',
         segmentOut: 'seg_out',
         anchorSegmentBuffer: 'seg_anchor',
-        modelSource: { kind: 'fs', path: '/m' },
+        model: { modelSource: { kind: 'fs', path: '/m' } },
         granularity: 'word',
       })
     ).rejects.toMatchObject({ code: 'ALIGNMENT_OPTIONS_INVALID' });
@@ -156,7 +156,7 @@ describe('chunkedForcedCtc/driver options', () => {
         audioIn: 'off_audio',
         segmentOut: 'seg_out',
         anchorSegmentBuffer: 'seg_anchor',
-        modelSource: { kind: 'fs', path: '/m' },
+        model: { modelSource: { kind: 'fs', path: '/m' } },
         granularity: 'word',
       })
     ).rejects.toMatchObject({ code: 'ALIGNMENT_ANCHOR_OUT_OF_RANGE' });
@@ -178,7 +178,7 @@ describe('chunkedForcedCtc/driver options', () => {
         audioIn: 'off_audio',
         segmentOut: 'seg_out',
         anchorSegmentBuffer: 'seg_anchor',
-        modelSource: { kind: 'fs', path: '/m' },
+        model: { modelSource: { kind: 'fs', path: '/m' } },
         granularity: 'word',
       })
     ).rejects.toMatchObject({ code: 'ALIGNMENT_FORCED_CTC_FAILED' });

--- a/src/alignment/chunkedForcedCtc/__tests__/driver-pipeline.test.ts
+++ b/src/alignment/chunkedForcedCtc/__tests__/driver-pipeline.test.ts
@@ -163,7 +163,7 @@ describe('chunkedForcedCtc/driver pipeline', () => {
       audioIn: 'off_audio',
       segmentOut: 'seg_out',
       anchorSegmentBuffer: 'seg_anchor',
-      modelSource: { kind: 'fs', path: '/m' },
+      model: { modelSource: { kind: 'fs', path: '/m' } },
       granularity: 'word',
       language: 'en',
       onProgress,
@@ -265,7 +265,7 @@ describe('chunkedForcedCtc/driver pipeline', () => {
         audioIn: 'off_audio',
         segmentOut: 'seg_out',
         anchorSegmentBuffer: 'seg_anchor',
-        modelSource: { kind: 'fs', path: '/m' },
+        model: { modelSource: { kind: 'fs', path: '/m' } },
         granularity: 'word',
         language: 'en',
       })

--- a/src/alignment/chunkedForcedCtc/__tests__/driver-progress.test.ts
+++ b/src/alignment/chunkedForcedCtc/__tests__/driver-progress.test.ts
@@ -103,7 +103,7 @@ describe('chunkedForcedCtc/driver progress', () => {
       audioIn: 'off_audio',
       segmentOut: 'seg_out',
       anchorSegmentBuffer: 'seg_anchor',
-      modelSource: { kind: 'fs', path: '/m' },
+      model: { modelSource: { kind: 'fs', path: '/m' } },
       granularity: 'word',
     });
 

--- a/src/alignment/chunkedForcedCtc/__tests__/driver-stuck.test.ts
+++ b/src/alignment/chunkedForcedCtc/__tests__/driver-stuck.test.ts
@@ -122,7 +122,7 @@ describe('chunkedForcedCtc/driver stuck detection', () => {
         audioIn: 'off_audio',
         segmentOut: 'seg_out',
         anchorSegmentBuffer: 'seg_anchor',
-        modelSource: { kind: 'fs', path: '/m' },
+        model: { modelSource: { kind: 'fs', path: '/m' } },
         granularity: 'word',
       })
     ).rejects.toMatchObject({ code: 'ALIGNMENT_FORCED_CTC_STUCK' });

--- a/src/alignment/chunkedForcedCtc/driver.ts
+++ b/src/alignment/chunkedForcedCtc/driver.ts
@@ -31,10 +31,10 @@ import type {
   OfflineTextBufferIdSource,
   OfflineTextBufferInfo,
 } from '../../textbuffer/types';
-import type { FileSource } from '../../fileio/types';
-import { resolveFileSourceForModelInit } from '../../detect/resolveModelInput';
+import { resolveAlignmentOnnxPath } from '../resolveAlignmentOnnxPath';
 import { addSegmentLink, createSegmentLinkMap } from '../../segment';
 import type {
+  AlignmentAccurateModelConfig,
   AlignmentErrorCode,
   AlignmentWarning,
   AlignmentWarningCode,
@@ -336,7 +336,7 @@ interface RunAccurateChunkedForcedCtcInput {
   audioIn: OfflineAudioBufferIdSource;
   segmentOut: OfflineSegmentBufferIdSource;
   anchorSegmentBuffer: OfflineSegmentBufferIdSource;
-  modelSource: FileSource;
+  model: AlignmentAccurateModelConfig;
   granularity?: 'sentence' | 'word';
   language?: string;
   onProgress?: (progress: OrchestrationProgress) => void;
@@ -370,28 +370,7 @@ export async function runAccurateChunkedForcedCtc(
     getPipelineSegmentBufferInfo(anchorSegmentBufferId),
     getPipelineSegmentBufferInfo(segmentOutBufferId),
     getOfflineTextBufferTextSlice(textInBufferId, 0, textInfo.utf16Length ?? 0),
-    (async () => {
-      const dir = (
-        await resolveFileSourceForModelInit(input.modelSource)
-      ).trim();
-      if (!dir) {
-        throw createChunkedForcedCtcError(
-          'ALIGNMENT_MODEL_LOAD_FAILED',
-          'resolveFileSourceForModelInit returned empty for alignment modelSource.'
-        );
-      }
-      const det = await SherpaOnnx.detectAlignmentModel(dir, 'auto');
-      const onnx =
-        typeof det.paths?.model === 'string' ? det.paths.model.trim() : '';
-      if (!det.success || !onnx) {
-        const msg =
-          typeof det.error === 'string' && det.error.trim().length > 0
-            ? det.error.trim()
-            : 'Alignment model detection failed: no ONNX path.';
-        throw createChunkedForcedCtcError('ALIGNMENT_MODEL_LOAD_FAILED', msg);
-      }
-      return onnx;
-    })(),
+    resolveAlignmentOnnxPath(input.model),
   ]);
 
   const audioInfo = asOfflineAudioBufferInfo(audioInfoRaw);

--- a/src/alignment/customConfig.ts
+++ b/src/alignment/customConfig.ts
@@ -1,0 +1,37 @@
+import type { FileSource } from '../fileio/types';
+import { ModelCategory } from '../download/types';
+import {
+  assertCustomModelConfig,
+  resolveCustomModelConfigPaths,
+} from '../detect/customConfigResolver';
+import type { AlignmentConcreteModelType } from './types';
+
+export const AlignmentErrorCode = {
+  INVALID_ARGUMENT: 'ALIGNMENT_INVALID_ARGUMENT',
+} as const;
+
+export type AlignmentCustomPathKey = 'model';
+
+export interface AlignmentCustomConfig {
+  model: FileSource;
+}
+
+export function assertAlignmentCustomConfig(
+  customConfig: Record<string, unknown>
+): void {
+  assertCustomModelConfig(customConfig, AlignmentErrorCode.INVALID_ARGUMENT);
+}
+
+export async function resolveAlignmentCustomConfigPaths(
+  modelType: AlignmentConcreteModelType,
+  customConfig: AlignmentCustomConfig
+): Promise<Record<string, string>> {
+  return resolveCustomModelConfigPaths({
+    category: ModelCategory.Alignment,
+    modelType,
+    customConfig: customConfig as unknown as Record<string, unknown>,
+    errorCode: AlignmentErrorCode.INVALID_ARGUMENT,
+    unknownKeyMessage: (key, mt) =>
+      `Unknown customConfig key '${key}' for alignment modelType '${mt}'`,
+  });
+}

--- a/src/alignment/engine.ts
+++ b/src/alignment/engine.ts
@@ -1,4 +1,5 @@
 import type { FileSource } from '../fileio/types';
+import { assertAlignmentCustomConfig } from './customConfig';
 import { runAlignTextToAudio } from './alignTextToAudio';
 import type {
   AlignTextToAudioFn,
@@ -76,7 +77,28 @@ function validateGranularity(
 }
 
 function validateAccurateOptions(options: Record<string, unknown>): void {
-  if (!isFileSource(options.modelSource)) {
+  if (options.initMode === 'custom') {
+    if (options.modelType !== 'wav2vec2') {
+      throw createAlignmentError(
+        'ALIGNMENT_MODEL_PATH_INVALID',
+        "Accurate custom mode requires modelType: 'wav2vec2'."
+      );
+    }
+    if (!isRecord(options.customConfig)) {
+      throw createAlignmentError(
+        'ALIGNMENT_MODEL_PATH_INVALID',
+        'Accurate custom mode requires customConfig with model: FileSource.'
+      );
+    }
+    try {
+      assertAlignmentCustomConfig(options.customConfig);
+    } catch (error) {
+      throw createAlignmentError(
+        'ALIGNMENT_MODEL_PATH_INVALID',
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+  } else if (!isFileSource(options.modelSource)) {
     throw createAlignmentError(
       'ALIGNMENT_MODEL_PATH_INVALID',
       'Accurate mode requires modelSource: FileSource.'

--- a/src/alignment/index.ts
+++ b/src/alignment/index.ts
@@ -13,6 +13,19 @@ import { ModelCategory } from '../download/types';
 
 export { createAlignment } from './engine';
 export type { AlignmentEngine, AlignmentEngineOptions } from './engine';
+export {
+  assertAlignmentCustomConfig,
+  resolveAlignmentCustomConfigPaths,
+  AlignmentErrorCode,
+} from './customConfig';
+export type {
+  AlignmentCustomConfig,
+  AlignmentCustomPathKey,
+} from './customConfig';
+export {
+  resolveAlignmentOnnxPath,
+  accurateOptionsToModelConfig,
+} from './resolveAlignmentOnnxPath';
 
 export type {
   AlignTextToAudioFn,
@@ -21,6 +34,10 @@ export type {
   AlignTextToAudioOptionsEstimated,
   AlignTextToAudioOptionsProportional,
   AlignTextToAudioOptionsVad,
+  AlignmentAccurateModelAuto,
+  AlignmentAccurateModelConfig,
+  AlignmentAccurateModelCustom,
+  AlignmentConcreteModelType,
   AlignmentProgressCallbacks,
   AlignTextToAudioWriteResult,
   AlignmentAccurateSegmentationConfig,
@@ -28,7 +45,6 @@ export type {
   AlignmentVadSegmentationConfig,
   AlignmentChunkTimeline,
   AlignmentDetectResult,
-  AlignmentErrorCode,
   AlignmentGranularity,
   AlignmentMappingStrategy,
   AlignmentModelType,

--- a/src/alignment/resolveAlignmentOnnxPath.ts
+++ b/src/alignment/resolveAlignmentOnnxPath.ts
@@ -1,0 +1,61 @@
+import SherpaOnnx from '../NativeSherpaOnnx';
+import { resolveFileSourceForModelInit } from '../detect/resolveModelInput';
+import { resolveAlignmentCustomConfigPaths } from './customConfig';
+import type {
+  AlignTextToAudioOptionsAccurate,
+  AlignmentAccurateModelConfig,
+} from './types';
+
+export async function resolveAlignmentOnnxPath(
+  model: AlignmentAccurateModelConfig
+): Promise<string> {
+  if (model.initMode === 'custom') {
+    const paths = await resolveAlignmentCustomConfigPaths(
+      model.modelType,
+      model.customConfig
+    );
+    const onnxPath = paths.model?.trim() ?? '';
+    if (!onnxPath) {
+      throw new Error(
+        'ALIGNMENT_MODEL_LOAD_FAILED: Custom alignment model path is missing after validation.'
+      );
+    }
+    return onnxPath;
+  }
+
+  const modelDir = (
+    await resolveFileSourceForModelInit(model.modelSource)
+  ).trim();
+  if (!modelDir) {
+    throw new Error(
+      'ALIGNMENT_MODEL_MISSING: Provide modelSource for accurate alignment.'
+    );
+  }
+  const det = await SherpaOnnx.detectAlignmentModel(modelDir, 'auto');
+  const onnxPath =
+    typeof det.paths?.model === 'string' ? det.paths.model.trim() : '';
+  if (!det.success || !onnxPath) {
+    const err =
+      typeof det.error === 'string' && det.error.trim().length > 0
+        ? det.error.trim()
+        : 'Alignment model detection failed: no ONNX path.';
+    throw new Error(`ALIGNMENT_MODEL_LOAD_FAILED: ${err}`);
+  }
+  return onnxPath;
+}
+
+export function accurateOptionsToModelConfig(
+  options: AlignTextToAudioOptionsAccurate
+): AlignmentAccurateModelConfig {
+  if (options.initMode === 'custom') {
+    return {
+      initMode: 'custom',
+      modelType: options.modelType,
+      customConfig: options.customConfig,
+    };
+  }
+  return {
+    initMode: 'auto',
+    modelSource: options.modelSource,
+  };
+}

--- a/src/alignment/types.ts
+++ b/src/alignment/types.ts
@@ -13,6 +13,23 @@ export interface AlignmentTimestamp {
 
 export type AlignmentModelType = 'wav2vec2' | 'auto';
 
+export type AlignmentConcreteModelType = 'wav2vec2';
+
+export type AlignmentAccurateModelAuto = {
+  initMode?: 'auto';
+  modelSource: FileSource;
+};
+
+export type AlignmentAccurateModelCustom = {
+  initMode: 'custom';
+  modelType: AlignmentConcreteModelType;
+  customConfig: import('./customConfig').AlignmentCustomConfig;
+};
+
+export type AlignmentAccurateModelConfig =
+  | AlignmentAccurateModelAuto
+  | AlignmentAccurateModelCustom;
+
 export type { AlignmentDetectModelResult as AlignmentDetectResult } from '../types/modelDetect';
 
 /** Subtitle/timestamp granularity (character only with `accurate`). */
@@ -116,26 +133,23 @@ export type AlignTextToAudioOptionsEstimated = {
 } & AlignmentProgressCallbacks;
 
 type AlignTextToAudioOptionsAccurateBase =
-  | {
+  | ({
       mode: 'accurate';
-      /** FileSource for the alignment model; resolved before the native bridge. */
-      modelSource: FileSource;
       granularity?: AlignmentGranularity;
       language?: string;
       segmentation?: {
         mode: 'off';
       };
-    }
-  | {
+    } & AlignmentAccurateModelConfig)
+  | ({
       mode: 'accurate';
-      modelSource: FileSource;
       granularity?: 'sentence' | 'word';
       language?: string;
       segmentation: Extract<
         AlignmentAccurateSegmentationConfig,
         { mode: 'auto' }
       >;
-    };
+    } & AlignmentAccurateModelConfig);
 
 /** Accurate: wav2vec2 CTC forced alignment. */
 export type AlignTextToAudioOptionsAccurate =
@@ -181,4 +195,5 @@ export type AlignmentErrorCode =
   | 'ALIGNMENT_FORCED_CTC_FAILED'
   | 'ALIGNMENT_FORCED_CTC_STUCK'
   | 'ALIGNMENT_NOT_IMPLEMENTED'
-  | 'ALIGNMENT_ENGINE_DESTROYED';
+  | 'ALIGNMENT_ENGINE_DESTROYED'
+  | 'ALIGNMENT_INVALID_ARGUMENT';

--- a/src/detect/__tests__/customConfigResolver.test.ts
+++ b/src/detect/__tests__/customConfigResolver.test.ts
@@ -1,0 +1,119 @@
+jest.mock('../resolveModelInput', () => ({
+  resolveModelFileSources: jest.fn(
+    async (sources: Record<string, { path: string }>) =>
+      Object.fromEntries(
+        Object.entries(sources).map(([key, value]) => [key, value.path])
+      )
+  ),
+}));
+
+jest.mock('../validateCustomModelPaths', () => ({
+  getCustomModelPathRequirements: jest.fn(async () => ({
+    required: ['encoder', 'decoder', 'joiner', 'tokens'],
+    optional: ['bpeVocab'],
+  })),
+  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+}));
+
+import {
+  assertCustomModelConfig,
+  isFileSource,
+  resolveCustomModelConfigPaths,
+} from '../customConfigResolver';
+import {
+  getCustomModelPathRequirements,
+  validateCustomModelPaths,
+} from '../validateCustomModelPaths';
+import { ModelCategory } from '../../download/types';
+
+const mockGetRequirements = getCustomModelPathRequirements as jest.Mock;
+const mockValidate = validateCustomModelPaths as jest.Mock;
+
+describe('isFileSource', () => {
+  it('accepts FileSource objects', () => {
+    expect(isFileSource({ kind: 'fs', path: '/x' })).toBe(true);
+  });
+
+  it('rejects plain strings', () => {
+    expect(isFileSource('/x')).toBe(false);
+  });
+});
+
+describe('assertCustomModelConfig', () => {
+  it('throws with the provided error code', () => {
+    expect(() =>
+      assertCustomModelConfig({ tokens: '/bad' }, 'TEST_INVALID')
+    ).toThrow('TEST_INVALID');
+  });
+});
+
+describe('resolveCustomModelConfigPaths', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetRequirements.mockResolvedValue({
+      required: ['encoder', 'decoder', 'joiner', 'tokens'],
+      optional: [],
+    });
+    mockValidate.mockResolvedValue({ ok: true });
+  });
+
+  it('resolves and validates paths for a category', async () => {
+    const paths = await resolveCustomModelConfigPaths({
+      category: ModelCategory.Stt,
+      modelType: 'transducer',
+      customConfig: {
+        encoder: fsPath('/enc.onnx'),
+        decoder: fsPath('/dec.onnx'),
+        joiner: fsPath('/join.onnx'),
+        tokens: fsPath('/tokens.txt'),
+      },
+      errorCode: 'TEST_INVALID',
+    });
+    expect(paths).toEqual({
+      encoder: '/enc.onnx',
+      decoder: '/dec.onnx',
+      joiner: '/join.onnx',
+      tokens: '/tokens.txt',
+    });
+    expect(mockValidate).toHaveBeenCalledWith(
+      ModelCategory.Stt,
+      'transducer',
+      paths
+    );
+  });
+
+  it('rejects unknown keys using native schema', async () => {
+    await expect(
+      resolveCustomModelConfigPaths({
+        category: 'stt_streaming',
+        modelType: 'transducer',
+        customConfig: {
+          encoder: fsPath('/enc.onnx'),
+          unknownKey: fsPath('/x.onnx'),
+        },
+        errorCode: 'TEST_INVALID',
+      })
+    ).rejects.toThrow('TEST_INVALID');
+  });
+
+  it('throws when native validation fails', async () => {
+    mockValidate.mockResolvedValueOnce({
+      ok: false,
+      error: 'missing files',
+      missingRequired: ['tokens'],
+    });
+
+    await expect(
+      resolveCustomModelConfigPaths({
+        category: ModelCategory.Tts,
+        modelType: 'vits',
+        customConfig: {
+          ttsModel: fsPath('/model.onnx'),
+        },
+        errorCode: 'TEST_INVALID',
+      })
+    ).rejects.toThrow('TEST_INVALID');
+  });
+});

--- a/src/detect/__tests__/customConfigResolver.test.ts
+++ b/src/detect/__tests__/customConfigResolver.test.ts
@@ -7,13 +7,22 @@ jest.mock('../resolveModelInput', () => ({
   ),
 }));
 
-jest.mock('../validateCustomModelPaths', () => ({
-  getCustomModelPathRequirements: jest.fn(async () => ({
-    required: ['encoder', 'decoder', 'joiner', 'tokens'],
-    optional: ['bpeVocab'],
-  })),
-  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
-}));
+jest.mock('../validateCustomModelPaths', () => {
+  const helpers = jest.requireActual('../customModelPathRequirements');
+  return {
+    ...helpers,
+    getCustomModelPathRequirements: jest.fn(async () => ({
+      fields: [
+        { key: 'encoder', required: true, kind: 'file' },
+        { key: 'decoder', required: true, kind: 'file' },
+        { key: 'joiner', required: true, kind: 'file' },
+        { key: 'tokens', required: true, kind: 'file' },
+        { key: 'bpeVocab', required: false, kind: 'file' },
+      ],
+    })),
+    validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+  };
+});
 
 import {
   assertCustomModelConfig,
@@ -53,8 +62,12 @@ describe('resolveCustomModelConfigPaths', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetRequirements.mockResolvedValue({
-      required: ['encoder', 'decoder', 'joiner', 'tokens'],
-      optional: [],
+      fields: [
+        { key: 'encoder', required: true, kind: 'file' },
+        { key: 'decoder', required: true, kind: 'file' },
+        { key: 'joiner', required: true, kind: 'file' },
+        { key: 'tokens', required: true, kind: 'file' },
+      ],
     });
     mockValidate.mockResolvedValue({ ok: true });
   });

--- a/src/detect/__tests__/customModelPathRequirements.test.ts
+++ b/src/detect/__tests__/customModelPathRequirements.test.ts
@@ -1,0 +1,30 @@
+import {
+  customModelPathFieldKeys,
+  requiredCustomModelPathFieldKeys,
+  type CustomModelPathRequirements,
+} from '../customModelPathRequirements';
+
+describe('customModelPathFieldKeys', () => {
+  const schema: CustomModelPathRequirements = {
+    fields: [
+      { key: 'ttsModel', required: true, kind: 'file' },
+      { key: 'tokens', required: true, kind: 'file' },
+      { key: 'dataDir', required: false, kind: 'dir' },
+    ],
+  };
+
+  it('lists all keys in order', () => {
+    expect(customModelPathFieldKeys(schema)).toEqual([
+      'ttsModel',
+      'tokens',
+      'dataDir',
+    ]);
+  });
+
+  it('lists required keys only', () => {
+    expect(requiredCustomModelPathFieldKeys(schema)).toEqual([
+      'ttsModel',
+      'tokens',
+    ]);
+  });
+});

--- a/src/detect/__tests__/detectModelOutput.test.ts
+++ b/src/detect/__tests__/detectModelOutput.test.ts
@@ -1,0 +1,45 @@
+import {
+  readDetectedModels,
+  readDetectionSources,
+  readNonEmptyDetectPathsMap,
+} from '../detectModelOutput';
+
+describe('readNonEmptyDetectPathsMap', () => {
+  it('keeps only non-empty string values', () => {
+    expect(
+      readNonEmptyDetectPathsMap({
+        ttsModel: '/a/model.onnx',
+        tokens: '/a/tokens.txt',
+        dataDir: '',
+        lexicon: '   ',
+      })
+    ).toEqual({
+      ttsModel: '/a/model.onnx',
+      tokens: '/a/tokens.txt',
+    });
+  });
+
+  it('returns undefined for empty or invalid input', () => {
+    expect(readNonEmptyDetectPathsMap(undefined)).toBeUndefined();
+    expect(readNonEmptyDetectPathsMap({})).toBeUndefined();
+  });
+});
+
+describe('readDetectionSources', () => {
+  it('filters to known detection sources', () => {
+    expect(
+      readDetectionSources(['fileListing', 'invalid', 'nameOnly'])
+    ).toEqual(['fileListing', 'nameOnly']);
+  });
+});
+
+describe('readDetectedModels', () => {
+  it('maps native detected model entries', () => {
+    expect(
+      readDetectedModels([
+        { type: 'vits', modelDir: '/models/vits' },
+        { type: 1, modelDir: '/bad' },
+      ])
+    ).toEqual([{ type: 'vits', modelDir: '/models/vits' }]);
+  });
+});

--- a/src/detect/__tests__/validateCustomModelPaths.test.ts
+++ b/src/detect/__tests__/validateCustomModelPaths.test.ts
@@ -1,0 +1,87 @@
+jest.mock('../../NativeSherpaOnnx', () => ({
+  __esModule: true,
+  default: {
+    getCustomModelPathRequirements: jest.fn(),
+    validateCustomModelPaths: jest.fn(),
+  },
+}));
+
+import NativeSherpaOnnx from '../../NativeSherpaOnnx';
+import {
+  customModelPathFieldKeys,
+  getCustomModelPathRequirements,
+  requiredCustomModelPathFieldKeys,
+  validateCustomModelPaths,
+} from '../validateCustomModelPaths';
+
+const mockGetRequirements =
+  NativeSherpaOnnx.getCustomModelPathRequirements as jest.Mock;
+const mockValidate = NativeSherpaOnnx.validateCustomModelPaths as jest.Mock;
+
+describe('getCustomModelPathRequirements', () => {
+  beforeEach(() => {
+    mockGetRequirements.mockReset();
+  });
+
+  it('returns native fields with file/dir kinds', async () => {
+    mockGetRequirements.mockResolvedValue({
+      fields: [
+        { key: 'ttsModel', required: true, kind: 'file' },
+        { key: 'tokens', required: true, kind: 'file' },
+        { key: 'dataDir', required: false, kind: 'dir' },
+      ],
+    });
+
+    const schema = await getCustomModelPathRequirements('tts', 'vits');
+
+    expect(schema.fields).toEqual([
+      { key: 'ttsModel', required: true, kind: 'file' },
+      { key: 'tokens', required: true, kind: 'file' },
+      { key: 'dataDir', required: false, kind: 'dir' },
+    ]);
+    expect(requiredCustomModelPathFieldKeys(schema)).toEqual([
+      'ttsModel',
+      'tokens',
+    ]);
+    expect(customModelPathFieldKeys(schema)).toEqual([
+      'ttsModel',
+      'tokens',
+      'dataDir',
+    ]);
+  });
+
+  it('returns an empty fields array when native sends none', async () => {
+    mockGetRequirements.mockResolvedValue({ fields: [] });
+
+    const schema = await getCustomModelPathRequirements('stt', 'unknown');
+
+    expect(schema).toEqual({ fields: [] });
+  });
+});
+
+describe('validateCustomModelPaths', () => {
+  beforeEach(() => {
+    mockValidate.mockReset();
+  });
+
+  it('passes through native validation results', async () => {
+    mockValidate.mockResolvedValue({
+      ok: false,
+      error: 'missing files',
+      missingRequired: ['tokens'],
+    });
+
+    const result = await validateCustomModelPaths('tts', 'vits', {
+      ttsModel: '/tmp/model.onnx',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'missing files',
+      missingRequired: ['tokens'],
+    });
+    expect(mockValidate).toHaveBeenCalledWith('tts', 'vits', {
+      ttsModel: '/tmp/model.onnx',
+    });
+  });
+});

--- a/src/detect/customConfigResolver.ts
+++ b/src/detect/customConfigResolver.ts
@@ -1,0 +1,93 @@
+import type { FileSource } from '../fileio/types';
+import { resolveModelFileSources } from './resolveModelInput';
+import {
+  getCustomModelPathRequirements,
+  validateCustomModelPaths,
+  type CustomModelPathCategory,
+} from './validateCustomModelPaths';
+
+export function isFileSource(value: unknown): value is FileSource {
+  if (typeof value !== 'object' || value === null || !('kind' in value)) {
+    return false;
+  }
+  const kind = (value as { kind?: unknown }).kind;
+  return typeof kind === 'string';
+}
+
+export function createInvalidArgumentError(
+  errorCode: string,
+  message: string
+): never {
+  const err = new Error(`${errorCode}: ${message}`) as Error & {
+    code?: string;
+  };
+  err.code = errorCode;
+  throw err;
+}
+
+/** Structural check: every present customConfig value must be a FileSource. */
+export function assertCustomModelConfig(
+  customConfig: Record<string, unknown>,
+  errorCode: string
+): void {
+  for (const [key, value] of Object.entries(customConfig)) {
+    if (!isFileSource(value)) {
+      createInvalidArgumentError(
+        errorCode,
+        `customConfig.${key} must be a FileSource object`
+      );
+    }
+  }
+}
+
+export async function resolveCustomModelConfigPaths(args: {
+  category: CustomModelPathCategory | string;
+  modelType: string;
+  customConfig: Readonly<Record<string, unknown>>;
+  errorCode: string;
+  unknownKeyMessage?: (key: string, modelType: string) => string;
+}): Promise<Record<string, string>> {
+  const {
+    category,
+    modelType,
+    customConfig,
+    errorCode,
+    unknownKeyMessage = (key, mt) =>
+      `Unknown customConfig key '${key}' for modelType '${mt}'`,
+  } = args;
+
+  assertCustomModelConfig(customConfig, errorCode);
+
+  const schema = await getCustomModelPathRequirements(category, modelType);
+  const allowedKeys = new Set([...schema.required, ...schema.optional]);
+  for (const key of Object.keys(customConfig)) {
+    if (!allowedKeys.has(key)) {
+      createInvalidArgumentError(errorCode, unknownKeyMessage(key, modelType));
+    }
+  }
+
+  const fileSources: Record<string, FileSource> = {};
+  for (const [key, value] of Object.entries(customConfig)) {
+    if (isFileSource(value)) {
+      fileSources[key] = value;
+    }
+  }
+  const resolvedPaths = await resolveModelFileSources(fileSources);
+
+  const validation = await validateCustomModelPaths(
+    category,
+    modelType,
+    resolvedPaths
+  );
+  if (!validation.ok) {
+    createInvalidArgumentError(
+      errorCode,
+      validation.error?.trim() ||
+        `Missing required paths: ${(validation.missingRequired ?? []).join(
+          ', '
+        )}`
+    );
+  }
+
+  return resolvedPaths;
+}

--- a/src/detect/customConfigResolver.ts
+++ b/src/detect/customConfigResolver.ts
@@ -1,5 +1,6 @@
 import type { FileSource } from '../fileio/types';
 import { resolveModelFileSources } from './resolveModelInput';
+import { customModelPathFieldKeys } from './customModelPathRequirements';
 import {
   getCustomModelPathRequirements,
   validateCustomModelPaths,
@@ -59,7 +60,7 @@ export async function resolveCustomModelConfigPaths(args: {
   assertCustomModelConfig(customConfig, errorCode);
 
   const schema = await getCustomModelPathRequirements(category, modelType);
-  const allowedKeys = new Set([...schema.required, ...schema.optional]);
+  const allowedKeys = new Set(customModelPathFieldKeys(schema));
   for (const key of Object.keys(customConfig)) {
     if (!allowedKeys.has(key)) {
       createInvalidArgumentError(errorCode, unknownKeyMessage(key, modelType));

--- a/src/detect/customModelPathRequirements.ts
+++ b/src/detect/customModelPathRequirements.ts
@@ -1,0 +1,30 @@
+export type CustomModelPathFieldKind = 'file' | 'dir';
+
+/** One config key the native engine accepts for custom init. */
+export type CustomModelPathField = {
+  readonly key: string;
+  readonly required: boolean;
+  readonly kind: CustomModelPathFieldKind;
+};
+
+/**
+ * Native schema for one `(category, modelType)` pair.
+ * `fields` preserves declaration order from the C++ requirement tables.
+ */
+export type CustomModelPathRequirements = {
+  readonly fields: ReadonlyArray<CustomModelPathField>;
+};
+
+export function customModelPathFieldKeys(
+  requirements: CustomModelPathRequirements
+): string[] {
+  return requirements.fields.map((field) => field.key);
+}
+
+export function requiredCustomModelPathFieldKeys(
+  requirements: CustomModelPathRequirements
+): string[] {
+  return requirements.fields
+    .filter((field) => field.required)
+    .map((field) => field.key);
+}

--- a/src/detect/detectModel.ts
+++ b/src/detect/detectModel.ts
@@ -12,6 +12,13 @@ import {
   type Quantization,
   type SizeTier,
 } from '../download/types';
+import type { DetectedModelEntry, DetectionSource } from '../types/modelDetect';
+import {
+  readDetectedModels,
+  readDetectionSources,
+  readNonEmptyDetectPathsMap,
+  type DetectModelPathsMap,
+} from './detectModelOutput';
 
 /** Name-only or directory-backed detect input without a full {@link FileSource}. */
 export type DetectModelNameInput = {
@@ -32,6 +39,10 @@ export type DetectModelMatchedResult = {
   isHardwareSpecificUnsupported?: boolean;
   /** Set when an STT hit also matches the QNN release naming convention. */
   supportsQnn?: boolean;
+  /** Non-empty resolved path keys from native detection (folder scans). */
+  paths?: DetectModelPathsMap;
+  detectionSources?: readonly DetectionSource[];
+  detectedModels?: readonly DetectedModelEntry[];
 };
 
 export type DetectModelResult = { matched: false } | DetectModelMatchedResult;
@@ -39,6 +50,8 @@ export type DetectModelResult = { matched: false } | DetectModelMatchedResult;
 export type DetectModelsBatchOptions = {
   /** Parallel batch jobs (default 8). Splits inputs into chunks when less than input count. */
   concurrency?: number;
+  /** Include `paths` in each matched result (default false). Single `detectModel` always includes paths when present. */
+  includePaths?: boolean;
 };
 
 type ResolvedDetectModelInput = ResolvedDetectInput & {
@@ -150,7 +163,8 @@ function languagesFromNative(
 function buildMatchedResult(
   category: ModelCategory,
   modelKey: string,
-  raw: UnifiedDetectNativeResult
+  raw: UnifiedDetectNativeResult,
+  includePaths: boolean
 ): DetectModelMatchedResult {
   const modelType = (raw.modelType ?? 'unknown').trim();
   const result: DetectModelMatchedResult = {
@@ -180,12 +194,51 @@ function buildMatchedResult(
     result.supportsQnn = true;
   }
 
+  const detectionSources = readDetectionSources(raw.detectionSources);
+  if (detectionSources.length > 0) {
+    result.detectionSources = detectionSources;
+  }
+
+  const detectedModels = readDetectedModels(raw.detectedModels);
+  if (detectedModels.length > 0) {
+    result.detectedModels = detectedModels;
+  }
+
+  if (includePaths) {
+    const paths = readNonEmptyDetectPathsMap(raw.paths);
+    if (paths != null) {
+      result.paths = paths;
+    }
+  }
+
   return result;
+}
+
+function omitPathsFromMatched(
+  result: DetectModelMatchedResult
+): DetectModelMatchedResult {
+  if (result.paths == null) {
+    return result;
+  }
+  const rest = { ...result };
+  delete rest.paths;
+  return rest;
+}
+
+function finalizeDetectResult(
+  result: DetectModelResult,
+  includePaths: boolean
+): DetectModelResult {
+  if (!result.matched || includePaths) {
+    return result;
+  }
+  return omitPathsFromMatched(result);
 }
 
 function mapNativeDetectResult(
   resolved: ResolvedDetectModelInput,
-  raw: UnifiedDetectNativeResult
+  raw: UnifiedDetectNativeResult,
+  includePaths: boolean
 ): DetectModelResult {
   if (raw.matched !== true) {
     return { matched: false };
@@ -196,7 +249,7 @@ function mapNativeDetectResult(
     return { matched: false };
   }
 
-  return buildMatchedResult(category, resolved.modelKey, raw);
+  return buildMatchedResult(category, resolved.modelKey, raw, includePaths);
 }
 
 function toNativeDetectInput(resolved: ResolvedDetectModelInput): {
@@ -224,7 +277,7 @@ export async function detectModel(
     resolved.modelDir,
     resolved.assetName
   );
-  return mapNativeDetectResult(resolved, raw);
+  return mapNativeDetectResult(resolved, raw, true);
 }
 
 /** Batch wrapper around unified native detection with optional chunked parallelism. */
@@ -237,6 +290,7 @@ export async function detectModelsBatch(
   }
 
   const concurrency = options?.concurrency ?? DEFAULT_BATCH_CONCURRENCY;
+  const includePaths = options?.includePaths === true;
   const resolvedList = await Promise.all(
     inputs.map((input) => resolveDetectModelInput(input))
   );
@@ -247,7 +301,10 @@ export async function detectModelsBatch(
     const nativeInputs = chunk.map((r) => toNativeDetectInput(r));
     const rawResults = await SherpaOnnx.detectModelsBatch(nativeInputs);
     return rawResults.map((raw, index) =>
-      mapNativeDetectResult(chunk[index]!, raw)
+      finalizeDetectResult(
+        mapNativeDetectResult(chunk[index]!, raw, includePaths),
+        includePaths
+      )
     );
   };
 

--- a/src/detect/detectModelOutput.ts
+++ b/src/detect/detectModelOutput.ts
@@ -1,0 +1,56 @@
+import {
+  isDetectionSource,
+  type DetectedModelEntry,
+  type DetectionSource,
+} from '../types/modelDetect';
+
+export type DetectModelPathsMap = Readonly<Record<string, string>>;
+
+export function readNonEmptyDetectPathsMap(
+  raw: unknown
+): DetectModelPathsMap | undefined {
+  if (raw == null || typeof raw !== 'object') {
+    return undefined;
+  }
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      out[key] = value;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+export function readDetectionSources(raw: unknown): DetectionSource[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const sources: DetectionSource[] = [];
+  for (const entry of raw) {
+    if (typeof entry === 'string' && isDetectionSource(entry)) {
+      sources.push(entry);
+    }
+  }
+  return sources;
+}
+
+export function readDetectedModels(raw: unknown): DetectedModelEntry[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const models: DetectedModelEntry[] = [];
+  for (const entry of raw) {
+    if (
+      entry != null &&
+      typeof entry === 'object' &&
+      typeof (entry as { type?: unknown }).type === 'string' &&
+      typeof (entry as { modelDir?: unknown }).modelDir === 'string'
+    ) {
+      models.push({
+        type: (entry as { type: string }).type,
+        modelDir: (entry as { modelDir: string }).modelDir,
+      });
+    }
+  }
+  return models;
+}

--- a/src/detect/index.ts
+++ b/src/detect/index.ts
@@ -31,10 +31,17 @@ export {
 } from './detectModel';
 
 export {
+  customModelPathFieldKeys,
+  requiredCustomModelPathFieldKeys,
+  type CustomModelPathField,
+  type CustomModelPathFieldKind,
+  type CustomModelPathRequirements,
+} from './customModelPathRequirements';
+
+export {
   getCustomModelPathRequirements,
   validateCustomModelPaths,
   type CustomModelPathCategory,
-  type CustomModelPathRequirements,
   type CustomModelPathValidationResult,
 } from './validateCustomModelPaths';
 

--- a/src/detect/index.ts
+++ b/src/detect/index.ts
@@ -6,6 +6,7 @@
  *
  * - {@link detectModel} / {@link detectModelsBatch} — category + type (native C++)
  * - {@link validateCustomModelPaths} / {@link getCustomModelPathRequirements} — custom-init path schema + validation (native C++)
+ * - {@link resolveCustomModelConfigPaths} / {@link isFileSource} — shared custom-init FileSource → path resolution
  * - {@link resolveFileSourceForDetect} — `FileSource` → `modelDir` + `assetName` (supports `kind: 'auto'`)
  */
 
@@ -36,3 +37,10 @@ export {
   type CustomModelPathRequirements,
   type CustomModelPathValidationResult,
 } from './validateCustomModelPaths';
+
+export {
+  assertCustomModelConfig,
+  createInvalidArgumentError,
+  isFileSource,
+  resolveCustomModelConfigPaths,
+} from './customConfigResolver';

--- a/src/detect/index.ts
+++ b/src/detect/index.ts
@@ -5,12 +5,15 @@
  * User guide: `docs/model-detect.md` in the package repo.
  *
  * - {@link detectModel} / {@link detectModelsBatch} — category + type (native C++)
+ * - {@link validateCustomModelPaths} / {@link getCustomModelPathRequirements} — custom-init path schema + validation (native C++)
  * - {@link resolveFileSourceForDetect} — `FileSource` → `modelDir` + `assetName` (supports `kind: 'auto'`)
  */
 
 export {
   resolveFileSourceForDetect,
   resolveFileSourceForModelInit,
+  resolveFileSourceForModelFile,
+  resolveModelFileSources,
   type ResolvedDetectInput,
 } from './resolveModelInput';
 
@@ -25,3 +28,11 @@ export {
   type DetectModelResult,
   type DetectModelsBatchOptions,
 } from './detectModel';
+
+export {
+  getCustomModelPathRequirements,
+  validateCustomModelPaths,
+  type CustomModelPathCategory,
+  type CustomModelPathRequirements,
+  type CustomModelPathValidationResult,
+} from './validateCustomModelPaths';

--- a/src/detect/resolveModelInput.ts
+++ b/src/detect/resolveModelInput.ts
@@ -213,6 +213,176 @@ async function isUsableModelDirectory(modelDir: string): Promise<boolean> {
   }
 }
 
+async function isUsableModelFile(filePath: string): Promise<boolean> {
+  const trimmed = filePath.trim();
+  if (!trimmed) {
+    return false;
+  }
+  try {
+    return await exists(trimmed);
+  } catch {
+    return false;
+  }
+}
+
+let modelFileCacheCounter = 0;
+
+async function materializeUriFileSourceToCache(
+  source: Extract<FileSource, { kind: 'contentUri' | 'securityScoped' }>
+): Promise<string> {
+  const cacheName = `model_file_${Date.now()}_${++modelFileCacheCounter}`;
+  const displayName = source.displayName?.trim();
+  const destPath =
+    displayName && displayName.length > 0
+      ? `tmp/${cacheName}_${displayName.replace(/[/\\]/g, '_')}`
+      : `tmp/${cacheName}`;
+  const result = await SherpaOnnx.copyFile(
+    source,
+    { kind: 'app', base: 'tmp', path: destPath },
+    true,
+    true,
+    `resolve_model_file_${++modelFileCacheCounter}`
+  );
+  if (result.outputKind !== 'fs' || !result.outputPath?.trim()) {
+    createFileIOError(
+      FileIOErrorCode.RESOLVE_ERROR,
+      `Failed to materialize ${source.kind} source to a readable file path`
+    );
+  }
+  return result.outputPath;
+}
+
+async function resolveConcreteFileSourceForModelFile(
+  source: ConcreteFileSource
+): Promise<string> {
+  switch (source.kind) {
+    case 'fs': {
+      const path = source.path.trim();
+      if (!path) {
+        createFileIOError(
+          FileIOErrorCode.INVALID_ARGUMENT,
+          "FileSource kind 'fs' requires a non-empty path"
+        );
+      }
+      if (!(await isUsableModelFile(path))) {
+        createFileIOError(
+          FileIOErrorCode.NOT_FOUND,
+          `Model file not found: ${path}`
+        );
+      }
+      return path;
+    }
+
+    case 'app': {
+      const safeRelativePath = normalizeRelativePathForDetect(
+        source.path,
+        'app'
+      );
+      if (source.base === 'apkAsset' || source.base === 'appBundle') {
+        if (source.base === 'apkAsset' && platformOs() !== 'android') {
+          createFileIOError(
+            FileIOErrorCode.UNSUPPORTED_ON_PLATFORM,
+            'app:apkAsset is supported on Android only. Use app:appBundle or fs on this platform.'
+          );
+        }
+        if (source.base === 'appBundle' && platformOs() !== 'ios') {
+          createFileIOError(
+            FileIOErrorCode.UNSUPPORTED_ON_PLATFORM,
+            'app:appBundle is supported on iOS only. Use app:apkAsset or fs on this platform.'
+          );
+        }
+        const resolved = await resolveBundledRelativePath(safeRelativePath);
+        if (!(await isUsableModelFile(resolved))) {
+          createFileIOError(
+            FileIOErrorCode.NOT_FOUND,
+            `Bundled model file not found: ${safeRelativePath}`
+          );
+        }
+        return resolved;
+      }
+      const baseDir = await SherpaOnnx.resolveAppBaseDir(source.base);
+      const fullPath = joinBaseAndRelativePath(baseDir, safeRelativePath);
+      if (!(await isUsableModelFile(fullPath))) {
+        createFileIOError(
+          FileIOErrorCode.NOT_FOUND,
+          `Model file not found: ${fullPath}`
+        );
+      }
+      return fullPath;
+    }
+
+    case 'pad': {
+      if (platformOs() !== 'android') {
+        createFileIOError(
+          FileIOErrorCode.UNSUPPORTED_ON_PLATFORM,
+          'pad is supported on Android only.'
+        );
+      }
+      const safeRelativePath = normalizeRelativePathForDetect(
+        source.path,
+        'pad'
+      );
+      const packPath = await SherpaOnnx.getAssetPackPath(source.packName);
+      if (!packPath) {
+        createFileIOError(
+          FileIOErrorCode.RESOLVE_ERROR,
+          `Play Asset Delivery pack not available: ${source.packName}`
+        );
+      }
+      const fullPath = joinBaseAndRelativePath(packPath, safeRelativePath);
+      if (!(await isUsableModelFile(fullPath))) {
+        createFileIOError(
+          FileIOErrorCode.NOT_FOUND,
+          `Model file not found in pack ${source.packName}: ${fullPath}`
+        );
+      }
+      return fullPath;
+    }
+
+    case 'contentUri':
+    case 'securityScoped':
+      return materializeUriFileSourceToCache(source);
+  }
+}
+
+async function resolveAutoFileSourceForModelFile(source: {
+  kind: 'auto';
+  path: string;
+  tryOrder: FileSourceAutoTryTarget[];
+}): Promise<string> {
+  validateAutoFileSource(source);
+
+  const attemptErrors: string[] = [];
+
+  for (const target of source.tryOrder) {
+    const label = autoTryTargetLabel(target);
+    try {
+      const concrete = fileSourceFromAutoTryTarget(target, source.path);
+      const resolved = await resolveConcreteFileSourceForModelFile(concrete);
+      if (!(await isUsableModelFile(resolved))) {
+        attemptErrors.push(`${label}: file not found (${resolved})`);
+        continue;
+      }
+      return resolved;
+    } catch (error) {
+      if (isFatalAutoResolveError(error)) {
+        throw toFileIOResolveError(error);
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      attemptErrors.push(`${label}: ${message}`);
+    }
+  }
+
+  createFileIOError(
+    FileIOErrorCode.NOT_FOUND,
+    `No FileSource location matched file path "${
+      source.path
+    }". tryOrder=[${source.tryOrder
+      .map(autoTryTargetLabel)
+      .join(', ')}]. ${attemptErrors.join(' | ')}`
+  );
+}
+
 async function resolveConcreteFileSourceForDetect(
   source: ConcreteFileSource
 ): Promise<ResolvedDetectInput> {
@@ -371,4 +541,37 @@ export async function resolveFileSourceForModelInit(
     FileIOErrorCode.RESOLVE_ERROR,
     `Unable to resolve a local model directory for source kind '${source.kind}'.`
   );
+}
+
+/**
+ * Resolve a {@link FileSource} to an absolute filesystem path for a single model file.
+ * Mirror of {@link resolveFileSourceForModelInit} for file-backed custom configs.
+ */
+export async function resolveFileSourceForModelFile(
+  source: FileSource
+): Promise<string> {
+  try {
+    if (source.kind === 'auto') {
+      return await resolveAutoFileSourceForModelFile(source);
+    }
+    return await resolveConcreteFileSourceForModelFile(source);
+  } catch (error) {
+    throw toFileIOResolveError(error);
+  }
+}
+
+/**
+ * Resolve every {@link FileSource} value in a map to absolute file paths (parallel).
+ */
+export async function resolveModelFileSources(
+  config: Record<string, FileSource>
+): Promise<Record<string, string>> {
+  const entries = Object.entries(config);
+  const resolvedEntries = await Promise.all(
+    entries.map(async ([key, source]) => {
+      const path = await resolveFileSourceForModelFile(source);
+      return [key, path] as const;
+    })
+  );
+  return Object.fromEntries(resolvedEntries);
 }

--- a/src/detect/validateCustomModelPaths.ts
+++ b/src/detect/validateCustomModelPaths.ts
@@ -1,5 +1,20 @@
 import { ModelCategory } from '../download/types';
 import NativeSherpaOnnx from '../NativeSherpaOnnx';
+import type {
+  CustomModelPathField,
+  CustomModelPathRequirements,
+} from './customModelPathRequirements';
+
+export type {
+  CustomModelPathField,
+  CustomModelPathFieldKind,
+  CustomModelPathRequirements,
+} from './customModelPathRequirements';
+
+export {
+  customModelPathFieldKeys,
+  requiredCustomModelPathFieldKeys,
+} from './customModelPathRequirements';
 
 export type CustomModelPathCategory =
   | ModelCategory.Stt
@@ -16,13 +31,39 @@ export type CustomModelPathValidationResult = {
   missingRequired?: string[];
 };
 
-export type CustomModelPathRequirements = {
-  required: string[];
-  optional: string[];
+type NativeCustomModelPathField = {
+  key?: string;
+  required?: boolean;
+  kind?: string;
+};
+
+type NativeCustomModelPathRequirements = {
+  fields?: NativeCustomModelPathField[];
 };
 
 function normalizeCategory(category: CustomModelPathCategory | string): string {
   return typeof category === 'string' ? category : category;
+}
+
+function normalizeCustomModelPathField(
+  field: NativeCustomModelPathField
+): CustomModelPathField | null {
+  if (!field.key) return null;
+  return {
+    key: field.key,
+    required: field.required ?? false,
+    kind: field.kind === 'dir' ? 'dir' : 'file',
+  };
+}
+
+function normalizeCustomModelPathRequirements(
+  raw: NativeCustomModelPathRequirements
+): CustomModelPathRequirements {
+  const fields = (raw.fields ?? [])
+    .map(normalizeCustomModelPathField)
+    .filter((field): field is CustomModelPathField => field != null);
+
+  return { fields };
 }
 
 export async function validateCustomModelPaths(
@@ -50,8 +91,5 @@ export async function getCustomModelPathRequirements(
     normalizeCategory(category),
     modelType
   );
-  return {
-    required: raw.required ?? [],
-    optional: raw.optional ?? [],
-  };
+  return normalizeCustomModelPathRequirements(raw);
 }

--- a/src/detect/validateCustomModelPaths.ts
+++ b/src/detect/validateCustomModelPaths.ts
@@ -1,0 +1,56 @@
+import { ModelCategory } from '../download/types';
+import NativeSherpaOnnx from '../NativeSherpaOnnx';
+
+export type CustomModelPathCategory =
+  | ModelCategory.Stt
+  | ModelCategory.Tts
+  | ModelCategory.Vad
+  | ModelCategory.Enhancement
+  | ModelCategory.Punctuation
+  | ModelCategory.Alignment;
+
+export type CustomModelPathValidationResult = {
+  ok: boolean;
+  error?: string;
+  missingRequired?: string[];
+};
+
+export type CustomModelPathRequirements = {
+  required: string[];
+  optional: string[];
+};
+
+function normalizeCategory(category: CustomModelPathCategory | string): string {
+  return typeof category === 'string' ? category : category;
+}
+
+export async function validateCustomModelPaths(
+  category: CustomModelPathCategory | string,
+  modelType: string,
+  paths: Readonly<Record<string, string>>
+): Promise<CustomModelPathValidationResult> {
+  const raw = await NativeSherpaOnnx.validateCustomModelPaths(
+    normalizeCategory(category),
+    modelType,
+    paths
+  );
+  return {
+    ok: raw.ok ?? false,
+    error: raw.error,
+    missingRequired: raw.missingRequired,
+  };
+}
+
+export async function getCustomModelPathRequirements(
+  category: CustomModelPathCategory | string,
+  modelType: string
+): Promise<CustomModelPathRequirements> {
+  const raw = await NativeSherpaOnnx.getCustomModelPathRequirements(
+    normalizeCategory(category),
+    modelType
+  );
+  return {
+    required: raw.required ?? [],
+    optional: raw.optional ?? [],
+  };
+}

--- a/src/detect/validateCustomModelPaths.ts
+++ b/src/detect/validateCustomModelPaths.ts
@@ -3,6 +3,7 @@ import NativeSherpaOnnx from '../NativeSherpaOnnx';
 
 export type CustomModelPathCategory =
   | ModelCategory.Stt
+  | 'stt_streaming'
   | ModelCategory.Tts
   | ModelCategory.Vad
   | ModelCategory.Enhancement

--- a/src/enhancement/__tests__/customConfig.test.ts
+++ b/src/enhancement/__tests__/customConfig.test.ts
@@ -1,10 +1,15 @@
-jest.mock('../../detect/validateCustomModelPaths', () => ({
-  getCustomModelPathRequirements: jest.fn(async () => ({
-    required: ['model'],
-    optional: [],
-  })),
-  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
-}));
+jest.mock('../../detect/validateCustomModelPaths', () => {
+  const helpers = jest.requireActual(
+    '../../detect/customModelPathRequirements'
+  );
+  return {
+    ...helpers,
+    getCustomModelPathRequirements: jest.fn(async () => ({
+      fields: [{ key: 'model', required: true, kind: 'file' }],
+    })),
+    validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+  };
+});
 
 jest.mock('../../detect/resolveModelInput', () => ({
   resolveModelFileSources: jest.fn(async (sources: Record<string, unknown>) => {
@@ -56,8 +61,7 @@ describe('resolveEnhancementCustomConfigPaths', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetRequirements.mockResolvedValue({
-      required: ['model'],
-      optional: [],
+      fields: [{ key: 'model', required: true, kind: 'file' }],
     });
     mockValidate.mockResolvedValue({ ok: true });
   });

--- a/src/enhancement/__tests__/customConfig.test.ts
+++ b/src/enhancement/__tests__/customConfig.test.ts
@@ -1,0 +1,81 @@
+jest.mock('../../detect/validateCustomModelPaths', () => ({
+  getCustomModelPathRequirements: jest.fn(async () => ({
+    required: ['model'],
+    optional: [],
+  })),
+  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+}));
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveModelFileSources: jest.fn(async (sources: Record<string, unknown>) => {
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(sources)) {
+      const path = (value as { path?: string })?.path;
+      if (path) out[key] = path;
+    }
+    return out;
+  }),
+}));
+
+import {
+  assertEnhancementCustomConfig,
+  resolveEnhancementCustomConfigPaths,
+  EnhancementErrorCode,
+} from '../customConfig';
+import {
+  getCustomModelPathRequirements,
+  validateCustomModelPaths,
+} from '../../detect/validateCustomModelPaths';
+
+const mockGetRequirements = getCustomModelPathRequirements as jest.Mock;
+const mockValidate = validateCustomModelPaths as jest.Mock;
+
+describe('assertEnhancementCustomConfig', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  it('accepts FileSource values', () => {
+    expect(() =>
+      assertEnhancementCustomConfig({
+        model: fsPath('/gtcrn.onnx'),
+      })
+    ).not.toThrow();
+  });
+
+  it('throws ENHANCEMENT_INVALID_ARGUMENT when a value is not a FileSource', () => {
+    expect(() =>
+      assertEnhancementCustomConfig({
+        model: '/gtcrn.onnx',
+      })
+    ).toThrow(EnhancementErrorCode.INVALID_ARGUMENT);
+  });
+});
+
+describe('resolveEnhancementCustomConfigPaths', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetRequirements.mockResolvedValue({
+      required: ['model'],
+      optional: [],
+    });
+    mockValidate.mockResolvedValue({ ok: true });
+  });
+
+  it('rejects unknown keys using native schema', async () => {
+    await expect(
+      resolveEnhancementCustomConfigPaths('gtcrn', {
+        model: fsPath('/gtcrn.onnx'),
+        unknownKey: fsPath('/x.onnx'),
+      } as never)
+    ).rejects.toThrow(EnhancementErrorCode.INVALID_ARGUMENT);
+  });
+
+  it('resolves paths via shared resolver', async () => {
+    const paths = await resolveEnhancementCustomConfigPaths('dpdfnet', {
+      model: fsPath('/dpdfnet.onnx'),
+    });
+    expect(paths).toEqual({ model: '/dpdfnet.onnx' });
+    expect(mockValidate).toHaveBeenCalled();
+  });
+});

--- a/src/enhancement/__tests__/detectEnhancementModel.test.ts
+++ b/src/enhancement/__tests__/detectEnhancementModel.test.ts
@@ -1,0 +1,61 @@
+jest.mock('../../NativeSherpaOnnx', () => ({
+  __esModule: true,
+  default: {
+    detectEnhancementModel: jest.fn(),
+  },
+}));
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveFileSourceForDetect: jest.fn(async () => ({
+    modelDir: '/models/enhancement',
+    assetName: 'sherpa-onnx-speech-enhancement-gtcrn',
+  })),
+}));
+
+jest.mock('../../model-languages', () => ({
+  resolvePublicLanguageHints: jest.fn(() => []),
+}));
+
+import SherpaOnnx from '../../NativeSherpaOnnx';
+import { detectEnhancementModel } from '../index';
+
+describe('detectEnhancementModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('maps non-empty native paths.model into the result', async () => {
+    (SherpaOnnx.detectEnhancementModel as jest.Mock).mockResolvedValue({
+      success: true,
+      isStreaming: true,
+      modelType: 'gtcrn',
+      detectedModels: [{ type: 'gtcrn', modelDir: '/models/enhancement' }],
+      paths: { model: '/models/enhancement/gtcrn.onnx' },
+    });
+
+    const result = await detectEnhancementModel({
+      kind: 'fs',
+      path: '/models/enhancement',
+    });
+
+    expect(result.paths).toEqual({
+      model: '/models/enhancement/gtcrn.onnx',
+    });
+  });
+
+  it('omits paths when native model path is empty or whitespace', async () => {
+    (SherpaOnnx.detectEnhancementModel as jest.Mock).mockResolvedValue({
+      success: false,
+      isStreaming: false,
+      detectedModels: [],
+      paths: { model: '   ' },
+    });
+
+    const result = await detectEnhancementModel({
+      kind: 'fs',
+      path: '/models/enhancement',
+    });
+
+    expect(result.paths).toBeUndefined();
+  });
+});

--- a/src/enhancement/__tests__/enhance-live-offline.test.ts
+++ b/src/enhancement/__tests__/enhance-live-offline.test.ts
@@ -17,6 +17,12 @@ jest.mock('react-native', () => ({
   })),
 }));
 
+jest.mock('../../audiobuffer/streamingPipelineCompletion', () => ({
+  createStreamingPipelineCompletionPromise: jest.fn(() =>
+    Promise.resolve({ pipelineId: 'pipe_1', reason: 'completed' })
+  ),
+}));
+
 jest.mock('../../NativeSherpaOnnx', () => {
   return {
     __esModule: true,

--- a/src/enhancement/__tests__/enhancementNativeBridge.test.ts
+++ b/src/enhancement/__tests__/enhancementNativeBridge.test.ts
@@ -1,0 +1,43 @@
+import { buildEnhancementInitBridgeOptions } from '../enhancementNativeBridge';
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveFileSourceForModelInit: jest.fn(async () => '/models/gtcrn'),
+}));
+
+jest.mock('../customConfig', () => ({
+  resolveEnhancementCustomConfigPaths: jest.fn(async () => ({
+    model: '/models/gtcrn.onnx',
+  })),
+}));
+
+describe('enhancementNativeBridge', () => {
+  it('buildEnhancementInitBridgeOptions maps auto options to bridge map', async () => {
+    const bridge = await buildEnhancementInitBridgeOptions({
+      modelSource: { kind: 'fs', path: '/models/gtcrn' },
+      modelType: 'gtcrn',
+      numThreads: 2,
+      debug: false,
+    });
+    expect(bridge).toEqual({
+      initMode: 'auto',
+      modelDir: '/models/gtcrn',
+      modelType: 'gtcrn',
+      numThreads: 2,
+      debug: false,
+    });
+  });
+
+  it('buildEnhancementInitBridgeOptions maps custom options to modelPaths', async () => {
+    const bridge = await buildEnhancementInitBridgeOptions({
+      initMode: 'custom',
+      modelType: 'gtcrn',
+      customConfig: {
+        model: { kind: 'fs', path: '/models/gtcrn.onnx' },
+      },
+    });
+    expect(bridge.initMode).toBe('custom');
+    expect(bridge.modelDir).toBeUndefined();
+    expect(bridge.modelPaths).toEqual({ model: '/models/gtcrn.onnx' });
+    expect(bridge.modelType).toBe('gtcrn');
+  });
+});

--- a/src/enhancement/customConfig.ts
+++ b/src/enhancement/customConfig.ts
@@ -1,0 +1,37 @@
+import type { FileSource } from '../fileio/types';
+import { ModelCategory } from '../download/types';
+import {
+  assertCustomModelConfig,
+  resolveCustomModelConfigPaths,
+} from '../detect/customConfigResolver';
+import type { EnhancementConcreteModelType } from './types';
+
+export const EnhancementErrorCode = {
+  INVALID_ARGUMENT: 'ENHANCEMENT_INVALID_ARGUMENT',
+} as const;
+
+export type EnhancementCustomPathKey = 'model';
+
+export interface EnhancementCustomConfig {
+  model: FileSource;
+}
+
+export function assertEnhancementCustomConfig(
+  customConfig: Record<string, unknown>
+): void {
+  assertCustomModelConfig(customConfig, EnhancementErrorCode.INVALID_ARGUMENT);
+}
+
+export async function resolveEnhancementCustomConfigPaths(
+  modelType: EnhancementConcreteModelType,
+  customConfig: EnhancementCustomConfig
+): Promise<Record<string, string>> {
+  return resolveCustomModelConfigPaths({
+    category: ModelCategory.Enhancement,
+    modelType,
+    customConfig: customConfig as unknown as Record<string, unknown>,
+    errorCode: EnhancementErrorCode.INVALID_ARGUMENT,
+    unknownKeyMessage: (key, mt) =>
+      `Unknown customConfig key '${key}' for enhancement modelType '${mt}'`,
+  });
+}

--- a/src/enhancement/enhancementNativeBridge.ts
+++ b/src/enhancement/enhancementNativeBridge.ts
@@ -1,0 +1,54 @@
+import type {
+  EnhancementAutoInitializeOptions,
+  EnhancementCustomInitializeOptions,
+  EnhancementInitializeOptions,
+} from './types';
+import type { EnhancementInitBridgeOptions } from '../nativeBridge/initBridgeTypes';
+import { resolveFileSourceForModelInit } from '../detect/resolveModelInput';
+import { resolveEnhancementCustomConfigPaths } from './customConfig';
+
+export type { EnhancementInitBridgeOptions };
+
+function appendSharedInitBridgeFields(
+  options: EnhancementInitializeOptions
+): Omit<
+  EnhancementInitBridgeOptions,
+  'initMode' | 'modelDir' | 'modelPaths' | 'modelType'
+> {
+  return {
+    ...(options.numThreads !== undefined
+      ? { numThreads: options.numThreads }
+      : {}),
+    ...(options.provider !== undefined ? { provider: options.provider } : {}),
+    ...(options.debug !== undefined ? { debug: options.debug } : {}),
+  };
+}
+
+export async function buildEnhancementInitBridgeOptions(
+  options: EnhancementInitializeOptions
+): Promise<EnhancementInitBridgeOptions> {
+  const sharedFields = appendSharedInitBridgeFields(options);
+
+  if (options.initMode === 'custom') {
+    const customOptions = options as EnhancementCustomInitializeOptions;
+    const modelPaths = await resolveEnhancementCustomConfigPaths(
+      customOptions.modelType,
+      customOptions.customConfig
+    );
+    return {
+      initMode: 'custom',
+      modelType: customOptions.modelType,
+      modelPaths,
+      ...sharedFields,
+    };
+  }
+
+  const autoOptions = options as EnhancementAutoInitializeOptions;
+  const modelDir = await resolveFileSourceForModelInit(autoOptions.modelSource);
+  return {
+    initMode: 'auto',
+    modelDir,
+    modelType: autoOptions.modelType ?? 'auto',
+    ...sharedFields,
+  };
+}

--- a/src/enhancement/index.ts
+++ b/src/enhancement/index.ts
@@ -200,6 +200,8 @@ export async function detectEnhancementModel(
     typeof raw.quantization === 'string' && raw.quantization.length > 0
       ? raw.quantization
       : undefined;
+  const modelFilePath =
+    typeof raw.paths?.model === 'string' ? raw.paths.model.trim() : '';
   const isStreaming = raw.isStreaming === true;
   return {
     success: raw.success,
@@ -212,6 +214,7 @@ export async function detectEnhancementModel(
     ...(resolvedLanguages.length > 0 ? { languages: resolvedLanguages } : {}),
     ...(quantization != null ? { quantization } : {}),
     ...(detectionSources.length > 0 ? { detectionSources } : {}),
+    ...(modelFilePath.length > 0 ? { paths: { model: modelFilePath } } : {}),
   };
 }
 

--- a/src/enhancement/index.ts
+++ b/src/enhancement/index.ts
@@ -1,7 +1,6 @@
 import SherpaOnnx from '../NativeSherpaOnnx';
 import type { FileSource } from '../fileio/types';
 import { resolveFileSourceForDetect } from '../detect/resolveModelInput';
-import { resolveFileSourceForModelInit } from '../detect/resolveModelInput';
 import { resolvePublicLanguageHints } from '../model-languages';
 import { ModelCategory } from '../download/types';
 import { isDetectionSource } from './types';
@@ -35,6 +34,7 @@ import {
   getSegmentationEngineInfo,
 } from '../segment';
 import { createStreamingPipelineCompletionPromise } from '../audiobuffer/streamingPipelineCompletion';
+import { buildEnhancementInitBridgeOptions } from './enhancementNativeBridge';
 
 let enhancementInstanceCounter = 0;
 
@@ -219,14 +219,10 @@ export async function createEnhancement(
   options: EnhancementInitializeOptions
 ): Promise<EnhancementEngine> {
   const instanceId = `enhancement_${++enhancementInstanceCounter}`;
-  const resolvedPath = await resolveFileSourceForModelInit(options.modelSource);
+  const bridgeOptions = await buildEnhancementInitBridgeOptions(options);
   const init = await SherpaOnnx.initializeEnhancement(
     instanceId,
-    resolvedPath,
-    options.modelType ?? 'auto',
-    options.numThreads,
-    options.provider,
-    options.debug
+    bridgeOptions
   );
 
   if (!init.success) {
@@ -350,6 +346,10 @@ export type {
 
 export type {
   EnhancementModelType,
+  EnhancementConcreteModelType,
+  EnhancementInitOptionsShared,
+  EnhancementAutoInitializeOptions,
+  EnhancementCustomInitializeOptions,
   EnhancementInitializeOptions,
   EnhancementDetectResult,
   EnhancementEngine,
@@ -357,4 +357,11 @@ export type {
   EnhancementResult,
   EnhanceSegmentationConfig,
 } from './types';
+export {
+  assertEnhancementCustomConfig,
+  resolveEnhancementCustomConfigPaths,
+  EnhancementErrorCode,
+  type EnhancementCustomConfig,
+  type EnhancementCustomPathKey,
+} from './customConfig';
 export { ENHANCEMENT_MODEL_TYPES } from './types';

--- a/src/enhancement/streaming.ts
+++ b/src/enhancement/streaming.ts
@@ -4,7 +4,7 @@ import type { StreamingPipelineStatus } from '../audiobuffer/streamingPipelineTy
 import { createStreamingPipelineCompletionPromise } from '../audiobuffer/streamingPipelineCompletion';
 import { attachSegmentationEngine, detachSegmentationEngine } from '../segment';
 import { validateSegmentationConfig } from '../segment/validation';
-import { resolveFileSourceForModelInit } from '../detect/resolveModelInput';
+import { buildEnhancementInitBridgeOptions } from './enhancementNativeBridge';
 import type { EnhancementModelType } from './types';
 import type {
   EnhancementPipelineHandle,
@@ -67,14 +67,10 @@ export async function createStreamingEnhancement(
   options: StreamingEnhancementInitializeOptions
 ): Promise<StreamingEnhancementEngine> {
   const instanceId = `streaming_enhancement_${++streamingEnhancementInstanceCounter}`;
-  const resolvedPath = await resolveFileSourceForModelInit(options.modelSource);
+  const bridgeOptions = await buildEnhancementInitBridgeOptions(options);
   const result = await SherpaOnnx.initializeOnlineEnhancement(
     instanceId,
-    resolvedPath,
-    options.modelType ?? 'auto',
-    options.numThreads,
-    options.provider,
-    options.debug
+    bridgeOptions
   );
 
   if (!result.success) {

--- a/src/enhancement/types.ts
+++ b/src/enhancement/types.ts
@@ -31,13 +31,30 @@ export const ENHANCEMENT_MODEL_TYPES: readonly EnhancementModelType[] = [
   'dpdfnet',
 ] as const;
 
-export interface EnhancementInitializeOptions {
-  modelSource: FileSource;
-  modelType?: EnhancementModelType | 'auto';
+export type EnhancementConcreteModelType = EnhancementModelType;
+
+export type EnhancementInitOptionsShared = {
   numThreads?: number;
   provider?: string;
   debug?: boolean;
-}
+};
+
+export type EnhancementAutoInitializeOptions = EnhancementInitOptionsShared & {
+  initMode?: 'auto';
+  modelSource: FileSource;
+  modelType?: EnhancementModelType | 'auto';
+};
+
+export type EnhancementCustomInitializeOptions =
+  EnhancementInitOptionsShared & {
+    initMode: 'custom';
+    modelType: EnhancementConcreteModelType;
+    customConfig: import('./customConfig').EnhancementCustomConfig;
+  };
+
+export type EnhancementInitializeOptions =
+  | EnhancementAutoInitializeOptions
+  | EnhancementCustomInitializeOptions;
 
 export type EnhancementDetectResult = EnhancementDetectModelResult;
 

--- a/src/nativeBridge/fileSourceBridgeHelpers.ts
+++ b/src/nativeBridge/fileSourceBridgeHelpers.ts
@@ -1,0 +1,27 @@
+import type { FileSource } from '../fileio/types';
+import { resolveFileSourceForModelFile } from '../detect/resolveModelInput';
+
+export async function resolveOptionalFileSourcePath(
+  source: FileSource | undefined
+): Promise<string | undefined> {
+  if (source === undefined) {
+    return undefined;
+  }
+  return resolveFileSourceForModelFile(source);
+}
+
+export async function resolveOptionalFileSourceList(
+  sources: FileSource | readonly FileSource[] | undefined
+): Promise<string | undefined> {
+  if (sources === undefined) {
+    return undefined;
+  }
+  const list = Array.isArray(sources) ? sources : [sources];
+  if (list.length === 0) {
+    return undefined;
+  }
+  const paths = await Promise.all(
+    list.map((source) => resolveFileSourceForModelFile(source))
+  );
+  return paths.join(',');
+}

--- a/src/nativeBridge/initBridgeTypes.ts
+++ b/src/nativeBridge/initBridgeTypes.ts
@@ -6,6 +6,7 @@
 export type {
   EnhancementInitBridgeOptions,
   OnlineSttInitBridgeOptions,
+  PunctuationInitBridgeOptions,
   SttInitBridgeOptions,
   TtsInitBridgeOptions,
   VadInitBridgeOptions,

--- a/src/nativeBridge/initBridgeTypes.ts
+++ b/src/nativeBridge/initBridgeTypes.ts
@@ -4,6 +4,7 @@
  */
 
 export type {
+  EnhancementInitBridgeOptions,
   OnlineSttInitBridgeOptions,
   SttInitBridgeOptions,
   TtsInitBridgeOptions,

--- a/src/nativeBridge/initBridgeTypes.ts
+++ b/src/nativeBridge/initBridgeTypes.ts
@@ -7,4 +7,5 @@ export type {
   OnlineSttInitBridgeOptions,
   SttInitBridgeOptions,
   TtsInitBridgeOptions,
+  VadInitBridgeOptions,
 } from '../NativeSherpaOnnx';

--- a/src/pad/assetPack.ts
+++ b/src/pad/assetPack.ts
@@ -92,8 +92,11 @@ export async function removeAssetPack(packName: string): Promise<number> {
 export function assetPackDownloadPercent(
   state: AssetPackStateSnapshot
 ): number | null {
-  if (state.totalBytes <= 0) {
-    return state.status === 'completed' ? 100 : null;
+  if (state.status === 'completed') {
+    return 100;
+  }
+  if (state.totalBytes <= 0 || state.bytesDownloaded <= 0) {
+    return null;
   }
   return Math.min(
     100,

--- a/src/punctuation/__tests__/customConfig.test.ts
+++ b/src/punctuation/__tests__/customConfig.test.ts
@@ -1,0 +1,130 @@
+jest.mock('../../detect/validateCustomModelPaths', () => ({
+  getCustomModelPathRequirements: jest.fn(
+    async (_category: string, modelType: string) => {
+      if (modelType === 'ct_transformer') {
+        return { required: ['ct_transformer'], optional: [] };
+      }
+      return { required: ['cnn_bilstm', 'bpe_vocab'], optional: [] };
+    }
+  ),
+  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+}));
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveModelFileSources: jest.fn(async (sources: Record<string, unknown>) => {
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(sources)) {
+      const path = (value as { path?: string })?.path;
+      if (path) out[key] = path;
+    }
+    return out;
+  }),
+}));
+
+import {
+  assertOfflinePunctuationCustomConfig,
+  assertStreamingPunctuationCustomConfig,
+  resolveOfflinePunctuationCustomConfigPaths,
+  resolveStreamingPunctuationCustomConfigPaths,
+  PunctuationErrorCode,
+} from '../customConfig';
+import {
+  getCustomModelPathRequirements,
+  validateCustomModelPaths,
+} from '../../detect/validateCustomModelPaths';
+
+const mockGetRequirements = getCustomModelPathRequirements as jest.Mock;
+const mockValidate = validateCustomModelPaths as jest.Mock;
+
+describe('assertOfflinePunctuationCustomConfig', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  it('accepts FileSource values', () => {
+    expect(() =>
+      assertOfflinePunctuationCustomConfig({
+        ct_transformer: fsPath('/ct.onnx'),
+      })
+    ).not.toThrow();
+  });
+
+  it('throws PUNCTUATION_INVALID_ARGUMENT when a value is not a FileSource', () => {
+    expect(() =>
+      assertOfflinePunctuationCustomConfig({
+        ct_transformer: '/ct.onnx',
+      })
+    ).toThrow(PunctuationErrorCode.INVALID_ARGUMENT);
+  });
+});
+
+describe('assertStreamingPunctuationCustomConfig', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  it('accepts FileSource values', () => {
+    expect(() =>
+      assertStreamingPunctuationCustomConfig({
+        cnn_bilstm: fsPath('/cnn.onnx'),
+        bpe_vocab: fsPath('/bpe.vocab'),
+      })
+    ).not.toThrow();
+  });
+});
+
+describe('resolveOfflinePunctuationCustomConfigPaths', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetRequirements.mockResolvedValue({
+      required: ['ct_transformer'],
+      optional: [],
+    });
+    mockValidate.mockResolvedValue({ ok: true });
+  });
+
+  it('rejects unknown keys using native schema', async () => {
+    await expect(
+      resolveOfflinePunctuationCustomConfigPaths('ct_transformer', {
+        ct_transformer: fsPath('/ct.onnx'),
+        unknownKey: fsPath('/x.onnx'),
+      } as never)
+    ).rejects.toThrow(PunctuationErrorCode.INVALID_ARGUMENT);
+  });
+
+  it('resolves paths via shared resolver', async () => {
+    const paths = await resolveOfflinePunctuationCustomConfigPaths(
+      'ct_transformer',
+      {
+        ct_transformer: fsPath('/ct.onnx'),
+      }
+    );
+    expect(paths).toEqual({ ct_transformer: '/ct.onnx' });
+    expect(mockValidate).toHaveBeenCalled();
+  });
+});
+
+describe('resolveStreamingPunctuationCustomConfigPaths', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetRequirements.mockResolvedValue({
+      required: ['cnn_bilstm', 'bpe_vocab'],
+      optional: [],
+    });
+    mockValidate.mockResolvedValue({ ok: true });
+  });
+
+  it('resolves both streaming paths', async () => {
+    const paths = await resolveStreamingPunctuationCustomConfigPaths(
+      'cnn_bilstm',
+      {
+        cnn_bilstm: fsPath('/cnn.onnx'),
+        bpe_vocab: fsPath('/bpe.vocab'),
+      }
+    );
+    expect(paths).toEqual({
+      cnn_bilstm: '/cnn.onnx',
+      bpe_vocab: '/bpe.vocab',
+    });
+  });
+});

--- a/src/punctuation/__tests__/customConfig.test.ts
+++ b/src/punctuation/__tests__/customConfig.test.ts
@@ -1,14 +1,27 @@
-jest.mock('../../detect/validateCustomModelPaths', () => ({
-  getCustomModelPathRequirements: jest.fn(
-    async (_category: string, modelType: string) => {
-      if (modelType === 'ct_transformer') {
-        return { required: ['ct_transformer'], optional: [] };
+jest.mock('../../detect/validateCustomModelPaths', () => {
+  const helpers = jest.requireActual(
+    '../../detect/customModelPathRequirements'
+  );
+  return {
+    ...helpers,
+    getCustomModelPathRequirements: jest.fn(
+      async (_category: string, modelType: string) => {
+        if (modelType === 'ct_transformer') {
+          return {
+            fields: [{ key: 'ct_transformer', required: true, kind: 'file' }],
+          };
+        }
+        return {
+          fields: [
+            { key: 'cnn_bilstm', required: true, kind: 'file' },
+            { key: 'bpe_vocab', required: true, kind: 'file' },
+          ],
+        };
       }
-      return { required: ['cnn_bilstm', 'bpe_vocab'], optional: [] };
-    }
-  ),
-  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
-}));
+    ),
+    validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+  };
+});
 
 jest.mock('../../detect/resolveModelInput', () => ({
   resolveModelFileSources: jest.fn(async (sources: Record<string, unknown>) => {
@@ -75,8 +88,7 @@ describe('resolveOfflinePunctuationCustomConfigPaths', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetRequirements.mockResolvedValue({
-      required: ['ct_transformer'],
-      optional: [],
+      fields: [{ key: 'ct_transformer', required: true, kind: 'file' }],
     });
     mockValidate.mockResolvedValue({ ok: true });
   });
@@ -108,8 +120,10 @@ describe('resolveStreamingPunctuationCustomConfigPaths', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetRequirements.mockResolvedValue({
-      required: ['cnn_bilstm', 'bpe_vocab'],
-      optional: [],
+      fields: [
+        { key: 'cnn_bilstm', required: true, kind: 'file' },
+        { key: 'bpe_vocab', required: true, kind: 'file' },
+      ],
     });
     mockValidate.mockResolvedValue({ ok: true });
   });

--- a/src/punctuation/__tests__/punctuationNativeBridge.test.ts
+++ b/src/punctuation/__tests__/punctuationNativeBridge.test.ts
@@ -1,0 +1,80 @@
+import {
+  buildOfflinePunctuationInitBridgeOptions,
+  buildStreamingPunctuationInitBridgeOptions,
+} from '../punctuationNativeBridge';
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveFileSourceForModelInit: jest.fn(async () => '/models/punctuation'),
+}));
+
+jest.mock('../customConfig', () => ({
+  resolveOfflinePunctuationCustomConfigPaths: jest.fn(async () => ({
+    ct_transformer: '/models/ct.onnx',
+  })),
+  resolveStreamingPunctuationCustomConfigPaths: jest.fn(async () => ({
+    cnn_bilstm: '/models/cnn.onnx',
+    bpe_vocab: '/models/bpe.vocab',
+  })),
+}));
+
+describe('punctuationNativeBridge', () => {
+  it('buildOfflinePunctuationInitBridgeOptions maps auto options to bridge map', async () => {
+    const bridge = await buildOfflinePunctuationInitBridgeOptions({
+      modelSource: { kind: 'fs', path: '/models/punctuation-offline' },
+      modelType: 'ct_transformer',
+      numThreads: 2,
+      debug: false,
+    });
+    expect(bridge).toEqual({
+      initMode: 'auto',
+      modelDir: '/models/punctuation',
+      modelType: 'ct_transformer',
+      numThreads: 2,
+      debug: false,
+    });
+  });
+
+  it('buildOfflinePunctuationInitBridgeOptions maps custom options to modelPaths', async () => {
+    const bridge = await buildOfflinePunctuationInitBridgeOptions({
+      initMode: 'custom',
+      modelType: 'ct_transformer',
+      customConfig: {
+        ct_transformer: { kind: 'fs', path: '/models/ct.onnx' },
+      },
+    });
+    expect(bridge.initMode).toBe('custom');
+    expect(bridge.modelDir).toBeUndefined();
+    expect(bridge.modelPaths).toEqual({ ct_transformer: '/models/ct.onnx' });
+    expect(bridge.modelType).toBe('ct_transformer');
+  });
+
+  it('buildStreamingPunctuationInitBridgeOptions maps auto options to bridge map', async () => {
+    const bridge = await buildStreamingPunctuationInitBridgeOptions({
+      modelSource: { kind: 'fs', path: '/models/punctuation-online' },
+      modelType: 'cnn_bilstm',
+      provider: 'cpu',
+    });
+    expect(bridge).toEqual({
+      initMode: 'auto',
+      modelDir: '/models/punctuation',
+      modelType: 'cnn_bilstm',
+      provider: 'cpu',
+    });
+  });
+
+  it('buildStreamingPunctuationInitBridgeOptions maps custom options to modelPaths', async () => {
+    const bridge = await buildStreamingPunctuationInitBridgeOptions({
+      initMode: 'custom',
+      modelType: 'cnn_bilstm',
+      customConfig: {
+        cnn_bilstm: { kind: 'fs', path: '/models/cnn.onnx' },
+        bpe_vocab: { kind: 'fs', path: '/models/bpe.vocab' },
+      },
+    });
+    expect(bridge.initMode).toBe('custom');
+    expect(bridge.modelPaths).toEqual({
+      cnn_bilstm: '/models/cnn.onnx',
+      bpe_vocab: '/models/bpe.vocab',
+    });
+  });
+});

--- a/src/punctuation/__tests__/streaming-punctuation.test.ts
+++ b/src/punctuation/__tests__/streaming-punctuation.test.ts
@@ -131,11 +131,11 @@ describe('streaming punctuation', () => {
 
     expect(native.initializeOnlinePunctuation).toHaveBeenCalledWith(
       expect.stringMatching(/^punc_on_/),
-      '/models/punctuation-online',
-      'auto',
-      undefined,
-      undefined,
-      undefined
+      {
+        initMode: 'auto',
+        modelDir: '/models/punctuation-online',
+        modelType: 'auto',
+      }
     );
     expect(native.startStreamingPunctuationPipeline).toHaveBeenCalledWith(
       punc.instanceId,

--- a/src/punctuation/customConfig.ts
+++ b/src/punctuation/customConfig.ts
@@ -1,0 +1,65 @@
+import type { FileSource } from '../fileio/types';
+import { ModelCategory } from '../download/types';
+import {
+  assertCustomModelConfig,
+  resolveCustomModelConfigPaths,
+} from '../detect/customConfigResolver';
+import type { OfflinePunctuationConcreteModelType } from './types';
+import type { StreamingPunctuationConcreteModelType } from './streamingTypes';
+
+export const PunctuationErrorCode = {
+  INVALID_ARGUMENT: 'PUNCTUATION_INVALID_ARGUMENT',
+} as const;
+
+export type OfflinePunctuationCustomPathKey = 'ct_transformer';
+
+export type StreamingPunctuationCustomPathKey = 'cnn_bilstm' | 'bpe_vocab';
+
+export interface OfflinePunctuationCustomConfig {
+  ct_transformer: FileSource;
+}
+
+export interface StreamingPunctuationCustomConfig {
+  cnn_bilstm: FileSource;
+  bpe_vocab: FileSource;
+}
+
+export function assertOfflinePunctuationCustomConfig(
+  customConfig: Record<string, unknown>
+): void {
+  assertCustomModelConfig(customConfig, PunctuationErrorCode.INVALID_ARGUMENT);
+}
+
+export function assertStreamingPunctuationCustomConfig(
+  customConfig: Record<string, unknown>
+): void {
+  assertCustomModelConfig(customConfig, PunctuationErrorCode.INVALID_ARGUMENT);
+}
+
+export async function resolveOfflinePunctuationCustomConfigPaths(
+  modelType: OfflinePunctuationConcreteModelType,
+  customConfig: OfflinePunctuationCustomConfig
+): Promise<Record<string, string>> {
+  return resolveCustomModelConfigPaths({
+    category: ModelCategory.Punctuation,
+    modelType,
+    customConfig: customConfig as unknown as Record<string, unknown>,
+    errorCode: PunctuationErrorCode.INVALID_ARGUMENT,
+    unknownKeyMessage: (key, mt) =>
+      `Unknown customConfig key '${key}' for offline punctuation modelType '${mt}'`,
+  });
+}
+
+export async function resolveStreamingPunctuationCustomConfigPaths(
+  modelType: StreamingPunctuationConcreteModelType,
+  customConfig: StreamingPunctuationCustomConfig
+): Promise<Record<string, string>> {
+  return resolveCustomModelConfigPaths({
+    category: ModelCategory.Punctuation,
+    modelType,
+    customConfig: customConfig as unknown as Record<string, unknown>,
+    errorCode: PunctuationErrorCode.INVALID_ARGUMENT,
+    unknownKeyMessage: (key, mt) =>
+      `Unknown customConfig key '${key}' for streaming punctuation modelType '${mt}'`,
+  });
+}

--- a/src/punctuation/index.ts
+++ b/src/punctuation/index.ts
@@ -3,9 +3,25 @@ export { createOfflinePunctuation } from './offline';
 export { createStreamingPunctuation } from './streaming';
 export type { PunctuationModelType } from './detect';
 export type { PunctuationDetectModelResult } from '../types/modelDetect';
+export {
+  assertOfflinePunctuationCustomConfig,
+  assertStreamingPunctuationCustomConfig,
+  resolveOfflinePunctuationCustomConfigPaths,
+  resolveStreamingPunctuationCustomConfigPaths,
+  PunctuationErrorCode,
+} from './customConfig';
+export type {
+  OfflinePunctuationCustomConfig,
+  OfflinePunctuationCustomPathKey,
+  StreamingPunctuationCustomConfig,
+  StreamingPunctuationCustomPathKey,
+} from './customConfig';
 export type {
   OfflinePunctuationEngine,
   OfflinePunctuationInitializeOptions,
+  OfflinePunctuationAutoInitializeOptions,
+  OfflinePunctuationCustomInitializeOptions,
+  OfflinePunctuationConcreteModelType,
   OfflinePunctuateResult,
   OfflinePunctuateOptions,
   OfflinePunctuationModelType,
@@ -15,6 +31,9 @@ export type {
   OnlinePunctuationModelType,
   StreamingPunctuationEngine,
   StreamingPunctuationInitializeOptions,
+  StreamingPunctuationAutoInitializeOptions,
+  StreamingPunctuationCustomInitializeOptions,
+  StreamingPunctuationConcreteModelType,
   StreamingPunctuationOptions,
   PunctuationPipelineHandle,
 } from './streamingTypes';

--- a/src/punctuation/offline.ts
+++ b/src/punctuation/offline.ts
@@ -1,6 +1,5 @@
 import SherpaOnnx from '../NativeSherpaOnnx';
 import { createStreamingPipelineCompletionPromise } from '../audiobuffer/streamingPipelineCompletion';
-import { resolveFileSourceForModelInit } from '../detect/resolveModelInput';
 import { validateLiveOfflinePipelineOptions } from '../livePipeline';
 import {
   attachSegmentationEngine,
@@ -34,6 +33,7 @@ import { runOfflinePunctuationPipeline } from './orchestrate';
 import { resolveTextInputNormalization } from './textInputNormalization';
 import type { TextSegment } from '../segment/segment';
 import type { PunctuationPipelineHandle } from './streamingTypes';
+import { buildOfflinePunctuationInitBridgeOptions } from './punctuationNativeBridge';
 
 let offlinePunctInstanceCounter = 0;
 
@@ -173,16 +173,11 @@ export async function createOfflinePunctuation(
   options: OfflinePunctuationInitializeOptions
 ): Promise<OfflinePunctuationEngine> {
   const instanceId = `punc_off_${++offlinePunctInstanceCounter}`;
-  const resolvedPath = await resolveFileSourceForModelInit(options.modelSource);
-  const modelType = options.modelType ?? 'auto';
+  const bridgeOptions = await buildOfflinePunctuationInitBridgeOptions(options);
 
   const init = await SherpaOnnx.initializeOfflinePunctuation(
     instanceId,
-    resolvedPath,
-    modelType,
-    options.numThreads,
-    options.provider,
-    options.debug
+    bridgeOptions
   );
 
   if (!init.success) {

--- a/src/punctuation/punctuationNativeBridge.ts
+++ b/src/punctuation/punctuationNativeBridge.ts
@@ -1,0 +1,96 @@
+import type {
+  OfflinePunctuationAutoInitializeOptions,
+  OfflinePunctuationCustomInitializeOptions,
+  OfflinePunctuationInitializeOptions,
+} from './types';
+import type {
+  StreamingPunctuationAutoInitializeOptions,
+  StreamingPunctuationCustomInitializeOptions,
+  StreamingPunctuationInitializeOptions,
+} from './streamingTypes';
+import type { PunctuationInitBridgeOptions } from '../nativeBridge/initBridgeTypes';
+import { resolveFileSourceForModelInit } from '../detect/resolveModelInput';
+import {
+  resolveOfflinePunctuationCustomConfigPaths,
+  resolveStreamingPunctuationCustomConfigPaths,
+} from './customConfig';
+
+export type { PunctuationInitBridgeOptions };
+
+type PunctuationInitScalars = Pick<
+  PunctuationInitBridgeOptions,
+  'numThreads' | 'provider' | 'debug'
+>;
+
+function appendSharedInitBridgeFields(
+  options:
+    | OfflinePunctuationInitializeOptions
+    | StreamingPunctuationInitializeOptions
+): PunctuationInitScalars {
+  return {
+    ...(options.numThreads !== undefined
+      ? { numThreads: options.numThreads }
+      : {}),
+    ...(options.provider !== undefined ? { provider: options.provider } : {}),
+    ...(options.debug !== undefined ? { debug: options.debug } : {}),
+  };
+}
+
+export async function buildOfflinePunctuationInitBridgeOptions(
+  options: OfflinePunctuationInitializeOptions
+): Promise<PunctuationInitBridgeOptions> {
+  const sharedFields = appendSharedInitBridgeFields(options);
+
+  if (options.initMode === 'custom') {
+    const customOptions = options as OfflinePunctuationCustomInitializeOptions;
+    const modelPaths = await resolveOfflinePunctuationCustomConfigPaths(
+      customOptions.modelType,
+      customOptions.customConfig
+    );
+    return {
+      initMode: 'custom',
+      modelType: customOptions.modelType,
+      modelPaths,
+      ...sharedFields,
+    };
+  }
+
+  const autoOptions = options as OfflinePunctuationAutoInitializeOptions;
+  const modelDir = await resolveFileSourceForModelInit(autoOptions.modelSource);
+  return {
+    initMode: 'auto',
+    modelDir,
+    modelType: autoOptions.modelType ?? 'auto',
+    ...sharedFields,
+  };
+}
+
+export async function buildStreamingPunctuationInitBridgeOptions(
+  options: StreamingPunctuationInitializeOptions
+): Promise<PunctuationInitBridgeOptions> {
+  const sharedFields = appendSharedInitBridgeFields(options);
+
+  if (options.initMode === 'custom') {
+    const customOptions =
+      options as StreamingPunctuationCustomInitializeOptions;
+    const modelPaths = await resolveStreamingPunctuationCustomConfigPaths(
+      customOptions.modelType,
+      customOptions.customConfig
+    );
+    return {
+      initMode: 'custom',
+      modelType: customOptions.modelType,
+      modelPaths,
+      ...sharedFields,
+    };
+  }
+
+  const autoOptions = options as StreamingPunctuationAutoInitializeOptions;
+  const modelDir = await resolveFileSourceForModelInit(autoOptions.modelSource);
+  return {
+    initMode: 'auto',
+    modelDir,
+    modelType: autoOptions.modelType ?? 'auto',
+    ...sharedFields,
+  };
+}

--- a/src/punctuation/streaming.ts
+++ b/src/punctuation/streaming.ts
@@ -10,6 +10,7 @@ import {
 import { resolveFileSourceForModelInit } from '../detect/resolveModelInput';
 import { createOnlinePunctuationConfig } from './detect';
 import { resolveTextInputNormalization } from './textInputNormalization';
+import { buildStreamingPunctuationInitBridgeOptions } from './punctuationNativeBridge';
 import type {
   PunctuationPipelineHandle,
   StreamingPunctuationEngine,
@@ -71,17 +72,20 @@ export async function createStreamingPunctuation(
   options: StreamingPunctuationInitializeOptions
 ): Promise<StreamingPunctuationEngine> {
   const instanceId = `punc_on_${++streamingPunctuationInstanceCounter}`;
-  const resolvedPath = await resolveFileSourceForModelInit(options.modelSource);
-  await createOnlinePunctuationConfig(resolvedPath, {
-    modelType: options.modelType ?? 'auto',
-  });
+  if (options.initMode !== 'custom') {
+    const resolvedPath = await resolveFileSourceForModelInit(
+      options.modelSource
+    );
+    await createOnlinePunctuationConfig(resolvedPath, {
+      modelType: options.modelType ?? 'auto',
+    });
+  }
+  const bridgeOptions = await buildStreamingPunctuationInitBridgeOptions(
+    options
+  );
   const result = await SherpaOnnx.initializeOnlinePunctuation(
     instanceId,
-    resolvedPath,
-    options.modelType ?? 'auto',
-    options.numThreads,
-    options.provider,
-    options.debug
+    bridgeOptions
   );
 
   if (!result.success) {

--- a/src/punctuation/streamingTypes.ts
+++ b/src/punctuation/streamingTypes.ts
@@ -13,14 +13,32 @@ export type OnlinePunctuationModelType = Extract<
   'cnn_bilstm' | 'auto'
 >;
 
-export type StreamingPunctuationInitializeOptions = {
-  /** OnlinePunctuation layout (CNN-BiLSTM + bpe.vocab). */
-  modelSource: FileSource;
-  modelType?: OnlinePunctuationModelType;
+export type StreamingPunctuationConcreteModelType = 'cnn_bilstm';
+
+export type StreamingPunctuationInitOptionsShared = {
   numThreads?: number;
   provider?: string;
   debug?: boolean;
 };
+
+export type StreamingPunctuationAutoInitializeOptions =
+  StreamingPunctuationInitOptionsShared & {
+    initMode?: 'auto';
+    /** OnlinePunctuation layout (CNN-BiLSTM + bpe.vocab). */
+    modelSource: FileSource;
+    modelType?: OnlinePunctuationModelType;
+  };
+
+export type StreamingPunctuationCustomInitializeOptions =
+  StreamingPunctuationInitOptionsShared & {
+    initMode: 'custom';
+    modelType: StreamingPunctuationConcreteModelType;
+    customConfig: import('./customConfig').StreamingPunctuationCustomConfig;
+  };
+
+export type StreamingPunctuationInitializeOptions =
+  | StreamingPunctuationAutoInitializeOptions
+  | StreamingPunctuationCustomInitializeOptions;
 
 export type StreamingPunctuationOptions = {
   /**

--- a/src/punctuation/types.ts
+++ b/src/punctuation/types.ts
@@ -57,18 +57,36 @@ export type OfflinePunctuateOptions = {
 
 export type OfflinePunctuationModelType = 'ct_transformer' | 'auto';
 
-export type OfflinePunctuationInitializeOptions = {
-  /** Directory-backed model source used for punctuation initialization. */
-  modelSource: FileSource;
-  /**
-   * `'auto'` resolves **offline CT only** (same as `ct_transformer` for native detect).
-   * Does not select online/CNN layout.
-   */
-  modelType?: OfflinePunctuationModelType;
+export type OfflinePunctuationConcreteModelType = 'ct_transformer';
+
+export type OfflinePunctuationInitOptionsShared = {
   numThreads?: number;
   provider?: string;
   debug?: boolean;
 };
+
+export type OfflinePunctuationAutoInitializeOptions =
+  OfflinePunctuationInitOptionsShared & {
+    initMode?: 'auto';
+    /** Directory-backed model source used for punctuation initialization. */
+    modelSource: FileSource;
+    /**
+     * `'auto'` resolves **offline CT only** (same as `ct_transformer` for native detect).
+     * Does not select online/CNN layout.
+     */
+    modelType?: OfflinePunctuationModelType;
+  };
+
+export type OfflinePunctuationCustomInitializeOptions =
+  OfflinePunctuationInitOptionsShared & {
+    initMode: 'custom';
+    modelType: OfflinePunctuationConcreteModelType;
+    customConfig: import('./customConfig').OfflinePunctuationCustomConfig;
+  };
+
+export type OfflinePunctuationInitializeOptions =
+  | OfflinePunctuationAutoInitializeOptions
+  | OfflinePunctuationCustomInitializeOptions;
 
 export type OfflinePunctuationEngine = {
   readonly instanceId: string;

--- a/src/segment/__tests__/resolveSpeechVadModelForPolicy.test.ts
+++ b/src/segment/__tests__/resolveSpeechVadModelForPolicy.test.ts
@@ -1,0 +1,112 @@
+jest.mock('../../vad/engine', () => ({
+  detectVadModel: jest.fn(),
+}));
+
+jest.mock('../../vad/customConfig', () => ({
+  resolveVadCustomConfigPaths: jest.fn(),
+}));
+
+import { detectVadModel } from '../../vad/engine';
+import { resolveVadCustomConfigPaths } from '../../vad/customConfig';
+import {
+  resolveSpeechVadModelForPolicy,
+  speechVadPolicyToModelConfig,
+} from '../resolveSpeechVadModelForPolicy';
+import type { SpeechVadSegmentationPolicy } from '../engine-types';
+
+const mockDetect = detectVadModel as jest.Mock;
+const mockResolveCustom = resolveVadCustomConfigPaths as jest.Mock;
+
+describe('resolveSpeechVadModelForPolicy', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDetect.mockResolvedValue({
+      success: true,
+      modelType: 'silero_vad',
+      paths: { model: '/models/vad/silero_vad.onnx' },
+    });
+    mockResolveCustom.mockResolvedValue({ model: '/custom/silero.onnx' });
+  });
+
+  it('auto mode resolves modelPath via detectVadModel', async () => {
+    const result = await resolveSpeechVadModelForPolicy({
+      modelPath: fsPath('/models/vad'),
+    });
+    expect(result).toEqual({
+      modelPath: '/models/vad/silero_vad.onnx',
+      modelType: 'silero_vad',
+    });
+    expect(mockDetect).toHaveBeenCalledWith(fsPath('/models/vad'), {
+      modelType: 'auto',
+    });
+    expect(mockResolveCustom).not.toHaveBeenCalled();
+  });
+
+  it('custom mode resolves customConfig without detectVadModel', async () => {
+    const customConfig = { model: fsPath('/custom/silero.onnx') };
+    const result = await resolveSpeechVadModelForPolicy({
+      initMode: 'custom',
+      modelType: 'silero_vad',
+      customConfig,
+    });
+    expect(result).toEqual({
+      modelPath: '/custom/silero.onnx',
+      modelType: 'silero_vad',
+    });
+    expect(mockResolveCustom).toHaveBeenCalledWith('silero_vad', customConfig);
+    expect(mockDetect).not.toHaveBeenCalled();
+  });
+
+  it('throws POLICY_MODEL_UNAVAILABLE when auto detect fails', async () => {
+    mockDetect.mockResolvedValue({ success: false, error: 'missing onnx' });
+    await expect(
+      resolveSpeechVadModelForPolicy({ modelPath: fsPath('/bad') })
+    ).rejects.toMatchObject({
+      code: 'POLICY_MODEL_UNAVAILABLE',
+      message: expect.stringContaining('missing onnx'),
+    });
+  });
+
+  it('throws POLICY_MODEL_UNAVAILABLE when custom path is empty', async () => {
+    mockResolveCustom.mockResolvedValue({ model: '' });
+    await expect(
+      resolveSpeechVadModelForPolicy({
+        initMode: 'custom',
+        modelType: 'ten_vad',
+        customConfig: { model: fsPath('/empty.onnx') },
+      })
+    ).rejects.toMatchObject({ code: 'POLICY_MODEL_UNAVAILABLE' });
+  });
+});
+
+describe('speechVadPolicyToModelConfig', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  it('maps auto speech_vad policy', () => {
+    const policy: SpeechVadSegmentationPolicy = {
+      evaluator: 'speech_vad_model',
+      modelPath: fsPath('/models/vad'),
+    };
+    expect(speechVadPolicyToModelConfig(policy)).toEqual({
+      initMode: 'auto',
+      modelPath: fsPath('/models/vad'),
+    });
+  });
+
+  it('maps custom speech_vad policy', () => {
+    const customConfig = { model: fsPath('/custom.onnx') };
+    const policy: SpeechVadSegmentationPolicy = {
+      evaluator: 'speech_vad_model',
+      initMode: 'custom',
+      modelType: 'silero_vad',
+      customConfig,
+    };
+    expect(speechVadPolicyToModelConfig(policy)).toEqual({
+      initMode: 'custom',
+      modelType: 'silero_vad',
+      customConfig,
+    });
+  });
+});

--- a/src/segment/__tests__/segmentation-engine-vad.test.ts
+++ b/src/segment/__tests__/segmentation-engine-vad.test.ts
@@ -45,9 +45,16 @@ jest.mock('../../audiobuffer', () => ({
 }));
 
 const mockDetectVadModel = jest.fn();
+const mockResolveVadCustomConfigPaths = jest.fn();
 
 jest.mock('../../vad/engine', () => ({
   detectVadModel: (...args: unknown[]) => mockDetectVadModel(...args),
+}));
+
+jest.mock('../../vad/customConfig', () => ({
+  resolveVadCustomConfigPaths: (...args: unknown[]) =>
+    mockResolveVadCustomConfigPaths(...args),
+  assertVadCustomConfig: jest.fn(),
 }));
 
 jest.mock('../../segmentbuffer', () => ({
@@ -96,6 +103,9 @@ describe('segmentation engine VAD (speech_vad_model)', () => {
       paths: { model: '/models/vad/silero_vad.onnx' },
       isStreaming: false,
     });
+    mockResolveVadCustomConfigPaths.mockResolvedValue({
+      model: '/custom/silero.onnx',
+    });
 
     native.attachSegmentationEngine.mockResolvedValue({
       engineId: ENGINE_ID,
@@ -128,6 +138,32 @@ describe('segmentation engine VAD (speech_vad_model)', () => {
         createdAtMs: 42_000,
       },
     ]);
+  });
+
+  it('forwards custom speech_vad_model policy without detectVadModel', async () => {
+    const customPolicy = {
+      evaluator: 'speech_vad_model' as const,
+      initMode: 'custom' as const,
+      modelType: 'silero_vad' as const,
+      customConfig: {
+        model: { kind: 'fs' as const, path: '/custom/silero.onnx' },
+      },
+      vadThreshold: 0.48,
+    };
+
+    await attachSegmentationEngine(LIVE_AUDIO_ID, { policy: customPolicy });
+
+    expect(native.attachSegmentationEngine).toHaveBeenCalledWith(
+      LIVE_AUDIO_ID,
+      'speech',
+      expect.objectContaining({
+        evaluator: 'speech_vad_model',
+        modelPath: '/custom/silero.onnx',
+        modelType: 'silero_vad',
+        vadThreshold: 0.48,
+      })
+    );
+    expect(mockDetectVadModel).not.toHaveBeenCalled();
   });
 
   it('forwards speech_vad_model policy to native attachSegmentationEngine', async () => {

--- a/src/segment/engine-types.ts
+++ b/src/segment/engine-types.ts
@@ -7,8 +7,20 @@ export type SegmentationEvaluator =
   | 'speech_vad_model'
   | 'continuous_frames';
 
-export interface SegmentationPolicy {
-  evaluator: SegmentationEvaluator;
+export type SpeechVadModelAuto = {
+  initMode?: 'auto';
+  modelPath: FileSource;
+};
+
+export type SpeechVadModelCustom = {
+  initMode: 'custom';
+  modelType: import('../vad/types').VADConcreteModelType;
+  customConfig: import('../vad/customConfig').VadCustomConfig;
+};
+
+export type SpeechVadModelConfig = SpeechVadModelAuto | SpeechVadModelCustom;
+
+type SegmentationPolicyCommon = {
   maxLengthChars?: number;
   sentenceBoundary?: boolean;
   /**
@@ -26,15 +38,22 @@ export interface SegmentationPolicy {
   hangoverMs?: number;
   checkpointIntervalMs?: number;
   punctuationInstanceId?: string;
-  /**
-   * Required for `speech_vad_model`. Same `FileSource` model location as
-   * `detectVadModel` / `createStreamingVAD`; JS runs detection before native attach.
-   */
-  modelPath?: FileSource;
+};
+
+export type SpeechVadSegmentationPolicy = SegmentationPolicyCommon & {
+  evaluator: 'speech_vad_model';
   vadThreshold?: number;
   vadMinSpeechMs?: number;
   vadMinSilenceMs?: number;
-}
+} & SpeechVadModelConfig;
+
+export type NonSpeechVadSegmentationPolicy = SegmentationPolicyCommon & {
+  evaluator: Exclude<SegmentationEvaluator, 'speech_vad_model'>;
+};
+
+export type SegmentationPolicy =
+  | SpeechVadSegmentationPolicy
+  | NonSpeechVadSegmentationPolicy;
 
 export interface SegmentationConfig {
   policy?: SegmentationPolicy;

--- a/src/segment/index.ts
+++ b/src/segment/index.ts
@@ -59,7 +59,11 @@ import type {
   SegmentationEngineRef,
   SegmentationPolicy,
 } from './engine-types';
-import { detectVadModel } from '../vad/engine';
+import {
+  isSpeechVadSegmentationPolicy,
+  resolveSpeechVadModelForPolicy,
+  speechVadPolicyToModelConfig,
+} from './resolveSpeechVadModelForPolicy';
 import { toSegmentReason, toSegmentSource } from './utils';
 
 const getNative = (): Spec =>
@@ -133,7 +137,7 @@ function normalizeSegmentationPolicyFromNative(
 async function segmentationPolicyForNative(
   policy: SegmentationPolicy
 ): Promise<Object> {
-  const { modelPath: fileSource, sentenceBoundaryChars, ...rest } = policy;
+  const { sentenceBoundaryChars, ...rest } = policy;
   const out: Record<string, unknown> = { ...rest };
   const normalized = normalizeSentenceBoundaryCharsForNative(
     sentenceBoundaryChars
@@ -141,35 +145,15 @@ async function segmentationPolicyForNative(
   if (normalized !== undefined) {
     out.sentenceBoundaryChars = normalized;
   }
-  if (policy.evaluator === 'speech_vad_model') {
-    if (fileSource == null) {
-      throw new Error(
-        'SEGMENT_INVALID_ARGUMENT: speech_vad_model requires policy.modelPath'
-      );
-    }
-    const detect = await detectVadModel(fileSource, { modelType: 'auto' });
-    const onnxPath = detect.paths?.model?.trim();
-    if (
-      !detect.success ||
-      onnxPath == null ||
-      onnxPath.length === 0 ||
-      detect.modelType == null ||
-      detect.modelType === ''
-    ) {
-      const detail =
-        typeof detect.error === 'string' && detect.error.trim().length > 0
-          ? detect.error.trim()
-          : 'VAD model detection failed';
-      throw Object.assign(
-        new Error(
-          `POLICY_MODEL_UNAVAILABLE: speech_vad_model requires a detectable VAD bundle (${detail})`
-        ),
-        { code: 'POLICY_MODEL_UNAVAILABLE' }
-      );
-    }
-    out.modelPath = onnxPath;
-    out.modelType = detect.modelType;
-  } else if (fileSource != null) {
+  if (isSpeechVadSegmentationPolicy(policy)) {
+    const resolved = await resolveSpeechVadModelForPolicy(
+      speechVadPolicyToModelConfig(policy)
+    );
+    out.modelPath = resolved.modelPath;
+    out.modelType = resolved.modelType;
+    delete out.initMode;
+    delete out.customConfig;
+  } else if ('modelPath' in policy && policy.modelPath != null) {
     throw new Error(
       'SEGMENT_INVALID_ARGUMENT: policy.modelPath is only valid for speech_vad_model'
     );
@@ -1210,7 +1194,19 @@ export type {
   SegmentationEngineRef,
   SegmentationEvaluator,
   SegmentationPolicy,
+  NonSpeechVadSegmentationPolicy,
+  SpeechVadModelAuto,
+  SpeechVadModelConfig,
+  SpeechVadModelCustom,
+  SpeechVadSegmentationPolicy,
 } from './engine-types';
+
+export {
+  isSpeechVadSegmentationPolicy,
+  resolveSpeechVadModelForPolicy,
+  speechVadPolicyToModelConfig,
+} from './resolveSpeechVadModelForPolicy';
+export type { VADConcreteModelType } from './resolveSpeechVadModelForPolicy';
 
 export type { SegmentationMode } from './runtime-state';
 

--- a/src/segment/resolveSpeechVadModelForPolicy.ts
+++ b/src/segment/resolveSpeechVadModelForPolicy.ts
@@ -1,0 +1,74 @@
+import { detectVadModel } from '../vad/engine';
+import { resolveVadCustomConfigPaths } from '../vad/customConfig';
+import type { VADConcreteModelType } from '../vad/types';
+import type {
+  SpeechVadModelConfig,
+  SpeechVadSegmentationPolicy,
+} from './engine-types';
+
+export async function resolveSpeechVadModelForPolicy(
+  config: SpeechVadModelConfig
+): Promise<{ modelPath: string; modelType: string }> {
+  if (config.initMode === 'custom') {
+    const paths = await resolveVadCustomConfigPaths(
+      config.modelType,
+      config.customConfig
+    );
+    const onnxPath = paths.model?.trim() ?? '';
+    if (!onnxPath) {
+      throw Object.assign(
+        new Error(
+          'POLICY_MODEL_UNAVAILABLE: Custom VAD model path is missing after validation.'
+        ),
+        { code: 'POLICY_MODEL_UNAVAILABLE' }
+      );
+    }
+    return { modelPath: onnxPath, modelType: config.modelType };
+  }
+
+  const detect = await detectVadModel(config.modelPath, { modelType: 'auto' });
+  const onnxPath = detect.paths?.model?.trim();
+  if (
+    !detect.success ||
+    onnxPath == null ||
+    onnxPath.length === 0 ||
+    detect.modelType == null ||
+    detect.modelType === ''
+  ) {
+    const detail =
+      typeof detect.error === 'string' && detect.error.trim().length > 0
+        ? detect.error.trim()
+        : 'VAD model detection failed';
+    throw Object.assign(
+      new Error(
+        `POLICY_MODEL_UNAVAILABLE: speech_vad_model requires a detectable VAD bundle (${detail})`
+      ),
+      { code: 'POLICY_MODEL_UNAVAILABLE' }
+    );
+  }
+  return { modelPath: onnxPath, modelType: detect.modelType };
+}
+
+export function speechVadPolicyToModelConfig(
+  policy: SpeechVadSegmentationPolicy
+): SpeechVadModelConfig {
+  if (policy.initMode === 'custom') {
+    return {
+      initMode: 'custom',
+      modelType: policy.modelType,
+      customConfig: policy.customConfig,
+    };
+  }
+  return {
+    initMode: 'auto',
+    modelPath: policy.modelPath,
+  };
+}
+
+export function isSpeechVadSegmentationPolicy(policy: {
+  evaluator: string;
+}): policy is SpeechVadSegmentationPolicy {
+  return policy.evaluator === 'speech_vad_model';
+}
+
+export type { VADConcreteModelType };

--- a/src/segment/validation.ts
+++ b/src/segment/validation.ts
@@ -1,5 +1,7 @@
 import type { FileSource } from '../fileio/types';
+import { assertVadCustomConfig } from '../vad/customConfig';
 import type { SegmentationPolicy } from './engine-types';
+import { isSpeechVadSegmentationPolicy } from './resolveSpeechVadModelForPolicy';
 
 function isFileSource(value: unknown): value is FileSource {
   if (value == null || typeof value !== 'object' || Array.isArray(value)) {
@@ -125,18 +127,48 @@ export function validateSegmentationConfig(
         `${errorPrefix}: ${featureName} requires a speech segmentation evaluator; received ${evaluator}`
       );
     }
-    if (policy.modelPath != null && evaluator !== 'speech_vad_model') {
+    if (
+      'modelPath' in policy &&
+      policy.modelPath != null &&
+      evaluator !== 'speech_vad_model'
+    ) {
       throw new Error(
         `${errorPrefix}: policy.modelPath is only valid for speech_vad_model`
       );
     }
     if (evaluator === 'speech_vad_model') {
-      if (!policy.modelPath) {
+      const speechVadPolicy = policy as SegmentationPolicy;
+      if (!isSpeechVadSegmentationPolicy(speechVadPolicy)) {
         throw new Error(
-          `${errorPrefix}: speech_vad_model requires policy.modelPath`
+          `${errorPrefix}: speech_vad_model policy shape is invalid`
         );
       }
-      if (!isFileSource(policy.modelPath)) {
+      if (speechVadPolicy.initMode === 'custom') {
+        if (
+          speechVadPolicy.modelType !== 'silero_vad' &&
+          speechVadPolicy.modelType !== 'ten_vad'
+        ) {
+          throw new Error(
+            `${errorPrefix}: speech_vad_model custom mode requires modelType silero_vad or ten_vad`
+          );
+        }
+        if (speechVadPolicy.customConfig == null) {
+          throw new Error(
+            `${errorPrefix}: speech_vad_model custom mode requires customConfig with model: FileSource`
+          );
+        }
+        try {
+          assertVadCustomConfig(
+            speechVadPolicy.customConfig as unknown as Record<string, unknown>
+          );
+        } catch (error) {
+          throw new Error(
+            `${errorPrefix}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      } else if (!isFileSource(speechVadPolicy.modelPath)) {
         throw new Error(
           `${errorPrefix}: speech_vad_model requires policy.modelPath to be a valid FileSource`
         );

--- a/src/stt/__tests__/customConfig.test.ts
+++ b/src/stt/__tests__/customConfig.test.ts
@@ -1,10 +1,21 @@
-jest.mock('../../detect/validateCustomModelPaths', () => ({
-  getCustomModelPathRequirements: jest.fn(async () => ({
-    required: ['encoder', 'decoder', 'joiner', 'tokens'],
-    optional: ['bpeVocab'],
-  })),
-  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
-}));
+jest.mock('../../detect/validateCustomModelPaths', () => {
+  const helpers = jest.requireActual(
+    '../../detect/customModelPathRequirements'
+  );
+  return {
+    ...helpers,
+    getCustomModelPathRequirements: jest.fn(async () => ({
+      fields: [
+        { key: 'encoder', required: true, kind: 'file' },
+        { key: 'decoder', required: true, kind: 'file' },
+        { key: 'joiner', required: true, kind: 'file' },
+        { key: 'tokens', required: true, kind: 'file' },
+        { key: 'bpeVocab', required: false, kind: 'file' },
+      ],
+    })),
+    validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+  };
+});
 
 jest.mock('../../detect/resolveModelInput', () => ({
   resolveModelFileSources: jest.fn(async (sources: Record<string, unknown>) => {
@@ -57,16 +68,23 @@ describe('resolveSttCustomConfigPaths', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetRequirements.mockResolvedValue({
-      required: ['whisperEncoder', 'whisperDecoder', 'tokens'],
-      optional: [],
+      fields: [
+        { key: 'whisperEncoder', required: true, kind: 'file' },
+        { key: 'whisperDecoder', required: true, kind: 'file' },
+        { key: 'tokens', required: true, kind: 'file' },
+      ],
     });
     mockValidate.mockResolvedValue({ ok: true });
   });
 
   it('rejects unknown keys using native schema', async () => {
     mockGetRequirements.mockResolvedValueOnce({
-      required: ['encoder', 'decoder', 'joiner', 'tokens'],
-      optional: [],
+      fields: [
+        { key: 'encoder', required: true, kind: 'file' },
+        { key: 'decoder', required: true, kind: 'file' },
+        { key: 'joiner', required: true, kind: 'file' },
+        { key: 'tokens', required: true, kind: 'file' },
+      ],
     });
 
     await expect(

--- a/src/stt/__tests__/customConfig.test.ts
+++ b/src/stt/__tests__/customConfig.test.ts
@@ -1,0 +1,97 @@
+jest.mock('../../detect/validateCustomModelPaths', () => ({
+  getCustomModelPathRequirements: jest.fn(async () => ({
+    required: ['encoder', 'decoder', 'joiner', 'tokens'],
+    optional: ['bpeVocab'],
+  })),
+  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+}));
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveModelFileSources: jest.fn(async (sources: Record<string, unknown>) => {
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(sources)) {
+      const path = (value as { path?: string })?.path;
+      if (path) out[key] = path;
+    }
+    return out;
+  }),
+}));
+
+import {
+  assertSttCustomConfig,
+  resolveSttCustomConfigPaths,
+} from '../customConfig';
+import {
+  getCustomModelPathRequirements,
+  validateCustomModelPaths,
+} from '../../detect/validateCustomModelPaths';
+import { SttErrorCode } from '../types';
+
+const mockGetRequirements = getCustomModelPathRequirements as jest.Mock;
+const mockValidate = validateCustomModelPaths as jest.Mock;
+
+describe('assertSttCustomConfig', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  it('accepts FileSource values', () => {
+    expect(() =>
+      assertSttCustomConfig({
+        encoder: fsPath('/enc.onnx'),
+        decoder: fsPath('/dec.onnx'),
+      })
+    ).not.toThrow();
+  });
+
+  it('throws STT_INVALID_ARGUMENT when a value is not a FileSource', () => {
+    expect(() =>
+      assertSttCustomConfig({
+        encoder: '/enc.onnx',
+      })
+    ).toThrow(SttErrorCode.INVALID_ARGUMENT);
+  });
+});
+
+describe('resolveSttCustomConfigPaths', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetRequirements.mockResolvedValue({
+      required: ['whisperEncoder', 'whisperDecoder', 'tokens'],
+      optional: [],
+    });
+    mockValidate.mockResolvedValue({ ok: true });
+  });
+
+  it('rejects unknown keys using native schema', async () => {
+    mockGetRequirements.mockResolvedValueOnce({
+      required: ['encoder', 'decoder', 'joiner', 'tokens'],
+      optional: [],
+    });
+
+    await expect(
+      resolveSttCustomConfigPaths('transducer', {
+        encoder: fsPath('/enc.onnx'),
+        decoder: fsPath('/dec.onnx'),
+        joiner: fsPath('/join.onnx'),
+        tokens: fsPath('/tokens.txt'),
+        unknownKey: fsPath('/x.onnx'),
+      } as never)
+    ).rejects.toThrow(SttErrorCode.INVALID_ARGUMENT);
+  });
+
+  it('throws when native validation fails', async () => {
+    mockValidate.mockResolvedValueOnce({
+      ok: false,
+      error: 'STT Whisper: missing required files',
+      missingRequired: ['whisperDecoder'],
+    });
+
+    await expect(
+      resolveSttCustomConfigPaths('whisper', {
+        whisperEncoder: fsPath('/enc.onnx'),
+        tokens: fsPath('/tokens.txt'),
+      } as never)
+    ).rejects.toThrow(SttErrorCode.INVALID_ARGUMENT);
+  });
+});

--- a/src/stt/__tests__/streamingCustomConfig.test.ts
+++ b/src/stt/__tests__/streamingCustomConfig.test.ts
@@ -10,13 +10,23 @@ jest.mock('../../detect/resolveModelInput', () => ({
   ),
 }));
 
-jest.mock('../../detect/validateCustomModelPaths', () => ({
-  getCustomModelPathRequirements: jest.fn(async () => ({
-    required: ['encoder', 'decoder', 'joiner', 'tokens'],
-    optional: [],
-  })),
-  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
-}));
+jest.mock('../../detect/validateCustomModelPaths', () => {
+  const helpers = jest.requireActual(
+    '../../detect/customModelPathRequirements'
+  );
+  return {
+    ...helpers,
+    getCustomModelPathRequirements: jest.fn(async () => ({
+      fields: [
+        { key: 'encoder', required: true, kind: 'file' },
+        { key: 'decoder', required: true, kind: 'file' },
+        { key: 'joiner', required: true, kind: 'file' },
+        { key: 'tokens', required: true, kind: 'file' },
+      ],
+    })),
+    validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+  };
+});
 
 describe('streamingCustomConfig', () => {
   it('resolveStreamingSttCustomConfigPaths validates and resolves transducer paths', async () => {

--- a/src/stt/__tests__/streamingCustomConfig.test.ts
+++ b/src/stt/__tests__/streamingCustomConfig.test.ts
@@ -1,0 +1,42 @@
+import {
+  assertStreamingSttCustomConfig,
+  resolveStreamingSttCustomConfigPaths,
+} from '../streamingCustomConfig';
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveModelFileSources: jest.fn(
+    async (config: Record<string, { path: string }>) =>
+      Object.fromEntries(Object.entries(config).map(([k, v]) => [k, v.path]))
+  ),
+}));
+
+jest.mock('../../detect/validateCustomModelPaths', () => ({
+  getCustomModelPathRequirements: jest.fn(async () => ({
+    required: ['encoder', 'decoder', 'joiner', 'tokens'],
+    optional: [],
+  })),
+  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+}));
+
+describe('streamingCustomConfig', () => {
+  it('resolveStreamingSttCustomConfigPaths validates and resolves transducer paths', async () => {
+    const paths = await resolveStreamingSttCustomConfigPaths('transducer', {
+      encoder: { kind: 'fs', path: '/enc.onnx' },
+      decoder: { kind: 'fs', path: '/dec.onnx' },
+      joiner: { kind: 'fs', path: '/join.onnx' },
+      tokens: { kind: 'fs', path: '/tokens.txt' },
+    });
+    expect(paths).toEqual({
+      encoder: '/enc.onnx',
+      decoder: '/dec.onnx',
+      joiner: '/join.onnx',
+      tokens: '/tokens.txt',
+    });
+  });
+
+  it('assertStreamingSttCustomConfig rejects non-FileSource values', () => {
+    expect(() =>
+      assertStreamingSttCustomConfig({ tokens: '/not-a-file-source' })
+    ).toThrow(/FileSource/);
+  });
+});

--- a/src/stt/__tests__/sttNativeBridge.test.ts
+++ b/src/stt/__tests__/sttNativeBridge.test.ts
@@ -3,9 +3,29 @@ import {
   buildSttInitBridgeOptions,
 } from '../sttNativeBridge';
 
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveFileSourceForModelInit: jest.fn(async () => '/models/whisper'),
+  resolveFileSourceForModelFile: jest.fn(
+    async (source: { path: string }) => source.path
+  ),
+  resolveModelFileSources: jest.fn(
+    async (config: Record<string, { path: string }>) =>
+      Object.fromEntries(Object.entries(config).map(([k, v]) => [k, v.path]))
+  ),
+}));
+
+jest.mock('../customConfig', () => ({
+  resolveSttCustomConfigPaths: jest.fn(async () => ({
+    encoder: '/enc.onnx',
+    decoder: '/dec.onnx',
+    joiner: '/join.onnx',
+    tokens: '/tokens.txt',
+  })),
+}));
+
 describe('sttNativeBridge', () => {
-  it('buildSttInitBridgeOptions maps public STT options to bridge map', () => {
-    const bridge = buildSttInitBridgeOptions('/models/whisper', {
+  it('buildSttInitBridgeOptions maps auto STT options to bridge map', async () => {
+    const bridge = await buildSttInitBridgeOptions({
       modelSource: { kind: 'fs', path: '/models/whisper' },
       modelType: 'whisper',
       preferInt8: true,
@@ -13,12 +33,35 @@ describe('sttNativeBridge', () => {
       modelOptions: { whisper: { language: 'en', task: 'transcribe' } },
     });
     expect(bridge).toEqual({
+      initMode: 'auto',
       modelDir: '/models/whisper',
       modelType: 'whisper',
       preferInt8: true,
       debug: true,
       modelOptions: { whisper: { language: 'en', task: 'transcribe' } },
     });
+  });
+
+  it('buildSttInitBridgeOptions maps custom STT options to modelPaths', async () => {
+    const bridge = await buildSttInitBridgeOptions({
+      initMode: 'custom',
+      modelType: 'transducer',
+      customConfig: {
+        encoder: { kind: 'fs', path: '/enc.onnx' },
+        decoder: { kind: 'fs', path: '/dec.onnx' },
+        joiner: { kind: 'fs', path: '/join.onnx' },
+        tokens: { kind: 'fs', path: '/tokens.txt' },
+      },
+    });
+    expect(bridge.initMode).toBe('custom');
+    expect(bridge.modelDir).toBeUndefined();
+    expect(bridge.modelPaths).toEqual({
+      encoder: '/enc.onnx',
+      decoder: '/dec.onnx',
+      joiner: '/join.onnx',
+      tokens: '/tokens.txt',
+    });
+    expect(bridge.modelType).toBe('transducer');
   });
 
   it('buildOnlineSttInitBridgeOptions flattens endpoint rules', () => {

--- a/src/stt/__tests__/sttNativeBridge.test.ts
+++ b/src/stt/__tests__/sttNativeBridge.test.ts
@@ -1,5 +1,6 @@
 import {
   buildOnlineSttInitBridgeOptions,
+  buildStreamingSttInitBridgeOptions,
   buildSttInitBridgeOptions,
 } from '../sttNativeBridge';
 
@@ -16,6 +17,15 @@ jest.mock('../../detect/resolveModelInput', () => ({
 
 jest.mock('../customConfig', () => ({
   resolveSttCustomConfigPaths: jest.fn(async () => ({
+    encoder: '/enc.onnx',
+    decoder: '/dec.onnx',
+    joiner: '/join.onnx',
+    tokens: '/tokens.txt',
+  })),
+}));
+
+jest.mock('../streamingCustomConfig', () => ({
+  resolveStreamingSttCustomConfigPaths: jest.fn(async () => ({
     encoder: '/enc.onnx',
     decoder: '/dec.onnx',
     joiner: '/join.onnx',
@@ -53,6 +63,31 @@ describe('sttNativeBridge', () => {
         tokens: { kind: 'fs', path: '/tokens.txt' },
       },
     });
+    expect(bridge.initMode).toBe('custom');
+    expect(bridge.modelDir).toBeUndefined();
+    expect(bridge.modelPaths).toEqual({
+      encoder: '/enc.onnx',
+      decoder: '/dec.onnx',
+      joiner: '/join.onnx',
+      tokens: '/tokens.txt',
+    });
+    expect(bridge.modelType).toBe('transducer');
+  });
+
+  it('buildStreamingSttInitBridgeOptions maps custom streaming options to modelPaths', async () => {
+    const bridge = await buildStreamingSttInitBridgeOptions(
+      {
+        initMode: 'custom',
+        modelType: 'transducer',
+        customConfig: {
+          encoder: { kind: 'fs', path: '/enc.onnx' },
+          decoder: { kind: 'fs', path: '/dec.onnx' },
+          joiner: { kind: 'fs', path: '/join.onnx' },
+          tokens: { kind: 'fs', path: '/tokens.txt' },
+        },
+      },
+      'transducer'
+    );
     expect(bridge.initMode).toBe('custom');
     expect(bridge.modelDir).toBeUndefined();
     expect(bridge.modelPaths).toEqual({

--- a/src/stt/customConfig.ts
+++ b/src/stt/customConfig.ts
@@ -4,6 +4,7 @@ import {
   getCustomModelPathRequirements,
   validateCustomModelPaths,
 } from '../detect/validateCustomModelPaths';
+import { resolveModelFileSources } from '../detect/resolveModelInput';
 import type { STTConcreteModelType } from './types';
 import { SttErrorCode } from './types';
 
@@ -206,9 +207,6 @@ export async function resolveSttCustomConfigPaths(
       fileSources[key] = value;
     }
   }
-  const { resolveModelFileSources } = await import(
-    '../detect/resolveModelInput'
-  );
   const resolvedPaths = await resolveModelFileSources(fileSources);
 
   const validation = await validateCustomModelPaths(

--- a/src/stt/customConfig.ts
+++ b/src/stt/customConfig.ts
@@ -1,0 +1,229 @@
+import type { FileSource } from '../fileio/types';
+import { ModelCategory } from '../download/types';
+import {
+  getCustomModelPathRequirements,
+  validateCustomModelPaths,
+} from '../detect/validateCustomModelPaths';
+import type { STTConcreteModelType } from './types';
+import { SttErrorCode } from './types';
+
+export type SttCustomPathKey =
+  | 'encoder'
+  | 'decoder'
+  | 'joiner'
+  | 'tokens'
+  | 'bpeVocab'
+  | 'paraformerModel'
+  | 'ctcModel'
+  | 'whisperEncoder'
+  | 'whisperDecoder'
+  | 'funasrEncoderAdaptor'
+  | 'funasrLLM'
+  | 'funasrEmbedding'
+  | 'funasrTokenizer'
+  | 'qwen3ConvFrontend'
+  | 'qwen3Encoder'
+  | 'qwen3Decoder'
+  | 'qwen3Tokenizer'
+  | 'cohereEncoder'
+  | 'cohereDecoder'
+  | 'moonshinePreprocessor'
+  | 'moonshineEncoder'
+  | 'moonshineUncachedDecoder'
+  | 'moonshineCachedDecoder'
+  | 'moonshineMergedDecoder'
+  | 'fireRedEncoder'
+  | 'fireRedDecoder'
+  | 'canaryEncoder'
+  | 'canaryDecoder'
+  | 'dolphinModel'
+  | 'omnilingualModel'
+  | 'medasrModel'
+  | 'telespeechCtcModel';
+
+type SttCustomConfigBase = Partial<Record<SttCustomPathKey, FileSource>>;
+
+export interface SttTransducerCustomConfig extends SttCustomConfigBase {
+  encoder: FileSource;
+  decoder: FileSource;
+  joiner: FileSource;
+  tokens: FileSource;
+  bpeVocab?: FileSource;
+}
+
+export interface SttParaformerCustomConfig extends SttCustomConfigBase {
+  tokens: FileSource;
+  paraformerModel?: FileSource;
+  encoder?: FileSource;
+  decoder?: FileSource;
+}
+
+export interface SttCtcCustomConfig extends SttCustomConfigBase {
+  ctcModel: FileSource;
+  tokens: FileSource;
+}
+
+export interface SttWhisperCustomConfig extends SttCustomConfigBase {
+  whisperEncoder: FileSource;
+  whisperDecoder: FileSource;
+  tokens: FileSource;
+}
+
+export interface SttFunAsrNanoCustomConfig extends SttCustomConfigBase {
+  funasrEncoderAdaptor: FileSource;
+  funasrLLM: FileSource;
+  funasrEmbedding: FileSource;
+  funasrTokenizer: FileSource;
+}
+
+export interface SttQwen3AsrCustomConfig extends SttCustomConfigBase {
+  qwen3ConvFrontend: FileSource;
+  qwen3Encoder: FileSource;
+  qwen3Decoder: FileSource;
+  qwen3Tokenizer: FileSource;
+}
+
+export interface SttCohereTranscribeCustomConfig extends SttCustomConfigBase {
+  cohereEncoder: FileSource;
+  cohereDecoder: FileSource;
+  tokens: FileSource;
+}
+
+export interface SttMoonshineCustomConfig extends SttCustomConfigBase {
+  moonshinePreprocessor: FileSource;
+  moonshineEncoder: FileSource;
+  moonshineUncachedDecoder: FileSource;
+  moonshineCachedDecoder: FileSource;
+  tokens: FileSource;
+}
+
+export interface SttMoonshineV2CustomConfig extends SttCustomConfigBase {
+  moonshineEncoder: FileSource;
+  moonshineMergedDecoder: FileSource;
+}
+
+export interface SttFireRedAsrCustomConfig extends SttCustomConfigBase {
+  fireRedEncoder: FileSource;
+  fireRedDecoder: FileSource;
+  tokens: FileSource;
+}
+
+export interface SttCanaryCustomConfig extends SttCustomConfigBase {
+  canaryEncoder: FileSource;
+  canaryDecoder: FileSource;
+  tokens: FileSource;
+}
+
+export interface SttSingleModelCustomConfig extends SttCustomConfigBase {
+  tokens: FileSource;
+  dolphinModel?: FileSource;
+  omnilingualModel?: FileSource;
+  medasrModel?: FileSource;
+  telespeechCtcModel?: FileSource;
+}
+
+export type SttCustomConfigByModelType = {
+  transducer: SttTransducerCustomConfig;
+  nemo_transducer: SttTransducerCustomConfig;
+  paraformer: SttParaformerCustomConfig;
+  nemo_ctc: SttCtcCustomConfig;
+  wenet_ctc: SttCtcCustomConfig;
+  sense_voice: SttCtcCustomConfig;
+  zipformer_ctc: SttCtcCustomConfig;
+  ctc: SttCtcCustomConfig;
+  tone_ctc: SttCtcCustomConfig;
+  whisper: SttWhisperCustomConfig;
+  funasr_nano: SttFunAsrNanoCustomConfig;
+  qwen3_asr: SttQwen3AsrCustomConfig;
+  cohere_transcribe: SttCohereTranscribeCustomConfig;
+  fire_red_asr: SttFireRedAsrCustomConfig;
+  moonshine: SttMoonshineCustomConfig;
+  moonshine_v2: SttMoonshineV2CustomConfig;
+  dolphin: SttSingleModelCustomConfig & { dolphinModel: FileSource };
+  canary: SttCanaryCustomConfig;
+  omnilingual: SttSingleModelCustomConfig & { omnilingualModel: FileSource };
+  medasr: SttSingleModelCustomConfig & { medasrModel: FileSource };
+  telespeech_ctc: SttSingleModelCustomConfig & {
+    telespeechCtcModel: FileSource;
+  };
+};
+
+export type SttCustomConfig = SttCustomConfigByModelType[STTConcreteModelType];
+
+function createSttInvalidArgumentError(message: string): never {
+  const err = new Error(
+    `${SttErrorCode.INVALID_ARGUMENT}: ${message}`
+  ) as Error & {
+    code?: string;
+  };
+  err.code = SttErrorCode.INVALID_ARGUMENT;
+  throw err;
+}
+
+function isFileSource(value: unknown): value is FileSource {
+  if (typeof value !== 'object' || value === null || !('kind' in value)) {
+    return false;
+  }
+  const kind = (value as { kind?: unknown }).kind;
+  return typeof kind === 'string';
+}
+
+/** Structural check: every present customConfig value must be a FileSource. */
+export function assertSttCustomConfig(
+  customConfig: Record<string, unknown>
+): void {
+  for (const [key, value] of Object.entries(customConfig)) {
+    if (!isFileSource(value)) {
+      createSttInvalidArgumentError(
+        `customConfig.${key} must be a FileSource object`
+      );
+    }
+  }
+}
+
+export async function resolveSttCustomConfigPaths(
+  modelType: STTConcreteModelType,
+  customConfig: SttCustomConfig
+): Promise<Record<string, string>> {
+  assertSttCustomConfig(customConfig as unknown as Record<string, unknown>);
+
+  const schema = await getCustomModelPathRequirements(
+    ModelCategory.Stt,
+    modelType
+  );
+  const allowedKeys = new Set([...schema.required, ...schema.optional]);
+  for (const key of Object.keys(customConfig)) {
+    if (!allowedKeys.has(key)) {
+      createSttInvalidArgumentError(
+        `Unknown customConfig key '${key}' for modelType '${modelType}'`
+      );
+    }
+  }
+
+  const fileSources: Record<string, FileSource> = {};
+  for (const [key, value] of Object.entries(customConfig)) {
+    if (isFileSource(value)) {
+      fileSources[key] = value;
+    }
+  }
+  const { resolveModelFileSources } = await import(
+    '../detect/resolveModelInput'
+  );
+  const resolvedPaths = await resolveModelFileSources(fileSources);
+
+  const validation = await validateCustomModelPaths(
+    ModelCategory.Stt,
+    modelType,
+    resolvedPaths
+  );
+  if (!validation.ok) {
+    createSttInvalidArgumentError(
+      validation.error?.trim() ||
+        `Missing required paths: ${(validation.missingRequired ?? []).join(
+          ', '
+        )}`
+    );
+  }
+
+  return resolvedPaths;
+}

--- a/src/stt/customConfig.ts
+++ b/src/stt/customConfig.ts
@@ -1,10 +1,9 @@
 import type { FileSource } from '../fileio/types';
 import { ModelCategory } from '../download/types';
 import {
-  getCustomModelPathRequirements,
-  validateCustomModelPaths,
-} from '../detect/validateCustomModelPaths';
-import { resolveModelFileSources } from '../detect/resolveModelInput';
+  assertCustomModelConfig,
+  resolveCustomModelConfigPaths,
+} from '../detect/customConfigResolver';
 import type { STTConcreteModelType } from './types';
 import { SttErrorCode } from './types';
 
@@ -151,77 +150,23 @@ export type SttCustomConfigByModelType = {
 
 export type SttCustomConfig = SttCustomConfigByModelType[STTConcreteModelType];
 
-function createSttInvalidArgumentError(message: string): never {
-  const err = new Error(
-    `${SttErrorCode.INVALID_ARGUMENT}: ${message}`
-  ) as Error & {
-    code?: string;
-  };
-  err.code = SttErrorCode.INVALID_ARGUMENT;
-  throw err;
-}
-
-function isFileSource(value: unknown): value is FileSource {
-  if (typeof value !== 'object' || value === null || !('kind' in value)) {
-    return false;
-  }
-  const kind = (value as { kind?: unknown }).kind;
-  return typeof kind === 'string';
-}
-
 /** Structural check: every present customConfig value must be a FileSource. */
 export function assertSttCustomConfig(
   customConfig: Record<string, unknown>
 ): void {
-  for (const [key, value] of Object.entries(customConfig)) {
-    if (!isFileSource(value)) {
-      createSttInvalidArgumentError(
-        `customConfig.${key} must be a FileSource object`
-      );
-    }
-  }
+  assertCustomModelConfig(customConfig, SttErrorCode.INVALID_ARGUMENT);
 }
 
 export async function resolveSttCustomConfigPaths(
   modelType: STTConcreteModelType,
   customConfig: SttCustomConfig
 ): Promise<Record<string, string>> {
-  assertSttCustomConfig(customConfig as unknown as Record<string, unknown>);
-
-  const schema = await getCustomModelPathRequirements(
-    ModelCategory.Stt,
-    modelType
-  );
-  const allowedKeys = new Set([...schema.required, ...schema.optional]);
-  for (const key of Object.keys(customConfig)) {
-    if (!allowedKeys.has(key)) {
-      createSttInvalidArgumentError(
-        `Unknown customConfig key '${key}' for modelType '${modelType}'`
-      );
-    }
-  }
-
-  const fileSources: Record<string, FileSource> = {};
-  for (const [key, value] of Object.entries(customConfig)) {
-    if (isFileSource(value)) {
-      fileSources[key] = value;
-    }
-  }
-  const resolvedPaths = await resolveModelFileSources(fileSources);
-
-  const validation = await validateCustomModelPaths(
-    ModelCategory.Stt,
+  return resolveCustomModelConfigPaths({
+    category: ModelCategory.Stt,
     modelType,
-    resolvedPaths
-  );
-  if (!validation.ok) {
-    createSttInvalidArgumentError(
-      validation.error?.trim() ||
-        `Missing required paths: ${(validation.missingRequired ?? []).join(
-          ', '
-        )}`
-    );
-  }
-
-  return resolvedPaths;
+    customConfig: customConfig as unknown as Record<string, unknown>,
+    errorCode: SttErrorCode.INVALID_ARGUMENT,
+    unknownKeyMessage: (key, mt) =>
+      `Unknown customConfig key '${key}' for modelType '${mt}'`,
+  });
 }

--- a/src/stt/index.ts
+++ b/src/stt/index.ts
@@ -40,10 +40,7 @@ import {
 import { createStreamingPipelineCompletionPromise } from '../audiobuffer/streamingPipelineCompletion';
 import type { SttPipelineHandle } from './streamingTypes';
 import type { FileSource } from '../fileio/types';
-import {
-  resolveFileSourceForDetect,
-  resolveFileSourceForModelInit,
-} from '../detect/resolveModelInput';
+import { resolveFileSourceForDetect } from '../detect/resolveModelInput';
 import { resolvePublicLanguageHints } from '../model-languages';
 import { ModelCategory } from '../download/types';
 import {
@@ -303,7 +300,8 @@ export async function detectSttModel(
  *   getOfflineTextBufferTextSlice,
  * } from 'react-native-sherpa-onnx/textbuffer';
  * const stt = await createSTT({
- *   modelPath: { type: 'asset', path: 'models/whisper-tiny' },
+ *   modelSource: { kind: 'fs', path: '/path/to/model-dir' },
+ *   modelType: 'auto',
  * });
  * const audio = await createOfflineAudioBufferFromFile({
  *   kind: 'fs',
@@ -319,8 +317,7 @@ export async function createSTT(
   options: STTInitializeOptions
 ): Promise<SttEngine> {
   const instanceId = `stt_${++sttInstanceCounter}`;
-  const resolvedPath = await resolveFileSourceForModelInit(options.modelSource);
-  const bridgeOptions = buildSttInitBridgeOptions(resolvedPath, options);
+  const bridgeOptions = await buildSttInitBridgeOptions(options);
 
   const result = await SherpaOnnx.initializeStt(instanceId, bridgeOptions);
 
@@ -603,6 +600,10 @@ export { ONLINE_STT_MODEL_TYPES } from './streamingTypes';
 // Export types and runtime type list
 export type {
   STTInitializeOptions,
+  STTAutoInitializeOptions,
+  STTCustomInitializeOptions,
+  STTConcreteModelType,
+  STTInitializeOptionsBase,
   STTModelType,
   SttModelOptions,
   SttQwen3AsrModelOptions,
@@ -615,6 +616,17 @@ export type {
   SttInitResult,
   SttErrorCodeValue,
 } from './types';
+export type {
+  SttCustomConfig,
+  SttCustomConfigByModelType,
+  SttCustomPathKey,
+  SttTransducerCustomConfig,
+  SttWhisperCustomConfig,
+} from './customConfig';
+export {
+  assertSttCustomConfig,
+  resolveSttCustomConfigPaths,
+} from './customConfig';
 export type { SttDetectModelResult } from '../types/modelDetect';
 export {
   STT_MODEL_TYPES,

--- a/src/stt/index.ts
+++ b/src/stt/index.ts
@@ -590,6 +590,8 @@ export type {
   OnlineSTTModelType,
   LiveSttEngine,
   StreamingSttInitOptions,
+  StreamingSttAutoInitOptions,
+  StreamingSttCustomInitOptions,
   SttPipelineHandle,
   SttPipelineOptions,
   EndpointConfig,
@@ -627,6 +629,18 @@ export {
   assertSttCustomConfig,
   resolveSttCustomConfigPaths,
 } from './customConfig';
+export type {
+  StreamingSttCustomConfig,
+  StreamingSttCustomConfigByModelType,
+  StreamingSttCustomPathKey,
+  StreamingTransducerCustomConfig,
+  StreamingParaformerCustomConfig,
+  StreamingSingleModelCustomConfig,
+} from './streamingCustomConfig';
+export {
+  assertStreamingSttCustomConfig,
+  resolveStreamingSttCustomConfigPaths,
+} from './streamingCustomConfig';
 export type { SttDetectModelResult } from '../types/modelDetect';
 export {
   STT_MODEL_TYPES,

--- a/src/stt/index.ts
+++ b/src/stt/index.ts
@@ -42,6 +42,7 @@ import type { SttPipelineHandle } from './streamingTypes';
 import type { FileSource } from '../fileio/types';
 import { resolveFileSourceForDetect } from '../detect/resolveModelInput';
 import { resolvePublicLanguageHints } from '../model-languages';
+import { readNonEmptyDetectPathsMap } from '../detect/detectModelOutput';
 import { ModelCategory } from '../download/types';
 import {
   isDetectionSource,
@@ -268,9 +269,8 @@ export async function detectSttModel(
       ? raw.quantization
       : undefined;
 
-  // isStreaming is now provided by the native online-compatibility guard.
-  // Falls back to false when the native layer does not return the field.
   const isStreaming = raw.isStreaming === true;
+  const paths = readNonEmptyDetectPathsMap(raw.paths);
 
   return {
     success: raw.success,
@@ -284,6 +284,7 @@ export async function detectSttModel(
     ...(resolvedLanguages.length > 0 ? { languages: resolvedLanguages } : {}),
     ...(quantization != null ? { quantization } : {}),
     ...(detectionSources.length > 0 ? { detectionSources } : {}),
+    ...(paths != null ? { paths } : {}),
   };
 }
 

--- a/src/stt/streaming.ts
+++ b/src/stt/streaming.ts
@@ -1,6 +1,6 @@
 import SherpaOnnx from '../NativeSherpaOnnx';
 import { resolveFileSourceForModelInit } from '../detect/resolveModelInput';
-import { buildOnlineSttInitBridgeOptions } from './sttNativeBridge';
+import { buildStreamingSttInitBridgeOptions } from './sttNativeBridge';
 import type {
   OnlineSTTModelType,
   LiveSttEngine,
@@ -65,10 +65,14 @@ export async function createStreamingSTT(
   options: StreamingSttInitOptions
 ): Promise<LiveSttEngine> {
   const instanceId = `streaming_stt_${++streamingSttInstanceCounter}`;
-  const resolvedPath = await resolveFileSourceForModelInit(options.modelSource);
 
   let effectiveModelType: OnlineSTTModelType;
-  if (options.modelType === 'auto' || options.modelType === undefined) {
+  if (options.initMode === 'custom') {
+    effectiveModelType = normalizeToOnlineType(options.modelType);
+  } else if (options.modelType === 'auto' || options.modelType === undefined) {
+    const resolvedPath = await resolveFileSourceForModelInit(
+      options.modelSource
+    );
     const detectResult = await SherpaOnnx.detectSttModel(
       resolvedPath,
       null,
@@ -91,10 +95,9 @@ export async function createStreamingSTT(
     effectiveModelType = normalizeToOnlineType(options.modelType);
   }
 
-  const optionsWithResolvedType = { ...options, modelType: effectiveModelType };
-  const bridgeOptions = buildOnlineSttInitBridgeOptions(
-    resolvedPath,
-    optionsWithResolvedType
+  const bridgeOptions = await buildStreamingSttInitBridgeOptions(
+    options,
+    effectiveModelType
   );
 
   const result = await SherpaOnnx.initializeOnlineStt(

--- a/src/stt/streamingCustomConfig.ts
+++ b/src/stt/streamingCustomConfig.ts
@@ -1,0 +1,122 @@
+import type { FileSource } from '../fileio/types';
+import {
+  getCustomModelPathRequirements,
+  validateCustomModelPaths,
+} from '../detect/validateCustomModelPaths';
+import { resolveModelFileSources } from '../detect/resolveModelInput';
+import type { OnlineSTTModelType } from './streamingTypes';
+import { SttErrorCode } from './types';
+
+export type StreamingSttCustomPathKey =
+  | 'encoder'
+  | 'decoder'
+  | 'joiner'
+  | 'tokens'
+  | 'model';
+
+export interface StreamingTransducerCustomConfig {
+  encoder: FileSource;
+  decoder: FileSource;
+  joiner: FileSource;
+  tokens: FileSource;
+}
+
+export interface StreamingParaformerCustomConfig {
+  encoder: FileSource;
+  decoder: FileSource;
+  tokens: FileSource;
+}
+
+export interface StreamingSingleModelCustomConfig {
+  model: FileSource;
+  tokens: FileSource;
+}
+
+export type StreamingSttCustomConfigByModelType = {
+  transducer: StreamingTransducerCustomConfig;
+  nemo_transducer: StreamingTransducerCustomConfig;
+  paraformer: StreamingParaformerCustomConfig;
+  zipformer2_ctc: StreamingSingleModelCustomConfig;
+  wenet_ctc: StreamingSingleModelCustomConfig;
+  nemo_ctc: StreamingSingleModelCustomConfig;
+  tone_ctc: StreamingSingleModelCustomConfig;
+};
+
+export type StreamingSttCustomConfig =
+  StreamingSttCustomConfigByModelType[OnlineSTTModelType];
+
+const STREAMING_STT_CATEGORY = 'stt_streaming';
+
+function createStreamingInvalidArgumentError(message: string): never {
+  const err = new Error(
+    `${SttErrorCode.INVALID_ARGUMENT}: ${message}`
+  ) as Error & { code?: string };
+  err.code = SttErrorCode.INVALID_ARGUMENT;
+  throw err;
+}
+
+function isFileSource(value: unknown): value is FileSource {
+  if (typeof value !== 'object' || value === null || !('kind' in value)) {
+    return false;
+  }
+  const kind = (value as { kind?: unknown }).kind;
+  return typeof kind === 'string';
+}
+
+export function assertStreamingSttCustomConfig(
+  customConfig: Record<string, unknown>
+): void {
+  for (const [key, value] of Object.entries(customConfig)) {
+    if (!isFileSource(value)) {
+      createStreamingInvalidArgumentError(
+        `customConfig.${key} must be a FileSource object`
+      );
+    }
+  }
+}
+
+export async function resolveStreamingSttCustomConfigPaths(
+  modelType: OnlineSTTModelType,
+  customConfig: StreamingSttCustomConfig
+): Promise<Record<string, string>> {
+  assertStreamingSttCustomConfig(
+    customConfig as unknown as Record<string, unknown>
+  );
+
+  const schema = await getCustomModelPathRequirements(
+    STREAMING_STT_CATEGORY,
+    modelType
+  );
+  const allowedKeys = new Set([...schema.required, ...schema.optional]);
+  for (const key of Object.keys(customConfig)) {
+    if (!allowedKeys.has(key)) {
+      createStreamingInvalidArgumentError(
+        `Unknown customConfig key '${key}' for streaming modelType '${modelType}'`
+      );
+    }
+  }
+
+  const fileSources: Record<string, FileSource> = {};
+  for (const [key, value] of Object.entries(customConfig)) {
+    if (isFileSource(value)) {
+      fileSources[key] = value;
+    }
+  }
+  const resolvedPaths = await resolveModelFileSources(fileSources);
+
+  const validation = await validateCustomModelPaths(
+    STREAMING_STT_CATEGORY,
+    modelType,
+    resolvedPaths
+  );
+  if (!validation.ok) {
+    createStreamingInvalidArgumentError(
+      validation.error?.trim() ||
+        `Missing required paths: ${(validation.missingRequired ?? []).join(
+          ', '
+        )}`
+    );
+  }
+
+  return resolvedPaths;
+}

--- a/src/stt/streamingCustomConfig.ts
+++ b/src/stt/streamingCustomConfig.ts
@@ -1,9 +1,8 @@
 import type { FileSource } from '../fileio/types';
 import {
-  getCustomModelPathRequirements,
-  validateCustomModelPaths,
-} from '../detect/validateCustomModelPaths';
-import { resolveModelFileSources } from '../detect/resolveModelInput';
+  assertCustomModelConfig,
+  resolveCustomModelConfigPaths,
+} from '../detect/customConfigResolver';
 import type { OnlineSTTModelType } from './streamingTypes';
 import { SttErrorCode } from './types';
 
@@ -47,76 +46,22 @@ export type StreamingSttCustomConfig =
 
 const STREAMING_STT_CATEGORY = 'stt_streaming';
 
-function createStreamingInvalidArgumentError(message: string): never {
-  const err = new Error(
-    `${SttErrorCode.INVALID_ARGUMENT}: ${message}`
-  ) as Error & { code?: string };
-  err.code = SttErrorCode.INVALID_ARGUMENT;
-  throw err;
-}
-
-function isFileSource(value: unknown): value is FileSource {
-  if (typeof value !== 'object' || value === null || !('kind' in value)) {
-    return false;
-  }
-  const kind = (value as { kind?: unknown }).kind;
-  return typeof kind === 'string';
-}
-
 export function assertStreamingSttCustomConfig(
   customConfig: Record<string, unknown>
 ): void {
-  for (const [key, value] of Object.entries(customConfig)) {
-    if (!isFileSource(value)) {
-      createStreamingInvalidArgumentError(
-        `customConfig.${key} must be a FileSource object`
-      );
-    }
-  }
+  assertCustomModelConfig(customConfig, SttErrorCode.INVALID_ARGUMENT);
 }
 
 export async function resolveStreamingSttCustomConfigPaths(
   modelType: OnlineSTTModelType,
   customConfig: StreamingSttCustomConfig
 ): Promise<Record<string, string>> {
-  assertStreamingSttCustomConfig(
-    customConfig as unknown as Record<string, unknown>
-  );
-
-  const schema = await getCustomModelPathRequirements(
-    STREAMING_STT_CATEGORY,
-    modelType
-  );
-  const allowedKeys = new Set([...schema.required, ...schema.optional]);
-  for (const key of Object.keys(customConfig)) {
-    if (!allowedKeys.has(key)) {
-      createStreamingInvalidArgumentError(
-        `Unknown customConfig key '${key}' for streaming modelType '${modelType}'`
-      );
-    }
-  }
-
-  const fileSources: Record<string, FileSource> = {};
-  for (const [key, value] of Object.entries(customConfig)) {
-    if (isFileSource(value)) {
-      fileSources[key] = value;
-    }
-  }
-  const resolvedPaths = await resolveModelFileSources(fileSources);
-
-  const validation = await validateCustomModelPaths(
-    STREAMING_STT_CATEGORY,
+  return resolveCustomModelConfigPaths({
+    category: STREAMING_STT_CATEGORY,
     modelType,
-    resolvedPaths
-  );
-  if (!validation.ok) {
-    createStreamingInvalidArgumentError(
-      validation.error?.trim() ||
-        `Missing required paths: ${(validation.missingRequired ?? []).join(
-          ', '
-        )}`
-    );
-  }
-
-  return resolvedPaths;
+    customConfig: customConfig as unknown as Record<string, unknown>,
+    errorCode: SttErrorCode.INVALID_ARGUMENT,
+    unknownKeyMessage: (key, mt) =>
+      `Unknown customConfig key '${key}' for streaming modelType '${mt}'`,
+  });
 }

--- a/src/stt/streamingCustomConfig.ts
+++ b/src/stt/streamingCustomConfig.ts
@@ -36,7 +36,6 @@ export type StreamingSttCustomConfigByModelType = {
   nemo_transducer: StreamingTransducerCustomConfig;
   paraformer: StreamingParaformerCustomConfig;
   zipformer2_ctc: StreamingSingleModelCustomConfig;
-  wenet_ctc: StreamingSingleModelCustomConfig;
   nemo_ctc: StreamingSingleModelCustomConfig;
   tone_ctc: StreamingSingleModelCustomConfig;
 };

--- a/src/stt/streamingTypes.ts
+++ b/src/stt/streamingTypes.ts
@@ -55,13 +55,9 @@ export interface EndpointConfig {
 }
 
 /**
- * Options for initializing the streaming (online) STT engine.
+ * Options shared by auto and custom streaming STT initialization.
  */
-export interface StreamingSttInitOptions {
-  /** Model source configuration. */
-  modelSource: FileSource;
-  /** Online model type. Use 'auto' to detect from model directory (calls detectSttModel and maps to an online type). */
-  modelType: OnlineSTTModelType | 'auto';
+export interface StreamingSttInitOptionsBase {
   /** Enable endpoint detection. Default: true. */
   enableEndpoint?: boolean;
   /** Endpoint rules. Defaults match Kotlin (rule1: 2.4s silence, rule2: 1.4s + speech, rule3: 20s max). */
@@ -92,6 +88,32 @@ export interface StreamingSttInitOptions {
   /** Enable debug logging. Default: false. */
   debug?: boolean;
 }
+
+/** Auto-detect model files from a directory-backed {@link FileSource}. */
+export interface StreamingSttAutoInitOptions
+  extends StreamingSttInitOptionsBase {
+  initMode?: 'auto';
+  /** Model source configuration. */
+  modelSource: FileSource;
+  /** Online model type. Use 'auto' to detect from model directory. */
+  modelType: OnlineSTTModelType | 'auto';
+}
+
+/** Explicit per-file paths; skips directory scan / detect. */
+export interface StreamingSttCustomInitOptions
+  extends StreamingSttInitOptionsBase {
+  initMode: 'custom';
+  /** Concrete online model type (not `'auto'`). */
+  modelType: OnlineSTTModelType;
+  customConfig: import('./streamingCustomConfig').StreamingSttCustomConfig;
+}
+
+/**
+ * Options for initializing the streaming (online) STT engine.
+ */
+export type StreamingSttInitOptions =
+  | StreamingSttAutoInitOptions
+  | StreamingSttCustomInitOptions;
 
 /** Options for starting a native **streaming (online)** STT pipeline worker. */
 export interface SttPipelineOptions {

--- a/src/stt/streamingTypes.ts
+++ b/src/stt/streamingTypes.ts
@@ -13,7 +13,6 @@ export type OnlineSTTModelType =
   | 'nemo_transducer'
   | 'paraformer'
   | 'zipformer2_ctc'
-  | 'wenet_ctc'
   | 'nemo_ctc'
   | 'tone_ctc';
 
@@ -23,7 +22,6 @@ export const ONLINE_STT_MODEL_TYPES: readonly OnlineSTTModelType[] = [
   'nemo_transducer',
   'paraformer',
   'zipformer2_ctc',
-  'wenet_ctc',
   'nemo_ctc',
   'tone_ctc',
 ] as const;

--- a/src/stt/sttNativeBridge.ts
+++ b/src/stt/sttNativeBridge.ts
@@ -10,41 +10,14 @@ import type {
 } from '../nativeBridge/initBridgeTypes';
 import type { StreamingSttInitOptions } from './streamingTypes';
 import { resolveStreamingSttCustomConfigPaths } from './streamingCustomConfig';
+import { resolveFileSourceForModelInit } from '../detect/resolveModelInput';
 import {
-  resolveFileSourceForModelFile,
-  resolveFileSourceForModelInit,
-} from '../detect/resolveModelInput';
+  resolveOptionalFileSourceList,
+  resolveOptionalFileSourcePath,
+} from '../nativeBridge/fileSourceBridgeHelpers';
 import { resolveSttCustomConfigPaths } from './customConfig';
 
 export type { OnlineSttInitBridgeOptions, SttInitBridgeOptions };
-
-async function resolveOptionalFileSourcePath(
-  source: import('../fileio/types').FileSource | undefined
-): Promise<string | undefined> {
-  if (source === undefined) {
-    return undefined;
-  }
-  return resolveFileSourceForModelFile(source);
-}
-
-async function resolveOptionalFileSourceList(
-  sources:
-    | import('../fileio/types').FileSource
-    | readonly import('../fileio/types').FileSource[]
-    | undefined
-): Promise<string | undefined> {
-  if (sources === undefined) {
-    return undefined;
-  }
-  const list = Array.isArray(sources) ? sources : [sources];
-  if (list.length === 0) {
-    return undefined;
-  }
-  const paths = await Promise.all(
-    list.map((source) => resolveFileSourceForModelFile(source))
-  );
-  return paths.join(',');
-}
 
 function appendSharedInitBridgeFields(
   options: STTInitializeOptionsBase,

--- a/src/stt/sttNativeBridge.ts
+++ b/src/stt/sttNativeBridge.ts
@@ -1,27 +1,63 @@
-import type { STTInitializeOptions } from './types';
+import type {
+  STTAutoInitializeOptions,
+  STTCustomInitializeOptions,
+  STTInitializeOptions,
+  STTInitializeOptionsBase,
+} from './types';
 import type {
   OnlineSttInitBridgeOptions,
   SttInitBridgeOptions,
 } from '../nativeBridge/initBridgeTypes';
 import type { StreamingSttInitOptions } from './streamingTypes';
+import { resolveFileSourceForModelFile } from '../detect/resolveModelInput';
+import { resolveSttCustomConfigPaths } from './customConfig';
 
 export type { OnlineSttInitBridgeOptions, SttInitBridgeOptions };
 
-export function buildSttInitBridgeOptions(
-  modelDir: string,
-  options: STTInitializeOptions
-): SttInitBridgeOptions {
+async function resolveOptionalFileSourcePath(
+  source: import('../fileio/types').FileSource | undefined
+): Promise<string | undefined> {
+  if (source === undefined) {
+    return undefined;
+  }
+  return resolveFileSourceForModelFile(source);
+}
+
+async function resolveOptionalFileSourceList(
+  sources:
+    | import('../fileio/types').FileSource
+    | readonly import('../fileio/types').FileSource[]
+    | undefined
+): Promise<string | undefined> {
+  if (sources === undefined) {
+    return undefined;
+  }
+  const list = Array.isArray(sources) ? sources : [sources];
+  if (list.length === 0) {
+    return undefined;
+  }
+  const paths = await Promise.all(
+    list.map((source) => resolveFileSourceForModelFile(source))
+  );
+  return paths.join(',');
+}
+
+function appendSharedInitBridgeFields(
+  options: STTInitializeOptionsBase,
+  resolved: {
+    hotwordsFile?: string;
+    bpeVocab?: string;
+    ruleFsts?: string;
+    ruleFars?: string;
+  }
+): Omit<
+  SttInitBridgeOptions,
+  'initMode' | 'modelDir' | 'modelPaths' | 'modelType' | 'preferInt8'
+> {
   return {
-    modelDir,
-    ...(options.preferInt8 !== undefined
-      ? { preferInt8: options.preferInt8 }
-      : {}),
-    ...(options.modelType !== undefined
-      ? { modelType: options.modelType }
-      : {}),
     ...(options.debug !== undefined ? { debug: options.debug } : {}),
-    ...(options.hotwordsFile !== undefined
-      ? { hotwordsFile: options.hotwordsFile }
+    ...(resolved.hotwordsFile !== undefined
+      ? { hotwordsFile: resolved.hotwordsFile }
       : {}),
     ...(options.hotwordsScore !== undefined
       ? { hotwordsScore: options.hotwordsScore }
@@ -30,8 +66,8 @@ export function buildSttInitBridgeOptions(
       ? { numThreads: options.numThreads }
       : {}),
     ...(options.provider !== undefined ? { provider: options.provider } : {}),
-    ...(options.ruleFsts !== undefined ? { ruleFsts: options.ruleFsts } : {}),
-    ...(options.ruleFars !== undefined ? { ruleFars: options.ruleFars } : {}),
+    ...(resolved.ruleFsts !== undefined ? { ruleFsts: resolved.ruleFsts } : {}),
+    ...(resolved.ruleFars !== undefined ? { ruleFars: resolved.ruleFars } : {}),
     ...(options.dither !== undefined ? { dither: options.dither } : {}),
     ...(options.modelOptions !== undefined
       ? { modelOptions: options.modelOptions }
@@ -39,7 +75,67 @@ export function buildSttInitBridgeOptions(
     ...(options.modelingUnit !== undefined
       ? { modelingUnit: options.modelingUnit }
       : {}),
-    ...(options.bpeVocab !== undefined ? { bpeVocab: options.bpeVocab } : {}),
+    ...(resolved.bpeVocab !== undefined ? { bpeVocab: resolved.bpeVocab } : {}),
+  };
+}
+
+async function resolveSharedFilePaths(
+  options: STTInitializeOptionsBase
+): Promise<{
+  hotwordsFile?: string;
+  bpeVocab?: string;
+  ruleFsts?: string;
+  ruleFars?: string;
+}> {
+  const [hotwordsFile, bpeVocab, ruleFsts, ruleFars] = await Promise.all([
+    resolveOptionalFileSourcePath(options.hotwordsFile),
+    resolveOptionalFileSourcePath(options.bpeVocab),
+    resolveOptionalFileSourceList(options.ruleFsts),
+    resolveOptionalFileSourceList(options.ruleFars),
+  ]);
+  return {
+    ...(hotwordsFile !== undefined ? { hotwordsFile } : {}),
+    ...(bpeVocab !== undefined ? { bpeVocab } : {}),
+    ...(ruleFsts !== undefined ? { ruleFsts } : {}),
+    ...(ruleFars !== undefined ? { ruleFars } : {}),
+  };
+}
+
+export async function buildSttInitBridgeOptions(
+  options: STTInitializeOptions
+): Promise<SttInitBridgeOptions> {
+  const sharedPaths = await resolveSharedFilePaths(options);
+  const sharedFields = appendSharedInitBridgeFields(options, sharedPaths);
+
+  if (options.initMode === 'custom') {
+    const customOptions = options as STTCustomInitializeOptions;
+    const modelPaths = await resolveSttCustomConfigPaths(
+      customOptions.modelType,
+      customOptions.customConfig
+    );
+    return {
+      initMode: 'custom',
+      modelType: customOptions.modelType,
+      modelPaths,
+      ...sharedFields,
+    };
+  }
+
+  const autoOptions = options as STTAutoInitializeOptions;
+  const { resolveFileSourceForModelInit } = await import(
+    '../detect/resolveModelInput'
+  );
+  const modelDir = await resolveFileSourceForModelInit(autoOptions.modelSource);
+  return {
+    initMode: 'auto',
+    modelDir,
+    ...(autoOptions.preferInt8 !== undefined
+      ? { preferInt8: autoOptions.preferInt8 }
+      : {}),
+    ...(autoOptions.modelType !== undefined
+      ? { modelType: autoOptions.modelType }
+      : {}),
+    ...sharedFields,
   };
 }
 

--- a/src/stt/sttNativeBridge.ts
+++ b/src/stt/sttNativeBridge.ts
@@ -9,6 +9,7 @@ import type {
   SttInitBridgeOptions,
 } from '../nativeBridge/initBridgeTypes';
 import type { StreamingSttInitOptions } from './streamingTypes';
+import { resolveStreamingSttCustomConfigPaths } from './streamingCustomConfig';
 import {
   resolveFileSourceForModelFile,
   resolveFileSourceForModelInit,
@@ -140,7 +141,103 @@ export async function buildSttInitBridgeOptions(
 }
 
 /**
+ * Build bridge options for `initializeOnlineStt` (auto or custom init).
+ */
+export async function buildStreamingSttInitBridgeOptions(
+  options: StreamingSttInitOptions,
+  resolvedModelType: string
+): Promise<OnlineSttInitBridgeOptions> {
+  const shared = appendStreamingInitBridgeFields(options);
+
+  if (options.initMode === 'custom') {
+    const modelPaths = await resolveStreamingSttCustomConfigPaths(
+      options.modelType,
+      options.customConfig
+    );
+    return {
+      initMode: 'custom',
+      modelType: resolvedModelType,
+      modelPaths,
+      ...shared,
+    };
+  }
+
+  const modelDir = await resolveFileSourceForModelInit(options.modelSource);
+  return {
+    initMode: 'auto',
+    modelDir,
+    modelType: resolvedModelType,
+    ...shared,
+  };
+}
+
+function appendStreamingInitBridgeFields(
+  options: StreamingSttInitOptions
+): Omit<
+  OnlineSttInitBridgeOptions,
+  'initMode' | 'modelDir' | 'modelPaths' | 'modelType'
+> {
+  const ep = options.endpointConfig;
+  return {
+    ...(options.enableEndpoint !== undefined
+      ? { enableEndpoint: options.enableEndpoint }
+      : {}),
+    ...(options.decodingMethod !== undefined
+      ? { decodingMethod: options.decodingMethod }
+      : {}),
+    ...(options.maxActivePaths !== undefined
+      ? { maxActivePaths: options.maxActivePaths }
+      : {}),
+    ...(options.hotwordsFile !== undefined
+      ? { hotwordsFile: options.hotwordsFile }
+      : {}),
+    ...(options.hotwordsScore !== undefined
+      ? { hotwordsScore: options.hotwordsScore }
+      : {}),
+    ...(options.numThreads !== undefined
+      ? { numThreads: options.numThreads }
+      : {}),
+    ...(options.provider !== undefined ? { provider: options.provider } : {}),
+    ...(options.ruleFsts !== undefined ? { ruleFsts: options.ruleFsts } : {}),
+    ...(options.ruleFars !== undefined ? { ruleFars: options.ruleFars } : {}),
+    ...(options.dither !== undefined ? { dither: options.dither } : {}),
+    ...(options.blankPenalty !== undefined
+      ? { blankPenalty: options.blankPenalty }
+      : {}),
+    ...(options.debug !== undefined ? { debug: options.debug } : {}),
+    ...(ep?.rule1?.mustContainNonSilence !== undefined
+      ? { rule1MustContainNonSilence: ep.rule1.mustContainNonSilence }
+      : {}),
+    ...(ep?.rule1?.minTrailingSilence !== undefined
+      ? { rule1MinTrailingSilence: ep.rule1.minTrailingSilence }
+      : {}),
+    ...(ep?.rule1?.minUtteranceLength !== undefined
+      ? { rule1MinUtteranceLength: ep.rule1.minUtteranceLength }
+      : {}),
+    ...(ep?.rule2?.mustContainNonSilence !== undefined
+      ? { rule2MustContainNonSilence: ep.rule2.mustContainNonSilence }
+      : {}),
+    ...(ep?.rule2?.minTrailingSilence !== undefined
+      ? { rule2MinTrailingSilence: ep.rule2.minTrailingSilence }
+      : {}),
+    ...(ep?.rule2?.minUtteranceLength !== undefined
+      ? { rule2MinUtteranceLength: ep.rule2.minUtteranceLength }
+      : {}),
+    ...(ep?.rule3?.mustContainNonSilence !== undefined
+      ? { rule3MustContainNonSilence: ep.rule3.mustContainNonSilence }
+      : {}),
+    ...(ep?.rule3?.minTrailingSilence !== undefined
+      ? { rule3MinTrailingSilence: ep.rule3.minTrailingSilence }
+      : {}),
+    ...(ep?.rule3?.minUtteranceLength !== undefined
+      ? { rule3MinUtteranceLength: ep.rule3.minUtteranceLength }
+      : {}),
+  };
+}
+
+/**
  * Flatten public streaming init options for `initializeOnlineStt` (endpoint rules → top-level keys).
+ * @deprecated Prefer {@link buildStreamingSttInitBridgeOptions}.
  */
 export function buildOnlineSttInitBridgeOptions(
   modelDir: string,
@@ -148,6 +245,7 @@ export function buildOnlineSttInitBridgeOptions(
 ): OnlineSttInitBridgeOptions {
   const ep = options.endpointConfig;
   return {
+    initMode: 'auto',
     modelDir,
     modelType: options.modelType,
     enableEndpoint: options.enableEndpoint ?? true,

--- a/src/stt/sttNativeBridge.ts
+++ b/src/stt/sttNativeBridge.ts
@@ -9,7 +9,10 @@ import type {
   SttInitBridgeOptions,
 } from '../nativeBridge/initBridgeTypes';
 import type { StreamingSttInitOptions } from './streamingTypes';
-import { resolveFileSourceForModelFile } from '../detect/resolveModelInput';
+import {
+  resolveFileSourceForModelFile,
+  resolveFileSourceForModelInit,
+} from '../detect/resolveModelInput';
 import { resolveSttCustomConfigPaths } from './customConfig';
 
 export type { OnlineSttInitBridgeOptions, SttInitBridgeOptions };
@@ -122,9 +125,6 @@ export async function buildSttInitBridgeOptions(
   }
 
   const autoOptions = options as STTAutoInitializeOptions;
-  const { resolveFileSourceForModelInit } = await import(
-    '../detect/resolveModelInput'
-  );
   const modelDir = await resolveFileSourceForModelInit(autoOptions.modelSource);
   return {
     initMode: 'auto',

--- a/src/stt/types.ts
+++ b/src/stt/types.ts
@@ -40,12 +40,53 @@ export type STTModelType =
   | 'cohere_transcribe'
   | 'fire_red_asr'
   | 'moonshine'
+  | 'moonshine_v2'
   | 'dolphin'
   | 'canary'
   | 'omnilingual'
   | 'medasr'
   | 'telespeech_ctc'
+  | 'tone_ctc'
   | 'auto';
+
+/** Concrete offline STT model types (excludes `'auto'`). */
+export type STTConcreteModelType = Exclude<STTModelType, 'auto'>;
+
+/** Shared STT init fields for auto and custom modes. */
+export interface STTInitializeOptionsBase {
+  debug?: boolean;
+  hotwordsFile?: FileSource;
+  hotwordsScore?: number;
+  modelingUnit?: 'cjkchar' | 'bpe' | 'cjkchar+bpe';
+  bpeVocab?: FileSource;
+  numThreads?: number;
+  provider?: string;
+  ruleFsts?: FileSource | readonly FileSource[];
+  ruleFars?: FileSource | readonly FileSource[];
+  dither?: number;
+  modelOptions?: SttModelOptions;
+}
+
+/** Automatic model detection from a model directory (default). */
+export interface STTAutoInitializeOptions extends STTInitializeOptionsBase {
+  initMode?: 'auto';
+  modelSource: FileSource;
+  preferInt8?: boolean;
+  modelType?: STTModelType;
+}
+
+/** Explicit per-file model layout; skips native auto-detection. */
+export interface STTCustomInitializeOptions<
+  T extends STTConcreteModelType = STTConcreteModelType
+> extends STTInitializeOptionsBase {
+  initMode: 'custom';
+  modelType: T;
+  customConfig: import('./customConfig').SttCustomConfigByModelType[T];
+}
+
+export type STTInitializeOptions =
+  | STTAutoInitializeOptions
+  | STTCustomInitializeOptions;
 
 /** Model types that support hotwords (contextual biasing). Transducer and NeMo transducer support hotwords in sherpa-onnx (NeMo: see k2-fsa/sherpa-onnx#3077). */
 export const STT_HOTWORDS_MODEL_TYPES: readonly STTModelType[] = [
@@ -77,11 +118,13 @@ export const STT_MODEL_TYPES: readonly STTModelType[] = [
   'cohere_transcribe',
   'fire_red_asr',
   'moonshine',
+  'moonshine_v2',
   'dolphin',
   'canary',
   'omnilingual',
   'medasr',
   'telespeech_ctc',
+  'tone_ctc',
   'auto',
 ] as const;
 
@@ -192,114 +235,6 @@ export interface SttModelOptions {
   funasrNano?: SttFunAsrNanoModelOptions;
   qwen3Asr?: SttQwen3AsrModelOptions;
   cohereTranscribe?: SttCohereTranscribeModelOptions;
-}
-
-/**
- * STT-specific initialization options
- */
-export interface STTInitializeOptions {
-  /**
-   * Model directory source configuration.
-   */
-  modelSource: FileSource;
-
-  /**
-   * Model quantization preference
-   * - true: Prefer int8 quantized models (model.int8.onnx) - smaller, faster
-   * - false: Prefer regular models (model.onnx) - higher accuracy
-   * - undefined: Try int8 first, then fall back to regular (default behavior)
-   */
-  preferInt8?: boolean;
-
-  /**
-   * Explicit model type specification for STT models
-   * - 'transducer': Force detection as Transducer model
-   * - 'zipformer_ctc' | 'ctc': Force detection as Zipformer CTC model
-   * - 'paraformer': Force detection as Paraformer model
-   * - 'nemo_ctc': Force detection as NeMo CTC model
-   * - 'whisper': Force detection as Whisper model
-   * - 'wenet_ctc': Force detection as WeNet CTC model
-   * - 'sense_voice': Force detection as SenseVoice model
-   * - 'funasr_nano': Force detection as FunASR Nano model
-   * - 'qwen3_asr': Force detection as Qwen3 ASR
-   * - 'cohere_transcribe': Cohere Transcribe (encoder/decoder + tokens.txt)
-   * - 'fire_red_asr': FireRed ASR (encoder/decoder)
-   * - 'moonshine': Moonshine (preprocess, encode, uncached_decode, cached_decode)
-   * - 'dolphin': Dolphin (single model)
-   * - 'canary': Canary (encoder/decoder)
-   * - 'omnilingual': Omnilingual CTC (single model)
-   * - 'medasr': MedASR CTC (single model)
-   * - 'telespeech_ctc': TeleSpeech CTC (single model)
-   * - 'auto': Automatic detection based on files (default)
-   */
-  modelType?: STTModelType;
-
-  /**
-   * Enable debug logging in native layer and sherpa-onnx (config.model_config.debug).
-   * When true, wrapper and JNI emit verbose logs (config dumps, file checks, init/transcribe flow).
-   * Default: false.
-   */
-  debug?: boolean;
-
-  /**
-   * Path to hotwords file for keyword boosting (Kotlin OfflineRecognizerConfig.hotwordsFile).
-   */
-  hotwordsFile?: string;
-
-  /**
-   * Hotwords score/weight (Kotlin OfflineRecognizerConfig.hotwordsScore).
-   * Default in Kotlin: 1.5.
-   */
-  hotwordsScore?: number;
-
-  /**
-   * Modeling unit for hotwords tokenization (Kotlin OfflineModelConfig.modelingUnit).
-   * Only used when hotwords are set and model is transducer/nemo_transducer.
-   * Must match how the model was trained: 'bpe' (e.g. English zipformer), 'cjkchar' (e.g. Chinese conformer), 'cjkchar+bpe' (bilingual zh-en).
-   * See docs/stt-offline.md "When to use which modelingUnit" and sherpa-onnx hotwords docs.
-   */
-  modelingUnit?: 'cjkchar' | 'bpe' | 'cjkchar+bpe';
-
-  /**
-   * Path to BPE vocabulary file for hotwords (Kotlin OfflineModelConfig.bpeVocab).
-   * Required when modelingUnit is 'bpe' or 'cjkchar+bpe'. Sentencepiece .vocab export (bpe.vocab), not the hotwords file.
-   */
-  bpeVocab?: string;
-
-  /**
-   * Number of threads for inference (Kotlin OfflineModelConfig.numThreads).
-   * Default in Kotlin: 1.
-   */
-  numThreads?: number;
-
-  /**
-   * Provider string (e.g. "cpu"). Stored in config only; no special logic on change.
-   * Kotlin OfflineModelConfig.provider.
-   */
-  provider?: string;
-
-  /**
-   * Path to rule FSTs (Kotlin OfflineRecognizerConfig.ruleFsts).
-   */
-  ruleFsts?: string;
-
-  /**
-   * Path to rule FARs (Kotlin OfflineRecognizerConfig.ruleFars).
-   */
-  ruleFars?: string;
-
-  /**
-   * Dither for feature extraction (Kotlin `FeatureConfig.dither`). Default: no dither.
-   * **Android:** applied natively. **iOS:** ignored — the bundled sherpa-onnx C/CXX API does not
-   * expose this field; the native default is used.
-   */
-  dither?: number;
-
-  /**
-   * Model-specific options. Only options for the loaded model type are applied.
-   * E.g. when modelType is 'whisper', only modelOptions.whisper is used.
-   */
-  modelOptions?: SttModelOptions;
 }
 
 // ========== STT error codes ==========

--- a/src/tts/__tests__/customConfig.test.ts
+++ b/src/tts/__tests__/customConfig.test.ts
@@ -1,0 +1,87 @@
+jest.mock('../../detect/validateCustomModelPaths', () => ({
+  getCustomModelPathRequirements: jest.fn(async () => ({
+    required: ['ttsModel', 'tokens'],
+    optional: ['dataDir', 'lexicon'],
+  })),
+  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+}));
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveModelFileSources: jest.fn(async (sources: Record<string, unknown>) => {
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(sources)) {
+      const path = (value as { path?: string })?.path;
+      if (path) out[key] = path;
+    }
+    return out;
+  }),
+}));
+
+import {
+  assertTtsCustomConfig,
+  resolveTtsCustomConfigPaths,
+} from '../customConfig';
+import {
+  getCustomModelPathRequirements,
+  validateCustomModelPaths,
+} from '../../detect/validateCustomModelPaths';
+import { TtsErrorCode } from '../customConfig';
+
+const mockGetRequirements = getCustomModelPathRequirements as jest.Mock;
+const mockValidate = validateCustomModelPaths as jest.Mock;
+
+describe('assertTtsCustomConfig', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  it('accepts FileSource values', () => {
+    expect(() =>
+      assertTtsCustomConfig({
+        ttsModel: fsPath('/model.onnx'),
+        tokens: fsPath('/tokens.txt'),
+      })
+    ).not.toThrow();
+  });
+
+  it('throws TTS_INVALID_ARGUMENT when a value is not a FileSource', () => {
+    expect(() =>
+      assertTtsCustomConfig({
+        ttsModel: '/model.onnx',
+      })
+    ).toThrow(TtsErrorCode.INVALID_ARGUMENT);
+  });
+});
+
+describe('resolveTtsCustomConfigPaths', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetRequirements.mockResolvedValue({
+      required: ['ttsModel', 'tokens'],
+      optional: ['dataDir', 'lexicon'],
+    });
+    mockValidate.mockResolvedValue({ ok: true });
+  });
+
+  it('rejects unknown keys using native schema', async () => {
+    await expect(
+      resolveTtsCustomConfigPaths('vits', {
+        ttsModel: fsPath('/model.onnx'),
+        tokens: fsPath('/tokens.txt'),
+        unknownKey: fsPath('/x.onnx'),
+      } as never)
+    ).rejects.toThrow(TtsErrorCode.INVALID_ARGUMENT);
+  });
+
+  it('resolves paths via shared resolver', async () => {
+    const paths = await resolveTtsCustomConfigPaths('vits', {
+      ttsModel: fsPath('/model.onnx'),
+      tokens: fsPath('/tokens.txt'),
+    });
+    expect(paths).toEqual({
+      ttsModel: '/model.onnx',
+      tokens: '/tokens.txt',
+    });
+    expect(mockValidate).toHaveBeenCalled();
+  });
+});

--- a/src/tts/__tests__/customConfig.test.ts
+++ b/src/tts/__tests__/customConfig.test.ts
@@ -1,10 +1,20 @@
-jest.mock('../../detect/validateCustomModelPaths', () => ({
-  getCustomModelPathRequirements: jest.fn(async () => ({
-    required: ['ttsModel', 'tokens'],
-    optional: ['dataDir', 'lexicon'],
-  })),
-  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
-}));
+jest.mock('../../detect/validateCustomModelPaths', () => {
+  const helpers = jest.requireActual(
+    '../../detect/customModelPathRequirements'
+  );
+  return {
+    ...helpers,
+    getCustomModelPathRequirements: jest.fn(async () => ({
+      fields: [
+        { key: 'ttsModel', required: true, kind: 'file' },
+        { key: 'tokens', required: true, kind: 'file' },
+        { key: 'dataDir', required: false, kind: 'dir' },
+        { key: 'lexicon', required: false, kind: 'file' },
+      ],
+    })),
+    validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+  };
+});
 
 jest.mock('../../detect/resolveModelInput', () => ({
   resolveModelFileSources: jest.fn(async (sources: Record<string, unknown>) => {
@@ -57,8 +67,12 @@ describe('resolveTtsCustomConfigPaths', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetRequirements.mockResolvedValue({
-      required: ['ttsModel', 'tokens'],
-      optional: ['dataDir', 'lexicon'],
+      fields: [
+        { key: 'ttsModel', required: true, kind: 'file' },
+        { key: 'tokens', required: true, kind: 'file' },
+        { key: 'dataDir', required: false, kind: 'dir' },
+        { key: 'lexicon', required: false, kind: 'file' },
+      ],
     });
     mockValidate.mockResolvedValue({ ok: true });
   });

--- a/src/tts/__tests__/ttsNativeBridge.test.ts
+++ b/src/tts/__tests__/ttsNativeBridge.test.ts
@@ -1,0 +1,48 @@
+import { buildTtsInitBridgeOptions } from '../ttsNativeBridge';
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveFileSourceForModelInit: jest.fn(async () => '/models/vits-piper-en'),
+}));
+
+jest.mock('../customConfig', () => ({
+  resolveTtsCustomConfigPaths: jest.fn(async () => ({
+    ttsModel: '/model.onnx',
+    tokens: '/tokens.txt',
+  })),
+}));
+
+describe('ttsNativeBridge', () => {
+  it('buildTtsInitBridgeOptions maps auto TTS options to bridge map', async () => {
+    const bridge = await buildTtsInitBridgeOptions({
+      modelSource: { kind: 'fs', path: '/models/vits-piper-en' },
+      modelType: 'vits',
+      debug: true,
+      modelOptions: { vits: { noiseScale: 0.667 } },
+    });
+    expect(bridge).toEqual({
+      initMode: 'auto',
+      modelDir: '/models/vits-piper-en',
+      modelType: 'vits',
+      debug: true,
+      noiseScale: 0.667,
+    });
+  });
+
+  it('buildTtsInitBridgeOptions maps custom TTS options to modelPaths', async () => {
+    const bridge = await buildTtsInitBridgeOptions({
+      initMode: 'custom',
+      modelType: 'vits',
+      customConfig: {
+        ttsModel: { kind: 'fs', path: '/model.onnx' },
+        tokens: { kind: 'fs', path: '/tokens.txt' },
+      },
+    });
+    expect(bridge.initMode).toBe('custom');
+    expect(bridge.modelDir).toBeUndefined();
+    expect(bridge.modelPaths).toEqual({
+      ttsModel: '/model.onnx',
+      tokens: '/tokens.txt',
+    });
+    expect(bridge.modelType).toBe('vits');
+  });
+});

--- a/src/tts/customConfig.ts
+++ b/src/tts/customConfig.ts
@@ -1,0 +1,117 @@
+import type { FileSource } from '../fileio/types';
+import { ModelCategory } from '../download/types';
+import {
+  assertCustomModelConfig,
+  resolveCustomModelConfigPaths,
+} from '../detect/customConfigResolver';
+import type { TTSConcreteModelType } from './types';
+
+export const TtsErrorCode = {
+  INVALID_ARGUMENT: 'TTS_INVALID_ARGUMENT',
+} as const;
+
+export type TtsCustomPathKey =
+  | 'ttsModel'
+  | 'tokens'
+  | 'lexicon'
+  | 'dataDir'
+  | 'voices'
+  | 'acousticModel'
+  | 'vocoder'
+  | 'encoder'
+  | 'decoder'
+  | 'lmFlow'
+  | 'lmMain'
+  | 'textConditioner'
+  | 'vocabJson'
+  | 'tokenScoresJson'
+  | 'durationPredictor'
+  | 'textEncoder'
+  | 'vectorEstimator'
+  | 'ttsJson'
+  | 'unicodeIndexer'
+  | 'voiceStyle';
+
+export interface TtsVitsCustomConfig {
+  ttsModel: FileSource;
+  tokens: FileSource;
+  dataDir?: FileSource;
+  lexicon?: FileSource;
+}
+
+export interface TtsMatchaCustomConfig {
+  acousticModel: FileSource;
+  vocoder: FileSource;
+  tokens: FileSource;
+  dataDir?: FileSource;
+  lexicon?: FileSource;
+}
+
+export interface TtsKokoroCustomConfig {
+  ttsModel: FileSource;
+  tokens: FileSource;
+  voices: FileSource;
+  dataDir: FileSource;
+  lexicon?: FileSource;
+}
+
+export interface TtsPocketCustomConfig {
+  lmFlow: FileSource;
+  lmMain: FileSource;
+  encoder: FileSource;
+  decoder: FileSource;
+  textConditioner: FileSource;
+  vocabJson: FileSource;
+  tokenScoresJson: FileSource;
+}
+
+export interface TtsZipvoiceCustomConfig {
+  encoder: FileSource;
+  decoder: FileSource;
+  vocoder: FileSource;
+  tokens: FileSource;
+  dataDir: FileSource;
+  lexicon: FileSource;
+}
+
+export interface TtsSupertonicCustomConfig {
+  durationPredictor: FileSource;
+  textEncoder: FileSource;
+  vectorEstimator: FileSource;
+  vocoder: FileSource;
+  ttsJson: FileSource;
+  unicodeIndexer: FileSource;
+  voiceStyle: FileSource;
+}
+
+export type TtsCustomConfigByModelType = {
+  vits: TtsVitsCustomConfig;
+  matcha: TtsMatchaCustomConfig;
+  kokoro: TtsKokoroCustomConfig;
+  kitten: TtsKokoroCustomConfig;
+  pocket: TtsPocketCustomConfig;
+  zipvoice: TtsZipvoiceCustomConfig;
+  supertonic: TtsSupertonicCustomConfig;
+};
+
+export type TtsCustomConfig = TtsCustomConfigByModelType[TTSConcreteModelType];
+
+export function assertTtsCustomConfig(
+  customConfig: Record<string, unknown>
+): void {
+  assertCustomModelConfig(customConfig, TtsErrorCode.INVALID_ARGUMENT);
+}
+
+export async function resolveTtsCustomConfigPaths(
+  modelType: TTSConcreteModelType,
+  customConfig: TtsCustomConfig
+): Promise<Record<string, string>> {
+  return resolveCustomModelConfigPaths({
+    category: ModelCategory.Tts,
+    modelType,
+    customConfig: customConfig as unknown as Record<string, unknown>,
+    errorCode: TtsErrorCode.INVALID_ARGUMENT,
+    unknownKeyMessage: (key, mt) =>
+      `Unknown customConfig key '${key}' for TTS modelType '${mt}'`,
+  });
+}

--- a/src/tts/index.ts
+++ b/src/tts/index.ts
@@ -27,6 +27,7 @@ import {
   toNativeSynthesisOptions,
 } from './ttsNativeBridge';
 import { resolvePublicLanguageHints } from '../model-languages';
+import { readNonEmptyDetectPathsMap } from '../detect/detectModelOutput';
 import { ModelCategory } from '../download/types';
 import {
   releasePipelineAudioBuffer,
@@ -319,6 +320,7 @@ export async function detectTtsModel(
       }
     }
   }
+  const paths = readNonEmptyDetectPathsMap(raw.paths);
   return {
     success: raw.success,
     isStreaming: true,
@@ -330,6 +332,7 @@ export async function detectTtsModel(
     ...(quantization != null ? { quantization } : {}),
     ...(sizeTier != null ? { sizeTier } : {}),
     ...(detectionSources.length > 0 ? { detectionSources } : {}),
+    ...(paths != null ? { paths } : {}),
   };
 }
 

--- a/src/tts/index.ts
+++ b/src/tts/index.ts
@@ -19,13 +19,9 @@ import {
   type DetectedModelEntry,
 } from '../types/modelDetect';
 import type { FileSource } from '../fileio/types';
-import {
-  resolveFileSourceForDetect,
-  resolveFileSourceForModelInit,
-} from '../detect/resolveModelInput';
+import { resolveFileSourceForDetect } from '../detect/resolveModelInput';
 import {
   buildTtsInitBridgeOptions,
-  expandTtsInitializeOptions,
   expandTtsUpdateOptions,
   flattenTtsModelOptionsForNative,
   toNativeSynthesisOptions,
@@ -363,14 +359,7 @@ export async function createTTS(
 ): Promise<TtsEngine> {
   const instanceId = `tts_${++ttsInstanceCounter}`;
 
-  const modelSource = options.modelSource;
-  const expanded = expandTtsInitializeOptions(options);
-  const flat = flattenTtsModelOptionsForNative(
-    expanded.modelType,
-    expanded.modelOptions
-  );
-  const resolvedPath = await resolveFileSourceForModelInit(modelSource);
-  const bridgeOptions = buildTtsInitBridgeOptions(resolvedPath, expanded, flat);
+  const bridgeOptions = await buildTtsInitBridgeOptions(options);
 
   const result = await SherpaOnnx.initializeTts(instanceId, bridgeOptions);
 
@@ -387,8 +376,10 @@ export async function createTTS(
 
   const firstDetected = result.detectedModels?.[0];
   const effectiveModelType: TTSModelType | undefined =
-    expanded.modelType && expanded.modelType !== 'auto'
-      ? expanded.modelType
+    options.initMode === 'custom'
+      ? options.modelType
+      : options.modelType && options.modelType !== 'auto'
+      ? options.modelType
       : (firstDetected?.type as TTSModelType);
 
   let destroyed = false;
@@ -595,6 +586,11 @@ export async function createTTS(
 // Export types and runtime type list
 export type {
   TTSInitializeOptions,
+  TTSInitOptionsShared,
+  TTSAutoInitOptionsBase,
+  TTSAutoInitializeOptions,
+  TTSCustomInitializeOptions,
+  TTSConcreteModelType,
   TTSInitializeOptionsAuto,
   TTSInitializeOptionsBase,
   TTSInitializeOptionsVits,
@@ -631,6 +627,14 @@ export type {
   TtsLivePipelineOptions,
 } from './types';
 export { TTS_MODEL_TYPES, isTtsModelType } from './types';
+export {
+  assertTtsCustomConfig,
+  resolveTtsCustomConfigPaths,
+  TtsErrorCode,
+  type TtsCustomConfig,
+  type TtsCustomConfigByModelType,
+  type TtsCustomPathKey,
+} from './customConfig';
 export {
   resolveLexiconPath,
   resolveTtsLanguagePolicy,

--- a/src/tts/ttsNativeBridge.ts
+++ b/src/tts/ttsNativeBridge.ts
@@ -1,6 +1,7 @@
 import type {
   TTSInitializeOptions,
   TTSModelType,
+  TTSCustomInitializeOptions,
   TtsSynthesisOptions,
   TtsKittenModelOptions,
   TtsKokoroModelOptions,
@@ -12,6 +13,8 @@ import type {
 import type { TtsInitBridgeOptions } from '../nativeBridge/initBridgeTypes';
 import { resolvePipelineAudioBufferId } from '../audiobuffer';
 import type { OfflineAudioBufferIdSource } from '../audiobuffer/types';
+import { resolveFileSourceForModelInit } from '../detect/resolveModelInput';
+import { resolveTtsCustomConfigPaths } from './customConfig';
 
 export type FlattenedTtsModelNativeOptions = {
   noiseScale: number | undefined;
@@ -95,53 +98,48 @@ function modelOptionsBagFromInit(
     return undefined;
   }
   switch (mt) {
-    case 'vits':
-      return { vits: options.modelOptions.vits };
-    case 'matcha':
-      return { matcha: options.modelOptions.matcha };
-    case 'kokoro':
-      return { kokoro: options.modelOptions.kokoro };
-    case 'kitten':
-      return { kitten: options.modelOptions.kitten };
+    case 'vits': {
+      const mo = options.modelOptions as { vits: TtsVitsModelOptions };
+      return { vits: mo.vits };
+    }
+    case 'matcha': {
+      const mo = options.modelOptions as { matcha: TtsMatchaModelOptions };
+      return { matcha: mo.matcha };
+    }
+    case 'kokoro': {
+      const mo = options.modelOptions as { kokoro: TtsKokoroModelOptions };
+      return { kokoro: mo.kokoro };
+    }
+    case 'kitten': {
+      const mo = options.modelOptions as { kitten: TtsKittenModelOptions };
+      return { kitten: mo.kitten };
+    }
     default:
       return undefined;
   }
 }
 
-export type ExpandedTtsInitFields = {
-  modelSource: TTSInitializeOptions['modelSource'];
-  modelType: TTSModelType | undefined;
-  provider: string | undefined;
-  numThreads: number | undefined;
-  debug: boolean | undefined;
-  modelOptions: TtsModelOptions | undefined;
-  ruleFsts: string | undefined;
-  ruleFars: string | undefined;
-  maxNumSentences: number | undefined;
-  silenceScale: number | undefined;
-  lexiconLanguageId: string | undefined;
-};
+function kokoroLangFromInit(options: TTSInitializeOptions): string | undefined {
+  const bag = modelOptionsBagFromInit(options);
+  const lang = bag?.kokoro?.lang;
+  return lang !== undefined && typeof lang === 'string' && lang.length > 0
+    ? lang
+    : undefined;
+}
 
-export type { TtsInitBridgeOptions };
-
-export function buildTtsInitBridgeOptions(
-  modelDir: string,
-  expanded: ExpandedTtsInitFields,
+function appendTtsScalarBridgeFields(
+  options: TTSInitializeOptions,
   flat: FlattenedTtsModelNativeOptions
-): TtsInitBridgeOptions {
-  const kokoroLang =
-    expanded.modelOptions?.kokoro?.lang !== undefined &&
-    typeof expanded.modelOptions.kokoro.lang === 'string' &&
-    expanded.modelOptions.kokoro.lang.length > 0
-      ? expanded.modelOptions.kokoro.lang
-      : undefined;
+): Omit<
+  TtsInitBridgeOptions,
+  'initMode' | 'modelDir' | 'modelPaths' | 'modelType'
+> {
+  const kokoroLang = kokoroLangFromInit(options);
   return {
-    modelDir,
-    modelType: expanded.modelType ?? 'auto',
-    ...(expanded.numThreads !== undefined
-      ? { numThreads: expanded.numThreads }
+    ...(options.numThreads !== undefined
+      ? { numThreads: options.numThreads }
       : {}),
-    ...(expanded.debug !== undefined ? { debug: expanded.debug } : {}),
+    ...(options.debug !== undefined ? { debug: options.debug } : {}),
     ...(flat.noiseScale !== undefined ? { noiseScale: flat.noiseScale } : {}),
     ...(flat.noiseScaleW !== undefined
       ? { noiseScaleW: flat.noiseScaleW }
@@ -149,38 +147,53 @@ export function buildTtsInitBridgeOptions(
     ...(flat.lengthScale !== undefined
       ? { lengthScale: flat.lengthScale }
       : {}),
-    ...(expanded.ruleFsts !== undefined ? { ruleFsts: expanded.ruleFsts } : {}),
-    ...(expanded.ruleFars !== undefined ? { ruleFars: expanded.ruleFars } : {}),
-    ...(expanded.maxNumSentences !== undefined
-      ? { maxNumSentences: expanded.maxNumSentences }
+    ...(options.ruleFsts !== undefined ? { ruleFsts: options.ruleFsts } : {}),
+    ...(options.ruleFars !== undefined ? { ruleFars: options.ruleFars } : {}),
+    ...(options.maxNumSentences !== undefined
+      ? { maxNumSentences: options.maxNumSentences }
       : {}),
-    ...(expanded.silenceScale !== undefined
-      ? { silenceScale: expanded.silenceScale }
+    ...(options.silenceScale !== undefined
+      ? { silenceScale: options.silenceScale }
       : {}),
-    ...(expanded.provider !== undefined ? { provider: expanded.provider } : {}),
-    ...(expanded.lexiconLanguageId !== undefined
-      ? { lexiconLanguageId: expanded.lexiconLanguageId }
-      : {}),
+    ...(options.provider !== undefined ? { provider: options.provider } : {}),
     ...(kokoroLang !== undefined ? { kokoroLang } : {}),
   };
 }
 
-export function expandTtsInitializeOptions(
+export type { TtsInitBridgeOptions };
+
+export async function buildTtsInitBridgeOptions(
   options: TTSInitializeOptions
-): ExpandedTtsInitFields {
+): Promise<TtsInitBridgeOptions> {
+  const flat = flattenTtsModelOptionsForNative(
+    options.modelType,
+    modelOptionsBagFromInit(options)
+  );
+  const scalarFields = appendTtsScalarBridgeFields(options, flat);
+
+  if (options.initMode === 'custom') {
+    const customOptions = options as TTSCustomInitializeOptions;
+    const modelPaths = await resolveTtsCustomConfigPaths(
+      customOptions.modelType,
+      customOptions.customConfig
+    );
+    return {
+      initMode: 'custom',
+      modelType: customOptions.modelType,
+      modelPaths,
+      ...scalarFields,
+    };
+  }
+
+  const modelDir = await resolveFileSourceForModelInit(options.modelSource);
   return {
-    modelSource: options.modelSource,
-    modelType: options.modelType,
-    provider:
-      options.provider !== undefined ? String(options.provider) : undefined,
-    numThreads: options.numThreads,
-    debug: options.debug,
-    modelOptions: modelOptionsBagFromInit(options),
-    ruleFsts: options.ruleFsts,
-    ruleFars: options.ruleFars,
-    maxNumSentences: options.maxNumSentences,
-    silenceScale: options.silenceScale,
-    lexiconLanguageId: options.lexiconLanguageId,
+    initMode: 'auto',
+    modelDir,
+    modelType: options.modelType ?? 'auto',
+    ...(options.lexiconLanguageId !== undefined
+      ? { lexiconLanguageId: options.lexiconLanguageId }
+      : {}),
+    ...scalarFields,
   };
 }
 

--- a/src/tts/types.ts
+++ b/src/tts/types.ts
@@ -50,6 +50,9 @@ export type TTSModelType =
   | 'supertonic'
   | 'auto';
 
+/** Concrete TTS model types (excludes `'auto'`). */
+export type TTSConcreteModelType = Exclude<TTSModelType, 'auto'>;
+
 export {
   DETECTION_SOURCES,
   isDetectionSource,
@@ -122,7 +125,7 @@ export interface TtsMatchaModelOptions {
  * Options for Kokoro models. Applied only when modelType is 'kokoro'.
  * Kotlin OfflineTtsKokoroModelConfig.
  *
- * Init `lang` is separate from {@link TTSInitializeOptionsBase.lexiconLanguageId} (lexicon file)
+ * Init `lang` is separate from {@link TTSAutoInitOptionsBase.lexiconLanguageId} (lexicon file)
  * and from {@link TtsSynthesisOptions.lang} (per-synthesis override).
  */
 export interface TtsKokoroModelOptions {
@@ -168,14 +171,8 @@ export interface TtsModelOptions {
   supertonic?: TtsSupertonicModelOptions;
 }
 
-/** Shared init fields (excluding modelType / modelOptions). */
-export type TTSInitializeOptionsBase = {
-  /**
-   * Path to the model directory.
-   * Can be an asset path, file system path, or auto-detection path.
-   */
-  modelSource: FileSource;
-
+/** Shared TTS init fields for auto and custom modes. */
+export type TTSInitOptionsShared = {
   /**
    * Execution provider (e.g. `'cpu'`, `'coreml'`, `'xnnpack'`, `'nnapi'`, `'qnn'`).
    * Use getCoreMlSupport(), getXnnpackSupport(), etc. to check availability. See execution-providers.md.
@@ -222,6 +219,16 @@ export type TTSInitializeOptionsBase = {
    * Default: 0.2.
    */
   silenceScale?: number;
+};
+
+/** Automatic model detection from a model directory (default). */
+export type TTSAutoInitOptionsBase = TTSInitOptionsShared & {
+  initMode?: 'auto';
+  /**
+   * Path to the model directory.
+   * Can be an asset path, file system path, or auto-detection path.
+   */
+  modelSource: FileSource;
 
   /**
    * Which detected lexicon file to load at init, from `detectTtsModel().lexiconLanguages`
@@ -235,52 +242,70 @@ export type TTSInitializeOptionsBase = {
   lexiconLanguageId?: string;
 };
 
+/** Alias for auto-init shared fields (includes `modelSource`). */
+export type TTSInitializeOptionsBase = TTSAutoInitOptionsBase;
+
+type TtsCustomModelOptionsFor<T extends TTSConcreteModelType> = T extends 'vits'
+  ? { modelOptions?: { vits: TtsVitsModelOptions } }
+  : T extends 'matcha'
+  ? { modelOptions?: { matcha: TtsMatchaModelOptions } }
+  : T extends 'kokoro'
+  ? { modelOptions?: { kokoro: TtsKokoroModelOptions } }
+  : T extends 'kitten'
+  ? { modelOptions?: { kitten: TtsKittenModelOptions } }
+  : { modelOptions?: never };
+
+/** Explicit per-file paths; skips native auto-detection. */
+export type TTSCustomInitializeOptions<
+  T extends TTSConcreteModelType = TTSConcreteModelType
+> = TTSInitOptionsShared & {
+  initMode: 'custom';
+  modelType: T;
+  customConfig: import('./customConfig').TtsCustomConfigByModelType[T];
+} & TtsCustomModelOptionsFor<T>;
+
 /** `modelType` omitted or `'auto'`: no `modelOptions` (set an explicit `modelType` to pass scales). */
-export type TTSInitializeOptionsAuto = TTSInitializeOptionsBase & {
+export type TTSInitializeOptionsAuto = TTSAutoInitOptionsBase & {
   modelType?: 'auto' | undefined;
   modelOptions?: never;
 };
 
-export type TTSInitializeOptionsVits = TTSInitializeOptionsBase & {
+export type TTSInitializeOptionsVits = TTSAutoInitOptionsBase & {
   modelType: 'vits';
   modelOptions?: { vits: TtsVitsModelOptions };
 };
 
-export type TTSInitializeOptionsMatcha = TTSInitializeOptionsBase & {
+export type TTSInitializeOptionsMatcha = TTSAutoInitOptionsBase & {
   modelType: 'matcha';
   modelOptions?: { matcha: TtsMatchaModelOptions };
 };
 
-export type TTSInitializeOptionsKokoro = TTSInitializeOptionsBase & {
+export type TTSInitializeOptionsKokoro = TTSAutoInitOptionsBase & {
   modelType: 'kokoro';
   modelOptions?: { kokoro: TtsKokoroModelOptions };
 };
 
-export type TTSInitializeOptionsKitten = TTSInitializeOptionsBase & {
+export type TTSInitializeOptionsKitten = TTSAutoInitOptionsBase & {
   modelType: 'kitten';
   modelOptions?: { kitten: TtsKittenModelOptions };
 };
 
-export type TTSInitializeOptionsPocket = TTSInitializeOptionsBase & {
+export type TTSInitializeOptionsPocket = TTSAutoInitOptionsBase & {
   modelType: 'pocket';
   modelOptions?: never;
 };
 
-export type TTSInitializeOptionsZipvoice = TTSInitializeOptionsBase & {
+export type TTSInitializeOptionsZipvoice = TTSAutoInitOptionsBase & {
   modelType: 'zipvoice';
   modelOptions?: never;
 };
 
-export type TTSInitializeOptionsSupertonic = TTSInitializeOptionsBase & {
+export type TTSInitializeOptionsSupertonic = TTSAutoInitOptionsBase & {
   modelType: 'supertonic';
   modelOptions?: never;
 };
 
-/**
- * Configuration for TTS initialization. Discriminated by `modelType`:
- * with `'auto'` or omitted, `modelOptions` is not allowed; with a concrete synthesizer type, only the matching `modelOptions` block is allowed.
- */
-export type TTSInitializeOptions =
+export type TTSAutoInitializeOptions =
   | TTSInitializeOptionsAuto
   | TTSInitializeOptionsVits
   | TTSInitializeOptionsMatcha
@@ -289,6 +314,14 @@ export type TTSInitializeOptions =
   | TTSInitializeOptionsPocket
   | TTSInitializeOptionsZipvoice
   | TTSInitializeOptionsSupertonic;
+
+/**
+ * Configuration for TTS initialization. Discriminated by `initMode` and `modelType`:
+ * auto mode scans a model directory; custom mode supplies explicit {@link FileSource} paths.
+ */
+export type TTSInitializeOptions =
+  | TTSAutoInitializeOptions
+  | TTSCustomInitializeOptions;
 
 /** No runtime parameter change. */
 export type TtsUpdateOptionsEmpty = {

--- a/src/types/modelDetect.ts
+++ b/src/types/modelDetect.ts
@@ -70,6 +70,8 @@ export interface TtsDetectModelResult extends ModelDetectResultBase {
    * Not the same as catalog `languages` hints.
    */
   lexiconLanguages?: ReadonlyArray<TtsLexiconLanguage>;
+  /** Resolved non-empty path keys from native file-based detection. */
+  paths?: Readonly<Record<string, string>>;
 }
 
 // ─── STT extension ──────────────────────────────────────────────────────
@@ -77,6 +79,8 @@ export interface TtsDetectModelResult extends ModelDetectResultBase {
 export interface SttDetectModelResult extends ModelDetectResultBase {
   /** True when model targets unsupported hardware-specific acceleration (RK35xx, Ascend, CANN). */
   isHardwareSpecificUnsupported?: boolean;
+  /** Resolved non-empty path keys from native file-based detection. */
+  paths?: Readonly<Record<string, string>>;
 }
 
 // ─── Enhancement extension ─────────────────────────────────────────────

--- a/src/vad/__tests__/customConfig.test.ts
+++ b/src/vad/__tests__/customConfig.test.ts
@@ -1,0 +1,81 @@
+jest.mock('../../detect/validateCustomModelPaths', () => ({
+  getCustomModelPathRequirements: jest.fn(async () => ({
+    required: ['model'],
+    optional: [],
+  })),
+  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+}));
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveModelFileSources: jest.fn(async (sources: Record<string, unknown>) => {
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(sources)) {
+      const path = (value as { path?: string })?.path;
+      if (path) out[key] = path;
+    }
+    return out;
+  }),
+}));
+
+import {
+  assertVadCustomConfig,
+  resolveVadCustomConfigPaths,
+} from '../customConfig';
+import {
+  getCustomModelPathRequirements,
+  validateCustomModelPaths,
+} from '../../detect/validateCustomModelPaths';
+import { VadErrorCode } from '../customConfig';
+
+const mockGetRequirements = getCustomModelPathRequirements as jest.Mock;
+const mockValidate = validateCustomModelPaths as jest.Mock;
+
+describe('assertVadCustomConfig', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  it('accepts FileSource values', () => {
+    expect(() =>
+      assertVadCustomConfig({
+        model: fsPath('/silero_vad.onnx'),
+      })
+    ).not.toThrow();
+  });
+
+  it('throws VAD_INVALID_ARGUMENT when a value is not a FileSource', () => {
+    expect(() =>
+      assertVadCustomConfig({
+        model: '/silero_vad.onnx',
+      })
+    ).toThrow(VadErrorCode.INVALID_ARGUMENT);
+  });
+});
+
+describe('resolveVadCustomConfigPaths', () => {
+  const fsPath = (path: string) => ({ kind: 'fs' as const, path });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetRequirements.mockResolvedValue({
+      required: ['model'],
+      optional: [],
+    });
+    mockValidate.mockResolvedValue({ ok: true });
+  });
+
+  it('rejects unknown keys using native schema', async () => {
+    await expect(
+      resolveVadCustomConfigPaths('silero_vad', {
+        model: fsPath('/silero_vad.onnx'),
+        unknownKey: fsPath('/x.onnx'),
+      } as never)
+    ).rejects.toThrow(VadErrorCode.INVALID_ARGUMENT);
+  });
+
+  it('resolves paths via shared resolver', async () => {
+    const paths = await resolveVadCustomConfigPaths('ten_vad', {
+      model: fsPath('/ten_vad.onnx'),
+    });
+    expect(paths).toEqual({ model: '/ten_vad.onnx' });
+    expect(mockValidate).toHaveBeenCalled();
+  });
+});

--- a/src/vad/__tests__/customConfig.test.ts
+++ b/src/vad/__tests__/customConfig.test.ts
@@ -1,10 +1,15 @@
-jest.mock('../../detect/validateCustomModelPaths', () => ({
-  getCustomModelPathRequirements: jest.fn(async () => ({
-    required: ['model'],
-    optional: [],
-  })),
-  validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
-}));
+jest.mock('../../detect/validateCustomModelPaths', () => {
+  const helpers = jest.requireActual(
+    '../../detect/customModelPathRequirements'
+  );
+  return {
+    ...helpers,
+    getCustomModelPathRequirements: jest.fn(async () => ({
+      fields: [{ key: 'model', required: true, kind: 'file' }],
+    })),
+    validateCustomModelPaths: jest.fn(async () => ({ ok: true })),
+  };
+});
 
 jest.mock('../../detect/resolveModelInput', () => ({
   resolveModelFileSources: jest.fn(async (sources: Record<string, unknown>) => {
@@ -56,8 +61,7 @@ describe('resolveVadCustomConfigPaths', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetRequirements.mockResolvedValue({
-      required: ['model'],
-      optional: [],
+      fields: [{ key: 'model', required: true, kind: 'file' }],
     });
     mockValidate.mockResolvedValue({ ok: true });
   });

--- a/src/vad/__tests__/vadNativeBridge.test.ts
+++ b/src/vad/__tests__/vadNativeBridge.test.ts
@@ -1,0 +1,43 @@
+import { buildVadInitBridgeOptions } from '../vadNativeBridge';
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveFileSourceForModelInit: jest.fn(async () => '/models/silero-vad'),
+}));
+
+jest.mock('../customConfig', () => ({
+  resolveVadCustomConfigPaths: jest.fn(async () => ({
+    model: '/models/silero_vad.onnx',
+  })),
+}));
+
+describe('vadNativeBridge', () => {
+  it('buildVadInitBridgeOptions maps auto VAD options to bridge map', async () => {
+    const bridge = await buildVadInitBridgeOptions({
+      modelSource: { kind: 'fs', path: '/models/silero-vad' },
+      modelType: 'silero_vad',
+      sampleRate: 16000,
+      runtimeOptions: { sileroVad: { scoreThreshold: 0.5 } },
+    });
+    expect(bridge).toEqual({
+      initMode: 'auto',
+      modelDir: '/models/silero-vad',
+      modelType: 'silero_vad',
+      sampleRate: 16000,
+      threshold: 0.5,
+    });
+  });
+
+  it('buildVadInitBridgeOptions maps custom VAD options to modelPaths', async () => {
+    const bridge = await buildVadInitBridgeOptions({
+      initMode: 'custom',
+      modelType: 'silero_vad',
+      customConfig: {
+        model: { kind: 'fs', path: '/models/silero_vad.onnx' },
+      },
+    });
+    expect(bridge.initMode).toBe('custom');
+    expect(bridge.modelDir).toBeUndefined();
+    expect(bridge.modelPaths).toEqual({ model: '/models/silero_vad.onnx' });
+    expect(bridge.modelType).toBe('silero_vad');
+  });
+});

--- a/src/vad/customConfig.ts
+++ b/src/vad/customConfig.ts
@@ -1,0 +1,37 @@
+import type { FileSource } from '../fileio/types';
+import { ModelCategory } from '../download/types';
+import {
+  assertCustomModelConfig,
+  resolveCustomModelConfigPaths,
+} from '../detect/customConfigResolver';
+import type { VADConcreteModelType } from './types';
+
+export const VadErrorCode = {
+  INVALID_ARGUMENT: 'VAD_INVALID_ARGUMENT',
+} as const;
+
+export type VadCustomPathKey = 'model';
+
+export interface VadCustomConfig {
+  model: FileSource;
+}
+
+export function assertVadCustomConfig(
+  customConfig: Record<string, unknown>
+): void {
+  assertCustomModelConfig(customConfig, VadErrorCode.INVALID_ARGUMENT);
+}
+
+export async function resolveVadCustomConfigPaths(
+  modelType: VADConcreteModelType,
+  customConfig: VadCustomConfig
+): Promise<Record<string, string>> {
+  return resolveCustomModelConfigPaths({
+    category: ModelCategory.Vad,
+    modelType,
+    customConfig: customConfig as unknown as Record<string, unknown>,
+    errorCode: VadErrorCode.INVALID_ARGUMENT,
+    unknownKeyMessage: (key, mt) =>
+      `Unknown customConfig key '${key}' for VAD modelType '${mt}'`,
+  });
+}

--- a/src/vad/engine.ts
+++ b/src/vad/engine.ts
@@ -1,9 +1,7 @@
 import { NativeEventEmitter, NativeModules } from 'react-native';
 import SherpaOnnx from '../NativeSherpaOnnx';
-import {
-  resolveFileSourceForDetect,
-  resolveFileSourceForModelInit,
-} from '../detect/resolveModelInput';
+import { resolveFileSourceForDetect } from '../detect/resolveModelInput';
+import { buildVadInitBridgeOptions } from './vadNativeBridge';
 import { resolvePublicLanguageHints } from '../model-languages';
 import { ModelCategory } from '../download/types';
 import {
@@ -38,7 +36,6 @@ import type {
   VADOfflineResult,
   VADPipelineHandle,
   VADPipelineStatus,
-  VADModelType,
   VADSummary,
 } from './types';
 import type { FileSource } from '../fileio/types';
@@ -175,35 +172,6 @@ function toSummary(raw: any): VADSummary {
   };
 }
 
-function resolveRuntimeTuningOptions(
-  runtimeOptions: VADInitializeOptions['runtimeOptions'],
-  modelType: VADModelType
-) {
-  if (!runtimeOptions) {
-    return undefined;
-  }
-  if (modelType === 'silero_vad') {
-    if ('sileroVad' in runtimeOptions) {
-      return runtimeOptions.sileroVad;
-    }
-    throw Object.assign(
-      new Error(
-        'VAD runtime options mismatch: expected sileroVad options for silero_vad model'
-      ),
-      { code: 'VAD_INVALID_OPTIONS' }
-    );
-  }
-  if ('tenVad' in runtimeOptions) {
-    return runtimeOptions.tenVad;
-  }
-  throw Object.assign(
-    new Error(
-      'VAD runtime options mismatch: expected tenVad options for ten_vad model'
-    ),
-    { code: 'VAD_INVALID_OPTIONS' }
-  );
-}
-
 export async function detectVadModel(
   source: FileSource,
   options?: {
@@ -277,45 +245,8 @@ export async function createStreamingVAD(
   options: VADInitializeOptions
 ): Promise<VADEngine> {
   const instanceId = `vad_${++vadInstanceCounter}`;
-  const modelDir = await resolveFileSourceForModelInit(options.modelSource);
-  let resolvedModelType: 'auto' | VADModelType = options.modelType ?? 'auto';
-  if (resolvedModelType === 'auto') {
-    const detect = await SherpaOnnx.detectVadModel(modelDir, null, 'auto');
-    if (
-      !detect.success ||
-      detect.modelType == null ||
-      detect.modelType === ''
-    ) {
-      const reason =
-        (typeof detect.error === 'string' ? detect.error.trim() : '') ||
-        'Failed to detect VAD model type in auto mode';
-      throw Object.assign(new Error(reason), {
-        code: 'VAD_MODEL_INIT_FAILED',
-      });
-    }
-    resolvedModelType = detect.modelType as VADModelType;
-  }
-  const runtimeTuning = resolveRuntimeTuningOptions(
-    options.runtimeOptions,
-    resolvedModelType
-  );
-  await SherpaOnnx.initializeVad(instanceId, {
-    modelDir,
-    modelType: resolvedModelType,
-    sampleRate: options.sampleRate,
-    silenceDurationMs: runtimeTuning?.minSilenceDurationMs,
-    speechDurationMs: runtimeTuning?.minSpeechDurationMs,
-    maxSpeechDurationS:
-      typeof runtimeTuning?.maxSpeechDurationMs === 'number'
-        ? runtimeTuning.maxSpeechDurationMs / 1000
-        : undefined,
-    minSpeechDurationMs: runtimeTuning?.minSpeechDurationMs,
-    threshold: runtimeTuning?.scoreThreshold,
-    windowSize: runtimeTuning?.windowSize,
-    provider: options.provider,
-    numThreads: options.numThreads,
-    debug: options.debug,
-  });
+  const bridgeOptions = await buildVadInitBridgeOptions(options);
+  await SherpaOnnx.initializeVad(instanceId, bridgeOptions);
 
   let destroyed = false;
   let activePipelineId: string | null = null;

--- a/src/vad/index.ts
+++ b/src/vad/index.ts
@@ -6,6 +6,10 @@ export type {
   ModelDetectResultBase,
   OrchestrationProgress,
   VADModelType,
+  VADConcreteModelType,
+  VADInitOptionsShared,
+  VADAutoInitializeOptions,
+  VADCustomInitializeOptions,
   VADDetectResult,
   VADEngine,
   VADInitializeOptions,
@@ -23,3 +27,10 @@ export type {
   VADSpeechStateChangedEvent,
 } from './types';
 export { DETECTION_SOURCES, VAD_MODEL_TYPES, isDetectionSource } from './types';
+export {
+  assertVadCustomConfig,
+  resolveVadCustomConfigPaths,
+  VadErrorCode,
+  type VadCustomConfig,
+  type VadCustomPathKey,
+} from './customConfig';

--- a/src/vad/types.ts
+++ b/src/vad/types.ts
@@ -66,15 +66,39 @@ export type TenVadRuntimeOptions = {
 
 export type VADRuntimeOptions = SileroVadRuntimeOptions | TenVadRuntimeOptions;
 
-export type VADInitializeOptions = {
-  modelSource: FileSource;
-  modelType?: VADModelType | 'auto';
+/** Concrete VAD model types (excludes `'auto'`). */
+export type VADConcreteModelType = VADModelType;
+
+/** Shared VAD init fields for auto and custom modes. */
+export type VADInitOptionsShared = {
   sampleRate?: number;
   runtimeOptions?: VADRuntimeOptions;
   provider?: string;
   numThreads?: number;
   debug?: boolean;
 };
+
+/** Automatic model detection from a model directory (default). */
+export type VADAutoInitializeOptions = VADInitOptionsShared & {
+  initMode?: 'auto';
+  modelSource: FileSource;
+  modelType?: VADModelType | 'auto';
+};
+
+/** Explicit model file path; skips native auto-detection. */
+export type VADCustomInitializeOptions = VADInitOptionsShared & {
+  initMode: 'custom';
+  modelType: VADConcreteModelType;
+  customConfig: import('./customConfig').VadCustomConfig;
+};
+
+/**
+ * Configuration for VAD initialization. Discriminated by `initMode`:
+ * auto mode scans a model directory; custom mode supplies an explicit {@link FileSource} for the ONNX file.
+ */
+export type VADInitializeOptions =
+  | VADAutoInitializeOptions
+  | VADCustomInitializeOptions;
 
 export type VADLiveRunOptions = {
   /**

--- a/src/vad/vadNativeBridge.ts
+++ b/src/vad/vadNativeBridge.ts
@@ -1,0 +1,153 @@
+import type {
+  VADAutoInitializeOptions,
+  VADCustomInitializeOptions,
+  VADInitializeOptions,
+  VADModelType,
+  VADRuntimeOptions,
+  VADRuntimeTuningOptions,
+} from './types';
+import type { VadInitBridgeOptions } from '../nativeBridge/initBridgeTypes';
+import { resolveFileSourceForModelInit } from '../detect/resolveModelInput';
+import { resolveVadCustomConfigPaths } from './customConfig';
+
+export type { VadInitBridgeOptions };
+
+function flattenRuntimeTuning(
+  tuning: VADRuntimeTuningOptions
+): Pick<
+  VadInitBridgeOptions,
+  | 'threshold'
+  | 'silenceDurationMs'
+  | 'speechDurationMs'
+  | 'minSpeechDurationMs'
+  | 'maxSpeechDurationS'
+  | 'windowSize'
+> {
+  return {
+    ...(tuning.scoreThreshold !== undefined
+      ? { threshold: tuning.scoreThreshold }
+      : {}),
+    ...(tuning.minSilenceDurationMs !== undefined
+      ? { silenceDurationMs: tuning.minSilenceDurationMs }
+      : {}),
+    ...(tuning.minSpeechDurationMs !== undefined
+      ? {
+          speechDurationMs: tuning.minSpeechDurationMs,
+          minSpeechDurationMs: tuning.minSpeechDurationMs,
+        }
+      : {}),
+    ...(typeof tuning.maxSpeechDurationMs === 'number'
+      ? { maxSpeechDurationS: tuning.maxSpeechDurationMs / 1000 }
+      : {}),
+    ...(tuning.windowSize !== undefined
+      ? { windowSize: tuning.windowSize }
+      : {}),
+  };
+}
+
+function resolveRuntimeTuningOptions(
+  runtimeOptions: VADRuntimeOptions | undefined,
+  modelType: VADModelType
+): VADRuntimeTuningOptions | undefined {
+  if (!runtimeOptions) {
+    return undefined;
+  }
+  if (modelType === 'silero_vad') {
+    if ('sileroVad' in runtimeOptions) {
+      return runtimeOptions.sileroVad;
+    }
+    throw Object.assign(
+      new Error(
+        'VAD runtime options mismatch: expected sileroVad options for silero_vad model'
+      ),
+      { code: 'VAD_INVALID_OPTIONS' }
+    );
+  }
+  if ('tenVad' in runtimeOptions) {
+    return runtimeOptions.tenVad;
+  }
+  throw Object.assign(
+    new Error(
+      'VAD runtime options mismatch: expected tenVad options for ten_vad model'
+    ),
+    { code: 'VAD_INVALID_OPTIONS' }
+  );
+}
+
+function runtimeTuningFromOptions(
+  runtimeOptions: VADRuntimeOptions | undefined,
+  modelType: VADModelType | 'auto'
+): VADRuntimeTuningOptions | undefined {
+  if (!runtimeOptions) {
+    return undefined;
+  }
+  if (modelType === 'auto') {
+    if ('sileroVad' in runtimeOptions && runtimeOptions.sileroVad) {
+      return runtimeOptions.sileroVad;
+    }
+    if ('tenVad' in runtimeOptions && runtimeOptions.tenVad) {
+      return runtimeOptions.tenVad;
+    }
+    return undefined;
+  }
+  return resolveRuntimeTuningOptions(runtimeOptions, modelType);
+}
+
+function appendSharedInitBridgeFields(
+  options: VADInitializeOptions,
+  modelTypeForTuning: VADModelType | 'auto'
+): Omit<
+  VadInitBridgeOptions,
+  'initMode' | 'modelDir' | 'modelPaths' | 'modelType'
+> {
+  const tuning = runtimeTuningFromOptions(
+    options.runtimeOptions,
+    modelTypeForTuning
+  );
+  const flat = tuning ? flattenRuntimeTuning(tuning) : {};
+  return {
+    ...(options.sampleRate !== undefined
+      ? { sampleRate: options.sampleRate }
+      : {}),
+    ...flat,
+    ...(options.provider !== undefined ? { provider: options.provider } : {}),
+    ...(options.numThreads !== undefined
+      ? { numThreads: options.numThreads }
+      : {}),
+    ...(options.debug !== undefined ? { debug: options.debug } : {}),
+  };
+}
+
+export async function buildVadInitBridgeOptions(
+  options: VADInitializeOptions
+): Promise<VadInitBridgeOptions> {
+  const sharedFields = appendSharedInitBridgeFields(
+    options,
+    options.initMode === 'custom'
+      ? options.modelType
+      : options.modelType ?? 'auto'
+  );
+
+  if (options.initMode === 'custom') {
+    const customOptions = options as VADCustomInitializeOptions;
+    const modelPaths = await resolveVadCustomConfigPaths(
+      customOptions.modelType,
+      customOptions.customConfig
+    );
+    return {
+      initMode: 'custom',
+      modelType: customOptions.modelType,
+      modelPaths,
+      ...sharedFields,
+    };
+  }
+
+  const autoOptions = options as VADAutoInitializeOptions;
+  const modelDir = await resolveFileSourceForModelInit(autoOptions.modelSource);
+  return {
+    initMode: 'auto',
+    modelDir,
+    modelType: autoOptions.modelType ?? 'auto',
+    ...sharedFields,
+  };
+}

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -39,6 +39,7 @@ set(PRODUCTION_SOURCES
   "${MODEL_DETECT_DIR}/vad/sherpa-onnx-vad-catalog-metadata.cpp"
   "${MODEL_DETECT_DIR}/vad/sherpa-onnx-model-detect-vad.cpp"
   "${MODEL_DETECT_DIR}/stt/sherpa-onnx-validate-stt.cpp"
+  "${MODEL_DETECT_DIR}/stt/sherpa-onnx-validate-online-stt.cpp"
   "${MODEL_DETECT_DIR}/tts/sherpa-onnx-validate-tts.cpp"
   "${MODEL_DETECT_DIR}/enhancement/sherpa-onnx-validate-enhancement.cpp"
   "${MODEL_DETECT_DIR}/vad/sherpa-onnx-validate-vad.cpp"

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -15,6 +15,8 @@ set(JNI_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../android/src/main/cpp/jni")
 set(PRODUCTION_SOURCES
   "${MODEL_DETECT_DIR}/common/sherpa-onnx-model-detect-helper.cpp"
   "${MODEL_DETECT_DIR}/common/sherpa-onnx-model-detect-unified.cpp"
+  "${MODEL_DETECT_DIR}/common/sherpa-onnx-model-path-fill.cpp"
+  "${MODEL_DETECT_DIR}/common/sherpa-onnx-validate-custom.cpp"
   "${MODEL_DETECT_DIR}/common/sherpa-onnx-catalog-metadata.cpp"
   "${MODEL_DETECT_DIR}/alignment/sherpa-onnx-model-detect-alignment.cpp"
   "${MODEL_DETECT_DIR}/alignment/sherpa-onnx-validate-alignment.cpp"

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(model_detect_test
   "${MODEL_DETECT_TEST_DIR}/model_detect_test.cpp"
   "${MODEL_DETECT_TEST_DIR}/model_detect_test_utils.cpp"
   "${MODEL_DETECT_TEST_DIR}/tts_catalog_hints_test.cpp"
+  "${MODEL_DETECT_TEST_DIR}/custom_path_requirements_catalog_test.cpp"
 )
 
 target_sources(model_detect_test PRIVATE ${PRODUCTION_SOURCES})

--- a/test/cpp/model_detect/custom_path_requirements_catalog_test.cpp
+++ b/test/cpp/model_detect/custom_path_requirements_catalog_test.cpp
@@ -1,0 +1,271 @@
+/**
+ * Catalog test: GetCustomModelPathRequirements must match the static tables in
+ * sherpa-onnx-validate-*.cpp (source of truth for custom-init UI required/optional).
+ */
+#include "sherpa-onnx-validate-custom.h"
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct FieldExpectation {
+    const char* key;
+    bool required;
+    std::optional<bool> isDirectory;
+};
+
+using FieldList = std::vector<FieldExpectation>;
+
+void ExpectRequirementsMatch(
+    const char* category,
+    const char* modelType,
+    const FieldList& expected
+) {
+    const auto reqs = sherpaonnx::GetCustomModelPathRequirements(category, modelType);
+    ASSERT_EQ(reqs.fields.size(), expected.size())
+        << category << "/" << modelType << " field count mismatch";
+    for (const auto& exp : expected) {
+        const auto it = std::find_if(
+            reqs.fields.begin(),
+            reqs.fields.end(),
+            [&](const sherpaonnx::CustomPathFieldSpec& field) {
+                return field.key == exp.key;
+            });
+        ASSERT_NE(it, reqs.fields.end())
+            << category << "/" << modelType << " missing field " << exp.key;
+        EXPECT_EQ(it->required, exp.required)
+            << category << "/" << modelType << " required flag for " << exp.key;
+        if (exp.isDirectory.has_value()) {
+            EXPECT_EQ(it->isDirectory, *exp.isDirectory)
+                << category << "/" << modelType << " isDirectory for " << exp.key;
+        } else {
+            EXPECT_FALSE(it->isDirectory)
+                << category << "/" << modelType << " isDirectory for " << exp.key;
+        }
+    }
+}
+
+const FieldList kSttTransducerFields = {
+    {"encoder", true, std::nullopt},
+    {"decoder", true, std::nullopt},
+    {"joiner", true, std::nullopt},
+    {"tokens", true, std::nullopt},
+    {"bpeVocab", false, std::nullopt},
+};
+
+const FieldList kSttCtcFields = {
+    {"ctcModel", true, std::nullopt},
+    {"tokens", true, std::nullopt},
+};
+
+const FieldList kSttParaformerOfflineFields = {
+    {"paraformerModel", true, std::nullopt},
+    {"tokens", true, std::nullopt},
+};
+
+const FieldList kSttWhisperFields = {
+    {"whisperEncoder", true, std::nullopt},
+    {"whisperDecoder", true, std::nullopt},
+    {"tokens", true, std::nullopt},
+};
+
+const FieldList kSttFunAsrNanoFields = {
+    {"funasrEncoderAdaptor", true, std::nullopt},
+    {"funasrLLM", true, std::nullopt},
+    {"funasrEmbedding", true, std::nullopt},
+    {"funasrTokenizer", true, std::nullopt},
+};
+
+const FieldList kSttQwen3AsrFields = {
+    {"qwen3ConvFrontend", true, std::nullopt},
+    {"qwen3Encoder", true, std::nullopt},
+    {"qwen3Decoder", true, std::nullopt},
+    {"qwen3Tokenizer", true, std::nullopt},
+};
+
+const FieldList kSttCohereFields = {
+    {"cohereEncoder", true, std::nullopt},
+    {"cohereDecoder", true, std::nullopt},
+    {"tokens", true, std::nullopt},
+};
+
+const FieldList kSttMoonshineV1Fields = {
+    {"moonshinePreprocessor", true, std::nullopt},
+    {"moonshineEncoder", true, std::nullopt},
+    {"moonshineUncachedDecoder", true, std::nullopt},
+    {"moonshineCachedDecoder", true, std::nullopt},
+    {"tokens", true, std::nullopt},
+};
+
+const FieldList kSttMoonshineV2Fields = {
+    {"moonshineEncoder", true, std::nullopt},
+    {"moonshineMergedDecoder", true, std::nullopt},
+    {"tokens", true, std::nullopt},
+};
+
+const FieldList kSttEncoderDecoderTokensFields = {
+    {"fireRedEncoder", true, std::nullopt},
+    {"fireRedDecoder", true, std::nullopt},
+    {"tokens", true, std::nullopt},
+};
+
+const FieldList kSttSingleModelTokensFields = {
+    {"dolphinModel", true, std::nullopt},
+    {"tokens", true, std::nullopt},
+};
+
+const FieldList kStreamingTransducerFields = {
+    {"encoder", true, std::nullopt},
+    {"decoder", true, std::nullopt},
+    {"joiner", true, std::nullopt},
+    {"tokens", true, std::nullopt},
+};
+
+const FieldList kStreamingParaformerFields = {
+    {"encoder", true, std::nullopt},
+    {"decoder", true, std::nullopt},
+    {"tokens", true, std::nullopt},
+};
+
+const FieldList kStreamingSingleModelFields = {
+    {"model", true, std::nullopt},
+    {"tokens", true, std::nullopt},
+};
+
+const FieldList kTtsVitsFields = {
+    {"ttsModel", true, false},
+    {"tokens", true, false},
+    {"dataDir", false, true},
+    {"lexicon", false, false},
+};
+
+const FieldList kTtsMatchaFields = {
+    {"acousticModel", true, false},
+    {"vocoder", true, false},
+    {"tokens", true, false},
+    {"dataDir", false, true},
+    {"lexicon", false, false},
+};
+
+const FieldList kTtsKokoroFields = {
+    {"ttsModel", true, false},
+    {"tokens", true, false},
+    {"voices", true, false},
+    {"dataDir", true, true},
+    {"lexicon", false, false},
+};
+
+const FieldList kTtsPocketFields = {
+    {"lmFlow", true, false},
+    {"lmMain", true, false},
+    {"encoder", true, false},
+    {"decoder", true, false},
+    {"textConditioner", true, false},
+    {"vocabJson", true, false},
+    {"tokenScoresJson", true, false},
+};
+
+const FieldList kTtsZipvoiceFields = {
+    {"encoder", true, false},
+    {"decoder", true, false},
+    {"vocoder", true, false},
+    {"tokens", true, false},
+    {"dataDir", true, true},
+    {"lexicon", true, false},
+};
+
+const FieldList kTtsSupertonicFields = {
+    {"durationPredictor", true, false},
+    {"textEncoder", true, false},
+    {"vectorEstimator", true, false},
+    {"vocoder", true, false},
+    {"ttsJson", true, false},
+    {"unicodeIndexer", true, false},
+    {"voiceStyle", true, false},
+};
+
+}  // namespace
+
+TEST(CustomPathRequirementsCatalog, OfflineSttTransducerFamily) {
+    ExpectRequirementsMatch("stt", "transducer", kSttTransducerFields);
+    ExpectRequirementsMatch("stt", "nemo_transducer", kSttTransducerFields);
+}
+
+TEST(CustomPathRequirementsCatalog, OfflineSttCtcFamily) {
+    for (const char* modelType :
+         {"nemo_ctc", "wenet_ctc", "sense_voice", "zipformer_ctc", "ctc", "tone_ctc"}) {
+        ExpectRequirementsMatch("stt", modelType, kSttCtcFields);
+    }
+}
+
+TEST(CustomPathRequirementsCatalog, OfflineSttDistinctLayouts) {
+    ExpectRequirementsMatch("stt", "paraformer", kSttParaformerOfflineFields);
+    ExpectRequirementsMatch("stt", "whisper", kSttWhisperFields);
+    ExpectRequirementsMatch("stt", "funasr_nano", kSttFunAsrNanoFields);
+    ExpectRequirementsMatch("stt", "qwen3_asr", kSttQwen3AsrFields);
+    ExpectRequirementsMatch("stt", "cohere_transcribe", kSttCohereFields);
+    ExpectRequirementsMatch("stt", "moonshine", kSttMoonshineV1Fields);
+    ExpectRequirementsMatch("stt", "moonshine_v2", kSttMoonshineV2Fields);
+    ExpectRequirementsMatch("stt", "fire_red_asr", kSttEncoderDecoderTokensFields);
+    ExpectRequirementsMatch("stt", "canary", {
+        {"canaryEncoder", true, std::nullopt},
+        {"canaryDecoder", true, std::nullopt},
+        {"tokens", true, std::nullopt},
+    });
+    ExpectRequirementsMatch("stt", "dolphin", kSttSingleModelTokensFields);
+    ExpectRequirementsMatch("stt", "omnilingual", {
+        {"omnilingualModel", true, std::nullopt},
+        {"tokens", true, std::nullopt},
+    });
+    ExpectRequirementsMatch("stt", "medasr", {
+        {"medasrModel", true, std::nullopt},
+        {"tokens", true, std::nullopt},
+    });
+    ExpectRequirementsMatch("stt", "telespeech_ctc", {
+        {"telespeechCtcModel", true, std::nullopt},
+        {"tokens", true, std::nullopt},
+    });
+}
+
+TEST(CustomPathRequirementsCatalog, StreamingSttLayouts) {
+    ExpectRequirementsMatch("stt_streaming", "transducer", kStreamingTransducerFields);
+    ExpectRequirementsMatch("stt_streaming", "nemo_transducer", kStreamingTransducerFields);
+    ExpectRequirementsMatch("stt_streaming", "paraformer", kStreamingParaformerFields);
+    for (const char* modelType : {"zipformer2_ctc", "nemo_ctc", "tone_ctc"}) {
+        ExpectRequirementsMatch("stt_streaming", modelType, kStreamingSingleModelFields);
+    }
+}
+
+TEST(CustomPathRequirementsCatalog, TtsLayouts) {
+    ExpectRequirementsMatch("tts", "vits", kTtsVitsFields);
+    ExpectRequirementsMatch("tts", "matcha", kTtsMatchaFields);
+    ExpectRequirementsMatch("tts", "kokoro", kTtsKokoroFields);
+    ExpectRequirementsMatch("tts", "kitten", kTtsKokoroFields);
+    ExpectRequirementsMatch("tts", "pocket", kTtsPocketFields);
+    ExpectRequirementsMatch("tts", "zipvoice", kTtsZipvoiceFields);
+    ExpectRequirementsMatch("tts", "supertonic", kTtsSupertonicFields);
+}
+
+TEST(CustomPathRequirementsCatalog, VadEnhancementAlignmentPunctuation) {
+    ExpectRequirementsMatch("vad", "silero_vad", {{"model", true, std::nullopt}});
+    ExpectRequirementsMatch("vad", "ten_vad", {{"model", true, std::nullopt}});
+    ExpectRequirementsMatch("enhancement", "gtcrn", {{"model", true, std::nullopt}});
+    ExpectRequirementsMatch("enhancement", "dpdfnet", {{"model", true, std::nullopt}});
+    ExpectRequirementsMatch("alignment", "wav2vec2", {{"model", true, std::nullopt}});
+    ExpectRequirementsMatch("punctuation", "ct_transformer", {{"ct_transformer", true, std::nullopt}});
+    ExpectRequirementsMatch("punctuation", "cnn_bilstm", {
+        {"cnn_bilstm", true, std::nullopt},
+        {"bpe_vocab", true, std::nullopt},
+    });
+}
+
+TEST(CustomPathRequirementsCatalog, UnknownModelTypesReturnEmpty) {
+    EXPECT_TRUE(sherpaonnx::GetCustomModelPathRequirements("stt", "unknown_type").fields.empty());
+    EXPECT_TRUE(
+        sherpaonnx::GetCustomModelPathRequirements("stt_streaming", "wenet_ctc").fields.empty());
+    EXPECT_TRUE(sherpaonnx::GetCustomModelPathRequirements("tts", "unknown_type").fields.empty());
+}

--- a/test/cpp/model_detect/model_detect_test.cpp
+++ b/test/cpp/model_detect/model_detect_test.cpp
@@ -26,6 +26,7 @@
 #include "sherpa-onnx-model-detect-unified.h"
 #include "sherpa-onnx-model-detect-helper.h"
 #include "sherpa-onnx-validate-stt.h"
+#include "sherpa-onnx-validate-online-stt.h"
 #include "sherpa-onnx-validate-tts.h"
 #include "sherpa-onnx-validate-enhancement.h"
 #include "sherpa-onnx-validate-vad.h"
@@ -803,6 +804,34 @@ TEST(ModelDetectValidation, ValidateTtsPathsUnknownKindPassesThrough) {
 TEST(ModelDetectValidation, ValidateSttPathsUnknownKindPassesThrough) {
     sherpaonnx::SttModelPaths paths;
     auto v = sherpaonnx::ValidateSttPaths(sherpaonnx::SttModelKind::kUnknown, paths, "/m");
+    EXPECT_TRUE(v.ok) << "Unknown kind should not fail validation";
+}
+
+TEST(ModelDetectValidation, ValidateOnlineSttPathsDirectOk) {
+    sherpaonnx::OnlineSttModelPaths paths;
+    paths.encoder = "/m/encoder.onnx";
+    paths.decoder = "/m/decoder.onnx";
+    paths.joiner = "/m/joiner.onnx";
+    paths.tokens = "/m/tokens.txt";
+    auto v = sherpaonnx::ValidateOnlineSttPaths(
+        sherpaonnx::OnlineSttModelKind::kTransducer, paths, "/m");
+    EXPECT_TRUE(v.ok);
+    EXPECT_TRUE(v.missingRequired.empty());
+}
+
+TEST(ModelDetectValidation, ValidateOnlineSttPathsDirectMissing) {
+    sherpaonnx::OnlineSttModelPaths paths;
+    paths.encoder = "/m/encoder.onnx";
+    auto v = sherpaonnx::ValidateOnlineSttPaths(
+        sherpaonnx::OnlineSttModelKind::kTransducer, paths, "/m");
+    EXPECT_FALSE(v.ok);
+    EXPECT_FALSE(v.missingRequired.empty());
+}
+
+TEST(ModelDetectValidation, ValidateOnlineSttPathsUnknownKindPassesThrough) {
+    sherpaonnx::OnlineSttModelPaths paths;
+    auto v = sherpaonnx::ValidateOnlineSttPaths(
+        sherpaonnx::OnlineSttModelKind::kUnknown, paths, "/m");
     EXPECT_TRUE(v.ok) << "Unknown kind should not fail validation";
 }
 

--- a/test/cpp/model_detect/model_detect_test.cpp
+++ b/test/cpp/model_detect/model_detect_test.cpp
@@ -965,8 +965,21 @@ TEST(ModelDetectValidation, ValidateCustomModelPathsSttParaformerStreamingOk) {
         {"decoder", "/d.onnx"},
         {"tokens", "/tokens.txt"},
     };
-    auto result = sherpaonnx::ValidateCustomModelPaths("stt", "paraformer", paths, "custom");
+    auto result = sherpaonnx::ValidateCustomModelPaths(
+        "stt_streaming", "paraformer", paths, "custom");
     EXPECT_TRUE(result.ok) << result.error;
+}
+
+TEST(ModelDetectValidation, ValidateCustomModelPathsSttParaformerOfflineRejectsStreamingLayout) {
+    std::map<std::string, std::string> paths = {
+        {"encoder", "/e.onnx"},
+        {"decoder", "/d.onnx"},
+        {"tokens", "/tokens.txt"},
+    };
+    auto result = sherpaonnx::ValidateCustomModelPaths("stt", "paraformer", paths, "custom");
+    EXPECT_FALSE(result.ok);
+    ASSERT_FALSE(result.missingRequired.empty());
+    EXPECT_EQ(result.missingRequired[0], "paraformerModel");
 }
 
 TEST(ModelDetectValidation, ValidateCustomModelPathsSttParaformerMissingLayout) {
@@ -981,6 +994,7 @@ TEST(ModelDetectValidation, ValidateCustomModelPathsSttMoonshineV2Ok) {
     std::map<std::string, std::string> paths = {
         {"moonshineEncoder", "/e.onnx"},
         {"moonshineMergedDecoder", "/d.onnx"},
+        {"tokens", "/tokens.txt"},
     };
     auto result = sherpaonnx::ValidateCustomModelPaths("stt", "moonshine_v2", paths, "custom");
     EXPECT_TRUE(result.ok) << result.error;
@@ -1027,6 +1041,44 @@ TEST(ModelDetectValidation, ValidateCustomModelPathsAlignmentSmoke) {
     std::map<std::string, std::string> paths = {{"model", "/a.onnx"}};
     auto result = sherpaonnx::ValidateCustomModelPaths("alignment", "wav2vec2", paths, "custom");
     EXPECT_TRUE(result.ok) << result.error;
+}
+
+TEST(ModelDetectValidation, GetCustomModelPathRequirementsSttParaformerOffline) {
+    auto reqs = sherpaonnx::GetCustomModelPathRequirements("stt", "paraformer");
+    auto findField = [&reqs](const char* key) {
+        return std::find_if(
+            reqs.fields.begin(),
+            reqs.fields.end(),
+            [key](const sherpaonnx::CustomPathFieldSpec& field) {
+                return field.key == key;
+            });
+    };
+    auto paraformerModel = findField("paraformerModel");
+    ASSERT_NE(paraformerModel, reqs.fields.end());
+    EXPECT_TRUE(paraformerModel->required);
+    auto tokens = findField("tokens");
+    ASSERT_NE(tokens, reqs.fields.end());
+    EXPECT_TRUE(tokens->required);
+    EXPECT_EQ(findField("encoder"), reqs.fields.end());
+    EXPECT_EQ(findField("decoder"), reqs.fields.end());
+}
+
+TEST(ModelDetectValidation, GetCustomModelPathRequirementsSttStreamingParaformer) {
+    auto reqs = sherpaonnx::GetCustomModelPathRequirements("stt_streaming", "paraformer");
+    auto findField = [&reqs](const char* key) {
+        return std::find_if(
+            reqs.fields.begin(),
+            reqs.fields.end(),
+            [key](const sherpaonnx::CustomPathFieldSpec& field) {
+                return field.key == key;
+            });
+    };
+    for (const char* key : {"encoder", "decoder", "tokens"}) {
+        auto field = findField(key);
+        ASSERT_NE(field, reqs.fields.end()) << key;
+        EXPECT_TRUE(field->required) << key;
+    }
+    EXPECT_EQ(findField("paraformerModel"), reqs.fields.end());
 }
 
 TEST(ModelDetectValidation, GetCustomModelPathRequirementsSttTransducer) {

--- a/test/cpp/model_detect/model_detect_test.cpp
+++ b/test/cpp/model_detect/model_detect_test.cpp
@@ -29,11 +29,13 @@
 #include "sherpa-onnx-validate-tts.h"
 #include "sherpa-onnx-validate-enhancement.h"
 #include "sherpa-onnx-validate-vad.h"
+#include "sherpa-onnx-validate-custom.h"
 
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <cstdlib>
 #include <fstream>
+#include <map>
 #include <string>
 
 namespace {
@@ -893,6 +895,115 @@ TEST(ModelDetectValidation, EnhancementFileListGtcrnMarksStreaming) {
 
     EXPECT_TRUE(result.ok) << result.error;
     EXPECT_TRUE(result.isStreaming);
+}
+
+TEST(ModelDetectValidation, ValidateCustomModelPathsSttTransducerOk) {
+    std::map<std::string, std::string> paths = {
+        {"encoder", "/e.onnx"},
+        {"decoder", "/d.onnx"},
+        {"joiner", "/j.onnx"},
+        {"tokens", "/tokens.txt"},
+    };
+    auto result = sherpaonnx::ValidateCustomModelPaths("stt", "transducer", paths, "custom");
+    EXPECT_TRUE(result.ok) << result.error;
+}
+
+TEST(ModelDetectValidation, ValidateCustomModelPathsSttTransducerMissingJoiner) {
+    std::map<std::string, std::string> paths = {
+        {"encoder", "/e.onnx"},
+        {"decoder", "/d.onnx"},
+        {"tokens", "/tokens.txt"},
+    };
+    auto result = sherpaonnx::ValidateCustomModelPaths("stt", "transducer", paths, "custom");
+    EXPECT_FALSE(result.ok);
+    ASSERT_FALSE(result.missingRequired.empty());
+    EXPECT_EQ(result.missingRequired[0], "joiner");
+}
+
+TEST(ModelDetectValidation, ValidateCustomModelPathsSttParaformerOfflineOk) {
+    std::map<std::string, std::string> paths = {
+        {"paraformerModel", "/p.onnx"},
+        {"tokens", "/tokens.txt"},
+    };
+    auto result = sherpaonnx::ValidateCustomModelPaths("stt", "paraformer", paths, "custom");
+    EXPECT_TRUE(result.ok) << result.error;
+}
+
+TEST(ModelDetectValidation, ValidateCustomModelPathsSttParaformerStreamingOk) {
+    std::map<std::string, std::string> paths = {
+        {"encoder", "/e.onnx"},
+        {"decoder", "/d.onnx"},
+        {"tokens", "/tokens.txt"},
+    };
+    auto result = sherpaonnx::ValidateCustomModelPaths("stt", "paraformer", paths, "custom");
+    EXPECT_TRUE(result.ok) << result.error;
+}
+
+TEST(ModelDetectValidation, ValidateCustomModelPathsSttParaformerMissingLayout) {
+    std::map<std::string, std::string> paths = {
+        {"tokens", "/tokens.txt"},
+    };
+    auto result = sherpaonnx::ValidateCustomModelPaths("stt", "paraformer", paths, "custom");
+    EXPECT_FALSE(result.ok);
+}
+
+TEST(ModelDetectValidation, ValidateCustomModelPathsSttMoonshineV2Ok) {
+    std::map<std::string, std::string> paths = {
+        {"moonshineEncoder", "/e.onnx"},
+        {"moonshineMergedDecoder", "/d.onnx"},
+    };
+    auto result = sherpaonnx::ValidateCustomModelPaths("stt", "moonshine_v2", paths, "custom");
+    EXPECT_TRUE(result.ok) << result.error;
+}
+
+TEST(ModelDetectValidation, ValidateCustomModelPathsSttMoonshineV1Distinct) {
+    std::map<std::string, std::string> paths = {
+        {"moonshineEncoder", "/e.onnx"},
+        {"moonshineMergedDecoder", "/d.onnx"},
+    };
+    auto result = sherpaonnx::ValidateCustomModelPaths("stt", "moonshine", paths, "custom");
+    EXPECT_FALSE(result.ok);
+}
+
+TEST(ModelDetectValidation, ValidateCustomModelPathsTtsSmoke) {
+    std::map<std::string, std::string> paths = {
+        {"ttsModel", "/m.onnx"},
+        {"tokens", "/tokens.txt"},
+    };
+    auto result = sherpaonnx::ValidateCustomModelPaths("tts", "vits", paths, "custom");
+    EXPECT_TRUE(result.ok) << result.error;
+}
+
+TEST(ModelDetectValidation, ValidateCustomModelPathsVadSmoke) {
+    std::map<std::string, std::string> paths = {{"model", "/vad.onnx"}};
+    auto result = sherpaonnx::ValidateCustomModelPaths("vad", "silero_vad", paths, "custom");
+    EXPECT_TRUE(result.ok) << result.error;
+}
+
+TEST(ModelDetectValidation, ValidateCustomModelPathsEnhancementSmoke) {
+    std::map<std::string, std::string> paths = {{"model", "/gtcrn.onnx"}};
+    auto result = sherpaonnx::ValidateCustomModelPaths("enhancement", "gtcrn", paths, "custom");
+    EXPECT_TRUE(result.ok) << result.error;
+}
+
+TEST(ModelDetectValidation, ValidateCustomModelPathsPunctuationSmoke) {
+    std::map<std::string, std::string> paths = {{"ct_transformer", "/p.onnx"}};
+    auto result = sherpaonnx::ValidateCustomModelPaths(
+        "punctuation", "ct_transformer", paths, "custom");
+    EXPECT_TRUE(result.ok) << result.error;
+}
+
+TEST(ModelDetectValidation, ValidateCustomModelPathsAlignmentSmoke) {
+    std::map<std::string, std::string> paths = {{"model", "/a.onnx"}};
+    auto result = sherpaonnx::ValidateCustomModelPaths("alignment", "wav2vec2", paths, "custom");
+    EXPECT_TRUE(result.ok) << result.error;
+}
+
+TEST(ModelDetectValidation, GetCustomModelPathRequirementsSttTransducer) {
+    auto reqs = sherpaonnx::GetCustomModelPathRequirements("stt", "transducer");
+    EXPECT_NE(std::find(reqs.required.begin(), reqs.required.end(), "encoder"), reqs.required.end());
+    EXPECT_NE(std::find(reqs.required.begin(), reqs.required.end(), "joiner"), reqs.required.end());
+    EXPECT_NE(std::find(reqs.optional.begin(), reqs.optional.end(), "bpeVocab"), reqs.optional.end());
 }
 
 }  // namespace

--- a/test/cpp/model_detect/model_detect_test.cpp
+++ b/test/cpp/model_detect/model_detect_test.cpp
@@ -1030,9 +1030,50 @@ TEST(ModelDetectValidation, ValidateCustomModelPathsAlignmentSmoke) {
 
 TEST(ModelDetectValidation, GetCustomModelPathRequirementsSttTransducer) {
     auto reqs = sherpaonnx::GetCustomModelPathRequirements("stt", "transducer");
-    EXPECT_NE(std::find(reqs.required.begin(), reqs.required.end(), "encoder"), reqs.required.end());
-    EXPECT_NE(std::find(reqs.required.begin(), reqs.required.end(), "joiner"), reqs.required.end());
-    EXPECT_NE(std::find(reqs.optional.begin(), reqs.optional.end(), "bpeVocab"), reqs.optional.end());
+    auto hasKey = [&reqs](const char* key) {
+        return std::any_of(
+            reqs.fields.begin(),
+            reqs.fields.end(),
+            [key](const sherpaonnx::CustomPathFieldSpec& field) {
+                return field.key == key;
+            });
+    };
+    EXPECT_TRUE(hasKey("encoder"));
+    EXPECT_TRUE(hasKey("joiner"));
+    auto bpe = std::find_if(
+        reqs.fields.begin(),
+        reqs.fields.end(),
+        [](const sherpaonnx::CustomPathFieldSpec& field) {
+            return field.key == "bpeVocab";
+        });
+    ASSERT_NE(bpe, reqs.fields.end());
+    EXPECT_FALSE(bpe->required);
+    for (const auto& field : reqs.fields) {
+        EXPECT_FALSE(field.isDirectory) << field.key;
+    }
+}
+
+TEST(ModelDetectValidation, GetCustomModelPathRequirementsTtsVitsDataDirIsDirectory) {
+    auto reqs = sherpaonnx::GetCustomModelPathRequirements("tts", "vits");
+    ASSERT_FALSE(reqs.fields.empty());
+    auto dataDir = std::find_if(
+        reqs.fields.begin(),
+        reqs.fields.end(),
+        [](const sherpaonnx::CustomPathFieldSpec& field) {
+            return field.key == "dataDir";
+        });
+    ASSERT_NE(dataDir, reqs.fields.end());
+    EXPECT_FALSE(dataDir->required);
+    EXPECT_TRUE(dataDir->isDirectory);
+    auto ttsModel = std::find_if(
+        reqs.fields.begin(),
+        reqs.fields.end(),
+        [](const sherpaonnx::CustomPathFieldSpec& field) {
+            return field.key == "ttsModel";
+        });
+    ASSERT_NE(ttsModel, reqs.fields.end());
+    EXPECT_TRUE(ttsModel->required);
+    EXPECT_FALSE(ttsModel->isDirectory);
 }
 
 }  // namespace

--- a/test/cpp/model_detect/model_detect_test.cpp
+++ b/test/cpp/model_detect/model_detect_test.cpp
@@ -31,6 +31,7 @@
 #include "sherpa-onnx-validate-enhancement.h"
 #include "sherpa-onnx-validate-vad.h"
 #include "sherpa-onnx-validate-custom.h"
+#include "sherpa-onnx-model-path-fill.h"
 
 #include <gtest/gtest.h>
 #include <algorithm>
@@ -1074,6 +1075,18 @@ TEST(ModelDetectValidation, GetCustomModelPathRequirementsTtsVitsDataDirIsDirect
     ASSERT_NE(ttsModel, reqs.fields.end());
     EXPECT_TRUE(ttsModel->required);
     EXPECT_FALSE(ttsModel->isDirectory);
+}
+
+TEST(ModelDetectValidation, TtsModelPathsToStringMapOmitsEmptyValues) {
+    sherpaonnx::TtsModelPaths paths;
+    paths.ttsModel = "/tmp/model.onnx";
+    paths.tokens = "/tmp/tokens.txt";
+    paths.dataDir = "/tmp/espeak-ng-data";
+    auto map = sherpaonnx::TtsModelPathsToStringMap(paths);
+    EXPECT_EQ(map.at("ttsModel"), "/tmp/model.onnx");
+    EXPECT_EQ(map.at("tokens"), "/tmp/tokens.txt");
+    EXPECT_EQ(map.at("dataDir"), "/tmp/espeak-ng-data");
+    EXPECT_EQ(map.find("lexicon"), map.end());
 }
 
 }  // namespace


### PR DESCRIPTION
This pull request introduces significant improvements to the React Native SDK for sherpa-onnx, focusing on enhanced documentation for model setup and feature pipelines, as well as extending the native C++/JNI layer to support more flexible and robust model validation and detection. The changes improve the developer onboarding experience and expand the SDK's internal capabilities for handling model requirements and validation across different speech features.

**Documentation improvements:**

* Added a comprehensive "How to start" section in `README.md`, guiding users through model setup, detection, and feature usage, with step-by-step links and planning advice. The documentation index is now reorganized by theme for easier navigation and clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R86) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L337-R403)
* Updated feature support tables and documentation links to reflect new and planned features, including streaming TTS, segmentation, and enhanced OOM (out-of-memory) planning. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R86) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L337-R403)
* Removed and consolidated redundant installation and segmentation documentation sections for clarity.

**Native C++/JNI enhancements:**

* Added new utility functions in the JNI layer for converting between C++ maps and Java `HashMap<String, String>`, and for constructing validation result and requirements maps for custom model validation. [[1]](diffhunk://#diff-edfaaf770635312be7a79f75190ceaa2487a3ed3333a83d21f72cbea78db2470R109-R139) [[2]](diffhunk://#diff-edfaaf770635312be7a79f75190ceaa2487a3ed3333a83d21f72cbea78db2470R180-R365) [[3]](diffhunk://#diff-9a51bba6ef4eaac2af57a620a1b865da5c672e42f255bae2e3541e818f932f48R10-R12) [[4]](diffhunk://#diff-9a51bba6ef4eaac2af57a620a1b865da5c672e42f255bae2e3541e818f932f48R23-R44)
* Implemented `GetAlignmentPathRequirements` in the alignment validation module to expose required model path fields for different alignment model kinds. [[1]](diffhunk://#diff-e617a8e51770716c882f39de7920a200761c0c9accf65f51b8958fdd8d576e45R66-R77) [[2]](diffhunk://#diff-33df67f22399e5d58d4a6a3380ea27d76ff2f19818c2ee017dd7fb4ac45b00beR5) [[3]](diffhunk://#diff-33df67f22399e5d58d4a6a3380ea27d76ff2f19818c2ee017dd7fb4ac45b00beR29-R30)
* Added new C++ source files for model path filling and validation, and updated build scripts (`CMakeLists.txt`, `Podspec`) to include these and new header search paths for expanded model support (including VAD and alignment). [[1]](diffhunk://#diff-9c2798aa7ffaf63cbae7c421481a846035dd9078e8d0a84a856382150070a227R91-R99) [[2]](diffhunk://#diff-717bf771205b889224abf6dcec473d2231190138b9763c644c58544f79b03f32R134-R140) [[3]](diffhunk://#diff-dc0279b60adfe7166a218a1fcec179534e756e106f5a3916a9872d99470676f9R9)

These changes collectively improve both the usability of the SDK for developers and the flexibility of the underlying model detection and validation infrastructure.

**References:**  
[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R86) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L80-L102) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L337-R403) [[5]](diffhunk://#diff-717bf771205b889224abf6dcec473d2231190138b9763c644c58544f79b03f32R134-R140) [[6]](diffhunk://#diff-9c2798aa7ffaf63cbae7c421481a846035dd9078e8d0a84a856382150070a227R91-R99) [[7]](diffhunk://#diff-e617a8e51770716c882f39de7920a200761c0c9accf65f51b8958fdd8d576e45R66-R77) [[8]](diffhunk://#diff-33df67f22399e5d58d4a6a3380ea27d76ff2f19818c2ee017dd7fb4ac45b00beR5) [[9]](diffhunk://#diff-33df67f22399e5d58d4a6a3380ea27d76ff2f19818c2ee017dd7fb4ac45b00beR29-R30) [[10]](diffhunk://#diff-edfaaf770635312be7a79f75190ceaa2487a3ed3333a83d21f72cbea78db2470R109-R139) [[11]](diffhunk://#diff-edfaaf770635312be7a79f75190ceaa2487a3ed3333a83d21f72cbea78db2470R180-R365) [[12]](diffhunk://#diff-9a51bba6ef4eaac2af57a620a1b865da5c672e42f255bae2e3541e818f932f48R10-R12) [[13]](diffhunk://#diff-9a51bba6ef4eaac2af57a620a1b865da5c672e42f255bae2e3541e818f932f48R23-R44) [[14]](diffhunk://#diff-dc0279b60adfe7166a218a1fcec179534e756e106f5a3916a9872d99470676f9R9)