### PR TITLE
Feat/add separation support example app

### DIFF
--- a/SherpaOnnx.podspec
+++ b/SherpaOnnx.podspec
@@ -47,7 +47,10 @@ Pod::Spec.new do |s|
     # Native crash diagnostics (shared ring buffer + iOS signal handler).
     "android/src/main/cpp/jni/diagnostic/NativeDiagnostic.cpp",
     "android/src/main/cpp/jni/diagnostic/NativeDiagnostic.h",
-    "android/src/main/cpp/jni/diagnostic/NativeDiagnosticIOS.mm"
+    "android/src/main/cpp/jni/diagnostic/NativeDiagnosticIOS.mm",
+    # Shared separation inference core. JNI bridge excluded below.
+    "android/src/main/cpp/separation/sherpa-onnx-separation-wrapper.cpp",
+    "android/src/main/cpp/separation/sherpa-onnx-separation-wrapper.h"
   ]
   # Exclude vendored framework headers from the compile/copy phases to avoid
   # duplicate PrivateHeaders outputs when CocoaPods builds this pod as framework.
@@ -62,7 +65,8 @@ Pod::Spec.new do |s|
     "android/src/main/cpp/jni/audio/audio_decode_jni.cpp",
     "android/src/main/cpp/jni/audio/audio_encode_jni.cpp",
     "android/src/main/cpp/jni/diagnostic/NativeDiagnosticAndroid.cpp",
-    "android/src/main/cpp/jni/diagnostic/native_diagnostic_jni.cpp"
+    "android/src/main/cpp/jni/diagnostic/native_diagnostic_jni.cpp",
+    "android/src/main/cpp/jni/separation/sherpa-onnx-separation-jni.cpp"
   ]
   private_headers = Dir.glob(File.join(pod_root, "ios", "**", "*.h")).reject do |path|
     path.start_with?(File.join(pod_root, "ios", "Frameworks") + File::SEPARATOR)
@@ -73,7 +77,8 @@ Pod::Spec.new do |s|
     "android/src/main/cpp/jni/audio/AudioVisualization.h",
     "android/src/main/cpp/jni/audio/FfmpegFormatGuard.h",
     "android/src/main/cpp/jni/audio/AudioEncodeSession.h",
-    "android/src/main/cpp/jni/diagnostic/NativeDiagnostic.h"
+    "android/src/main/cpp/jni/diagnostic/NativeDiagnostic.h",
+    "android/src/main/cpp/separation/sherpa-onnx-separation-wrapper.h"
   ]
   s.private_header_files = private_headers.map { |path| path.sub("#{pod_root}/", "") }
 
@@ -137,6 +142,7 @@ Pod::Spec.new do |s|
     "\"#{pod_root}/android/src/main/cpp/jni/model_detect/tts\"",
     "\"#{pod_root}/android/src/main/cpp/jni/model_detect/enhancement\"",
     "\"#{pod_root}/android/src/main/cpp/jni/model_detect/separation\"",
+    "\"#{pod_root}/android/src/main/cpp/separation\"",
     "\"#{pod_root}/android/src/main/cpp/jni/model_detect/punctuation\"",
     "\"#{pod_root}/android/src/main/cpp/jni/model_detect/vad\"",
     "\"#{pod_root}/android/src/main/cpp/jni/model_detect/alignment\"",

--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -114,8 +114,8 @@ set(SOURCES
     jni/model_detect/enhancement/sherpa-onnx-enhancement-wrapper.cpp
     jni/model_detect/separation/sherpa-onnx-model-detect-separation.cpp
     jni/model_detect/separation/sherpa-onnx-validate-separation.cpp
-    jni/model_detect/separation/sherpa-onnx-separation-wrapper.cpp
-    ../../../ios/separation/sherpa-onnx-separation-wrapper.cpp
+    jni/model_detect/separation/sherpa-onnx-separation-detect-wrapper.cpp
+    separation/sherpa-onnx-separation-wrapper.cpp
     jni/separation/sherpa-onnx-separation-jni.cpp
     jni/model_detect/punctuation/sherpa-onnx-punctuation-catalog-metadata.cpp
     jni/model_detect/punctuation/sherpa-onnx-punctuation-online-guard.cpp
@@ -240,6 +240,7 @@ endif()
 target_include_directories(sherpaonnx PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/alignment
+    ${CMAKE_CURRENT_SOURCE_DIR}/separation
     ${ORT_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/jni
     ${CMAKE_CURRENT_SOURCE_DIR}/jni/module
@@ -249,7 +250,6 @@ target_include_directories(sherpaonnx PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/jni/model_detect/tts
     ${CMAKE_CURRENT_SOURCE_DIR}/jni/model_detect/enhancement
     ${CMAKE_CURRENT_SOURCE_DIR}/jni/model_detect/separation
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../ios/separation
     ${CMAKE_CURRENT_SOURCE_DIR}/jni/model_detect/punctuation
     ${CMAKE_CURRENT_SOURCE_DIR}/jni/model_detect/vad
     ${CMAKE_CURRENT_SOURCE_DIR}/jni/model_detect/alignment

--- a/android/src/main/cpp/jni/audio/AudioDecodeSession.cpp
+++ b/android/src/main/cpp/jni/audio/AudioDecodeSession.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <stdexcept>
@@ -41,12 +42,21 @@
 #define LOGE(...) ((void)0)
 #endif
 
+#ifndef NDEBUG
+#define AUDIO_DECODE_DBG(...) LOGI(__VA_ARGS__)
+#define AUDIO_DECODE_DBGW(...) LOGW(__VA_ARGS__)
+#else
+#define AUDIO_DECODE_DBG(...) ((void)0)
+#define AUDIO_DECODE_DBGW(...) ((void)0)
+#endif
+
 #ifdef HAVE_FFMPEG
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavutil/opt.h>
 #include <libavutil/error.h>
+#include <libavutil/intreadwrite.h>
 #include <libswresample/swresample.h>
 }
 #endif
@@ -365,6 +375,514 @@ int64_t avioSeekFd(void* opaque, int64_t offset, int whence) {
   return static_cast<int64_t>(result);
 }
 
+static const int kMpeg4AacSampleRates[] = {
+    96000, 88200, 64000, 48000, 44100, 32000,
+    24000, 22050, 16000, 12000, 11025, 8000, 7350,
+};
+
+static const int kAdtsChannelCount[] = {0, 1, 2, 3, 4, 5, 6, 8};
+static constexpr int kMinValidAdtsFrameBytes = 100;
+
+static void logDirectFdBytes(int fd, int64_t offset, size_t count, const char* label) {
+#ifndef NDEBUG
+  if (fd < 0 || !label || count == 0) {
+    return;
+  }
+
+  std::vector<uint8_t> buf(count);
+  const ssize_t got = pread(fd, buf.data(), count, static_cast<off_t>(offset));
+  if (got <= 0) {
+    AUDIO_DECODE_DBGW(
+        "fd_direct label=%s offset=%lld read_fail got=%zd",
+        label,
+        static_cast<long long>(offset),
+        got);
+    return;
+  }
+
+  char hex[128] = {0};
+  const int hexLen = std::min(static_cast<int>(got), 32);
+  for (int i = 0; i < hexLen; ++i) {
+    std::snprintf(hex + i * 3, sizeof(hex) - i * 3, "%02x ", buf[i]);
+  }
+  AUDIO_DECODE_DBG(
+      "fd_direct label=%s offset=%lld got=%zd hex=%s",
+      label,
+      static_cast<long long>(offset),
+      got,
+      hex);
+#else
+  (void)fd;
+  (void)offset;
+  (void)count;
+  (void)label;
+#endif
+}
+
+static int parseAdtsFrameLength(const uint8_t* hdr, int available) {
+  if (available < 7) {
+    return 0;
+  }
+  if ((AV_RB16(hdr) & 0xFFF6) != 0xFFF0) {
+    return 0;
+  }
+  return (AV_RB32(hdr + 3) >> 13) & 0x1FFF;
+}
+
+static int64_t resyncRawAdtsToValidFrame(AVFormatContext* fmtCtx, int minFrameBytes) {
+  if (!fmtCtx || !fmtCtx->pb || minFrameBytes <= 0) {
+    return -1;
+  }
+
+  const int64_t fileSize = avio_size(fmtCtx->pb);
+  const int64_t scanLimit = fileSize > 0 ? fileSize : (1024 * 1024);
+
+  if (avio_seek(fmtCtx->pb, 0, SEEK_SET) < 0) {
+    AUDIO_DECODE_DBGW("adts_resync seek_to_0_failed");
+    return -1;
+  }
+
+  int64_t scanPos = 0;
+  int candidates = 0;
+  while (scanPos + 7 <= scanLimit) {
+    if (avio_seek(fmtCtx->pb, scanPos, SEEK_SET) < 0) {
+      break;
+    }
+
+    uint8_t hdr[7];
+    const int got = avio_read(fmtCtx->pb, hdr, 7);
+    if (got != 7) {
+      break;
+    }
+
+    const int fsize = parseAdtsFrameLength(hdr, 7);
+    if (fsize <= 0) {
+      scanPos++;
+      continue;
+    }
+
+    candidates++;
+    char hex[32] = {0};
+    for (int i = 0; i < 7; ++i) {
+      std::snprintf(hex + i * 3, sizeof(hex) - i * 3, "%02x ", hdr[i]);
+    }
+    AUDIO_DECODE_DBG(
+        "adts_candidate #%d syncPos=%lld fsize=%d min=%d hex=%s",
+        candidates,
+        static_cast<long long>(scanPos),
+        fsize,
+        minFrameBytes,
+        hex);
+
+    if (fsize >= minFrameBytes && (fileSize <= 0 || scanPos + fsize <= fileSize)) {
+      avio_seek(fmtCtx->pb, scanPos, SEEK_SET);
+      AUDIO_DECODE_DBG(
+          "adts_resync_ok syncPos=%lld fsize=%d scanned=%lld",
+          static_cast<long long>(scanPos),
+          fsize,
+          static_cast<long long>(scanPos));
+      return scanPos;
+    }
+
+    scanPos++;
+  }
+
+  AUDIO_DECODE_DBGW(
+      "adts_resync_fail candidates=%d scanLimit=%lld fileSize=%lld",
+      candidates,
+      static_cast<long long>(scanLimit),
+      static_cast<long long>(fileSize));
+  return -1;
+}
+
+struct AdtsFrameHeader {
+  bool ok = false;
+  int frameLength = 0;
+  int sampleRateHz = 0;
+  int channelCount = 0;
+  int sfIndex = -1;
+  int chConfig = 0;
+  uint8_t bytes[7] = {};
+};
+
+static AdtsFrameHeader peekAdtsHeaderAtAvio(AVFormatContext* fmtCtx) {
+  AdtsFrameHeader hdr;
+  if (!fmtCtx || !fmtCtx->pb) {
+    return hdr;
+  }
+
+  const int64_t syncPos = avio_tell(fmtCtx->pb);
+  const int got = avio_read(fmtCtx->pb, hdr.bytes, 7);
+  if (got != 7) {
+    AUDIO_DECODE_DBGW("adts_peek read_fail syncPos=%lld got=%d", static_cast<long long>(syncPos), got);
+    avio_seek(fmtCtx->pb, syncPos, SEEK_SET);
+    return hdr;
+  }
+
+  if ((AV_RB16(hdr.bytes) & 0xFFF6) != 0xFFF0) {
+    char hex[32] = {0};
+    for (int i = 0; i < 7; ++i) {
+      std::snprintf(hex + i * 3, sizeof(hex) - i * 3, "%02x ", hdr.bytes[i]);
+    }
+    AUDIO_DECODE_DBGW(
+        "adts_peek sync_miss syncPos=%lld hex=%s",
+        static_cast<long long>(syncPos),
+        hex);
+    avio_seek(fmtCtx->pb, syncPos, SEEK_SET);
+    return hdr;
+  }
+
+  hdr.sfIndex = (hdr.bytes[2] & 0x3C) >> 2;
+  hdr.chConfig = ((hdr.bytes[2] & 0x01) << 2) | ((hdr.bytes[3] & 0xC0) >> 6);
+  hdr.frameLength = (AV_RB32(hdr.bytes + 3) >> 13) & 0x1FFF;
+  if (hdr.sfIndex >= 0 && hdr.sfIndex < static_cast<int>(sizeof(kMpeg4AacSampleRates) / sizeof(kMpeg4AacSampleRates[0]))) {
+    hdr.sampleRateHz = kMpeg4AacSampleRates[hdr.sfIndex];
+  }
+  if (hdr.chConfig >= 0 && hdr.chConfig < static_cast<int>(sizeof(kAdtsChannelCount) / sizeof(kAdtsChannelCount[0]))) {
+    hdr.channelCount = kAdtsChannelCount[hdr.chConfig];
+  }
+  hdr.ok = hdr.sampleRateHz > 0 && hdr.frameLength >= kMinValidAdtsFrameBytes;
+
+  const int64_t restoredPos = avio_seek(fmtCtx->pb, syncPos, SEEK_SET);
+  if (restoredPos < 0) {
+    AUDIO_DECODE_DBGW(
+        "adts_peek restore_fail syncPos=%lld restored=%lld",
+        static_cast<long long>(syncPos),
+        static_cast<long long>(restoredPos));
+    hdr.ok = false;
+    return hdr;
+  }
+
+  char hex[32] = {0};
+  for (int i = 0; i < 7; ++i) {
+    std::snprintf(hex + i * 3, sizeof(hex) - i * 3, "%02x ", hdr.bytes[i]);
+  }
+  AUDIO_DECODE_DBG(
+      "adts_peek syncPos=%lld frameLen=%d sfIdx=%d sr=%d chCfg=%d ch=%d hex=%s",
+      static_cast<long long>(syncPos),
+      hdr.frameLength,
+      hdr.sfIndex,
+      hdr.sampleRateHz,
+      hdr.chConfig,
+      hdr.channelCount,
+      hex);
+  return hdr;
+}
+
+static void logInputIoState(
+    AVFormatContext* fmtCtx,
+    int ownedFd,
+    int inputFd,
+    const char* phase) {
+#ifndef NDEBUG
+  int64_t avioPos = -1;
+  int64_t avioSize = -1;
+  int seekable = 0;
+  int eofReached = -1;
+  int avioError = 0;
+  int64_t bytesRead = -1;
+  if (fmtCtx && fmtCtx->pb) {
+    avioPos = avio_tell(fmtCtx->pb);
+    avioSize = avio_size(fmtCtx->pb);
+    seekable = fmtCtx->pb->seekable;
+    eofReached = fmtCtx->pb->eof_reached;
+    avioError = fmtCtx->pb->error;
+    bytesRead = fmtCtx->pb->bytes_read;
+    const int bufLeft = static_cast<int>(fmtCtx->pb->buf_end - fmtCtx->pb->buf_ptr);
+    const int bufTotal = static_cast<int>(fmtCtx->pb->buf_end - fmtCtx->pb->buffer);
+    const int64_t bufBasePos =
+        fmtCtx->pb->pos - (fmtCtx->pb->write_flag ? 0 : bufTotal);
+    AUDIO_DECODE_DBG(
+        "avio_detail phase=%s bufBasePos=%lld bufLeft=%d bufTotal=%d pos=%lld eof=%d avioErr=%d bytesRead=%lld",
+        phase ? phase : "?",
+        static_cast<long long>(bufBasePos),
+        bufLeft,
+        bufTotal,
+        static_cast<long long>(fmtCtx->pb->pos),
+        eofReached,
+        avioError,
+        static_cast<long long>(bytesRead));
+  }
+
+  off_t fdPos = -1;
+  off_t fdSize = -1;
+  if (ownedFd >= 0) {
+    fdPos = lseek(ownedFd, 0, SEEK_CUR);
+    fdSize = lseek(ownedFd, 0, SEEK_END);
+    if (fdSize >= 0) {
+      lseek(ownedFd, fdPos, SEEK_SET);
+    }
+  }
+
+  AUDIO_DECODE_DBG(
+      "io_state phase=%s inputFd=%d ownedFd=%d avioPos=%lld avioSize=%lld seekable=0x%x fdPos=%lld fdSize=%lld",
+      phase ? phase : "?",
+      inputFd,
+      ownedFd,
+      static_cast<long long>(avioPos),
+      static_cast<long long>(avioSize),
+      seekable,
+      static_cast<long long>(fdPos),
+      static_cast<long long>(fdSize));
+#else
+  (void)fmtCtx;
+  (void)ownedFd;
+  (void)inputFd;
+  (void)phase;
+#endif
+}
+
+static const char* mediaTypeName(int mediaType) {
+  switch (mediaType) {
+    case AVMEDIA_TYPE_AUDIO:
+      return "audio";
+    case AVMEDIA_TYPE_VIDEO:
+      return "video";
+    case AVMEDIA_TYPE_SUBTITLE:
+      return "subtitle";
+    case AVMEDIA_TYPE_DATA:
+      return "data";
+    default:
+      return "other";
+  }
+}
+
+static const char* identifyContainerMagic(const uint8_t* buf, size_t len) {
+  if (!buf || len < 2) {
+    return "too_short";
+  }
+  if (len >= 12 && buf[0] == 'R' && buf[1] == 'I' && buf[2] == 'F' && buf[3] == 'F' &&
+      buf[8] == 'W' && buf[9] == 'A' && buf[10] == 'V' && buf[11] == 'E') {
+    return "RIFF/WAVE";
+  }
+  if (len >= 8 && buf[4] == 'f' && buf[5] == 't' && buf[6] == 'y' && buf[7] == 'p') {
+    return "ISO/ftyp";
+  }
+  if (len >= 3 && buf[0] == 'I' && buf[1] == 'D' && buf[2] == '3') {
+    return "ID3v2";
+  }
+  if (len >= 4 && buf[0] == 'O' && buf[1] == 'g' && buf[2] == 'g' && buf[3] == 'S') {
+    return "OggS";
+  }
+  if (len >= 4 && buf[0] == 'f' && buf[1] == 'L' && buf[2] == 'a' && buf[3] == 'C') {
+    return "fLaC";
+  }
+  if (len >= 4 && buf[0] == 'F' && buf[1] == 'L' && buf[2] == 'A' && buf[3] == 'C') {
+    return "FLAC";
+  }
+  if (len >= 2 && (buf[0] & 0xFF) == 0xFF && ((buf[1] & 0xF6) == 0xF0)) {
+    return "ADTS";
+  }
+  if (len >= 4 && buf[0] == 0x1A && buf[1] == 'E' && buf[2] == 'B' && buf[3] == 'P') {
+    return "EBML/matroska";
+  }
+  if (len >= 2 && (buf[0] & 0xFF) == 0xFF && ((buf[1] & 0xE0) == 0xE0)) {
+    return "MP3_frame_sync";
+  }
+  if (len >= 4 && buf[0] == 'X' && buf[1] == 'i' && buf[2] == 'n' && buf[3] == 'g') {
+    return "Xing/MP3";
+  }
+  if (len >= 4 && buf[0] == 'I' && buf[1] == 'n' && buf[2] == 'f' && buf[3] == 'o') {
+    return "Info/MP3";
+  }
+  return "unknown";
+}
+
+static void logContainerMagicFromFd(int fd, const char* label) {
+#ifndef NDEBUG
+  if (fd < 0 || !label) {
+    return;
+  }
+
+  uint8_t buf[16] = {};
+  const ssize_t got = pread(fd, buf, sizeof(buf), 0);
+  if (got <= 0) {
+    AUDIO_DECODE_DBGW(
+        "container_magic label=%s read_fail got=%zd",
+        label,
+        got);
+    return;
+  }
+
+  char hex[64] = {0};
+  const int hexLen = std::min(static_cast<int>(got), 16);
+  for (int i = 0; i < hexLen; ++i) {
+    std::snprintf(hex + i * 3, sizeof(hex) - i * 3, "%02x ", buf[i]);
+  }
+  AUDIO_DECODE_DBG(
+      "container_magic label=%s magic=%s got=%zd hex=%s",
+      label,
+      identifyContainerMagic(buf, static_cast<size_t>(got)),
+      got,
+      hex);
+#else
+  (void)fd;
+  (void)label;
+#endif
+}
+
+static void logFormatContextSummary(
+    AVFormatContext* fmtCtx,
+    int selectedAudioIdx,
+    const char* phase) {
+#ifndef NDEBUG
+  if (!fmtCtx) {
+    return;
+  }
+
+  const char* iformat =
+      (fmtCtx->iformat && fmtCtx->iformat->name) ? fmtCtx->iformat->name : "?";
+  AUDIO_DECODE_DBG(
+      "format_summary phase=%s iformat=%s nb_streams=%u duration=%lld bit_rate=%lld",
+      phase ? phase : "?",
+      iformat,
+      fmtCtx->nb_streams,
+      static_cast<long long>(fmtCtx->duration),
+      static_cast<long long>(fmtCtx->bit_rate));
+
+  for (unsigned i = 0; i < fmtCtx->nb_streams; ++i) {
+    AVStream* st = fmtCtx->streams[i];
+    if (!st || !st->codecpar) {
+      continue;
+    }
+    AVCodecParameters* par = st->codecpar;
+    const char* codecName = avcodec_get_name(par->codec_id);
+    AUDIO_DECODE_DBG(
+        "format_stream phase=%s idx=%u type=%s codec=%s sr=%d ch=%d extradata=%d "
+        "selected_audio=%d",
+        phase ? phase : "?",
+        i,
+        mediaTypeName(par->codec_type),
+        codecName ? codecName : "?",
+        par->sample_rate,
+        par->ch_layout.nb_channels,
+        par->extradata_size,
+        static_cast<int>(i) == selectedAudioIdx ? 1 : 0);
+  }
+#else
+  (void)fmtCtx;
+  (void)selectedAudioIdx;
+  (void)phase;
+#endif
+}
+
+static void logStreamTimingState(AVStream* st, const char* phase) {
+#ifndef NDEBUG
+  if (!st) {
+    return;
+  }
+  AUDIO_DECODE_DBG(
+      "stream_timing phase=%s idx=%d start_time=%lld duration=%lld nb_frames=%lld "
+      "time_base=%d/%d",
+      phase ? phase : "?",
+      st->index,
+      static_cast<long long>(st->start_time),
+      static_cast<long long>(st->duration),
+      static_cast<long long>(st->nb_frames),
+      st->time_base.num,
+      st->time_base.den);
+#else
+  (void)st;
+  (void)phase;
+#endif
+}
+
+static const char* ffmpegErrLabel(int err, char* buf, size_t bufSize) {
+  if (err == 0) {
+    return "ok";
+  }
+  av_strerror(err, buf, bufSize);
+  return buf;
+}
+
+static bool isIsoMediaDemuxer(const AVFormatContext* fmtCtx) {
+  if (!fmtCtx || !fmtCtx->iformat || !fmtCtx->iformat->name) {
+    return false;
+  }
+  // FFmpeg short name list, e.g. "mov,mp4,m4a,3gp,3g2,mj2"
+  const char* name = fmtCtx->iformat->name;
+  return std::strstr(name, "mov") != nullptr || std::strstr(name, "mp4") != nullptr;
+}
+
+static bool initDecodeResampler(
+    SwrContext** swr,
+    AVCodecContext* decCtx,
+    int outSampleRate,
+    int outChannels,
+    int srcSampleRate,
+    const char* reason) {
+  if (!swr || !decCtx || srcSampleRate <= 0) {
+    LOGE(
+        "swr_init_skip reason=%s srcSr=%d decSr=%d decCh=%d",
+        reason ? reason : "?",
+        srcSampleRate,
+        decCtx ? decCtx->sample_rate : 0,
+        decCtx ? decCtx->ch_layout.nb_channels : 0);
+    return false;
+  }
+
+  if (*swr) {
+    swr_free(swr);
+  }
+
+  AVChannelLayout outLayout;
+  av_channel_layout_default(&outLayout, outChannels);
+
+  int swrRet = swr_alloc_set_opts2(
+      swr,
+      &outLayout,
+      AV_SAMPLE_FMT_FLT,
+      outSampleRate,
+      &decCtx->ch_layout,
+      decCtx->sample_fmt,
+      srcSampleRate,
+      0,
+      nullptr);
+  if (swrRet < 0 || !*swr) {
+    char errbuf[AV_ERROR_MAX_STRING_SIZE] = {0};
+    av_strerror(swrRet, errbuf, sizeof(errbuf));
+    LOGE(
+        "swr_alloc_fail reason=%s ret=%d (%s) outSr=%d outCh=%d inSr=%d inCh=%d inFmt=%d",
+        reason ? reason : "?",
+        swrRet,
+        errbuf,
+        outSampleRate,
+        outChannels,
+        srcSampleRate,
+        decCtx->ch_layout.nb_channels,
+        static_cast<int>(decCtx->sample_fmt));
+    return false;
+  }
+
+  const int initRet = swr_init(*swr);
+  if (initRet < 0) {
+    char errbuf[AV_ERROR_MAX_STRING_SIZE] = {0};
+    av_strerror(initRet, errbuf, sizeof(errbuf));
+    LOGE(
+        "swr_init_fail reason=%s ret=%d (%s) outSr=%d outCh=%d inSr=%d inCh=%d inFmt=%d",
+        reason ? reason : "?",
+        initRet,
+        errbuf,
+        outSampleRate,
+        outChannels,
+        srcSampleRate,
+        decCtx->ch_layout.nb_channels,
+        static_cast<int>(decCtx->sample_fmt));
+    swr_free(swr);
+    return false;
+  }
+
+  AUDIO_DECODE_DBG(
+      "swr_init_ok reason=%s outSr=%d outCh=%d inSr=%d inCh=%d inFmt=%d",
+      reason ? reason : "?",
+      outSampleRate,
+      outChannels,
+      srcSampleRate,
+      decCtx->ch_layout.nb_channels,
+      static_cast<int>(decCtx->sample_fmt));
+  return true;
+}
+
 AudioDecodeResult decodeFileFFmpeg(
     const char* path,
     int inputFd,
@@ -381,6 +899,11 @@ AudioDecodeResult decodeFileFFmpeg(
       "allowAutoProbe=%d",
       config.allowDemuxerAutoProbe ? 1 : 0);
   SHERPA_DIAG_D("audio.decode", "ffmpeg_start", diagDetail);
+  AUDIO_DECODE_DBG(
+      "ffmpeg_start pathHint=%s fd=%d allowAutoProbe=%d",
+      path ? path : "(null)",
+      inputFd,
+      config.allowDemuxerAutoProbe ? 1 : 0);
 
   AVFormatContext* fmtCtx = nullptr;
   AVIOContext* avioCtx = nullptr;
@@ -470,11 +993,62 @@ AudioDecodeResult decodeFileFFmpeg(
     }
   }
 
-  if (avformat_find_stream_info(fmtCtx, nullptr) < 0) {
-    throw std::runtime_error("DECODE_OPEN_FAILED: Failed to find stream info");
+  const bool isRawAdtsDemuxer =
+      fmtCtx->iformat && fmtCtx->iformat->name &&
+      std::strcmp(fmtCtx->iformat->name, "aac") == 0;
+  const char* inputKind = inputFd >= 0 ? "content_fd" : "path";
+  const char* iformatName =
+      (fmtCtx->iformat && fmtCtx->iformat->name) ? fmtCtx->iformat->name : "?";
+
+  AUDIO_DECODE_DBG(
+      "decode_open inputKind=%s iformat=%s rawAdts=%d pathHint=%s fd=%d",
+      inputKind,
+      iformatName,
+      isRawAdtsDemuxer ? 1 : 0,
+      path ? path : "(null)",
+      inputFd);
+  if (ownedFd >= 0) {
+    logContainerMagicFromFd(ownedFd, "decode_open");
+    logDirectFdBytes(ownedFd, 0, 32, "decode_file_start");
+  }
+  logInputIoState(fmtCtx, ownedFd, inputFd, "after_open");
+  logFormatContextSummary(fmtCtx, -1, "after_read_header");
+
+  // Raw ADTS: read_header already resynced to the first frame. find_stream_info
+  // reads ahead and leaves the demuxer mid-stream; rewinding to byte 0 does not
+  // re-run resync, so the first av_read_frame can yield a bogus 9-byte ADTS header.
+  if (!isRawAdtsDemuxer) {
+    logInputIoState(fmtCtx, ownedFd, inputFd, "before_find_stream_info");
+    if (avformat_find_stream_info(fmtCtx, nullptr) < 0) {
+      throw std::runtime_error("DECODE_OPEN_FAILED: Failed to find stream info");
+    }
+    logInputIoState(fmtCtx, ownedFd, inputFd, "after_find_stream_info");
+    logFormatContextSummary(fmtCtx, -1, "after_find_stream_info");
+  } else {
+    AUDIO_DECODE_DBG("skip find_stream_info for raw ADTS demuxer (read_header resync active)");
+    logInputIoState(fmtCtx, ownedFd, inputFd, "after_read_header");
+    logDirectFdBytes(ownedFd, 0, 32, "adts_file_start");
+    const int64_t resyncPos =
+        resyncRawAdtsToValidFrame(fmtCtx, kMinValidAdtsFrameBytes);
+    if (resyncPos < 0) {
+      AUDIO_DECODE_DBGW("adts_resync using read_header position (no valid frame found while scanning)");
+    }
+    logInputIoState(fmtCtx, ownedFd, inputFd, "after_adts_resync");
   }
 
-  // Find audio stream
+  AdtsFrameHeader adtsPeek;
+  if (isRawAdtsDemuxer) {
+    adtsPeek = peekAdtsHeaderAtAvio(fmtCtx);
+    if (!adtsPeek.ok) {
+      AUDIO_DECODE_DBGW(
+          "adts_peek invalid after resync frameLen=%d sr=%d — decode may still recover from parser",
+          adtsPeek.frameLength,
+          adtsPeek.sampleRateHz);
+    }
+    logInputIoState(fmtCtx, ownedFd, inputFd, "after_adts_peek");
+  }
+
+  // Find audio stream before rewinding custom inputs (seek may target this stream).
   int audioIdx = -1;
   for (unsigned i = 0; i < fmtCtx->nb_streams; ++i) {
     if (fmtCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
@@ -484,6 +1058,101 @@ AudioDecodeResult decodeFileFFmpeg(
   }
   if (audioIdx < 0) {
     throw std::runtime_error("DECODE_NO_AUDIO_STREAM: No audio stream found");
+  }
+  logFormatContextSummary(fmtCtx, audioIdx, "stream_selected");
+
+  // Custom AVIO (e.g. Android content:// fd): reset read position after probe.
+  // ISO-BMFF (mov/mp4/m4a): NEVER avio_seek(0). FFmpeg mov_read_packet() at pb->pos==0
+  // discards all index entries and re-parses from scratch — yields EOF on custom AVIO.
+  // Keep post-find_stream_info IO position; only stream-index seek to sample 0.
+  if (!isRawAdtsDemuxer && inputFd >= 0 && fmtCtx->pb != nullptr) {
+    char errbuf[AV_ERROR_MAX_STRING_SIZE] = {0};
+    const bool isoMedia = isIsoMediaDemuxer(fmtCtx);
+
+    if (isoMedia) {
+      const int64_t avioPosBeforeSeek = avio_tell(fmtCtx->pb);
+      int streamSeekRet = -1;
+      if (audioIdx >= 0) {
+        streamSeekRet = av_seek_frame(fmtCtx, audioIdx, 0, AVSEEK_FLAG_BACKWARD);
+        if (streamSeekRet < 0) {
+          streamSeekRet = avformat_seek_file(
+              fmtCtx,
+              audioIdx,
+              INT64_MIN,
+              0,
+              INT64_MAX,
+              AVSEEK_FLAG_BACKWARD);
+        }
+      }
+      AUDIO_DECODE_DBG(
+          "iso_custom_fd_seek streamSeekRet=%d (%s) avioPosBefore=%lld avioPosAfter=%lld "
+          "(must stay !=0)",
+          streamSeekRet,
+          ffmpegErrLabel(streamSeekRet, errbuf, sizeof(errbuf)),
+          static_cast<long long>(avioPosBeforeSeek),
+          fmtCtx->pb ? static_cast<long long>(avio_tell(fmtCtx->pb)) : -1LL);
+      if (streamSeekRet < 0) {
+        throw std::runtime_error(
+            "DECODE_OPEN_FAILED: Failed to seek ISO media stream to start on custom input");
+      }
+      logInputIoState(fmtCtx, ownedFd, inputFd, "after_iso_stream_seek");
+      if (audioIdx >= 0 && fmtCtx->streams[audioIdx]) {
+        logStreamTimingState(fmtCtx->streams[audioIdx], "after_iso_stream_seek");
+      }
+    } else {
+      const int64_t avioSeekRet = avio_seek(fmtCtx->pb, 0, SEEK_SET);
+      AUDIO_DECODE_DBG(
+          "rewind_step avio_seek ret=%lld eof_before=%d",
+          static_cast<long long>(avioSeekRet),
+          fmtCtx->pb->eof_reached);
+      logInputIoState(fmtCtx, ownedFd, inputFd, "after_avio_seek_0");
+
+      const int byteSeekRet =
+          avformat_seek_file(fmtCtx, -1, 0, 0, 0, AVSEEK_FLAG_BYTE);
+      AUDIO_DECODE_DBG(
+          "rewind_step byte_seek ret=%d (%s)",
+          byteSeekRet,
+          ffmpegErrLabel(byteSeekRet, errbuf, sizeof(errbuf)));
+      logInputIoState(fmtCtx, ownedFd, inputFd, "after_byte_seek");
+
+      int streamSeekRet = -1;
+      if (byteSeekRet < 0 && audioIdx >= 0) {
+        streamSeekRet = avformat_seek_file(fmtCtx, audioIdx, 0, 0, 0, 0);
+        AUDIO_DECODE_DBG(
+            "rewind_step stream_seek_fallback ret=%d (%s) audioIdx=%d",
+            streamSeekRet,
+            ffmpegErrLabel(streamSeekRet, errbuf, sizeof(errbuf)),
+            audioIdx);
+        logInputIoState(fmtCtx, ownedFd, inputFd, "after_stream_seek_fallback");
+      }
+
+      AUDIO_DECODE_DBG(
+          "rewind_after_probe fd=%d avioSeekRet=%lld byteSeekRet=%d streamSeekRet=%d audioIdx=%d",
+          inputFd,
+          static_cast<long long>(avioSeekRet),
+          byteSeekRet,
+          streamSeekRet,
+          audioIdx);
+      if (avioSeekRet < 0) {
+        throw std::runtime_error(
+            "DECODE_OPEN_FAILED: Failed to rewind custom input after stream probe");
+      }
+      if (byteSeekRet < 0 && streamSeekRet < 0) {
+        throw std::runtime_error(
+            "DECODE_OPEN_FAILED: Failed to seek custom input after stream probe");
+      }
+      if (audioIdx >= 0 && fmtCtx->streams[audioIdx]) {
+        logStreamTimingState(fmtCtx->streams[audioIdx], "after_rewind_after_probe");
+      }
+      if (ownedFd >= 0) {
+        logDirectFdBytes(ownedFd, 0, 32, "after_rewind_file_start");
+        logDirectFdBytes(ownedFd, avio_tell(fmtCtx->pb), 32, "after_rewind_avio_pos");
+      }
+      logInputIoState(fmtCtx, ownedFd, inputFd, "after_rewind_after_probe");
+    }
+    logFormatContextSummary(fmtCtx, audioIdx, "after_rewind_after_probe");
+  } else if (!isRawAdtsDemuxer && inputFd < 0) {
+    AUDIO_DECODE_DBG("rewind_after_probe skipped inputKind=path iformat=%s", iformatName);
   }
 
   AVStream* stream = fmtCtx->streams[audioIdx];
@@ -503,46 +1172,123 @@ AudioDecodeResult decodeFileFFmpeg(
     throw std::runtime_error("DECODE_CODEC_UNSUPPORTED: Failed to open decoder");
   }
 
-  // Source info
+  // Source info — raw ADTS leaves codecpar empty until packets are parsed.
   int srcSampleRate = decCtx->sample_rate;
   int srcChannels = decCtx->ch_layout.nb_channels;
+  if (isRawAdtsDemuxer && adtsPeek.ok) {
+    if (srcSampleRate <= 0) {
+      srcSampleRate = adtsPeek.sampleRateHz;
+    }
+    if (srcChannels <= 0 && adtsPeek.channelCount > 0) {
+      srcChannels = adtsPeek.channelCount;
+      av_channel_layout_uninit(&decCtx->ch_layout);
+      av_channel_layout_default(&decCtx->ch_layout, srcChannels);
+    }
+    if (stream->codecpar->bit_rate <= 0 && adtsPeek.frameLength > 0 && srcSampleRate > 0) {
+      stream->codecpar->bit_rate =
+          static_cast<int64_t>(adtsPeek.frameLength) * 8LL * srcSampleRate / 1024LL;
+    }
+  }
   if (srcChannels <= 0) srcChannels = 1;
 
   if (onStreamInfo) {
     onStreamInfo(srcSampleRate, srcChannels);
   }
 
+  AUDIO_DECODE_DBG(
+      "decode_stream_open inputKind=%s iformat=%s codec=%s profile=%d sample_fmt=%d sr=%d ch=%d "
+      "extradata=%d bit_rate=%lld adtsPeek=%d pathHint=%s fd=%d",
+      inputKind,
+      iformatName,
+      decoder->name ? decoder->name : "?",
+      stream->codecpar->profile,
+      static_cast<int>(decCtx->sample_fmt),
+      srcSampleRate,
+      srcChannels,
+      stream->codecpar->extradata_size,
+      static_cast<long long>(stream->codecpar->bit_rate),
+      adtsPeek.ok ? 1 : 0,
+      path ? path : "(null)",
+      inputFd);
+
   // Target config
   int outSampleRate = config.targetSampleRate > 0 ? config.targetSampleRate : srcSampleRate;
   int outChannels = config.forceMono ? 1 : srcChannels;
 
-  // Configure SwrContext for resampling + downmix → float32 mono output
-  AVChannelLayout outLayout;
-  av_channel_layout_default(&outLayout, outChannels);
-
-  int swrRet = swr_alloc_set_opts2(
-      &swr,
-      &outLayout, AV_SAMPLE_FMT_FLT, outSampleRate,
-      &decCtx->ch_layout, decCtx->sample_fmt, srcSampleRate,
-      0, nullptr
-  );
-  if (swrRet < 0 || !swr || swr_init(swr) < 0) {
-    throw std::runtime_error("DECODE_RESAMPLE_ERROR: Failed to initialize resampler");
+  bool swrReady = false;
+  if (srcSampleRate > 0) {
+    swrReady = initDecodeResampler(
+        &swr,
+        decCtx,
+        outSampleRate,
+        outChannels,
+        srcSampleRate,
+        isRawAdtsDemuxer ? "adts_peek" : "codecpar");
+    if (!swrReady) {
+      throw std::runtime_error("DECODE_RESAMPLE_ERROR: Failed to initialize resampler");
+    }
+  } else {
+    AUDIO_DECODE_DBG(
+        "swr_init_deferred iformat=%s waiting_for_first_decoded_frame",
+        iformatName);
   }
+
+  auto ensureSwrFromFrame = [&](AVFrame* decodedFrame, const char* reason) {
+    if (swrReady) {
+      return;
+    }
+    int frameSampleRate = decodedFrame->sample_rate > 0 ? decodedFrame->sample_rate : decCtx->sample_rate;
+    if (frameSampleRate <= 0) {
+      throw std::runtime_error("DECODE_RESAMPLE_ERROR: Unknown source sample rate after first frame");
+    }
+    if (decodedFrame->ch_layout.nb_channels > 0) {
+      srcChannels = decodedFrame->ch_layout.nb_channels;
+      av_channel_layout_uninit(&decCtx->ch_layout);
+      av_channel_layout_copy(&decCtx->ch_layout, &decodedFrame->ch_layout);
+    }
+    srcSampleRate = frameSampleRate;
+    if (config.targetSampleRate <= 0) {
+      outSampleRate = srcSampleRate;
+    }
+    outChannels = config.forceMono ? 1 : srcChannels;
+    if (onStreamInfo) {
+      onStreamInfo(srcSampleRate, srcChannels);
+    }
+    AUDIO_DECODE_DBG(
+        "swr_params_from_frame reason=%s sr=%d ch=%d sample_fmt=%d",
+        reason ? reason : "?",
+        srcSampleRate,
+        srcChannels,
+        static_cast<int>(decodedFrame->format));
+    if (!initDecodeResampler(
+            &swr,
+            decCtx,
+            outSampleRate,
+            outChannels,
+            srcSampleRate,
+            reason)) {
+      throw std::runtime_error("DECODE_RESAMPLE_ERROR: Failed to initialize resampler");
+    }
+    swrReady = true;
+  };
 
   // Progress estimation
   int64_t totalFramesEstimate = 0;
   if (fmtCtx->duration > 0) {
     double durationSec = (double)fmtCtx->duration / AV_TIME_BASE;
     totalFramesEstimate = (int64_t)(durationSec * outSampleRate);
-  } else if (fmtCtx->bit_rate > 0) {
-    struct stat st;
-    const bool hasSize =
-        (ownedFd >= 0 && fstat(ownedFd, &st) == 0 && st.st_size > 0) ||
-        (ownedFd < 0 && path && stat(path, &st) == 0 && st.st_size > 0);
-    if (hasSize) {
-      double durationSec = (double)(st.st_size * 8) / (double)fmtCtx->bit_rate;
-      totalFramesEstimate = (int64_t)(durationSec * outSampleRate);
+  } else {
+    const int64_t bitRate =
+        stream->codecpar->bit_rate > 0 ? stream->codecpar->bit_rate : fmtCtx->bit_rate;
+    if (bitRate > 0) {
+      struct stat st;
+      const bool hasSize =
+          (ownedFd >= 0 && fstat(ownedFd, &st) == 0 && st.st_size > 0) ||
+          (ownedFd < 0 && path && stat(path, &st) == 0 && st.st_size > 0);
+      if (hasSize) {
+        double durationSec = (double)(st.st_size * 8) / (double)bitRate;
+        totalFramesEstimate = (int64_t)(durationSec * outSampleRate);
+      }
     }
   }
 
@@ -557,29 +1303,132 @@ AudioDecodeResult decodeFileFFmpeg(
   chunkBuf.reserve(chunkSize * 2);
 
   int64_t totalFramesDecoded = 0;
+  int audioPacketsSeen = 0;
+  int audioFramesSeen = 0;
+  int readAttempts = 0;
+  int nonAudioPackets = 0;
+  int firstReadRet = 0;
+
+  logInputIoState(fmtCtx, ownedFd, inputFd, "before_read_loop");
+  if (audioIdx >= 0 && fmtCtx->streams[audioIdx]) {
+    logStreamTimingState(fmtCtx->streams[audioIdx], "before_read_loop");
+  }
 
   // Decode loop
-  while (av_read_frame(fmtCtx, pkt) >= 0) {
+  while (true) {
+    const int readRet = av_read_frame(fmtCtx, pkt);
+    readAttempts++;
+    if (readRet < 0) {
+      firstReadRet = readRet;
+      char errbuf[AV_ERROR_MAX_STRING_SIZE] = {0};
+      AUDIO_DECODE_DBG(
+          "read_frame_end attempt=%d ret=%d (%s) audioPackets=%d nonAudio=%d avioPos=%lld eof=%d",
+          readAttempts,
+          readRet,
+          ffmpegErrLabel(readRet, errbuf, sizeof(errbuf)),
+          audioPacketsSeen,
+          nonAudioPackets,
+          fmtCtx->pb ? static_cast<long long>(avio_tell(fmtCtx->pb)) : -1LL,
+          fmtCtx->pb ? fmtCtx->pb->eof_reached : -1);
+      if (readAttempts == 1) {
+        logInputIoState(fmtCtx, ownedFd, inputFd, "first_read_fail");
+        if (audioIdx >= 0 && fmtCtx->streams[audioIdx]) {
+          logStreamTimingState(fmtCtx->streams[audioIdx], "first_read_fail");
+        }
+      }
+      break;
+    }
+
     if (cancelFlag.load(std::memory_order_relaxed)) {
+      av_packet_unref(pkt);
       throw std::runtime_error("DECODE_CANCELLED: Operation cancelled");
     }
 
     if (pkt->stream_index != audioIdx) {
+      nonAudioPackets++;
+      if (nonAudioPackets == 1) {
+        AUDIO_DECODE_DBG(
+            "first_non_audio_packet stream_index=%d expected=%d size=%d pts=%lld",
+            pkt->stream_index,
+            audioIdx,
+            pkt->size,
+            static_cast<long long>(pkt->pts));
+      }
       av_packet_unref(pkt);
       continue;
     }
 
+    audioPacketsSeen++;
+    const int pktSize = pkt->size;
+    if (audioPacketsSeen == 1) {
+      char hexPrefix[64] = {0};
+      const int hexLen = pktSize > 0 && pkt->data != nullptr ? std::min(pktSize, 16) : 0;
+      for (int i = 0; i < hexLen; ++i) {
+        std::snprintf(hexPrefix + i * 3, sizeof(hexPrefix) - i * 3, "%02x ", pkt->data[i]);
+      }
+      AUDIO_DECODE_DBG(
+          "first_audio_packet iformat=%s pktSize=%d hex=%s avioPos=%lld fd=%d",
+          iformatName,
+          pktSize,
+          hexLen > 0 ? hexPrefix : "(empty)",
+          fmtCtx->pb ? static_cast<long long>(avio_tell(fmtCtx->pb)) : -1LL,
+          inputFd);
+    }
     int sendRet = avcodec_send_packet(decCtx, pkt);
-    av_packet_unref(pkt);
     if (sendRet < 0 && sendRet != AVERROR(EAGAIN) && sendRet != AVERROR_EOF) {
+#ifdef HAVE_FFMPEG
+      char errbuf[AV_ERROR_MAX_STRING_SIZE] = {0};
+      av_strerror(sendRet, errbuf, sizeof(errbuf));
+      char hexPrefix[64] = {0};
+      const int hexLen = pktSize > 0 && pkt->data != nullptr ? std::min(pktSize, 16) : 0;
+      for (int i = 0; i < hexLen; ++i) {
+        std::snprintf(hexPrefix + i * 3, sizeof(hexPrefix) - i * 3, "%02x ", pkt->data[i]);
+      }
+      LOGE(
+          "send_packet_fail pkt#=%d ret=%d (%s) pktSize=%d hex=%s codec=%s iformat=%s pathHint=%s fd=%d",
+          audioPacketsSeen,
+          sendRet,
+          errbuf,
+          pktSize,
+          hexLen > 0 ? hexPrefix : "(empty)",
+          decoder->name ? decoder->name : "?",
+          (fmtCtx->iformat && fmtCtx->iformat->name) ? fmtCtx->iformat->name : "?",
+          path ? path : "(null)",
+          inputFd);
+#else
+      LOGE(
+          "send_packet_fail pkt#=%d ret=%d pktSize=%d pathHint=%s fd=%d",
+          audioPacketsSeen,
+          sendRet,
+          pktSize,
+          path ? path : "(null)",
+          inputFd);
+#endif
+      av_packet_unref(pkt);
       throw std::runtime_error("DECODE_DECODE_ERROR: Error sending packet to decoder");
     }
+    av_packet_unref(pkt);
 
     while (true) {
       int recvRet = avcodec_receive_frame(decCtx, frame);
       if (recvRet == AVERROR(EAGAIN) || recvRet == AVERROR_EOF) break;
       if (recvRet < 0) {
         throw std::runtime_error("DECODE_DECODE_ERROR: Error receiving frame from decoder");
+      }
+
+      ensureSwrFromFrame(frame, "decode_loop");
+
+      audioFramesSeen++;
+      if (audioFramesSeen == 1) {
+        AUDIO_DECODE_DBG(
+            "first_audio_frame iformat=%s pkt#=%d nb_samples=%d sr=%d ch=%d fmt=%d pts=%lld",
+            iformatName,
+            audioPacketsSeen,
+            frame->nb_samples,
+            frame->sample_rate,
+            frame->ch_layout.nb_channels,
+            static_cast<int>(frame->format),
+            static_cast<long long>(frame->pts));
       }
 
       // Resample frame → float32
@@ -624,6 +1473,11 @@ AudioDecodeResult decodeFileFFmpeg(
     if (recvRet == AVERROR(EAGAIN) || recvRet == AVERROR_EOF) break;
     if (recvRet < 0) break;
 
+    ensureSwrFromFrame(frame, "decoder_flush");
+    if (!swrReady) {
+      break;
+    }
+
     int maxOutSamples = swr_get_out_samples(swr, frame->nb_samples);
     if (maxOutSamples <= 0) maxOutSamples = frame->nb_samples * 4;
 
@@ -640,13 +1494,15 @@ AudioDecodeResult decodeFileFFmpeg(
   }
 
   // Flush resampler
-  while (true) {
-    float flushBuf[1024];
-    uint8_t* outBuf[1] = { reinterpret_cast<uint8_t*>(flushBuf) };
-    int flushed = swr_convert(swr, outBuf, 1024, nullptr, 0);
-    if (flushed <= 0) break;
-    int samplesOut = flushed * outChannels;
-    chunkBuf.insert(chunkBuf.end(), flushBuf, flushBuf + samplesOut);
+  if (swrReady) {
+    while (true) {
+      float flushBuf[1024];
+      uint8_t* outBuf[1] = { reinterpret_cast<uint8_t*>(flushBuf) };
+      int flushed = swr_convert(swr, outBuf, 1024, nullptr, 0);
+      if (flushed <= 0) break;
+      int samplesOut = flushed * outChannels;
+      chunkBuf.insert(chunkBuf.end(), flushBuf, flushBuf + samplesOut);
+    }
   }
 
   // Deliver remaining samples
@@ -663,11 +1519,45 @@ AudioDecodeResult decodeFileFFmpeg(
   result.totalFramesDecoded = totalFramesDecoded;
   result.sourceSampleRate = srcSampleRate;
   result.sourceChannels = srcChannels;
+  AUDIO_DECODE_DBG(
+      "decode_done inputKind=%s iformat=%s totalFrames=%lld audioPackets=%d audioFrames=%d "
+      "readAttempts=%d firstReadRet=%d nonAudio=%d outSr=%d srcSr=%d srcCh=%d pathHint=%s fd=%d",
+      inputKind,
+      iformatName,
+      static_cast<long long>(totalFramesDecoded),
+      audioPacketsSeen,
+      audioFramesSeen,
+      readAttempts,
+      firstReadRet,
+      nonAudioPackets,
+      outSampleRate,
+      srcSampleRate,
+      srcChannels,
+      path ? path : "(null)",
+      inputFd);
+#ifdef NDEBUG
+  if (totalFramesDecoded <= 0) {
+    LOGW(
+        "decode_empty iformat=%s inputKind=%s pathHint=%s fd=%d packets=%d firstReadRet=%d",
+        iformatName,
+        inputKind,
+        path ? path : "(null)",
+        inputFd,
+        audioPacketsSeen,
+        firstReadRet);
+  }
+#endif
   SHERPA_DIAG("audio.decode", "ffmpeg_end");
   return result;
 }
 
 AudioFileProbeResult probeFileDurationFFmpeg(const char* path, int inputFd) {
+  AUDIO_DECODE_DBG(
+      "probe_duration_start pathHint=%s fd=%d inputKind=%s",
+      path ? path : "(null)",
+      inputFd,
+      inputFd >= 0 ? "content_fd" : "path");
+
   AVFormatContext* fmtCtx = nullptr;
   AVIOContext* avioCtx = nullptr;
   int ownedFd = -1;
@@ -725,6 +1615,19 @@ AudioFileProbeResult probeFileDurationFFmpeg(const char* path, int inputFd) {
     }
   }
 
+  const char* iformatName =
+      (fmtCtx->iformat && fmtCtx->iformat->name) ? fmtCtx->iformat->name : "?";
+  AUDIO_DECODE_DBG(
+      "probe_duration_open iformat=%s pathHint=%s fd=%d",
+      iformatName,
+      path ? path : "(null)",
+      inputFd);
+  if (ownedFd >= 0) {
+    logContainerMagicFromFd(ownedFd, "probe_duration_open");
+    logDirectFdBytes(ownedFd, 0, 32, "probe_duration_file_start");
+  }
+  logInputIoState(fmtCtx, ownedFd, inputFd, "probe_duration_after_open");
+
   AVDictionary* opts = nullptr;
   av_dict_set(&opts, "analyzeduration", "2000000", 0);
   av_dict_set(&opts, "probesize", "32768", 0);
@@ -733,6 +1636,8 @@ AudioFileProbeResult probeFileDurationFFmpeg(const char* path, int inputFd) {
     throw std::runtime_error("PROBE_STREAM_INFO_FAILED: Cannot read stream info");
   }
   av_dict_free(&opts);
+  logInputIoState(fmtCtx, ownedFd, inputFd, "probe_duration_after_find_stream_info");
+  logFormatContextSummary(fmtCtx, -1, "probe_duration_after_find_stream_info");
 
   int audioStreamIdx = -1;
   for (unsigned i = 0; i < fmtCtx->nb_streams; i++) {
@@ -744,6 +1649,7 @@ AudioFileProbeResult probeFileDurationFFmpeg(const char* path, int inputFd) {
   if (audioStreamIdx < 0) {
     throw std::runtime_error("PROBE_NO_AUDIO_STREAM: No audio stream found");
   }
+  logFormatContextSummary(fmtCtx, audioStreamIdx, "probe_duration_stream_selected");
 
   AudioFileProbeResult result;
   AVStream* stream = fmtCtx->streams[audioStreamIdx];
@@ -753,6 +1659,12 @@ AudioFileProbeResult probeFileDurationFFmpeg(const char* path, int inputFd) {
     if (sec > 0) {
       result.durationMs = static_cast<int64_t>(sec * 1000.0);
       result.isExact = true;
+      AUDIO_DECODE_DBG(
+          "probe_duration_ok source=stream durationMs=%lld exact=%d iformat=%s fd=%d",
+          static_cast<long long>(result.durationMs),
+          result.isExact ? 1 : 0,
+          iformatName,
+          inputFd);
       return result;
     }
   }
@@ -762,6 +1674,12 @@ AudioFileProbeResult probeFileDurationFFmpeg(const char* path, int inputFd) {
     if (sec > 0) {
       result.durationMs = static_cast<int64_t>(sec * 1000.0);
       result.isExact = true;
+      AUDIO_DECODE_DBG(
+          "probe_duration_ok source=format durationMs=%lld exact=%d iformat=%s fd=%d",
+          static_cast<long long>(result.durationMs),
+          result.isExact ? 1 : 0,
+          iformatName,
+          inputFd);
       return result;
     }
   }
@@ -777,6 +1695,12 @@ AudioFileProbeResult probeFileDurationFFmpeg(const char* path, int inputFd) {
       if (sec > 0) {
         result.durationMs = static_cast<int64_t>(sec * 1000.0);
         result.isExact = false;
+        AUDIO_DECODE_DBG(
+            "probe_duration_ok source=bitrate durationMs=%lld exact=%d iformat=%s fd=%d",
+            static_cast<long long>(result.durationMs),
+            result.isExact ? 1 : 0,
+            iformatName,
+            inputFd);
         return result;
       }
     }
@@ -786,6 +1710,12 @@ AudioFileProbeResult probeFileDurationFFmpeg(const char* path, int inputFd) {
 }
 
 AudioContainerProbeResult probeFileContainerFFmpeg(const char* path, int inputFd) {
+  AUDIO_DECODE_DBG(
+      "probe_container_start pathHint=%s fd=%d inputKind=%s",
+      path ? path : "(null)",
+      inputFd,
+      inputFd >= 0 ? "content_fd" : "path");
+
   AVFormatContext* fmtCtx = nullptr;
   AVIOContext* avioCtx = nullptr;
   int ownedFd = -1;
@@ -850,6 +1780,20 @@ AudioContainerProbeResult probeFileContainerFFmpeg(const char* path, int inputFd
     }
   }
 
+  const char* iformatName =
+      (fmtCtx->iformat && fmtCtx->iformat->name) ? fmtCtx->iformat->name : "?";
+  AUDIO_DECODE_DBG(
+      "probe_container_open iformat=%s pathHint=%s fd=%d autoProbeOnly=%d",
+      iformatName,
+      path ? path : "(null)",
+      inputFd,
+      1);
+  if (ownedFd >= 0) {
+    logContainerMagicFromFd(ownedFd, "probe_container_open");
+    logDirectFdBytes(ownedFd, 0, 32, "probe_container_file_start");
+  }
+  logInputIoState(fmtCtx, ownedFd, inputFd, "probe_container_after_open");
+
   AVDictionary* opts = nullptr;
   av_dict_set(&opts, "analyzeduration", "2000000", 0);
   av_dict_set(&opts, "probesize", "32768", 0);
@@ -858,6 +1802,8 @@ AudioContainerProbeResult probeFileContainerFFmpeg(const char* path, int inputFd
     throw std::runtime_error("PROBE_STREAM_INFO_FAILED: Cannot read stream info");
   }
   av_dict_free(&opts);
+  logInputIoState(fmtCtx, ownedFd, inputFd, "probe_container_after_find_stream_info");
+  logFormatContextSummary(fmtCtx, -1, "probe_container_after_find_stream_info");
 
   int audioStreamIdx = -1;
   for (unsigned i = 0; i < fmtCtx->nb_streams; i++) {
@@ -869,6 +1815,7 @@ AudioContainerProbeResult probeFileContainerFFmpeg(const char* path, int inputFd
   if (audioStreamIdx < 0) {
     throw std::runtime_error("PROBE_NO_AUDIO_STREAM: No audio stream found");
   }
+  logFormatContextSummary(fmtCtx, audioStreamIdx, "probe_container_stream_selected");
 
   AudioContainerProbeResult result;
   if (fmtCtx->iformat && fmtCtx->iformat->name && fmtCtx->iformat->name[0] != '\0') {
@@ -889,6 +1836,14 @@ AudioContainerProbeResult probeFileContainerFFmpeg(const char* path, int inputFd
   } else {
     result.codecName = "unknown";
   }
+
+  AUDIO_DECODE_DBG(
+      "probe_container_ok inputFormat=%s codec=%s iformat=%s fd=%d pathHint=%s",
+      result.inputFormatName.c_str(),
+      result.codecName.c_str(),
+      iformatName,
+      inputFd,
+      path ? path : "(null)");
 
   return result;
 }
@@ -933,7 +1888,7 @@ AudioDecodeResult decodeFile(
 
   WavInfo wavInfo = parseWavHeaderForFastPath(f);
   if (canUseWavFastPath(wavInfo, config)) {
-    LOGI("Using WAV fast path: rate=%d ch=%d bits=%d", wavInfo.sampleRate, wavInfo.channels, wavInfo.bitsPerSample);
+    AUDIO_DECODE_DBG("Using WAV fast path: rate=%d ch=%d bits=%d", wavInfo.sampleRate, wavInfo.channels, wavInfo.bitsPerSample);
     auto result = decodeWavFastPath(f, wavInfo, config, onChunk, onProgress, onStreamInfo, cancelFlag);
     fclose(f);
     return result;
@@ -946,7 +1901,7 @@ AudioDecodeResult decodeFile(
 
   // FFmpeg path
 #ifdef HAVE_FFMPEG
-  LOGI("Using FFmpeg decode path: %s targetRate=%d forceMono=%d", pathOrFd ? pathOrFd : "<fd>", config.targetSampleRate, config.forceMono);
+  AUDIO_DECODE_DBG("Using FFmpeg decode path: %s targetRate=%d forceMono=%d", pathOrFd ? pathOrFd : "<fd>", config.targetSampleRate, config.forceMono);
   return decodeFileFFmpeg(pathOrFd, inputFd, config, onChunk, onProgress, onStreamInfo, cancelFlag);
 #else
   throw std::runtime_error("DECODE_INTERNAL_ERROR: FFmpeg not available in this build");

--- a/android/src/main/cpp/jni/model_detect/separation/sherpa-onnx-separation-detect-wrapper.cpp
+++ b/android/src/main/cpp/jni/model_detect/separation/sherpa-onnx-separation-detect-wrapper.cpp
@@ -1,4 +1,4 @@
-#include "sherpa-onnx-separation-wrapper.h"
+#include "sherpa-onnx-separation-detect-wrapper.h"
 
 #include "sherpa-onnx-detect-jni-common.h"
 #include "sherpa-onnx-model-detect.h"

--- a/android/src/main/cpp/jni/model_detect/separation/sherpa-onnx-separation-detect-wrapper.h
+++ b/android/src/main/cpp/jni/model_detect/separation/sherpa-onnx-separation-detect-wrapper.h
@@ -1,5 +1,5 @@
-#ifndef SHERPA_ONNX_SEPARATION_WRAPPER_H
-#define SHERPA_ONNX_SEPARATION_WRAPPER_H
+#ifndef SHERPA_ONNX_SEPARATION_DETECT_WRAPPER_H
+#define SHERPA_ONNX_SEPARATION_DETECT_WRAPPER_H
 
 #include <jni.h>
 
@@ -14,4 +14,4 @@ jobject SeparationDetectResultToJava(
 
 } // namespace sherpaonnx
 
-#endif // SHERPA_ONNX_SEPARATION_WRAPPER_H
+#endif // SHERPA_ONNX_SEPARATION_DETECT_WRAPPER_H

--- a/android/src/main/cpp/jni/module/sherpa-onnx-module-jni.cpp
+++ b/android/src/main/cpp/jni/module/sherpa-onnx-module-jni.cpp
@@ -22,7 +22,7 @@
 #include "sherpa-onnx-stt-wrapper.h"
 #include "sherpa-onnx-tts-wrapper.h"
 #include "sherpa-onnx-enhancement-wrapper.h"
-#include "sherpa-onnx-separation-wrapper.h"
+#include "sherpa-onnx-separation-detect-wrapper.h"
 #include "sherpa-onnx-punctuation-wrapper.h"
 #include "sherpa-onnx-vad-wrapper.h"
 #include "sherpa-onnx-alignment-wrapper.h"

--- a/android/src/main/cpp/jni/separation/sherpa-onnx-separation-jni.cpp
+++ b/android/src/main/cpp/jni/separation/sherpa-onnx-separation-jni.cpp
@@ -13,6 +13,9 @@
 #include <unordered_map>
 
 #define SEPARATION_JNI_TAG "SherpaOnnxSeparationJNI"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, SEPARATION_JNI_TAG, __VA_ARGS__)
+#define LOGW(...) __android_log_print(ANDROID_LOG_WARN, SEPARATION_JNI_TAG, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, SEPARATION_JNI_TAG, __VA_ARGS__)
 
 namespace {
 
@@ -123,6 +126,14 @@ Java_com_sherpaonnx_separation_facade_SherpaOnnxSeparationHelper_nativeInitializ
   const std::string modelTypeStr = CopyRequiredJstring(env, modelType);
   const auto providerOpt = CopyOptionalJstring(env, provider);
 
+  LOGI(
+      "nativeInitializeSeparationAuto: instanceId=%s modelDir=%s modelType=%s threads=%d",
+      instanceIdStr.c_str(),
+      modelDirStr.c_str(),
+      modelTypeStr.c_str(),
+      numThreads
+  );
+
   sherpaonnx::SeparationInitializeResult result;
   {
     std::lock_guard<std::mutex> lock(g_separation_mutex);
@@ -140,7 +151,19 @@ Java_com_sherpaonnx_separation_facade_SherpaOnnxSeparationHelper_nativeInitializ
         debug == JNI_TRUE
     );
     if (!result.success) {
+      LOGE(
+          "nativeInitializeSeparationAuto failed: instanceId=%s error=%s",
+          instanceIdStr.c_str(),
+          result.error.c_str()
+      );
       g_separation_instances.erase(instanceIdStr);
+    } else {
+      LOGI(
+          "nativeInitializeSeparationAuto ok: instanceId=%s sampleRate=%d numStems=%d",
+          instanceIdStr.c_str(),
+          result.sampleRate,
+          result.numStems
+      );
     }
   }
   return SeparationInitializeResultToJava(env, result);
@@ -167,6 +190,13 @@ Java_com_sherpaonnx_separation_facade_SherpaOnnxSeparationHelper_nativeInitializ
       paths
   );
 
+  LOGI(
+      "nativeInitializeSeparationCustom: instanceId=%s modelType=%s threads=%d",
+      instanceIdStr.c_str(),
+      modelTypeStr.c_str(),
+      numThreads
+  );
+
   sherpaonnx::SeparationInitializeResult result;
   {
     std::lock_guard<std::mutex> lock(g_separation_mutex);
@@ -184,7 +214,19 @@ Java_com_sherpaonnx_separation_facade_SherpaOnnxSeparationHelper_nativeInitializ
         debug == JNI_TRUE
     );
     if (!result.success) {
+      LOGE(
+          "nativeInitializeSeparationCustom failed: instanceId=%s error=%s",
+          instanceIdStr.c_str(),
+          result.error.c_str()
+      );
       g_separation_instances.erase(instanceIdStr);
+    } else {
+      LOGI(
+          "nativeInitializeSeparationCustom ok: instanceId=%s sampleRate=%d numStems=%d",
+          instanceIdStr.c_str(),
+          result.sampleRate,
+          result.numStems
+      );
     }
   }
   return SeparationInitializeResultToJava(env, result);
@@ -201,25 +243,40 @@ Java_com_sherpaonnx_separation_facade_SherpaOnnxSeparationHelper_nativeProcessSe
   const std::string instanceIdStr = CopyRequiredJstring(env, instanceId);
   sherpaonnx::SeparationWrapper* wrapper = GetSeparationWrapperOrNull(instanceIdStr);
   if (wrapper == nullptr) {
-    __android_log_print(ANDROID_LOG_ERROR, SEPARATION_JNI_TAG,
-                        "Process: instance not found: %s", instanceIdStr.c_str());
+    LOGE("nativeProcessSeparation: instance not found: %s", instanceIdStr.c_str());
     return nullptr;
   }
 
   jsize n = env->GetArrayLength(samples);
   if (n <= 0 || sampleRate <= 0) {
+    LOGE(
+        "nativeProcessSeparation: invalid input instanceId=%s n=%d sampleRate=%d",
+        instanceIdStr.c_str(),
+        static_cast<int>(n),
+        sampleRate
+    );
     return nullptr;
   }
+  LOGI(
+      "nativeProcessSeparation: instanceId=%s n=%d sampleRate=%d",
+      instanceIdStr.c_str(),
+      static_cast<int>(n),
+      sampleRate
+  );
   std::vector<float> input(static_cast<size_t>(n));
   env->GetFloatArrayRegion(samples, 0, n, input.data());
 
   sherpaonnx::SeparationProcessResult result =
       wrapper->processMonoSamples(input, sampleRate);
   if (!result.success) {
-    __android_log_print(ANDROID_LOG_ERROR, SEPARATION_JNI_TAG,
-                        "Process failed: %s", result.error.c_str());
+    LOGE("nativeProcessSeparation failed: %s", result.error.c_str());
     return nullptr;
   }
+  LOGI(
+      "nativeProcessSeparation ok: instanceId=%s stems=%zu",
+      instanceIdStr.c_str(),
+      result.stems.size()
+  );
 
   jclass floatArrayClass = env->FindClass("[F");
   if (!floatArrayClass) return nullptr;
@@ -274,6 +331,7 @@ Java_com_sherpaonnx_separation_facade_SherpaOnnxSeparationHelper_nativeReleaseSe
     jstring instanceId
 ) {
   const std::string instanceIdStr = CopyRequiredJstring(env, instanceId);
+  LOGI("nativeReleaseSeparation: instanceId=%s", instanceIdStr.c_str());
   std::lock_guard<std::mutex> lock(g_separation_mutex);
   auto it = g_separation_instances.find(instanceIdStr);
   if (it != g_separation_instances.end()) {

--- a/android/src/main/cpp/separation/sherpa-onnx-separation-wrapper.cpp
+++ b/android/src/main/cpp/separation/sherpa-onnx-separation-wrapper.cpp
@@ -8,6 +8,23 @@
 
 #include "sherpa-onnx/c-api/c-api.h"
 
+#ifdef __ANDROID__
+#include <android/log.h>
+#define SEPARATION_LOG_TAG "SherpaOnnxSeparation"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, SEPARATION_LOG_TAG, __VA_ARGS__)
+#define LOGW(...) __android_log_print(ANDROID_LOG_WARN, SEPARATION_LOG_TAG, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, SEPARATION_LOG_TAG, __VA_ARGS__)
+#elif defined(__APPLE__)
+#include <os/log.h>
+#define LOGI(fmt, ...) os_log_info(OS_LOG_DEFAULT, fmt, ##__VA_ARGS__)
+#define LOGW(fmt, ...) os_log(OS_LOG_DEFAULT, fmt, ##__VA_ARGS__)
+#define LOGE(fmt, ...) os_log_error(OS_LOG_DEFAULT, fmt, ##__VA_ARGS__)
+#else
+#define LOGI(...) ((void)0)
+#define LOGW(...) ((void)0)
+#define LOGE(...) ((void)0)
+#endif
+
 namespace sherpaonnx {
 namespace {
 
@@ -184,9 +201,17 @@ SeparationInitializeResult SeparationWrapper::initialize(
     }
 
     auto engineConfig = BuildEngineConfig(detect, numThreads, provider, debug);
+    LOGI(
+        "initialize: modelDir=%s modelType=%s threads=%d debug=%d",
+        modelDir.c_str(),
+        result.modelType.c_str(),
+        numThreads,
+        debug ? 1 : 0
+    );
     pImpl->separation = SherpaOnnxCreateOfflineSourceSeparation(&engineConfig.config);
     if (pImpl->separation == nullptr) {
         result.error = "Failed to create offline source separation engine";
+        LOGE("initialize failed: %s", result.error.c_str());
         return result;
     }
 
@@ -194,6 +219,11 @@ SeparationInitializeResult SeparationWrapper::initialize(
     result.success = true;
     result.sampleRate = SherpaOnnxOfflineSourceSeparationGetOutputSampleRate(pImpl->separation);
     result.numStems = SherpaOnnxOfflineSourceSeparationGetNumberOfStems(pImpl->separation);
+    LOGI(
+        "initialize ok: sampleRate=%d numStems=%d",
+        result.sampleRate,
+        result.numStems
+    );
     return result;
 }
 
@@ -228,9 +258,16 @@ SeparationInitializeResult SeparationWrapper::initializeCustom(
     auto engineConfig = BuildEngineConfig(
         selectedKind, paths, numThreads, provider, debug
     );
+    LOGI(
+        "initializeCustom: modelType=%s threads=%d debug=%d",
+        result.modelType.c_str(),
+        numThreads,
+        debug ? 1 : 0
+    );
     pImpl->separation = SherpaOnnxCreateOfflineSourceSeparation(&engineConfig.config);
     if (pImpl->separation == nullptr) {
         result.error = "Failed to create offline source separation engine";
+        LOGE("initializeCustom failed: %s", result.error.c_str());
         return result;
     }
 
@@ -238,6 +275,11 @@ SeparationInitializeResult SeparationWrapper::initializeCustom(
     result.success = true;
     result.sampleRate = SherpaOnnxOfflineSourceSeparationGetOutputSampleRate(pImpl->separation);
     result.numStems = SherpaOnnxOfflineSourceSeparationGetNumberOfStems(pImpl->separation);
+    LOGI(
+        "initializeCustom ok: sampleRate=%d numStems=%d",
+        result.sampleRate,
+        result.numStems
+    );
     return result;
 }
 
@@ -261,17 +303,31 @@ SeparationProcessResult SeparationWrapper::processMonoSamples(
 
     const float* channels[] = {monoSamples.data()};
     const int32_t numSamples = static_cast<int32_t>(monoSamples.size());
+    LOGI(
+        "processMonoSamples: numSamples=%d sampleRate=%d",
+        numSamples,
+        sampleRate
+    );
     const SherpaOnnxSourceSeparationOutput* output =
         SherpaOnnxOfflineSourceSeparationProcess(
             pImpl->separation, channels, 1, numSamples, sampleRate
         );
     if (output == nullptr) {
         result.error = "Source separation processing failed";
+        LOGE("processMonoSamples failed: native Process returned null");
         return result;
     }
 
     result = ToSeparationProcessResult(output);
     SherpaOnnxDestroySourceSeparationOutput(output);
+    if (result.success) {
+        LOGI(
+            "processMonoSamples ok: stems=%zu",
+            result.stems.size()
+        );
+    } else {
+        LOGE("processMonoSamples failed: %s", result.error.c_str());
+    }
     return result;
 }
 
@@ -289,6 +345,7 @@ bool SeparationWrapper::isInitialized() const { return pImpl->initialized; }
 
 void SeparationWrapper::release() {
     if (pImpl->separation != nullptr) {
+        LOGI("release: destroying separation engine");
         SherpaOnnxDestroyOfflineSourceSeparation(pImpl->separation);
         pImpl->separation = nullptr;
     }

--- a/android/src/main/cpp/separation/sherpa-onnx-separation-wrapper.cpp
+++ b/android/src/main/cpp/separation/sherpa-onnx-separation-wrapper.cpp
@@ -301,16 +301,21 @@ SeparationProcessResult SeparationWrapper::processMonoSamples(
         return result;
     }
 
-    const float* channels[] = {monoSamples.data()};
+    // Spleeter's native path always reads channel 0 and 1; mono input alone
+    // triggers SHERPA_ONNX_EXIT inside sherpa-onnx. UVR tolerates missing ch1.
     const int32_t numSamples = static_cast<int32_t>(monoSamples.size());
+    std::vector<float> stereoRight = monoSamples;
+    const float* channels[] = {monoSamples.data(), stereoRight.data()};
+    constexpr int32_t kNumChannels = 2;
     LOGI(
-        "processMonoSamples: numSamples=%d sampleRate=%d",
+        "processMonoSamples: numSamples=%d sampleRate=%d channels=%d (mono upmixed to stereo)",
         numSamples,
-        sampleRate
+        sampleRate,
+        kNumChannels
     );
     const SherpaOnnxSourceSeparationOutput* output =
         SherpaOnnxOfflineSourceSeparationProcess(
-            pImpl->separation, channels, 1, numSamples, sampleRate
+            pImpl->separation, channels, kNumChannels, numSamples, sampleRate
         );
     if (output == nullptr) {
         result.error = "Source separation processing failed";

--- a/android/src/main/cpp/separation/sherpa-onnx-separation-wrapper.cpp
+++ b/android/src/main/cpp/separation/sherpa-onnx-separation-wrapper.cpp
@@ -3,9 +3,10 @@
 #include "sherpa-onnx-model-detect.h"
 #include "sherpa-onnx-validate-separation.h"
 
+#include <cstring>
 #include <optional>
 
-#include "sherpa-onnx/c-api/cxx-api.h"
+#include "sherpa-onnx/c-api/c-api.h"
 
 namespace sherpaonnx {
 namespace {
@@ -27,81 +28,99 @@ SeparationModelKind ParseSeparationModelTypeFromString(const std::string& modelT
     return SeparationModelKind::kUnknown;
 }
 
-sherpa_onnx::cxx::OfflineSourceSeparationModelConfig BuildModelConfigFromPaths(
+struct SeparationEngineConfig {
+    SherpaOnnxOfflineSourceSeparationConfig config{};
+    std::string vocals;
+    std::string accompaniment;
+    std::string uvrModel;
+    std::string provider;
+};
+
+SeparationEngineConfig BuildEngineConfig(
     SeparationModelKind kind,
     const SeparationModelPaths& paths,
     int32_t numThreads,
     const std::optional<std::string>& provider,
     bool debug
 ) {
-    sherpa_onnx::cxx::OfflineSourceSeparationModelConfig cfg;
-    cfg.num_threads = numThreads;
-    cfg.debug = debug;
+    SeparationEngineConfig bundle;
+    std::memset(&bundle.config, 0, sizeof(bundle.config));
+
+    bundle.config.model.num_threads = numThreads;
+    bundle.config.model.debug = debug ? 1 : 0;
     if (provider.has_value() && !provider->empty()) {
-        cfg.provider = *provider;
+        bundle.provider = *provider;
+        bundle.config.model.provider = bundle.provider.c_str();
     }
+
     switch (kind) {
         case SeparationModelKind::kSpleeter:
-            cfg.spleeter.vocals = paths.vocals;
-            cfg.spleeter.accompaniment = paths.accompaniment;
+            bundle.vocals = paths.vocals;
+            bundle.accompaniment = paths.accompaniment;
+            bundle.config.model.spleeter.vocals = bundle.vocals.c_str();
+            bundle.config.model.spleeter.accompaniment = bundle.accompaniment.c_str();
             break;
         case SeparationModelKind::kUvr:
-            cfg.uvr.model = paths.model;
+            bundle.uvrModel = paths.model;
+            bundle.config.model.uvr.model = bundle.uvrModel.c_str();
             break;
         default:
             break;
     }
-    return cfg;
+    return bundle;
 }
 
-sherpa_onnx::cxx::OfflineSourceSeparationModelConfig BuildModelConfig(
+SeparationEngineConfig BuildEngineConfig(
     const SeparationDetectResult& detect,
     int32_t numThreads,
     const std::optional<std::string>& provider,
     bool debug
 ) {
-    return BuildModelConfigFromPaths(
+    return BuildEngineConfig(
         detect.selectedKind, detect.paths, numThreads, provider, debug
     );
 }
 
-std::vector<float> DownmixStemToMono(
-    const sherpa_onnx::cxx::SourceSeparationStem& stem
-) {
-    if (stem.samples.empty()) {
+std::vector<float> DownmixStemToMono(const SherpaOnnxSourceSeparationStem& stem) {
+    if (stem.num_channels <= 0 || stem.samples == nullptr || stem.n <= 0) {
         return {};
     }
-    if (stem.samples.size() == 1) {
-        return stem.samples[0];
+    if (stem.num_channels == 1) {
+        return {stem.samples[0], stem.samples[0] + stem.n};
     }
-    const size_t n = stem.samples[0].size();
-    for (size_t c = 1; c < stem.samples.size(); ++c) {
-        if (stem.samples[c].size() != n) {
+    const int32_t n = stem.n;
+    for (int32_t c = 1; c < stem.num_channels; ++c) {
+        if (stem.samples[c] == nullptr) {
             return {};
         }
     }
-    std::vector<float> mono(n);
-    const float invChannels = 1.0f / static_cast<float>(stem.samples.size());
-    for (size_t i = 0; i < n; ++i) {
+    std::vector<float> mono(static_cast<size_t>(n));
+    const float invChannels = 1.0f / static_cast<float>(stem.num_channels);
+    for (int32_t i = 0; i < n; ++i) {
         float sum = 0.0f;
-        for (const auto& channel : stem.samples) {
-            sum += channel[i];
+        for (int32_t c = 0; c < stem.num_channels; ++c) {
+            sum += stem.samples[c][i];
         }
-        mono[i] = sum * invChannels;
+        mono[static_cast<size_t>(i)] = sum * invChannels;
     }
     return mono;
 }
 
 SeparationProcessResult ToSeparationProcessResult(
-    const sherpa_onnx::cxx::SourceSeparationOutput& output
+    const SherpaOnnxSourceSeparationOutput* output
 ) {
     SeparationProcessResult result;
-    result.stems.reserve(output.stems.size());
-    for (const auto& stem : output.stems) {
+    if (output == nullptr || output->stems == nullptr || output->num_stems <= 0) {
+        result.error = "Source separation produced no stems";
+        return result;
+    }
+
+    result.stems.reserve(static_cast<size_t>(output->num_stems));
+    for (int32_t s = 0; s < output->num_stems; ++s) {
         SeparationStemAudio audio;
-        audio.sampleRate = output.sample_rate;
-        audio.samples = DownmixStemToMono(stem);
-        if (audio.samples.empty() && !stem.samples.empty()) {
+        audio.sampleRate = output->sample_rate;
+        audio.samples = DownmixStemToMono(output->stems[s]);
+        if (audio.samples.empty()) {
             result.success = false;
             result.error = "Stem channel length mismatch during mono downmix";
             result.stems.clear();
@@ -121,7 +140,7 @@ SeparationProcessResult ToSeparationProcessResult(
 class SeparationWrapper::Impl {
 public:
     bool initialized = false;
-    std::optional<sherpa_onnx::cxx::OfflineSourceSeparation> separation;
+    const SherpaOnnxOfflineSourceSeparation* separation = nullptr;
 };
 
 SeparationWrapper::SeparationWrapper() : pImpl(std::make_unique<Impl>()) {}
@@ -164,19 +183,17 @@ SeparationInitializeResult SeparationWrapper::initialize(
         return result;
     }
 
-    sherpa_onnx::cxx::OfflineSourceSeparationConfig config;
-    config.model = BuildModelConfig(detect, numThreads, provider, debug);
-    pImpl->separation = sherpa_onnx::cxx::OfflineSourceSeparation::Create(config);
-    if (!pImpl->separation.has_value() || !pImpl->separation->Get()) {
+    auto engineConfig = BuildEngineConfig(detect, numThreads, provider, debug);
+    pImpl->separation = SherpaOnnxCreateOfflineSourceSeparation(&engineConfig.config);
+    if (pImpl->separation == nullptr) {
         result.error = "Failed to create offline source separation engine";
-        pImpl->separation.reset();
         return result;
     }
 
     pImpl->initialized = true;
     result.success = true;
-    result.sampleRate = pImpl->separation->GetOutputSampleRate();
-    result.numStems = pImpl->separation->GetNumberOfStems();
+    result.sampleRate = SherpaOnnxOfflineSourceSeparationGetOutputSampleRate(pImpl->separation);
+    result.numStems = SherpaOnnxOfflineSourceSeparationGetNumberOfStems(pImpl->separation);
     return result;
 }
 
@@ -208,21 +225,19 @@ SeparationInitializeResult SeparationWrapper::initializeCustom(
     result.modelType = SeparationKindToString(selectedKind);
     result.detectedModels.push_back({result.modelType, "custom"});
 
-    sherpa_onnx::cxx::OfflineSourceSeparationConfig config;
-    config.model = BuildModelConfigFromPaths(
+    auto engineConfig = BuildEngineConfig(
         selectedKind, paths, numThreads, provider, debug
     );
-    pImpl->separation = sherpa_onnx::cxx::OfflineSourceSeparation::Create(config);
-    if (!pImpl->separation.has_value() || !pImpl->separation->Get()) {
+    pImpl->separation = SherpaOnnxCreateOfflineSourceSeparation(&engineConfig.config);
+    if (pImpl->separation == nullptr) {
         result.error = "Failed to create offline source separation engine";
-        pImpl->separation.reset();
         return result;
     }
 
     pImpl->initialized = true;
     result.success = true;
-    result.sampleRate = pImpl->separation->GetOutputSampleRate();
-    result.numStems = pImpl->separation->GetNumberOfStems();
+    result.sampleRate = SherpaOnnxOfflineSourceSeparationGetOutputSampleRate(pImpl->separation);
+    result.numStems = SherpaOnnxOfflineSourceSeparationGetNumberOfStems(pImpl->separation);
     return result;
 }
 
@@ -231,7 +246,7 @@ SeparationProcessResult SeparationWrapper::processMonoSamples(
     int32_t sampleRate
 ) {
     SeparationProcessResult result;
-    if (!pImpl->initialized || !pImpl->separation.has_value()) {
+    if (!pImpl->initialized || pImpl->separation == nullptr) {
         result.error = "Separation engine is not initialized";
         return result;
     }
@@ -246,25 +261,36 @@ SeparationProcessResult SeparationWrapper::processMonoSamples(
 
     const float* channels[] = {monoSamples.data()};
     const int32_t numSamples = static_cast<int32_t>(monoSamples.size());
-    auto output = pImpl->separation->Process(channels, 1, numSamples, sampleRate);
-    return ToSeparationProcessResult(output);
+    const SherpaOnnxSourceSeparationOutput* output =
+        SherpaOnnxOfflineSourceSeparationProcess(
+            pImpl->separation, channels, 1, numSamples, sampleRate
+        );
+    if (output == nullptr) {
+        result.error = "Source separation processing failed";
+        return result;
+    }
+
+    result = ToSeparationProcessResult(output);
+    SherpaOnnxDestroySourceSeparationOutput(output);
+    return result;
 }
 
 int32_t SeparationWrapper::getSampleRate() const {
-    if (!pImpl->initialized || !pImpl->separation.has_value()) return 0;
-    return pImpl->separation->GetOutputSampleRate();
+    if (!pImpl->initialized || pImpl->separation == nullptr) return 0;
+    return SherpaOnnxOfflineSourceSeparationGetOutputSampleRate(pImpl->separation);
 }
 
 int32_t SeparationWrapper::getNumStems() const {
-    if (!pImpl->initialized || !pImpl->separation.has_value()) return 0;
-    return pImpl->separation->GetNumberOfStems();
+    if (!pImpl->initialized || pImpl->separation == nullptr) return 0;
+    return SherpaOnnxOfflineSourceSeparationGetNumberOfStems(pImpl->separation);
 }
 
 bool SeparationWrapper::isInitialized() const { return pImpl->initialized; }
 
 void SeparationWrapper::release() {
-    if (pImpl->separation.has_value()) {
-        pImpl->separation.reset();
+    if (pImpl->separation != nullptr) {
+        SherpaOnnxDestroyOfflineSourceSeparation(pImpl->separation);
+        pImpl->separation = nullptr;
     }
     pImpl->initialized = false;
 }

--- a/android/src/main/cpp/separation/sherpa-onnx-separation-wrapper.h
+++ b/android/src/main/cpp/separation/sherpa-onnx-separation-wrapper.h
@@ -1,5 +1,5 @@
-#ifndef SHERPA_ONNX_SEPARATION_INFERENCE_WRAPPER_H
-#define SHERPA_ONNX_SEPARATION_INFERENCE_WRAPPER_H
+#ifndef SHERPA_ONNX_SEPARATION_WRAPPER_H
+#define SHERPA_ONNX_SEPARATION_WRAPPER_H
 
 #include "sherpa-onnx-common.h"
 #include "sherpa-onnx-model-detect.h"
@@ -69,4 +69,4 @@ private:
 
 }  // namespace sherpaonnx
 
-#endif  // SHERPA_ONNX_SEPARATION_INFERENCE_WRAPPER_H
+#endif  // SHERPA_ONNX_SEPARATION_WRAPPER_H

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -1,10 +1,12 @@
 package com.sherpaonnx
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.net.Uri
 import android.os.Build
+import android.provider.OpenableColumns
 import android.os.SystemClock
 import android.util.Base64
 import com.facebook.react.bridge.ReadableArray
@@ -1136,11 +1138,44 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     val pathHint: String? = null,
   )
 
-  private fun sourcePathHint(source: ReadableMap): String? {
-    if (!source.hasKey("displayName")) {
+  private fun logDecodeDiag(message: String) {
+    if ((reactApplicationContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) == 0) {
+      return
+    }
+    android.util.Log.i("SherpaOnnxDecode", message)
+  }
+
+  private fun sourcePathHint(source: ReadableMap?): String? {
+    if (source == null) {
       return null
     }
-    return source.getString("displayName")?.trim()?.takeIf { it.isNotEmpty() }
+    source.getString("displayName")?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
+    return when (source.getString("kind")) {
+      "contentUri", "securityScoped" -> {
+        val uriStr = source.getString("uri")?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        displayNameFromContentUri(Uri.parse(uriStr))
+      }
+      else -> null
+    }
+  }
+
+  private fun displayNameFromContentUri(uri: Uri): String? {
+    return try {
+      reactApplicationContext.contentResolver
+        .query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+        ?.use { cursor ->
+          if (!cursor.moveToFirst()) {
+            return@use null
+          }
+          val idx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+          if (idx < 0) {
+            return@use null
+          }
+          cursor.getString(idx)?.trim()?.takeIf { it.isNotEmpty() }
+        }
+    } catch (_: Exception) {
+      null
+    }
   }
 
   private fun extensionFromFileName(fileName: String): String? {
@@ -1162,12 +1197,54 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     handle: com.sherpaonnx.fileio.FileIOResolver.ReadHandle,
     source: ReadableMap? = null,
   ): DecodableSource {
+    val jsDisplayName = source?.getString("displayName")?.trim()?.takeIf { it.isNotEmpty() }
     val displayName = source?.let { sourcePathHint(it) }
-    return when (handle) {
-      is com.sherpaonnx.fileio.FileIOResolver.ReadHandle.FilePath ->
-        DecodableSource(path = handle.file.absolutePath, fd = -1, pathHint = displayName)
-      is com.sherpaonnx.fileio.FileIOResolver.ReadHandle.FileDescriptor ->
+    logDecodeDiag(
+      "resolveDecodableSource: kind=${source?.getString("kind")} " +
+        "uri=${source?.getString("uri")} jsDisplayName=$jsDisplayName pathHint=$displayName " +
+        "handle=${handle.javaClass.simpleName}",
+    )
+    val resolved = when (handle) {
+      is com.sherpaonnx.fileio.FileIOResolver.ReadHandle.FilePath -> {
+        val file = handle.file
+        val fileExt = extensionFromFileName(file.name)
+        val hintExt = displayName?.let { extensionFromFileName(it) }
+        if (fileExt == null && hintExt != null) {
+          val tmpFile = File(
+            reactApplicationContext.cacheDir,
+            decodeTempFileName(displayName),
+          )
+          try {
+            file.inputStream().use { input ->
+              tmpFile.outputStream().use { output ->
+                input.copyTo(output, 65536)
+              }
+            }
+          } catch (e: Exception) {
+            try { tmpFile.delete() } catch (_: Exception) {}
+            throw FileIOException(
+              FileIOErrorCodes.READ_ERROR,
+              "Failed to materialize extensionless path for decode",
+              e,
+            )
+          }
+          DecodableSource(
+            path = tmpFile.absolutePath,
+            fd = -1,
+            tempFile = tmpFile,
+            pathHint = displayName,
+          )
+        } else {
+          DecodableSource(path = file.absolutePath, fd = -1, pathHint = displayName)
+        }
+      }
+      is com.sherpaonnx.fileio.FileIOResolver.ReadHandle.FileDescriptor -> {
+        val statSize = handle.pfd.statSize
+        logDecodeDiag(
+          "resolveDecodableSource.fileDescriptor statSize=$statSize fd=${handle.pfd.fd}",
+        )
         DecodableSource(path = null, fd = handle.pfd.fd, pathHint = displayName)
+      }
       is com.sherpaonnx.fileio.FileIOResolver.ReadHandle.Stream -> {
         val tmpFile = File(
           reactApplicationContext.cacheDir,
@@ -1193,6 +1270,11 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
         )
       }
     }
+    logDecodeDiag(
+      "resolveDecodableSource.result path=${resolved.path} fd=${resolved.fd} " +
+        "pathHint=${resolved.pathHint} temp=${resolved.tempFile?.absolutePath}",
+    )
+    return resolved
   }
 
   /** Path string passed to native decode/probe (filesystem path or demuxer hint for fd-only). */
@@ -1777,6 +1859,11 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
         val sourceFd = decodableSource.fd
         tempSourceFile = decodableSource.tempFile
         val nativePath = nativePathArg(decodableSource)
+        logDecodeDiag(
+          "decodeFileToOfflineBuffer: nativePath=$nativePath sourcePath=$sourcePath " +
+            "fd=$sourceFd temp=${tempSourceFile?.absolutePath} forceMono=$forceMono " +
+            "allowDemuxerAutoProbe=$allowDemuxerAutoProbe targetRate=$targetSampleRateHz",
+        )
 
         val targetRate = if (targetSampleRateHz > 0) targetSampleRateHz.toInt() else 0
 

--- a/android/src/main/java/com/sherpaonnx/separation/facade/SherpaOnnxSeparationHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/separation/facade/SherpaOnnxSeparationHelper.kt
@@ -139,12 +139,22 @@ internal class SherpaOnnxSeparationHelper(
       val success = result["success"] as? Boolean ?: false
       if (!success) {
         val error = result["error"] as? String
+        Log.e(
+          SeparationErrorCodes.TAG,
+          "initializeSeparation failed: instanceId=$instanceId error=$error",
+        )
         promise.reject(
           SeparationErrorCodes.SEPARATION_INIT_ERROR,
           error?.takeIf { it.isNotBlank() } ?: "Failed to initialize separation",
         )
         return
       }
+      val sampleRate = result["sampleRate"] as? Int ?: 0
+      val numStems = result["numStems"] as? Int ?: 0
+      Log.i(
+        SeparationErrorCodes.TAG,
+        "initializeSeparation ok: instanceId=$instanceId sampleRate=$sampleRate numStems=$numStems",
+      )
       promise.resolve(initResultToWritable(result))
     } catch (e: Exception) {
       Log.e(SeparationErrorCodes.TAG, "Failed to initialize separation", e)
@@ -249,19 +259,38 @@ internal class SherpaOnnxSeparationHelper(
     }
 
     try {
+      Log.i(
+        SeparationErrorCodes.TAG,
+        "separateOfflineAudioBuffers: instanceId=$instanceId audioIn=$audioInBufferId " +
+          "numSamples=${audioInEntry.numSamples} sampleRate=${audioInEntry.sampleRate} " +
+          "expectedStems=$expectedStems",
+      )
       val inputSamples = audioInEntry.readAllSamples()
+      Log.i(
+        SeparationErrorCodes.TAG,
+        "separateOfflineAudioBuffers: readAllSamples size=${inputSamples.size}",
+      )
       val stems = nativeProcessSeparation(
         instanceId,
         inputSamples,
         audioInEntry.sampleRate,
       )
       if (stems == null || stems.size != expectedStems) {
+        Log.e(
+          SeparationErrorCodes.TAG,
+          "separateOfflineAudioBuffers: native process invalid stems " +
+            "expected=$expectedStems got=${stems?.size ?: -1}",
+        )
         promise.reject(
           SeparationErrorCodes.SEPARATION_ERROR,
           "Failed to separate audio: native process returned invalid stems",
         )
         return
       }
+      Log.i(
+        SeparationErrorCodes.TAG,
+        "separateOfflineAudioBuffers: native ok stemSizes=${stems.map { it.size }}",
+      )
       for (i in 0 until expectedStems) {
         val stemSamples = stems[i]
         val outId = audioOutBufferIds.getString(i) ?: continue
@@ -275,6 +304,10 @@ internal class SherpaOnnxSeparationHelper(
         }
         PipelineAudioRegistry.upgradeToMmapIfNeeded(outId)
       }
+      Log.i(
+        SeparationErrorCodes.TAG,
+        "separateOfflineAudioBuffers ok: instanceId=$instanceId",
+      )
       promise.resolve(null)
     } catch (e: OutOfMemoryError) {
       Log.e(SeparationErrorCodes.TAG, "OOM Separation offline failed", e)
@@ -284,6 +317,7 @@ internal class SherpaOnnxSeparationHelper(
         e,
       )
     } catch (e: Exception) {
+      Log.e(SeparationErrorCodes.TAG, "separateOfflineAudioBuffers failed", e)
       promise.reject(
         SeparationErrorCodes.SEPARATION_ERROR,
         "Failed to separate audio: ${e.message}",

--- a/android/src/main/java/com/sherpaonnx/separation/pipeline/SeparationOfflineLivePipelineWorker.kt
+++ b/android/src/main/java/com/sherpaonnx/separation/pipeline/SeparationOfflineLivePipelineWorker.kt
@@ -1,9 +1,11 @@
 package com.sherpaonnx.separation.pipeline
 
+import android.util.Log
 import com.sherpaonnx.audio.pipeline.LIVE_APPEND_SOURCE_SEPARATION
 import com.sherpaonnx.audio.pipeline.LiveEntry
 import com.sherpaonnx.livePipeline.CommittedSegmentRef
 import com.sherpaonnx.livePipeline.OfflineLivePipelineWorker
+import com.sherpaonnx.separation.core.SeparationErrorCodes
 
 internal class SeparationOfflineLivePipelineWorker(
   pipelineId: String,
@@ -30,6 +32,11 @@ internal class SeparationOfflineLivePipelineWorker(
     )
     if (pcm.isEmpty()) return
 
+    Log.i(
+      SeparationErrorCodes.TAG,
+      "liveSeparation segment: pipelineId=$pipelineId frames=$frameCount " +
+        "sampleRate=${speech.sampleRate} start=${speech.startSample} end=${speech.endSample}",
+    )
     val stems = processSeparation(pcm, speech.sampleRate)
       ?: error("SEPARATION_ERROR: native separation returned null")
     if (stems.size != audioOutputEntries.size) {

--- a/docs/future-work/live-overload-audio-overlap-crossfade-future-work.md
+++ b/docs/future-work/live-overload-audio-overlap-crossfade-future-work.md
@@ -1,0 +1,162 @@
+# Live overload (audio): overlap + crossfade at segment boundaries (future work)
+
+**Status:** Design note — not implemented.  
+**Scope:** Live overload workers that run **offline audio→audio** engines on **committed speech segments** (`continuous_frames` checkpoints): **source separation** (Spleeter, UVR) and **enhancement** (offline denoiser live overload).  
+**Motivation:** Audible clicks/pops at segment boundaries whose cadence tracks `checkpointIntervalMs` (e.g. every 500 ms vs every 5 s) — observed on multiple model families, not model-specific bugs.
+
+**Related (today):**
+
+- [separation.md](../separation.md) — live overload warning on boundary artifacts  
+- [offlineOrchestrator.ts](../../src/pipeline/offlineOrchestrator.ts) — offline `overlapSamples` append path  
+- [SeparationOfflineLivePipelineWorker.kt](../../android/src/main/java/com/sherpaonnx/separation/pipeline/SeparationOfflineLivePipelineWorker.kt) — naive stem append  
+- [sub-06-enhancement-live-overload.md](../migration/liveOverload/sub-06-enhancement-live-overload.md) — OQ-6.2 (deferred overlap option)
+
+---
+
+## 1. Problem statement
+
+Live overload drives an **offline** separator/enhancer on a **live** input buffer. Segmentation with `continuous_frames` commits fixed-duration speech segments (`policy_checkpoint`). Each committed segment triggers:
+
+1. Slice PCM from the live input (`startSample` … `endSample`)  
+2. One full offline inference pass (no cross-chunk state)  
+3. Append output samples to live stem/output buffers **back-to-back**
+
+When `checkpointIntervalMs` is 500, listeners often hear a **loud click or tonal burst roughly every 500 ms**; at 5000 ms, the same artifact appears roughly every 5 s. The timing tracks the checkpoint interval, not model branding (reproduced on Spleeter and UVR).
+
+This is **expected** given the current architecture (documented in [separation.md](../separation.md)), but it is ** worse on the live path** than necessary because live workers do not apply any boundary stitching that offline orchestration partially addresses.
+
+---
+
+## 2. Root cause (architecture, not weights)
+
+| Factor | Effect |
+|--------|--------|
+| Offline STFT/chunk models | Each chunk is processed as an isolated utterance; phase/gain at chunk edges differs from interior. |
+| No inter-chunk state | `SeparationOfflineLivePipelineWorker` / `EnhancementOfflineLivePipelineWorker` reset the native engine context per segment. |
+| Naive concatenation | `tryAppendSamples(...)` appends stem/output PCM with **zero overlap** and **zero crossfade**. |
+| `continuous_frames` | Hard time cuts — not silence-aware — so boundaries often fall mid-waveform. |
+
+**Not the primary explanation:** a defect in Spleeter vs UVR weights. Both share the same live pipeline glue.
+
+---
+
+## 3. What offline orchestration does today
+
+Offline segmented separation (`runOfflineSeparationPipeline` → `runOfflineAudioMultiOutputPipeline`) accepts `overlapSamples?: number` on `SeparateOptions`.
+
+Current behaviour in `appendAudioSegmentOutputToAccumulator`:
+
+- For segment index `> 0`, if `overlapSamples > 0`, **trim** the first `overlapSamples` samples from the segment output before appending to the accumulator.  
+- There is **no input-side overlap extension** for audio segments in the orchestrator loop today (unlike text, which rewinds `overlapChars` on the input slice).  
+- There is **no crossfade** — the migration spec mentions “overlap/crossfade”, but the shipped audio path is **trim-only**.
+
+So offline overlap is a **partial** mitigation hook; live overload has **none**.
+
+---
+
+## 4. Proposed direction
+
+Add **overlap + crossfade** (or overlap-add) when appending live overload **audio outputs** after each committed segment.
+
+### 4.1 Processing model (per segment index `i`)
+
+Assume overlap length `O` samples (derived from options or policy — see §5).
+
+**Segment `i === 0`**
+
+- Input slice: `[start, end)` as today.  
+- Append full output to live buffer(s).
+
+**Segment `i > 0`**
+
+1. **Input overlap:** extend slice start backward by `O` samples (clamp at 0):  
+   `sliceStart = max(segment.startSample - O, 0)`  
+   Run offline inference on `[sliceStart, end)` (longer context for the model).  
+2. **Output overlap region:** the first `O'` samples of the new output correspond to the overlap window (`O' ≈ O`, or model output length mapping if lengths differ — must be validated per feature).  
+3. **Crossfade append:** instead of blind `tryAppendSamples(fullOutput)`, blend the overlap region with the **tail already written** to each output live buffer:  
+   - `fadeOut`: tail `O'` samples in accumulator (weight 1 → 0)  
+   - `fadeIn`: head `O'` samples of new chunk (weight 0 → 1)  
+   - Append only the **non-overlapped** tail of the new chunk (`output[O'..]`).
+
+Linear fade is acceptable for v1; raised-cosine (Hann) is a low-cost v2 improvement.
+
+### 4.2 Where to implement
+
+| Layer | Recommendation |
+|-------|----------------|
+| **Shared native helper** | Prefer one Kotlin/Swift helper used by `SeparationOfflineLivePipelineWorker` and `EnhancementOfflineLivePipelineWorker` (both audio→audio, same append shape). |
+| **Not in JS** | Boundary stitching must run where PCM is appended; avoid shipping overlap windows across the bridge. |
+| **Optional TS surface** | See §5 — may stay feature-local or move to shared live-pipeline options. |
+
+STT/TTS/punctuation live overload are **out of scope** (text domain; different discontinuity semantics).
+
+---
+
+## 5. API / configuration (revisit OQ-6.2)
+
+[sub-06-enhancement-live-overload.md](../migration/liveOverload/sub-06-enhancement-live-overload.md) **OQ-6.2** deferred a top-level `overlapSamples` on live overload (“policy-driven only”). Boundary clicks on separation motivate revisiting that decision.
+
+**Options (pick one in implementation PR):**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Feature option** `overlapSamples` on `SeparationLivePipelineOptions` / enhancement live options | Matches offline `SeparateOptions`; explicit tuning | Two knobs with `checkpointIntervalMs` |
+| **B. Policy field** e.g. `continuous_frames.overlapMs` / `overlapSamples` | Keeps live overload option shape minimal | Couples stitching to segmentation policy |
+| **C. Sensible default, no public knob (v1)** | Fast to ship; e.g. `O = min(2048, checkpointSamples/4)` | Harder for apps to tune |
+
+**Recommendation:** **A + documented default** (mirror offline separation), with **0 = today’s behaviour** (opt-in stitching). Document interaction:
+
+- Larger `checkpointIntervalMs` → fewer boundaries, but each boundary may carry more energy if unstitched.  
+- `overlapSamples` should be **≤ half of checkpoint samples** to avoid processing mostly duplicate context.  
+- At 44.1 kHz, starting point for experiments: `O ≈ 2048–4096` (~46–93 ms), tune by ear.
+
+---
+
+## 6. Implementation checklist
+
+- [ ] Shared helper: `appendLiveAudioWithCrossfade(output, liveEntry, overlapSamples, segmentIndex)` (+ iOS parity).  
+- [ ] Input slice extension in workers when `overlapSamples > 0 && segmentIndex > 0`.  
+- [ ] Handle output length ≠ input length (if native separation ever returns different counts — assert or map in wrapper).  
+- [ ] Wire **separation** live overload first (user-visible Spleeter/UVR case).  
+- [ ] Wire **enhancement** live overload (same helper).  
+- [ ] Unit/integration tests: synthetic sine/discontinuity — measure max delta at boundary with/without crossfade.  
+- [ ] Example app note in Separation live overload UI (overlap optional field).  
+- [ ] Update [separation.md](../separation.md) — link here; clarify that overlap reduces but does not eliminate chunking artifacts vs true streaming models.
+
+---
+
+## 7. Non-goals
+
+- **True online separation/enhancement models** — out of scope; overlap stitching does not replace streaming weights.  
+- **Changing `continuous_frames` checkpoint semantics** — still time-based cuts; overlap only affects how outputs are glued.  
+- **Offline orchestrator crossfade in the same PR** — can reuse the same helper later for parity (offline trim-only → full crossfade).  
+- **Automatic `checkpointIntervalMs` tuning** — remains app/SDK policy; not inferred from overlap.
+
+---
+
+## 8. Validation plan
+
+1. **Repro baseline:** Live overload separation, `checkpointIntervalMs: 500`, `overlapSamples: 0` → periodic clicks at ~500 ms.  
+2. **With overlap:** same checkpoint, `overlapSamples: 2048` (or default) → same cadence boundaries **inaudible or strongly reduced** on steady-state material.  
+3. **Control:** Offline batch on full file (`segmentation.mode: 'off'`) → clean reference.  
+4. **Regression:** Segment count / total output duration unchanged (overlap append must preserve timeline length, not shorten or duplicate wall-clock output).  
+5. **Models:** At least one Spleeter + one UVR fixture (confirms model-agnostic glue fix).
+
+---
+
+## 9. Open questions
+
+1. Should crossfade weights be **linear** or **Hann** by default?  
+2. If native output length differs from input chunk length (padding inside sherpa-onnx), how is `O'` mapped?  
+3. Should overlap apply on the **finalize** segment only at the leading edge (never trailing)?  
+4. Revisit **OQ-6.2** formally: accept top-level `overlapSamples` on all audio live-overload options vs policy-only field.  
+5. Optional future: **input overlap without crossfade** (offline-style trim-only) as a compatibility mode — likely insufficient alone for separation clicks.
+
+---
+
+## 10. Related documents
+
+- [streaming-pipelines-overview.md](../streaming-pipelines-overview.md) — live pipeline handle lifecycle  
+- [offline-stt-live-pipeline-mandatory-segmentation.md](../migration/liveOverload/offline-stt-live-pipeline-mandatory-segmentation.md) — live overload matrix (separation row)  
+- [sub-04-transfer-offline-orchestration.md](../migration/segmentationEngine/sub-04-transfer-offline-orchestration.md) — orchestrator overlap/crossfade intent  
+- [segmentation-engine.md](../segmentation-engine.md) — `continuous_frames` / `checkpointIntervalMs`

--- a/example/src/components/OfflineAudioBufferWidget.tsx
+++ b/example/src/components/OfflineAudioBufferWidget.tsx
@@ -105,6 +105,12 @@ type Props = {
    * that the parent already caught) to show alongside the widget's own errors.
    */
   externalError?: string | null;
+  /**
+   * When set, decode/resample the file to this sample rate before creating the
+   * offline buffer. Use the separation (or other feature) model sample rate so
+   * segmented pipelines match orchestrator output buffers.
+   */
+  decodeTargetSampleRateHz?: number;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -159,6 +165,7 @@ export const OfflineAudioBufferWidget = forwardRef<
     disabled = false,
     visible = true,
     externalError = null,
+    decodeTargetSampleRateHz,
   },
   ref
 ) {
@@ -305,6 +312,9 @@ export const OfflineAudioBufferWidget = forwardRef<
 
       const decodeOptions = {
         forceMono: true,
+        ...(decodeTargetSampleRateHz != null && decodeTargetSampleRateHz > 0
+          ? { targetSampleRateHz: decodeTargetSampleRateHz }
+          : {}),
         onProgress: (event: {
           percent?: number;
           framesDecoded?: number;
@@ -355,7 +365,7 @@ export const OfflineAudioBufferWidget = forwardRef<
         }
       }
     },
-    [onBufferReady, stopPlayer]
+    [decodeTargetSampleRateHz, onBufferReady, stopPlayer]
   );
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/example/src/components/OfflineAudioBufferWidget.tsx
+++ b/example/src/components/OfflineAudioBufferWidget.tsx
@@ -40,8 +40,9 @@ import { Ionicons } from '@react-native-vector-icons/ionicons';
 import {
   createOfflineAudioBufferFromFile,
   releasePipelineAudioBuffer,
+  type OfflineAudioBufferRef,
 } from 'react-native-sherpa-onnx/audiobuffer';
-import type { OfflineAudioBufferRef } from 'react-native-sherpa-onnx/audiobuffer';
+import { DECODABLE_AUDIO_PICKER_TYPES } from '../utils/decodableAudioPickerTypes';
 
 import { createPcmPlayer, type PcmPlayer } from 'react-native-sherpa-onnx/pcm';
 import { setPipelineAudioRoutePreference } from 'react-native-sherpa-onnx/audio';
@@ -52,7 +53,11 @@ import {
   keepValidDeviceSelection,
   type AudioRouteDevice,
 } from '../utils/audioDevices';
-import { fileSourceFromBundledPath } from '../utils/fileSourceFromUri';
+import {
+  fileSourceFromBundledPath,
+  resolveAudioFileDisplayName,
+  toFileSource as toFileSourceWithHint,
+} from '../utils/fileSourceFromUri';
 import { widgetStyles as s } from './OfflineAudioBufferWidget.styles';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -106,20 +111,17 @@ type Props = {
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-function toFileSource(pathOrUri: string) {
+function toFileSource(pathOrUri: string, displayName?: string) {
   const trimmed = pathOrUri.trim();
-  if (trimmed.startsWith('content://')) {
-    return { kind: 'contentUri' as const, uri: trimmed };
-  }
-  if (trimmed.startsWith('file://')) {
-    const p = decodeURI(trimmed.replace(/^file:\/\//, ''));
-    return { kind: 'fs' as const, path: p };
-  }
   // Relative paths are bundled example assets (test_wavs/test_codec).
-  if (!trimmed.startsWith('/')) {
+  if (
+    !trimmed.startsWith('content://') &&
+    !trimmed.startsWith('file://') &&
+    !trimmed.startsWith('/')
+  ) {
     return fileSourceFromBundledPath(trimmed);
   }
-  return { kind: 'fs' as const, path: trimmed };
+  return toFileSourceWithHint(trimmed, displayName);
 }
 
 function isEphemeralFd(pathOrUri: string): boolean {
@@ -284,11 +286,7 @@ export const OfflineAudioBufferWidget = forwardRef<
   // ─────────────────────────────────────────────────────────────────────────
 
   const decodeSource = useCallback(
-    async (
-      _uri: string,
-      label: string,
-      source: ReturnType<typeof toFileSource>
-    ) => {
+    async (label: string, source: ReturnType<typeof toFileSource>) => {
       const requestId = ++decodeRequestRef.current;
 
       // Release any existing buffer first
@@ -305,23 +303,32 @@ export const OfflineAudioBufferWidget = forwardRef<
       setDecodeStatus(`Decoding "${label}" into OfflineAudioBuffer…`);
       setDecodeError(null);
 
+      const decodeOptions = {
+        forceMono: true,
+        onProgress: (event: {
+          percent?: number;
+          framesDecoded?: number;
+          totalFramesEstimate?: number;
+        }) => {
+          if (requestId !== decodeRequestRef.current) return;
+          const pct = Math.max(0, Math.min(100, event.percent ?? 0));
+          setDecodeProgress(pct);
+          const total = event.totalFramesEstimate ?? 0;
+          setDecodeStatus(
+            total > 0
+              ? `Decoding "${label}"… ${Math.round(pct)}% (${
+                  event.framesDecoded
+                }/${total} frames)`
+              : `Decoding "${label}"… ${Math.round(pct)}%`
+          );
+        },
+      };
+
       try {
-        const audioRef = await createOfflineAudioBufferFromFile(source, {
-          forceMono: true,
-          onProgress: (event) => {
-            if (requestId !== decodeRequestRef.current) return;
-            const pct = Math.max(0, Math.min(100, event.percent ?? 0));
-            setDecodeProgress(pct);
-            const total = event.totalFramesEstimate ?? 0;
-            setDecodeStatus(
-              total > 0
-                ? `Decoding "${label}"… ${Math.round(pct)}% (${
-                    event.framesDecoded
-                  }/${total} frames)`
-                : `Decoding "${label}"… ${Math.round(pct)}%`
-            );
-          },
-        });
+        const audioRef = await createOfflineAudioBufferFromFile(
+          source,
+          decodeOptions
+        );
 
         if (requestId !== decodeRequestRef.current) {
           await releasePipelineAudioBuffer(audioRef.bufferId).catch(() => {});
@@ -358,11 +365,7 @@ export const OfflineAudioBufferWidget = forwardRef<
   const handleExamplePick = useCallback(
     async (audioFile: AudioFileInfo) => {
       try {
-        await decodeSource(
-          audioFile.id,
-          audioFile.name,
-          toFileSource(audioFile.id)
-        );
+        await decodeSource(audioFile.name, toFileSource(audioFile.id));
       } catch (err) {
         setDecodeError(err instanceof Error ? err.message : String(err));
       }
@@ -378,7 +381,7 @@ export const OfflineAudioBufferWidget = forwardRef<
     setDecodeError(null);
     try {
       const res = await DocumentPicker.pick({
-        type: [DocumentPicker.types.audio],
+        type: DECODABLE_AUDIO_PICKER_TYPES,
       });
       const file = Array.isArray(res) ? res[0] : res;
       const uri =
@@ -386,7 +389,11 @@ export const OfflineAudioBufferWidget = forwardRef<
         (file as any)?.fileCopyUri ??
         (file as any)?.localUri ??
         (file as any)?.nativeUri;
-      const name = file?.name || uri?.split('/')?.pop() || 'audio';
+      const name =
+        resolveAudioFileDisplayName(uri, file?.name) ??
+        file?.name?.trim() ??
+        uri?.split('/')?.pop() ??
+        'audio';
 
       if (!uri) {
         setDecodeError('Could not get file URI from picker result');
@@ -399,7 +406,8 @@ export const OfflineAudioBufferWidget = forwardRef<
         return;
       }
 
-      await decodeSource(uri, name, toFileSource(uri));
+      const source = toFileSource(uri, name);
+      await decodeSource(name, source);
     } catch (err) {
       if (isPickerCancel(err)) return;
       setDecodeError(err instanceof Error ? err.message : String(err));

--- a/example/src/components/ScreenIntroModal.tsx
+++ b/example/src/components/ScreenIntroModal.tsx
@@ -98,8 +98,8 @@ const INTRO_COPY: Record<ScreenId, ScreenIntroCopy> = {
     body: 'This screen mirrors the offline enhancement flow but runs through live input/output buffers and a streaming pipeline. Use it for long files that can trigger offline OOM when full decode buffers are too large.',
   },
   Separation: {
-    title: 'Source separation preview',
-    body: 'This placeholder screen shows where source separation will appear in the example app. It is useful for understanding how the SDK may split mixed audio into cleaner components.',
+    title: 'Source separation demo',
+    body: 'Split mixed audio into stems (typically vocals and accompaniment) using Spleeter or UVR models. Try offline batch with optional segmentation, or live overload with file ingest or microphone input. Download models from the Download screen if needed.',
   },
   Settings: {
     title: 'Runtime capability dashboard',

--- a/example/src/components/SegmentationPolicyControls.tsx
+++ b/example/src/components/SegmentationPolicyControls.tsx
@@ -82,6 +82,10 @@ type Props = {
   disableOff?: boolean;
   /** Alert message shown when the user presses the disabled 'Off' tab. */
   offDisabledMessage?: string;
+  /** When set, only these evaluator keys are shown (e.g. live separation: continuous_frames). */
+  allowedEvaluators?: readonly string[];
+  /** When true, the manual mode tab is hidden (live overload flows). */
+  disableManual?: boolean;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -727,9 +731,15 @@ export function SegmentationPolicyControls({
   disabled = false,
   disableOff = false,
   offDisabledMessage,
+  allowedEvaluators,
+  disableManual = false,
 }: Props) {
-  const modes = getAvailableModes(variant);
-  const evaluators = getEvaluators(variant);
+  const modes = getAvailableModes(variant).filter(
+    (mode) => !(disableManual && mode === 'manual')
+  );
+  const evaluators = getEvaluators(variant).filter(
+    ({ key }) => !allowedEvaluators || allowedEvaluators.includes(key)
+  );
 
   const handleModeChange = useCallback(
     (mode: SegmentationMode) => {

--- a/example/src/components/modelInit/FileSourceSlotPicker.tsx
+++ b/example/src/components/modelInit/FileSourceSlotPicker.tsx
@@ -3,6 +3,7 @@ import * as DocumentPicker from '@react-native-documents/picker';
 import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 import {
   describeFileSource,
+  resolveAudioFileDisplayName,
   toFileSource,
 } from '../../utils/fileSourceFromUri';
 
@@ -44,7 +45,8 @@ export function FileSourceSlotPicker({
       if (!uri) {
         return;
       }
-      onChange(toFileSource(uri));
+      const displayName = resolveAudioFileDisplayName(uri, picked?.name);
+      onChange(toFileSource(uri, displayName));
     } catch (err) {
       if (isPickerCancelled(err)) {
         return;

--- a/example/src/components/modelInit/SeparationCustomInitForm.tsx
+++ b/example/src/components/modelInit/SeparationCustomInitForm.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  SEPARATION_MODEL_TYPES,
+  type SeparationConcreteModelType,
+} from 'react-native-sherpa-onnx/separation';
+import {
+  getCustomModelPathRequirements,
+  type CustomModelPathRequirements,
+} from 'react-native-sherpa-onnx/detect';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import { FileSourceSlotPicker } from './FileSourceSlotPicker';
+import {
+  labelForSeparationCustomPathKey,
+  type SeparationCustomPathKey,
+} from '../../utils/separationCustomInitLabels';
+
+export type SeparationCustomInitFormState = {
+  modelType: SeparationConcreteModelType;
+  fileSources: Partial<Record<SeparationCustomPathKey, FileSource>>;
+};
+
+type SeparationCustomInitFormProps = {
+  value: SeparationCustomInitFormState;
+  onChange: (next: SeparationCustomInitFormState) => void;
+  selectedCatalogModelId: string | null;
+  onFillFromSelectedModel: () => void;
+  onPrepareScatteredTest: () => void;
+  fillLoading?: boolean;
+  disabled?: boolean;
+  fillHint?: string | null;
+};
+
+export function SeparationCustomInitForm({
+  value,
+  onChange,
+  selectedCatalogModelId,
+  onFillFromSelectedModel,
+  onPrepareScatteredTest,
+  fillLoading = false,
+  disabled = false,
+  fillHint = null,
+}: SeparationCustomInitFormProps) {
+  const [schema, setSchema] = useState<CustomModelPathRequirements>({
+    fields: [],
+  });
+  const [schemaLoading, setSchemaLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSchemaLoading(true);
+    getCustomModelPathRequirements('separation', value.modelType)
+      .then((requirements) => {
+        if (!cancelled) {
+          setSchema(requirements);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setSchemaLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value.modelType]);
+
+  const slotKeys = useMemo(
+    () =>
+      schema.fields.map((field) => ({
+        key: field.key as SeparationCustomPathKey,
+        required: field.required,
+      })),
+    [schema.fields]
+  );
+
+  const setModelType = (modelType: SeparationConcreteModelType) => {
+    onChange({ modelType, fileSources: {} });
+  };
+
+  const setFileSource = (
+    key: SeparationCustomPathKey,
+    source: FileSource | undefined
+  ) => {
+    const next = { ...value.fileSources };
+    if (source) {
+      next[key] = source;
+    } else {
+      delete next[key];
+    }
+    onChange({ ...value, fileSources: next });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.subheading}>Separation model type</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.typeRow}
+      >
+        {SEPARATION_MODEL_TYPES.map((type) => {
+          const active = value.modelType === type;
+          return (
+            <TouchableOpacity
+              key={type}
+              style={[styles.typeChip, active && styles.typeChipActive]}
+              onPress={() => setModelType(type)}
+              disabled={disabled || fillLoading}
+            >
+              <Text
+                style={[
+                  styles.typeChipText,
+                  active && styles.typeChipTextActive,
+                ]}
+              >
+                {type}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+
+      <View style={styles.helperRow}>
+        <TouchableOpacity
+          style={[
+            styles.helperButton,
+            (!selectedCatalogModelId || fillLoading || disabled) &&
+              styles.helperButtonDisabled,
+          ]}
+          onPress={onFillFromSelectedModel}
+          disabled={!selectedCatalogModelId || fillLoading || disabled}
+        >
+          {fillLoading ? (
+            <ActivityIndicator size="small" color="#FFFFFF" />
+          ) : (
+            <Text style={styles.helperButtonText}>
+              Fill from selected model
+            </Text>
+          )}
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[
+            styles.helperButtonSecondary,
+            disabled && styles.helperButtonDisabled,
+          ]}
+          onPress={onPrepareScatteredTest}
+          disabled={disabled || fillLoading}
+        >
+          <Text style={styles.helperButtonSecondaryText}>
+            Scattered test (clear slots)
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {fillHint ? <Text style={styles.fillHint}>{fillHint}</Text> : null}
+
+      <Text style={styles.subheading}>Model files</Text>
+      <Text style={styles.hint}>
+        Pick stem ONNX files (Spleeter: vocals + accompaniment; UVR: single
+        model). Use Fill to pre-populate from the catalog selection.
+      </Text>
+
+      {schemaLoading ? (
+        <ActivityIndicator
+          size="small"
+          color="#5856D6"
+          style={styles.schemaLoader}
+        />
+      ) : null}
+
+      {slotKeys.map(({ key, required }) => (
+        <FileSourceSlotPicker
+          key={key}
+          label={labelForSeparationCustomPathKey(key)}
+          value={value.fileSources[key]}
+          onChange={(source) => setFileSource(key, source)}
+          disabled={disabled || fillLoading}
+          required={required}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 4,
+  },
+  subheading: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#000000',
+    marginBottom: 8,
+    marginTop: 8,
+  },
+  hint: {
+    fontSize: 13,
+    color: '#8E8E93',
+    marginBottom: 8,
+  },
+  schemaLoader: {
+    marginVertical: 8,
+  },
+  typeRow: {
+    gap: 8,
+    paddingBottom: 4,
+  },
+  typeChip: {
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#C7C7CC',
+    backgroundColor: '#F2F2F7',
+  },
+  typeChipActive: {
+    borderColor: '#007AFF',
+    backgroundColor: '#E3F2FD',
+  },
+  typeChipText: {
+    fontSize: 12,
+    color: '#3A3A3C',
+  },
+  typeChipTextActive: {
+    color: '#007AFF',
+    fontWeight: '600',
+  },
+  helperRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginVertical: 8,
+  },
+  helperButton: {
+    backgroundColor: '#5856D6',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    minWidth: 160,
+    alignItems: 'center',
+  },
+  helperButtonSecondary: {
+    backgroundColor: '#F2F2F7',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#C7C7CC',
+  },
+  helperButtonDisabled: {
+    opacity: 0.5,
+  },
+  helperButtonText: {
+    color: '#FFFFFF',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  helperButtonSecondaryText: {
+    color: '#3A3A3C',
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  fillHint: {
+    fontSize: 12,
+    color: '#5856D6',
+    marginBottom: 4,
+  },
+});

--- a/example/src/components/modelInit/index.ts
+++ b/example/src/components/modelInit/index.ts
@@ -22,6 +22,10 @@ export {
   type EnhancementCustomInitFormState,
 } from './EnhancementCustomInitForm';
 export {
+  SeparationCustomInitForm,
+  type SeparationCustomInitFormState,
+} from './SeparationCustomInitForm';
+export {
   PunctuationOfflineCustomInitForm,
   type PunctuationOfflineCustomInitFormState,
 } from './PunctuationOfflineCustomInitForm';

--- a/example/src/screens/enhancement-streaming/EnhancementStreamingScreen.tsx
+++ b/example/src/screens/enhancement-streaming/EnhancementStreamingScreen.tsx
@@ -11,12 +11,17 @@ import {
 import { styles } from '../stt/STTScreen.styles';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as DocumentPicker from '@react-native-documents/picker';
+import { DECODABLE_AUDIO_PICKER_TYPES } from '../../utils/decodableAudioPickerTypes';
 import {
   getAssetPackPath,
   listAssetModels,
   listModelsAtPath,
 } from 'react-native-sherpa-onnx/utils';
 import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import {
+  resolveAudioFileDisplayName,
+  toFileSource,
+} from '../../utils/fileSourceFromUri';
 import { DocumentDirectoryPath } from '@dr.pogodin/react-native-fs';
 import {
   listDownloadedModels,
@@ -306,7 +311,7 @@ export default function EnhancementStreamingScreen() {
       const trimmed = effectiveCustomAudioPath.trim();
       if (trimmed.startsWith('content://')) {
         return {
-          source: { kind: 'contentUri', uri: trimmed },
+          source: toFileSource(trimmed, effectiveCustomAudioName ?? undefined),
           sourceType: 'own',
           sourceLabel: effectiveCustomAudioName ?? 'Local audio',
           sourcePathForPlayback: trimmed,
@@ -846,7 +851,7 @@ export default function EnhancementStreamingScreen() {
     setErrorSource(null);
     try {
       const res = await DocumentPicker.pick({
-        type: [DocumentPicker.types.audio],
+        type: DECODABLE_AUDIO_PICKER_TYPES,
       });
       const file = Array.isArray(res) ? res[0] : res;
       const uri =
@@ -854,7 +859,11 @@ export default function EnhancementStreamingScreen() {
         (file as any).fileCopyUri ??
         (file as any).localUri ??
         (file as any).nativeUri;
-      const name = file.name || uri?.split('/')?.pop() || 'local.wav';
+      const name =
+        resolveAudioFileDisplayName(uri, file.name) ??
+        file.name?.trim() ??
+        uri?.split('/')?.pop() ??
+        'local.wav';
       if (!uri) {
         setErrorSource('enhance');
         setError('Could not get file URI from picker result');
@@ -895,7 +904,7 @@ export default function EnhancementStreamingScreen() {
 
   const playPath = async (
     path: string | null,
-    options?: { bindResultOriginalUi?: boolean }
+    options?: { bindResultOriginalUi?: boolean; displayName?: string | null }
   ) => {
     if (!path) return;
     const bindResult = options?.bindResultOriginalUi === true;
@@ -914,6 +923,7 @@ export default function EnhancementStreamingScreen() {
         },
         {
           outputDeviceId: selectedOutputDeviceId ?? undefined,
+          displayName: options?.displayName ?? undefined,
         }
       );
       pcmPlaybackRef.current = nextPlayback;
@@ -1602,7 +1612,11 @@ export default function EnhancementStreamingScreen() {
                         styles.playButton,
                         preparingInputBuffer && styles.buttonDisabled,
                       ]}
-                      onPress={() => playPath(customAudioPath)}
+                      onPress={() =>
+                        playPath(customAudioPath, {
+                          displayName: customAudioName,
+                        })
+                      }
                       disabled={preparingInputBuffer}
                     >
                       <View style={styles.rowAlignCenter}>

--- a/example/src/screens/fileio/fileioInputChannels.ts
+++ b/example/src/screens/fileio/fileioInputChannels.ts
@@ -1,7 +1,6 @@
 import { Platform } from 'react-native';
 import {
   pick,
-  types,
   isErrorWithCode,
   errorCodes,
 } from '@react-native-documents/picker';
@@ -18,8 +17,10 @@ import {
 } from '../../audioConfig';
 import {
   fileSourceFromBundledPath,
+  resolveAudioFileDisplayName,
   toFileSource,
 } from '../../utils/fileSourceFromUri';
+import { DECODABLE_AUDIO_PICKER_TYPES } from '../../utils/decodableAudioPickerTypes';
 
 /** How the active sample is exposed as a {@link FileSource}. */
 export type FileioInputChannelId =
@@ -340,7 +341,7 @@ export async function pickFileioInputForChannel(
   try {
     const picked = await pick({
       mode: 'open',
-      type: [types.audio],
+      type: DECODABLE_AUDIO_PICKER_TYPES,
       requestLongTermAccess: channelId === 'securityScoped',
     });
     const file = picked[0];
@@ -349,15 +350,16 @@ export async function pickFileioInputForChannel(
       return null;
     }
 
+    const name =
+      resolveAudioFileDisplayName(uri, file.name) ??
+      file.name?.trim() ??
+      uri.split('/').pop()?.split('?')[0] ??
+      'Picked audio';
+
     const fileSource: FileSource =
       channelId === 'securityScoped'
-        ? { kind: 'securityScoped', uri }
-        : toFileSource(uri);
-
-    const name =
-      file.name?.trim() ||
-      uri.split('/').pop()?.split('?')[0] ||
-      'Picked audio';
+        ? { kind: 'securityScoped', uri, displayName: name }
+        : toFileSource(uri, name);
 
     return {
       fileSource,

--- a/example/src/screens/home/HomeScreen.tsx
+++ b/example/src/screens/home/HomeScreen.tsx
@@ -196,10 +196,10 @@ const FEATURES: HomeFeature[] = [
     id: 'separation',
     sectionTitle: 'Speakers & Separation',
     title: 'Source Separation',
-    description: 'Separate voice from background music',
+    description: 'Offline batch + live overload (vocals / accompaniment)',
     icon: 'musical-notes',
     screen: 'Separation',
-    implemented: false,
+    implemented: true,
   },
 ];
 

--- a/example/src/screens/live-pipeline-showcase/LivePipelineShowcaseScreen.tsx
+++ b/example/src/screens/live-pipeline-showcase/LivePipelineShowcaseScreen.tsx
@@ -9,6 +9,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
 import * as DocumentPicker from '@react-native-documents/picker';
+import { DECODABLE_AUDIO_PICKER_TYPES } from '../../utils/decodableAudioPickerTypes';
 import { DocumentDirectoryPath } from '@dr.pogodin/react-native-fs';
 import {
   getAssetPackPath,
@@ -53,7 +54,10 @@ import {
   releasePipelineTextBuffer,
   type LiveTextBufferRef,
 } from 'react-native-sherpa-onnx/textbuffer';
-import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import {
+  resolveAudioFileDisplayName,
+  toFileSource,
+} from '../../utils/fileSourceFromUri';
 import {
   getAssetModelPath,
   getFileModelPath,
@@ -102,14 +106,6 @@ function normalizeErrorMessage(error: unknown): string {
     if (maybe.message) return maybe.message;
   }
   return 'Unknown error';
-}
-
-function toFileSource(uri: string): FileSource {
-  const v = uri.trim();
-  if (v.startsWith('content://')) return { kind: 'contentUri', uri: v };
-  if (v.startsWith('file://'))
-    return { kind: 'fs', path: decodeURI(v.replace(/^file:\/\//, '')) };
-  return { kind: 'fs', path: v };
 }
 
 export default function LivePipelineShowcaseScreen() {
@@ -666,11 +662,15 @@ export default function LivePipelineShowcaseScreen() {
   const pickFile = useCallback(async () => {
     try {
       const [result] = await DocumentPicker.pick({
-        type: [DocumentPicker.types.audio],
+        type: DECODABLE_AUDIO_PICKER_TYPES,
       });
       if (result) {
         setPickedFileUri(result.uri);
-        setPickedFileName(result.name ?? result.uri);
+        setPickedFileName(
+          resolveAudioFileDisplayName(result.uri, result.name) ??
+            result.name ??
+            result.uri
+        );
       }
     } catch (pickErr) {
       const isPickCancel =
@@ -837,7 +837,10 @@ export default function LivePipelineShowcaseScreen() {
           'Microphone active. Speech → STT → TTS (no live playback; use TTS output below after stop).'
         );
       } else {
-        const source = toFileSource(pickedFileUri!);
+        const source = toFileSource(
+          pickedFileUri!,
+          pickedFileName ?? undefined
+        );
         setStatusText('Ingesting file into STT pipeline…');
         const ingest = await ingestFileToLiveAudioBuffer(
           sttInputAudio.bufferId,
@@ -889,6 +892,7 @@ export default function LivePipelineShowcaseScreen() {
     selectedTtsModel,
     sourceMode,
     pickedFileUri,
+    pickedFileName,
     pipelineState,
     textSegConfig,
     sttSegConfig,

--- a/example/src/screens/separation/SeparationScreen.tsx
+++ b/example/src/screens/separation/SeparationScreen.tsx
@@ -1,74 +1,1572 @@
-import { View, Text, StyleSheet } from 'react-native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import * as DocumentPicker from '@react-native-documents/picker';
+import { DocumentDirectoryPath } from '@dr.pogodin/react-native-fs';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
+import {
+  createSeparation,
+  detectSeparationModel,
+  assertSeparationCustomConfig,
+  SEPARATION_STEM_LABELS,
+  type SeparationEngine,
+  type SeparationModelType,
+  type SeparationPipelineHandle,
+  type SpleeterCustomConfig,
+  type UvrCustomConfig,
+} from 'react-native-sherpa-onnx/separation';
+import {
+  createEmptyOfflineAudioBuffer,
+  createEmptyLiveAudioBuffer,
+  createOfflineAudioBufferFromLive,
+  finalizeLiveAudioBuffer,
+  getPipelineAudioBufferInfo,
+  ingestFileToLiveAudioBuffer,
+  releasePipelineAudioBuffer,
+  startMicToLiveAudioBuffer,
+  stopMicToLiveAudioBuffer,
+  type FileIngestHandle,
+  type LiveAudioBufferRef,
+} from 'react-native-sherpa-onnx/audiobuffer';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import type { SpeechSegment } from 'react-native-sherpa-onnx/segment';
+import {
+  getAssetPackPath,
+  listAssetModels,
+  listModelsAtPath,
+} from 'react-native-sherpa-onnx/utils';
+import {
+  listDownloadedModels,
+  ModelCategory,
+  onModelsListUpdated,
+} from 'react-native-sherpa-onnx/download';
+import { styles as baseStyles } from '../stt/STTScreen.styles';
+import { styles as lpStyles } from '../live-pipeline-showcase/LivePipelineShowcaseScreen.styles';
 import { ScreenIntroModal } from '../../components/ScreenIntroModal';
+import {
+  OfflineAudioBufferWidget,
+  type OfflineAudioBufferInfo,
+  type OfflineAudioBufferWidgetHandle,
+} from '../../components/OfflineAudioBufferWidget';
+import {
+  SegmentationPolicyControls,
+  buildSegmentationOption,
+  type SegmentationControlConfig,
+} from '../../components/SegmentationPolicyControls';
+import { PipelineOfflineAudioResultCard } from '../../components/PipelineOfflineAudioResultCard';
+import {
+  InitModeSelector,
+  ModelFolderGrid,
+  SeparationCustomInitForm,
+  type ModelInitMode,
+  type SeparationCustomInitFormState,
+} from '../../components/modelInit';
+import {
+  getAssetModelPath,
+  getFileModelPath,
+  getModelDisplayName,
+  toDetectSource,
+} from '../../modelConfig';
+import { AUDIO_FILES } from '../../audioConfig';
+import { fileSourceFromBundledPath } from '../../utils/fileSourceFromUri';
+import { fillSeparationCustomConfigFromModelFolder } from '../../utils/separationCustomInitFill';
+
+const PAD_PACK_NAME = 'sherpa_models';
+const NUM_THREADS = 2;
+const PIPELINE_WAIT_TIMEOUT_MS = 10 * 60 * 1000;
+
+type ProcessingMode = 'batch' | 'liveOverload';
+type LiveSourceMode = 'file' | 'mic';
+type LiveFileSourceType = 'example' | 'own';
+
+type StemResult = {
+  bufferId: string;
+  label: string;
+  sampleRate: number;
+  numSamples: number;
+};
+
+const DEFAULT_SEPARATION_CUSTOM_INIT: SeparationCustomInitFormState = {
+  modelType: 'spleeter',
+  fileSources: {},
+};
+
+const LIVE_SEG_DEFAULT: SegmentationControlConfig = {
+  mode: 'auto',
+  policy: { evaluator: 'continuous_frames', checkpointIntervalMs: 500 },
+};
+
+function normalizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const code = (error as { code?: string }).code;
+    return code ? `[${code}] ${error.message}` : error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  return String(error);
+}
+
+function toFileSource(pathOrUri: string): FileSource {
+  const trimmed = pathOrUri.trim();
+  if (trimmed.startsWith('content://')) {
+    return { kind: 'contentUri', uri: trimmed };
+  }
+  if (trimmed.startsWith('file://')) {
+    return { kind: 'fs', path: decodeURI(trimmed.replace(/^file:\/\//, '')) };
+  }
+  return { kind: 'fs', path: trimmed };
+}
+
+function isSeparationHint(folder: string, hint: string): boolean {
+  if (hint === 'separation') return true;
+  const n = folder.toLowerCase();
+  return n.includes('spleeter') || n.includes('uvr') || n.includes('mdx');
+}
+
+function stemLabel(index: number, numStems: number): string {
+  if (numStems <= 2 && index < SEPARATION_STEM_LABELS.length) {
+    return SEPARATION_STEM_LABELS[index]!;
+  }
+  return `Stem ${index}`;
+}
 
 export default function SeparationScreen() {
+  const [processingMode, setProcessingMode] = useState<ProcessingMode>('batch');
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [padModelIds, setPadModelIds] = useState<string[]>([]);
+  const [downloadedModelIds, setDownloadedModelIds] = useState<string[]>([]);
+  const [padModelsPath, setPadModelsPath] = useState<string | null>(null);
+  const [loadingModels, setLoadingModels] = useState(false);
+  const [initMode, setInitMode] = useState<ModelInitMode>('auto');
+  const [customInitForm, setCustomInitForm] =
+    useState<SeparationCustomInitFormState>(DEFAULT_SEPARATION_CUSTOM_INIT);
+  const [customFillLoading, setCustomFillLoading] = useState(false);
+  const [customFillHint, setCustomFillHint] = useState<string | null>(null);
+  const [selectedModelForInit, setSelectedModelForInit] = useState<
+    string | null
+  >(null);
+  const [currentModelFolder, setCurrentModelFolder] = useState<string | null>(
+    null
+  );
+  const [initializedSummary, setInitializedSummary] = useState<string | null>(
+    null
+  );
+  const [selectedModelKind, setSelectedModelKind] =
+    useState<SeparationModelType | null>(null);
+  const [numStems, setNumStems] = useState(2);
+  const [modelSampleRate, setModelSampleRate] = useState<number | null>(null);
+  const [initResult, setInitResult] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [errorSource, setErrorSource] = useState<
+    'init' | 'separate' | 'live' | null
+  >(null);
+
+  const [segBatchConfig, setSegBatchConfig] =
+    useState<SegmentationControlConfig>({ mode: 'off' });
+  const [segLiveConfig, setSegLiveConfig] =
+    useState<SegmentationControlConfig>(LIVE_SEG_DEFAULT);
+
+  const [preparedInputBuffer, setPreparedInputBuffer] =
+    useState<OfflineAudioBufferInfo | null>(null);
+  const [separating, setSeparating] = useState(false);
+  const [separateResult, setSeparateResult] = useState<string | null>(null);
+  const [stemResults, setStemResults] = useState<StemResult[]>([]);
+
+  const [liveSourceMode, setLiveSourceMode] = useState<LiveSourceMode>('file');
+  const [liveFileSourceType, setLiveFileSourceType] =
+    useState<LiveFileSourceType>('example');
+  const [selectedExampleAudioId, setSelectedExampleAudioId] = useState(
+    AUDIO_FILES[0]?.id ?? ''
+  );
+  const [selectedFileUri, setSelectedFileUri] = useState<string | null>(null);
+  const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
+  const [liveProgress, setLiveProgress] = useState<number | null>(null);
+  const [liveStatus, setLiveStatus] = useState<string | null>(null);
+  const [liveRunState, setLiveRunState] = useState<
+    'idle' | 'running' | 'stopping'
+  >('idle');
+  const [liveSegmentLog, setLiveSegmentLog] = useState<string[]>([]);
+
+  const engineRef = useRef<SeparationEngine | null>(null);
+  const pipelineRef = useRef<SeparationPipelineHandle | null>(null);
+  const liveInRef = useRef<LiveAudioBufferRef | null>(null);
+  const liveOutRefs = useRef<LiveAudioBufferRef[]>([]);
+  const ingestHandleRef = useRef<FileIngestHandle | null>(null);
+  const liveUsingMicRef = useRef(false);
+  const cleanupLockRef = useRef(false);
+  const offlineWidgetRef = useRef<OfflineAudioBufferWidgetHandle | null>(null);
+  const stemResultsRef = useRef<StemResult[]>([]);
+
+  useEffect(() => {
+    stemResultsRef.current = stemResults;
+  }, [stemResults]);
+
+  const clearStemResults = useCallback(async () => {
+    const current = stemResultsRef.current;
+    stemResultsRef.current = [];
+    setStemResults([]);
+    for (const stem of current) {
+      await releasePipelineAudioBuffer(stem.bufferId).catch(() => {});
+    }
+  }, []);
+
+  const releaseLiveBuffers = useCallback(async () => {
+    const liveOuts = liveOutRefs.current;
+    liveOutRefs.current = [];
+    for (const out of liveOuts) {
+      await releasePipelineAudioBuffer(out.bufferId).catch(() => {});
+    }
+    const liveIn = liveInRef.current;
+    liveInRef.current = null;
+    if (liveIn) {
+      await releasePipelineAudioBuffer(liveIn.bufferId).catch(() => {});
+    }
+  }, []);
+
+  const loadAvailableModels = useCallback(async () => {
+    setLoadingModels(true);
+    setError(null);
+    setErrorSource(null);
+    try {
+      const assetModels = await listAssetModels();
+      const separationFolders = assetModels
+        .filter((m) => isSeparationHint(m.folder, m.hint))
+        .map((m) => m.folder);
+      const downloadedModels = await listDownloadedModels(
+        ModelCategory.Separation
+      );
+      const downloadedFolders = downloadedModels.map((model) => model.id);
+
+      let padFolders: string[] = [];
+      let resolvedPadPath: string | null = null;
+      try {
+        const padPathFromNative = await getAssetPackPath(PAD_PACK_NAME);
+        const fallbackPath = `${DocumentDirectoryPath}/models`;
+        const padPath = padPathFromNative ?? fallbackPath;
+        const padResults = await listModelsAtPath(padPath);
+        padFolders = (padResults || [])
+          .filter((m) => isSeparationHint(m.folder, m.hint))
+          .map((m) => m.folder);
+        if (padFolders.length > 0) {
+          resolvedPadPath = padPath;
+        }
+      } catch (loadPadErr) {
+        console.warn(
+          'SeparationScreen: PAD/listModelsAtPath failed',
+          loadPadErr
+        );
+        padFolders = [];
+      }
+      setPadModelsPath(resolvedPadPath);
+
+      const combined = [
+        ...padFolders,
+        ...separationFolders.filter((f) => !padFolders.includes(f)),
+        ...downloadedFolders.filter(
+          (f) => !padFolders.includes(f) && !separationFolders.includes(f)
+        ),
+      ];
+      setPadModelIds(padFolders);
+      setDownloadedModelIds(downloadedFolders);
+      setAvailableModels(combined);
+
+      if (combined.length === 0) {
+        setErrorSource('init');
+        setError(
+          'No separation models found. Add a Spleeter or UVR model as a bundled asset, downloaded model, or PAD model.'
+        );
+      }
+    } catch (loadErr) {
+      console.error('SeparationScreen: Failed to load models:', loadErr);
+      setErrorSource('init');
+      setError('Failed to load available models');
+      setAvailableModels([]);
+    } finally {
+      setLoadingModels(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAvailableModels().catch(() => {});
+    const unsubscribe = onModelsListUpdated((category) => {
+      if (category === ModelCategory.Separation) {
+        loadAvailableModels().catch(() => {});
+      }
+    });
+    return unsubscribe;
+  }, [loadAvailableModels]);
+
+  const resolveSeparationModelPath = useCallback(
+    (modelFolder: string) => {
+      if (padModelIds.includes(modelFolder)) {
+        return padModelsPath
+          ? getFileModelPath(
+              modelFolder,
+              ModelCategory.Separation,
+              padModelsPath
+            )
+          : getFileModelPath(modelFolder, ModelCategory.Separation);
+      }
+      if (downloadedModelIds.includes(modelFolder)) {
+        return getFileModelPath(modelFolder, ModelCategory.Separation);
+      }
+      return getAssetModelPath(modelFolder);
+    },
+    [downloadedModelIds, padModelIds, padModelsPath]
+  );
+
+  const catalogEntries = useMemo(
+    () =>
+      availableModels.map((id) => ({
+        id,
+        label: getModelDisplayName(id),
+      })),
+    [availableModels]
+  );
+
+  const cleanupLiveRuntime = useCallback(async () => {
+    if (cleanupLockRef.current) {
+      return;
+    }
+    cleanupLockRef.current = true;
+    try {
+      try {
+        ingestHandleRef.current?.cancel();
+      } catch {
+        // ignore teardown races
+      }
+      ingestHandleRef.current = null;
+
+      try {
+        await stopMicToLiveAudioBuffer();
+      } catch {
+        // ignore teardown races
+      }
+      liveUsingMicRef.current = false;
+
+      try {
+        await pipelineRef.current?.stop();
+      } catch {
+        // ignore teardown races
+      }
+      pipelineRef.current = null;
+
+      const liveOuts = liveOutRefs.current;
+      liveOutRefs.current = [];
+      for (const out of liveOuts) {
+        await releasePipelineAudioBuffer(out.bufferId).catch(() => {});
+      }
+
+      const liveIn = liveInRef.current;
+      liveInRef.current = null;
+      if (liveIn) {
+        await releasePipelineAudioBuffer(liveIn.bufferId).catch(() => {});
+      }
+    } finally {
+      cleanupLockRef.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      cleanupLiveRuntime().catch(() => {});
+      const stems = stemResultsRef.current;
+      stemResultsRef.current = [];
+      for (const stem of stems) {
+        releasePipelineAudioBuffer(stem.bufferId).catch(() => {});
+      }
+      const engine = engineRef.current;
+      engineRef.current = null;
+      if (engine) {
+        engine.destroy().catch(() => {});
+      }
+    };
+  }, [cleanupLiveRuntime]);
+
+  const handleFillFromSelectedModel = useCallback(async () => {
+    const modelFolder = selectedModelForInit;
+    if (!modelFolder) {
+      Alert.alert('Select a model', 'Pick a catalog model folder first.');
+      return;
+    }
+
+    setCustomFillLoading(true);
+    setCustomFillHint(null);
+    setError(null);
+    setErrorSource(null);
+    try {
+      const modelPath = resolveSeparationModelPath(modelFolder);
+      const fillResult = await fillSeparationCustomConfigFromModelFolder(
+        await toDetectSource(modelPath),
+        { modelTypeOverride: customInitForm.modelType }
+      );
+      setCustomInitForm({
+        modelType: fillResult.modelType,
+        fileSources: fillResult.customConfig,
+      });
+      const missing =
+        fillResult.missingKeys.length > 0
+          ? ` Missing: ${fillResult.missingKeys.join(', ')}`
+          : '';
+      setCustomFillHint(
+        `Filled from ${getModelDisplayName(modelFolder)} (${
+          fillResult.modelDir
+        }).${missing}`
+      );
+    } catch (fillErr) {
+      setCustomFillHint(null);
+      setErrorSource('init');
+      setError(normalizeErrorMessage(fillErr));
+    } finally {
+      setCustomFillLoading(false);
+    }
+  }, [
+    customInitForm.modelType,
+    resolveSeparationModelPath,
+    selectedModelForInit,
+  ]);
+
+  const handlePrepareScatteredTest = useCallback(() => {
+    setCustomInitForm((prev) => ({ ...prev, fileSources: {} }));
+    setCustomFillHint(
+      'Scattered test: pick stem files from different locations, then Initialize.'
+    );
+  }, []);
+
+  const applyEngineMetadata = useCallback(async (engine: SeparationEngine) => {
+    const stems = await engine.getNumStems();
+    const sr = await engine.getSampleRate();
+    setNumStems(stems);
+    setModelSampleRate(sr);
+    return { stems, sr };
+  }, []);
+
+  const handleInitializeCustom = async () => {
+    setLoading(true);
+    setError(null);
+    setErrorSource(null);
+    setInitResult(null);
+    setInitializedSummary(null);
+    setSelectedModelKind(null);
+
+    try {
+      const previous = engineRef.current;
+      if (previous) {
+        await previous.destroy();
+        engineRef.current = null;
+      }
+      await clearStemResults();
+
+      const customConfig = { ...customInitForm.fileSources };
+      assertSeparationCustomConfig(
+        customConfig as unknown as Record<string, unknown>
+      );
+
+      const engine =
+        customInitForm.modelType === 'spleeter'
+          ? await createSeparation({
+              initMode: 'custom',
+              modelType: 'spleeter',
+              customConfig: customConfig as SpleeterCustomConfig,
+              numThreads: NUM_THREADS,
+            })
+          : await createSeparation({
+              initMode: 'custom',
+              modelType: 'uvr',
+              customConfig: customConfig as UvrCustomConfig,
+              numThreads: NUM_THREADS,
+            });
+
+      engineRef.current = engine;
+      const { stems, sr } = await applyEngineMetadata(engine);
+      setCurrentModelFolder(null);
+      setSelectedModelKind(customInitForm.modelType);
+      setInitializedSummary(`custom:${customInitForm.modelType}`);
+      setInitResult(
+        `Initialized (custom): ${customInitForm.modelType}\nStems: ${stems}\nSample rate: ${sr} Hz`
+      );
+      setSeparateResult(null);
+    } catch (initErr) {
+      setErrorSource('init');
+      setError(normalizeErrorMessage(initErr));
+      setInitResult(
+        `Custom initialization failed: ${normalizeErrorMessage(initErr)}`
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleInitialize = async (modelFolder: string) => {
+    setLoading(true);
+    setError(null);
+    setErrorSource(null);
+    setInitResult(null);
+    setInitializedSummary(null);
+    setSelectedModelKind(null);
+
+    try {
+      const previous = engineRef.current;
+      if (previous) {
+        await previous.destroy();
+        engineRef.current = null;
+      }
+      await clearStemResults();
+
+      const modelPath = resolveSeparationModelPath(modelFolder);
+      const modelSource = await toDetectSource(modelPath);
+
+      const detectResult = await detectSeparationModel(modelSource, {
+        modelType: 'auto',
+      });
+      if (!detectResult.success || !detectResult.detectedModels?.length) {
+        setErrorSource('init');
+        setError('No separation models detected in the directory');
+        return;
+      }
+
+      const modelType =
+        detectResult.modelType === 'spleeter' ||
+        detectResult.modelType === 'uvr'
+          ? detectResult.modelType
+          : (detectResult.detectedModels[0]?.type as SeparationModelType);
+
+      const engine = await createSeparation({
+        modelSource,
+        modelType,
+        numThreads: NUM_THREADS,
+      });
+
+      engineRef.current = engine;
+      const { stems, sr } = await applyEngineMetadata(engine);
+      setCurrentModelFolder(modelFolder);
+      setSelectedModelKind(modelType);
+      setInitializedSummary(modelFolder);
+      setInitResult(
+        `Initialized: ${getModelDisplayName(
+          modelFolder
+        )} (${modelType})\nStems: ${stems}\nSample rate: ${sr} Hz`
+      );
+      setSeparateResult(null);
+    } catch (initErr) {
+      setErrorSource('init');
+      setError(normalizeErrorMessage(initErr));
+      setInitResult(`Initialization failed: ${normalizeErrorMessage(initErr)}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleFree = async () => {
+    await cleanupLiveRuntime();
+    await clearStemResults();
+    const engine = engineRef.current;
+    if (engine) {
+      await engine.destroy().catch(() => {});
+    }
+    engineRef.current = null;
+    setCurrentModelFolder(null);
+    setInitializedSummary(null);
+    setSelectedModelForInit(null);
+    setSelectedModelKind(null);
+    setInitResult(null);
+    setModelSampleRate(null);
+    setNumStems(2);
+    setSeparateResult(null);
+    setLiveStatus(null);
+    setLiveProgress(null);
+    setLiveSegmentLog([]);
+    setLiveRunState('idle');
+    setError(null);
+    setErrorSource(null);
+    await offlineWidgetRef.current?.clear();
+    setPreparedInputBuffer(null);
+  };
+
+  const handleSeparateBatch = async () => {
+    if (!engineRef.current) {
+      setErrorSource('separate');
+      setError('Initialize a separation model first.');
+      return;
+    }
+    const prepared = preparedInputBuffer;
+    if (!prepared) {
+      setErrorSource('separate');
+      setError('Select audio and wait until OfflineAudioBuffer is ready.');
+      return;
+    }
+
+    setSeparating(true);
+    setError(null);
+    setErrorSource(null);
+    setSeparateResult(null);
+    await clearStemResults();
+
+    try {
+      const engine = engineRef.current;
+      const stems = await engine.getNumStems();
+      const sr = await engine.getSampleRate();
+      const outs = await Promise.all(
+        Array.from({ length: stems }, () => createEmptyOfflineAudioBuffer(sr))
+      );
+
+      const segOption = buildSegmentationOption(segBatchConfig);
+      const result = await engine.separate(
+        prepared.bufferId,
+        outs.map((out) => out.bufferId),
+        {
+          segmentation: segOption,
+          ...(segBatchConfig.mode !== 'off'
+            ? {
+                errorRecovery: 'partial_result' as const,
+                overlapSamples: Math.round(sr * 0.02),
+              }
+            : {}),
+        }
+      );
+
+      const nextStems: StemResult[] = [];
+      for (let i = 0; i < stems; i++) {
+        const out = outs[i]!;
+        const info = await getPipelineAudioBufferInfo(out.bufferId);
+        const n = info.numSamples ?? 0;
+        const outSr = info.sampleRate ?? sr;
+        nextStems.push({
+          bufferId: out.bufferId,
+          label: stemLabel(i, stems),
+          sampleRate: outSr,
+          numSamples: n,
+        });
+      }
+      setStemResults(nextStems);
+
+      const inInfo = await getPipelineAudioBufferInfo(prepared.bufferId);
+      const inSamples = inInfo.numSamples ?? 0;
+      const durationSec =
+        sr > 0 && inSamples > 0 ? (inSamples / sr).toFixed(2) : '?';
+      setSeparateResult(
+        `Mode: offline batch\nSegmentation: ${segBatchConfig.mode}\nStatus: ${result.status}\nSegments: ${result.completedSegments}/${result.totalSegments}\nSkipped: ${result.skippedSegments.length}\nInput duration: ~${durationSec} s\nProcessing: ${result.processingTimeMs} ms`
+      );
+    } catch (batchErr) {
+      setErrorSource('separate');
+      setError(normalizeErrorMessage(batchErr));
+    } finally {
+      setSeparating(false);
+    }
+  };
+
+  const finalizeLiveStemResults = useCallback(
+    async (sr: number, stems: number) => {
+      const liveOuts = liveOutRefs.current;
+      const nextStems: StemResult[] = [];
+      for (let i = 0; i < stems; i++) {
+        const liveOut = liveOuts[i];
+        if (!liveOut) continue;
+        await finalizeLiveAudioBuffer(liveOut.bufferId).catch(() => {});
+        const offline = await createOfflineAudioBufferFromLive(
+          liveOut.bufferId,
+          'fullIfSpooled'
+        );
+        const info = await getPipelineAudioBufferInfo(offline.bufferId);
+        const n = info.kind === 'offlinePcmBuffer' ? info.numSamples : 0;
+        const outSr = info.sampleRate ?? sr;
+        nextStems.push({
+          bufferId: offline.bufferId,
+          label: stemLabel(i, stems),
+          sampleRate: outSr,
+          numSamples: n,
+        });
+      }
+      setStemResults(nextStems);
+      return nextStems;
+    },
+    []
+  );
+
+  const waitForPipelineCompletion = useCallback(
+    async (pipeline: SeparationPipelineHandle) => {
+      return new Promise<Awaited<typeof pipeline.completed>>(
+        (resolve, reject) => {
+          const timeoutId = setTimeout(() => {
+            reject(
+              new Error(
+                `Separation pipeline timeout after ${PIPELINE_WAIT_TIMEOUT_MS}ms`
+              )
+            );
+          }, PIPELINE_WAIT_TIMEOUT_MS);
+
+          pipeline.completed.then(
+            (result) => {
+              clearTimeout(timeoutId);
+              resolve(result);
+            },
+            (pipelineError) => {
+              clearTimeout(timeoutId);
+              reject(pipelineError);
+            }
+          );
+        }
+      );
+    },
+    []
+  );
+
+  const resolveLiveFileSource = useCallback((): FileSource => {
+    if (liveFileSourceType === 'own') {
+      if (!selectedFileUri) {
+        throw new Error('Pick an audio file first.');
+      }
+      return toFileSource(selectedFileUri);
+    }
+    const example = AUDIO_FILES.find((f) => f.id === selectedExampleAudioId);
+    if (!example) {
+      throw new Error('Select example audio first.');
+    }
+    return fileSourceFromBundledPath(example.id);
+  }, [liveFileSourceType, selectedExampleAudioId, selectedFileUri]);
+
+  const handleSeparateLive = async () => {
+    if (!engineRef.current) {
+      setErrorSource('live');
+      setError('Initialize a separation model first.');
+      return;
+    }
+    if (liveSourceMode === 'file') {
+      if (liveFileSourceType === 'own' && !selectedFileUri) {
+        setErrorSource('live');
+        setError('Pick an audio file first.');
+        return;
+      }
+    }
+
+    const segOption = buildSegmentationOption(segLiveConfig);
+    if (
+      !segOption ||
+      segOption.mode === 'off' ||
+      !segOption.policy ||
+      segOption.policy.evaluator !== 'continuous_frames'
+    ) {
+      setErrorSource('live');
+      setError('Live overload requires continuous_frames segmentation.');
+      return;
+    }
+
+    setLiveRunState('running');
+    setError(null);
+    setErrorSource(null);
+    setSeparateResult(null);
+    setLiveProgress(null);
+    setLiveSegmentLog([]);
+    await clearStemResults();
+    await cleanupLiveRuntime();
+
+    try {
+      const engine = engineRef.current;
+      const stems = await engine.getNumStems();
+      const sr = await engine.getSampleRate();
+
+      const liveIn = await createEmptyLiveAudioBuffer({
+        sampleRate: sr,
+        channelCount: 1,
+        ringSeconds: 240,
+        retention: 'auto',
+        streamEvents: { framesAppended: { enabled: false, minIntervalMs: 0 } },
+      });
+      const liveOuts = await Promise.all(
+        Array.from({ length: stems }, () =>
+          createEmptyLiveAudioBuffer({
+            sampleRate: sr,
+            channelCount: 1,
+            ringSeconds: 240,
+            retention: 'auto',
+            streamEvents: {
+              framesAppended: { enabled: false, minIntervalMs: 0 },
+            },
+          })
+        )
+      );
+      liveInRef.current = liveIn;
+      liveOutRefs.current = liveOuts;
+
+      let segmentEventCount = 0;
+      const pipeline = await engine.separate(
+        liveIn.bufferId,
+        liveOuts.map((out) => out.bufferId),
+        {
+          segmentation: {
+            mode: 'auto',
+            policy: segOption.policy as typeof segOption.policy & {
+              evaluator: 'continuous_frames';
+            },
+          },
+          onSegment: (segment: SpeechSegment) => {
+            segmentEventCount += 1;
+            setLiveSegmentLog((prev) => {
+              const line = `seg #${segment.segmentIndex} (${segment.reason})`;
+              return [...prev.slice(-4), line];
+            });
+          },
+        }
+      );
+      pipelineRef.current = pipeline;
+      setLiveStatus('Separation pipeline running…');
+
+      if (liveSourceMode === 'file') {
+        const source = resolveLiveFileSource();
+        const ingest = await ingestFileToLiveAudioBuffer(
+          liveIn.bufferId,
+          source,
+          {
+            targetSampleRateHz: sr,
+            forceMono: true,
+            autoFinalize: true,
+            backpressure: 'block',
+            onProgress: (event) => {
+              setLiveProgress(event.percent);
+              setLiveStatus(
+                `Decoding ${event.percent.toFixed(
+                  0
+                )}% • ${event.framesDecoded.toLocaleString()} frames`
+              );
+            },
+          }
+        );
+        ingestHandleRef.current = ingest;
+        await ingest.done;
+        ingestHandleRef.current = null;
+
+        const completion = await waitForPipelineCompletion(pipeline);
+        pipelineRef.current = null;
+        await pipeline.stop().catch(() => {});
+
+        const finalized = await finalizeLiveStemResults(sr, stems);
+        const totalSamples = finalized.reduce(
+          (sum, s) => sum + s.numSamples,
+          0
+        );
+        setSeparateResult(
+          `Mode: live overload (file)\nSegmentation: ${segLiveConfig.mode} / continuous_frames\nPipeline: ${completion.reason}\nSegment events: ${segmentEventCount}\nOutput samples (all stems): ${totalSamples}\nSample rate: ${sr} Hz`
+        );
+        setLiveStatus('Live separation completed.');
+        await releaseLiveBuffers();
+        setLiveRunState('idle');
+        setLiveProgress(null);
+      } else {
+        ingestHandleRef.current = null;
+        await startMicToLiveAudioBuffer(liveIn, { emitToJs: false });
+        liveUsingMicRef.current = true;
+        setLiveStatus(
+          'Microphone active. Tap Stop when finished to finalize and collect stems.'
+        );
+      }
+    } catch (liveErr) {
+      setErrorSource('live');
+      setError(normalizeErrorMessage(liveErr));
+      setLiveStatus('Live separation failed.');
+      await cleanupLiveRuntime();
+      setLiveRunState('idle');
+    }
+  };
+
+  const stopLiveSeparation = useCallback(async () => {
+    if (liveRunState !== 'running') {
+      return;
+    }
+    setLiveRunState('stopping');
+    setLiveStatus('Stopping live separation…');
+
+    try {
+      const pipeline = pipelineRef.current;
+      const engine = engineRef.current;
+      if (!pipeline || !engine) {
+        throw new Error('Live pipeline is not active.');
+      }
+
+      if (liveUsingMicRef.current) {
+        try {
+          await stopMicToLiveAudioBuffer();
+        } catch {
+          // ignore mic stop races
+        }
+        liveUsingMicRef.current = false;
+      } else {
+        try {
+          ingestHandleRef.current?.cancel();
+        } catch {
+          // ignore ingest cancel races
+        }
+        ingestHandleRef.current = null;
+      }
+
+      const liveIn = liveInRef.current;
+      if (liveIn) {
+        await finalizeLiveAudioBuffer(liveIn.bufferId);
+      }
+
+      const completion = await waitForPipelineCompletion(pipeline);
+      pipelineRef.current = null;
+      await pipeline.stop().catch(() => {});
+
+      const stems = await engine.getNumStems();
+      const sr = await engine.getSampleRate();
+      const finalized = await finalizeLiveStemResults(sr, stems);
+      const totalSamples = finalized.reduce((sum, s) => sum + s.numSamples, 0);
+      setSeparateResult(
+        `Mode: live overload (${liveSourceMode})\nSegmentation: ${segLiveConfig.mode} / continuous_frames\nPipeline: ${completion.reason}\nOutput samples (all stems): ${totalSamples}\nSample rate: ${sr} Hz`
+      );
+      setLiveStatus('Live separation completed.');
+    } catch (stopErr) {
+      setErrorSource('live');
+      setError(normalizeErrorMessage(stopErr));
+      setLiveStatus('Live separation stop failed.');
+    } finally {
+      await releaseLiveBuffers();
+      setLiveRunState('idle');
+      setLiveProgress(null);
+    }
+  }, [
+    finalizeLiveStemResults,
+    liveRunState,
+    liveSourceMode,
+    releaseLiveBuffers,
+    segLiveConfig.mode,
+    waitForPipelineCompletion,
+  ]);
+
+  const pickFile = useCallback(async () => {
+    try {
+      const [result] = await DocumentPicker.pick({
+        type: [DocumentPicker.types.audio],
+      });
+      if (result) {
+        setSelectedFileUri(result.uri);
+        setSelectedFileName(result.name ?? result.uri);
+        setLiveFileSourceType('own');
+      }
+    } catch (pickErr) {
+      const isPickCancel =
+        (DocumentPicker as { isCancel?: (e: unknown) => boolean }).isCancel?.(
+          pickErr
+        ) ||
+        (pickErr as { code?: string })?.code === 'DOCUMENT_PICKER_CANCELED' ||
+        (pickErr as { name?: string })?.name === 'DocumentPickerCanceled';
+      if (!isPickCancel) {
+        setErrorSource('live');
+        setError(normalizeErrorMessage(pickErr));
+      }
+    }
+  }, []);
+
+  const canInitAuto =
+    initMode === 'auto' && !!selectedModelForInit && !loading && !separating;
+  const canInitCustom =
+    initMode === 'custom' &&
+    Object.keys(customInitForm.fileSources).length > 0 &&
+    !loading &&
+    !separating;
+
+  const engineReady = !!engineRef.current && !!initializedSummary;
+  const liveBusy = liveRunState !== 'idle';
+
+  const canRunBatch =
+    processingMode === 'batch' &&
+    engineReady &&
+    !!preparedInputBuffer &&
+    !separating &&
+    !liveBusy;
+
+  const canRunLive =
+    processingMode === 'liveOverload' &&
+    engineReady &&
+    liveRunState === 'idle' &&
+    (liveSourceMode === 'mic' ||
+      (liveFileSourceType === 'example' && !!selectedExampleAudioId) ||
+      (liveFileSourceType === 'own' && !!selectedFileUri));
+
   return (
-    <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
-      <View style={styles.content}>
-        <Ionicons name="musical-notes" size={72} style={styles.icon} />
-        <Text style={styles.title}>Source Separation</Text>
-        <Text style={styles.subtitle}>Coming Soon</Text>
-        <Text style={styles.description}>
-          This feature will separate voice from background music and other audio
-          sources.
-        </Text>
-        <View style={styles.featureList}>
-          <Text style={styles.featureItem}>• Voice/music separation</Text>
-          <Text style={styles.featureItem}>• Multi-track isolation</Text>
-          <Text style={styles.featureItem}>• Background removal</Text>
-          <Text style={styles.featureItem}>• Export separated tracks</Text>
+    <SafeAreaView
+      style={screenStyles.container}
+      edges={['left', 'right', 'bottom']}
+    >
+      <ScrollView contentContainerStyle={screenStyles.content}>
+        <View style={screenStyles.headerRow}>
+          <View style={screenStyles.headerIconWrap}>
+            <Ionicons name="musical-notes" size={20} color="#0F62FE" />
+          </View>
+          <Text style={screenStyles.headerTitle}>Source Separation</Text>
         </View>
-      </View>
+        <Text style={screenStyles.bodyText}>
+          Offline batch (1→N stems) and live overload with segmentation.
+        </Text>
+
+        <View style={screenStyles.card}>
+          <Text style={screenStyles.cardTitle}>Processing mode</Text>
+          <View style={lpStyles.sourceToggle}>
+            {(
+              [
+                ['batch', 'Offline batch'],
+                ['liveOverload', 'Live overload'],
+              ] as const
+            ).map(([mode, label]) => (
+              <TouchableOpacity
+                key={mode}
+                style={[
+                  lpStyles.sourceToggleBtn,
+                  processingMode === mode && lpStyles.sourceToggleBtnActive,
+                ]}
+                onPress={() => {
+                  if (liveBusy || separating) return;
+                  setProcessingMode(mode);
+                }}
+                disabled={liveBusy || separating}
+              >
+                <Text
+                  style={[
+                    lpStyles.sourceToggleText,
+                    processingMode === mode && lpStyles.sourceToggleTextActive,
+                  ]}
+                >
+                  {label}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+
+        <View style={screenStyles.card}>
+          <Text style={screenStyles.cardTitle}>Model</Text>
+          <InitModeSelector
+            value={initMode}
+            onChange={setInitMode}
+            disabled={loading || separating || liveBusy}
+          />
+
+          {initMode === 'auto' ? (
+            <>
+              <ModelFolderGrid
+                entries={catalogEntries}
+                selectedId={selectedModelForInit}
+                initializedId={currentModelFolder}
+                onSelect={setSelectedModelForInit}
+                loading={loadingModels}
+                disabled={loading || separating || liveBusy}
+                emptyMessage="No separation models found."
+              />
+              <TouchableOpacity
+                style={[
+                  screenStyles.primaryButton,
+                  !canInitAuto && screenStyles.buttonDisabled,
+                ]}
+                onPress={() => {
+                  if (selectedModelForInit) {
+                    handleInitialize(selectedModelForInit).catch(() => {});
+                  }
+                }}
+                disabled={!canInitAuto}
+              >
+                {loading ? (
+                  <ActivityIndicator color="#FFFFFF" />
+                ) : (
+                  <Text style={screenStyles.primaryButtonText}>
+                    Initialize model
+                  </Text>
+                )}
+              </TouchableOpacity>
+            </>
+          ) : (
+            <>
+              <SeparationCustomInitForm
+                value={customInitForm}
+                onChange={setCustomInitForm}
+                selectedCatalogModelId={selectedModelForInit}
+                onFillFromSelectedModel={() => {
+                  handleFillFromSelectedModel().catch(() => {});
+                }}
+                onPrepareScatteredTest={handlePrepareScatteredTest}
+                fillLoading={customFillLoading}
+                disabled={loading || separating || liveBusy}
+                fillHint={customFillHint}
+              />
+              <TouchableOpacity
+                style={[
+                  screenStyles.primaryButton,
+                  !canInitCustom && screenStyles.buttonDisabled,
+                ]}
+                onPress={() => {
+                  handleInitializeCustom().catch(() => {});
+                }}
+                disabled={!canInitCustom}
+              >
+                {loading ? (
+                  <ActivityIndicator color="#FFFFFF" />
+                ) : (
+                  <Text style={screenStyles.primaryButtonText}>
+                    Initialize (custom)
+                  </Text>
+                )}
+              </TouchableOpacity>
+            </>
+          )}
+
+          {initializedSummary ? (
+            <Text style={baseStyles.currentModelText}>
+              Ready: {initializedSummary}
+              {modelSampleRate != null
+                ? ` • ${numStems} stem(s) @ ${modelSampleRate} Hz`
+                : ''}
+            </Text>
+          ) : null}
+          {initResult ? (
+            <Text style={screenStyles.monoResultText}>{initResult}</Text>
+          ) : null}
+          {engineReady ? (
+            <TouchableOpacity
+              style={baseStyles.secondaryButton}
+              onPress={() => {
+                handleFree().catch(() => {});
+              }}
+              disabled={loading || separating || liveBusy}
+            >
+              <Text style={baseStyles.secondaryButtonText}>Release engine</Text>
+            </TouchableOpacity>
+          ) : null}
+        </View>
+
+        <View style={screenStyles.card}>
+          <Text style={screenStyles.cardTitle}>Segmentation</Text>
+          {processingMode === 'batch' ? (
+            <SegmentationPolicyControls
+              variant="speech-offline"
+              value={segBatchConfig}
+              onChange={setSegBatchConfig}
+              disabled={separating || liveBusy}
+            />
+          ) : (
+            <>
+              <Text style={screenStyles.bodyText}>
+                Live overload requires continuous_frames segmentation. Off and
+                manual modes are disabled.
+              </Text>
+              <SegmentationPolicyControls
+                variant="speech-streaming"
+                value={segLiveConfig}
+                onChange={setSegLiveConfig}
+                disabled={liveBusy}
+                disableOff
+                disableManual
+                allowedEvaluators={['continuous_frames']}
+                offDisabledMessage="Live separation overload requires mandatory segmentation with continuous_frames."
+              />
+            </>
+          )}
+        </View>
+
+        {processingMode === 'batch' ? (
+          <View style={screenStyles.card}>
+            <Text style={screenStyles.cardTitle}>Input (offline)</Text>
+            <OfflineAudioBufferWidget
+              ref={offlineWidgetRef}
+              audioFiles={AUDIO_FILES}
+              visible={engineReady}
+              disabled={!engineReady || separating || liveBusy}
+              onBufferReady={setPreparedInputBuffer}
+              onBufferReleased={() => {
+                setPreparedInputBuffer(null);
+                setSeparateResult(null);
+                clearStemResults().catch(() => {});
+              }}
+            />
+            <TouchableOpacity
+              style={[
+                screenStyles.primaryButton,
+                !canRunBatch && screenStyles.buttonDisabled,
+              ]}
+              onPress={() => {
+                handleSeparateBatch().catch(() => {});
+              }}
+              disabled={!canRunBatch}
+            >
+              {separating ? (
+                <ActivityIndicator color="#FFFFFF" />
+              ) : (
+                <Text style={screenStyles.primaryButtonText}>
+                  Run separation
+                </Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        ) : (
+          <View style={screenStyles.card}>
+            <Text style={screenStyles.cardTitle}>Input (live)</Text>
+            <View style={lpStyles.sourceToggle}>
+              {(['file', 'mic'] as LiveSourceMode[]).map((mode) => (
+                <TouchableOpacity
+                  key={mode}
+                  style={[
+                    lpStyles.sourceToggleBtn,
+                    liveSourceMode === mode && lpStyles.sourceToggleBtnActive,
+                  ]}
+                  onPress={() => setLiveSourceMode(mode)}
+                  disabled={liveBusy}
+                >
+                  <Text
+                    style={[
+                      lpStyles.sourceToggleText,
+                      liveSourceMode === mode &&
+                        lpStyles.sourceToggleTextActive,
+                    ]}
+                  >
+                    {mode === 'mic' ? 'Microphone' : 'File'}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+
+            {liveSourceMode === 'file' && (
+              <>
+                <View style={localStyles.exampleRow}>
+                  {AUDIO_FILES.slice(0, 4).map((audioFile) => {
+                    const active = selectedExampleAudioId === audioFile.id;
+                    return (
+                      <TouchableOpacity
+                        key={audioFile.id}
+                        style={[
+                          localStyles.exampleChip,
+                          active && localStyles.exampleChipActive,
+                        ]}
+                        onPress={() => {
+                          setLiveFileSourceType('example');
+                          setSelectedExampleAudioId(audioFile.id);
+                        }}
+                        disabled={liveBusy}
+                      >
+                        <Text
+                          style={[
+                            localStyles.exampleChipText,
+                            active && localStyles.exampleChipTextActive,
+                          ]}
+                          numberOfLines={1}
+                        >
+                          {audioFile.name}
+                        </Text>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+                {!selectedFileUri ? (
+                  <TouchableOpacity
+                    style={lpStyles.optionButton}
+                    onPress={() => {
+                      pickFile().catch(() => {});
+                    }}
+                    disabled={liveBusy}
+                  >
+                    <Text style={lpStyles.optionButtonText}>
+                      Pick audio file…
+                    </Text>
+                  </TouchableOpacity>
+                ) : (
+                  <View style={screenStyles.selectedFileCard}>
+                    <View style={screenStyles.selectedFileInfo}>
+                      <Text style={screenStyles.selectedFileLabel}>
+                        Selected file
+                      </Text>
+                      <Text
+                        style={screenStyles.selectedFileName}
+                        numberOfLines={2}
+                      >
+                        {selectedFileName ?? selectedFileUri}
+                      </Text>
+                    </View>
+                    <Pressable
+                      style={screenStyles.removeFileButton}
+                      onPress={() => {
+                        if (liveBusy) return;
+                        setSelectedFileUri(null);
+                        setSelectedFileName(null);
+                      }}
+                      disabled={liveBusy}
+                    >
+                      <Text style={screenStyles.removeFileButtonText}>
+                        Clear
+                      </Text>
+                    </Pressable>
+                  </View>
+                )}
+              </>
+            )}
+
+            {liveSourceMode === 'mic' && liveRunState === 'running' ? (
+              <Text style={screenStyles.bodyText}>
+                Recording into the live buffer. Tap Stop when you are done
+                speaking or playing source audio near the mic.
+              </Text>
+            ) : null}
+
+            {liveProgress != null ? (
+              <Text style={screenStyles.bodyText}>
+                Decode progress: {liveProgress.toFixed(0)}%
+              </Text>
+            ) : null}
+            {liveStatus ? (
+              <Text style={screenStyles.bodyText}>{liveStatus}</Text>
+            ) : null}
+            {liveSegmentLog.length > 0 ? (
+              <Text style={screenStyles.monoResultText}>
+                {liveSegmentLog.join('\n')}
+              </Text>
+            ) : null}
+
+            {liveRunState === 'running' && liveSourceMode === 'mic' ? (
+              <TouchableOpacity
+                style={[lpStyles.runButton, lpStyles.runButtonStop]}
+                onPress={() => {
+                  stopLiveSeparation().catch(() => {});
+                }}
+              >
+                <Text style={lpStyles.runButtonText}>Stop</Text>
+              </TouchableOpacity>
+            ) : (
+              <TouchableOpacity
+                style={[
+                  lpStyles.runButton,
+                  !canRunLive && lpStyles.runButtonDisabled,
+                ]}
+                onPress={() => {
+                  handleSeparateLive().catch(() => {});
+                }}
+                disabled={!canRunLive}
+              >
+                <Text style={lpStyles.runButtonText}>Run separation</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        )}
+
+        {error ? (
+          <View style={baseStyles.errorContainer}>
+            <Text style={baseStyles.errorLabel}>
+              {errorSource === 'init'
+                ? 'Initialization error'
+                : errorSource === 'live'
+                ? 'Live separation error'
+                : 'Separation error'}
+            </Text>
+            <Text style={baseStyles.errorText}>{error}</Text>
+          </View>
+        ) : null}
+
+        {separateResult ? (
+          <View style={screenStyles.card}>
+            <Text style={screenStyles.cardTitle}>Result</Text>
+            <Text style={screenStyles.monoResultText}>{separateResult}</Text>
+          </View>
+        ) : null}
+
+        {stemResults.length > 0 ? (
+          <View style={screenStyles.card}>
+            <Text style={screenStyles.cardTitle}>Separated stems</Text>
+            {stemResults.map((stem) => {
+              const durationMs =
+                stem.sampleRate > 0
+                  ? Math.round((stem.numSamples / stem.sampleRate) * 1000)
+                  : 0;
+              return (
+                <PipelineOfflineAudioResultCard
+                  key={stem.bufferId}
+                  bufferId={stem.bufferId}
+                  sourceLabel={stem.label}
+                  sampleRate={stem.sampleRate}
+                  durationMs={durationMs}
+                  onDismiss={() => {
+                    releasePipelineAudioBuffer(stem.bufferId)
+                      .catch(() => {})
+                      .finally(() => {
+                        setStemResults((prev) =>
+                          prev.filter((s) => s.bufferId !== stem.bufferId)
+                        );
+                      });
+                  }}
+                  disabled={separating || liveBusy}
+                />
+              );
+            })}
+          </View>
+        ) : null}
+
+        {selectedModelKind ? (
+          <Text style={screenStyles.footerHint}>
+            Model type: {selectedModelKind} • Expect {numStems} output stem
+            {numStems === 1 ? '' : 's'}
+          </Text>
+        ) : null}
+      </ScrollView>
       <ScreenIntroModal screenId="Separation" />
     </SafeAreaView>
   );
 }
 
-const styles = StyleSheet.create({
+const localStyles = StyleSheet.create({
+  exampleRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginVertical: 8,
+  },
+  exampleChip: {
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#C7C7CC',
+    backgroundColor: '#F2F2F7',
+    maxWidth: '48%',
+  },
+  exampleChipActive: {
+    borderColor: '#007AFF',
+    backgroundColor: '#E3F2FD',
+  },
+  exampleChipText: {
+    fontSize: 12,
+    color: '#3A3A3C',
+  },
+  exampleChipTextActive: {
+    color: '#007AFF',
+    fontWeight: '600',
+  },
+});
+
+const screenStyles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#F2F2F7',
   },
   content: {
-    flex: 1,
+    padding: 16,
+    gap: 14,
+    paddingBottom: 40,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginBottom: 2,
+  },
+  headerIconWrap: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: '#E8F1FF',
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 32,
   },
-  icon: {
-    marginBottom: 24,
+  headerTitle: {
+    fontSize: 24,
+    lineHeight: 30,
+    fontWeight: '800',
+    color: '#111827',
+    flex: 1,
   },
-  title: {
-    fontSize: 28,
-    fontWeight: 'bold',
-    color: '#000000',
-    marginBottom: 8,
-  },
-  subtitle: {
-    fontSize: 20,
-    fontWeight: '600',
-    color: '#FF9500',
-    marginBottom: 24,
-  },
-  description: {
-    fontSize: 16,
-    color: '#8E8E93',
-    textAlign: 'center',
-    lineHeight: 24,
-    marginBottom: 32,
-  },
-  featureList: {
-    alignSelf: 'stretch',
+  card: {
     backgroundColor: '#FFFFFF',
-    borderRadius: 12,
-    padding: 20,
+    borderRadius: 20,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
   },
-  featureItem: {
-    fontSize: 15,
-    color: '#000000',
+  cardTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: '#111827',
     marginBottom: 12,
-    lineHeight: 22,
+  },
+  bodyText: {
+    marginTop: 4,
+    marginBottom: 8,
+    fontSize: 14,
+    lineHeight: 20,
+    color: '#374151',
+  },
+  monoResultText: {
+    fontSize: 13,
+    lineHeight: 20,
+    color: '#1F2937',
+    fontFamily: 'Menlo',
+  },
+  primaryButton: {
+    backgroundColor: '#0F62FE',
+    borderRadius: 14,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 12,
+  },
+  primaryButtonText: {
+    color: '#FFFFFF',
+    fontWeight: '700',
+  },
+  buttonDisabled: {
+    opacity: 0.45,
+  },
+  selectedFileCard: {
+    marginTop: 8,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    backgroundColor: '#F9FAFB',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  selectedFileInfo: {
+    flex: 1,
+  },
+  selectedFileLabel: {
+    fontSize: 12,
+    lineHeight: 16,
+    fontWeight: '700',
+    color: '#6B7280',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    marginBottom: 4,
+  },
+  selectedFileName: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: '#111827',
+    fontWeight: '600',
+  },
+  removeFileButton: {
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#FFF5F4',
+    borderWidth: 1,
+    borderColor: '#F4C7C3',
+  },
+  removeFileButtonText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#B42318',
+  },
+  footerHint: {
+    fontSize: 12,
+    color: '#6B7280',
+    textAlign: 'center',
+    marginTop: 4,
   },
 });

--- a/example/src/screens/separation/SeparationScreen.tsx
+++ b/example/src/screens/separation/SeparationScreen.tsx
@@ -30,10 +30,10 @@ import {
   createOfflineAudioBufferFromLive,
   finalizeLiveAudioBuffer,
   getPipelineAudioBufferInfo,
-  ingestFileToLiveAudioBuffer,
   releasePipelineAudioBuffer,
   startMicToLiveAudioBuffer,
   stopMicToLiveAudioBuffer,
+  ingestFileToLiveAudioBuffer,
   type FileIngestHandle,
   type LiveAudioBufferRef,
 } from 'react-native-sherpa-onnx/audiobuffer';
@@ -77,7 +77,12 @@ import {
   toDetectSource,
 } from '../../modelConfig';
 import { AUDIO_FILES } from '../../audioConfig';
-import { fileSourceFromBundledPath } from '../../utils/fileSourceFromUri';
+import {
+  fileSourceFromBundledPath,
+  resolveAudioFileDisplayName,
+  toFileSource,
+} from '../../utils/fileSourceFromUri';
+import { DECODABLE_AUDIO_PICKER_TYPES } from '../../utils/decodableAudioPickerTypes';
 import { fillSeparationCustomConfigFromModelFolder } from '../../utils/separationCustomInitFill';
 
 const PAD_PACK_NAME = 'sherpa_models';
@@ -114,17 +119,6 @@ function normalizeErrorMessage(error: unknown): string {
     return error;
   }
   return String(error);
-}
-
-function toFileSource(pathOrUri: string): FileSource {
-  const trimmed = pathOrUri.trim();
-  if (trimmed.startsWith('content://')) {
-    return { kind: 'contentUri', uri: trimmed };
-  }
-  if (trimmed.startsWith('file://')) {
-    return { kind: 'fs', path: decodeURI(trimmed.replace(/^file:\/\//, '')) };
-  }
-  return { kind: 'fs', path: trimmed };
 }
 
 function isSeparationHint(folder: string, hint: string): boolean {
@@ -727,14 +721,19 @@ export default function SeparationScreen() {
       if (!selectedFileUri) {
         throw new Error('Pick an audio file first.');
       }
-      return toFileSource(selectedFileUri);
+      return toFileSource(selectedFileUri, selectedFileName ?? undefined);
     }
     const example = AUDIO_FILES.find((f) => f.id === selectedExampleAudioId);
     if (!example) {
       throw new Error('Select example audio first.');
     }
     return fileSourceFromBundledPath(example.id);
-  }, [liveFileSourceType, selectedExampleAudioId, selectedFileUri]);
+  }, [
+    liveFileSourceType,
+    selectedExampleAudioId,
+    selectedFileName,
+    selectedFileUri,
+  ]);
 
   const handleSeparateLive = async () => {
     if (!engineRef.current) {
@@ -947,11 +946,15 @@ export default function SeparationScreen() {
   const pickFile = useCallback(async () => {
     try {
       const [result] = await DocumentPicker.pick({
-        type: [DocumentPicker.types.audio],
+        type: DECODABLE_AUDIO_PICKER_TYPES,
       });
       if (result) {
+        const resolvedName =
+          resolveAudioFileDisplayName(result.uri, result.name) ??
+          result.name ??
+          result.uri;
         setSelectedFileUri(result.uri);
-        setSelectedFileName(result.name ?? result.uri);
+        setSelectedFileName(resolvedName);
         setLiveFileSourceType('own');
       }
     } catch (pickErr) {

--- a/example/src/screens/separation/SeparationScreen.tsx
+++ b/example/src/screens/separation/SeparationScreen.tsx
@@ -1183,6 +1183,7 @@ export default function SeparationScreen() {
               audioFiles={AUDIO_FILES}
               visible={engineReady}
               disabled={!engineReady || separating || liveBusy}
+              decodeTargetSampleRateHz={modelSampleRate ?? undefined}
               onBufferReady={setPreparedInputBuffer}
               onBufferReleased={() => {
                 setPreparedInputBuffer(null);

--- a/example/src/screens/stt-streaming/STTStreamingScreen.tsx
+++ b/example/src/screens/stt-streaming/STTStreamingScreen.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as DocumentPicker from '@react-native-documents/picker';
+import { DECODABLE_AUDIO_PICKER_TYPES } from '../../utils/decodableAudioPickerTypes';
 import { DocumentDirectoryPath } from '@dr.pogodin/react-native-fs';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
 import {
@@ -50,7 +51,6 @@ import {
   ModelCategory,
   onModelsListUpdated,
 } from 'react-native-sherpa-onnx/download';
-import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 import { ScreenIntroModal } from '../../components/ScreenIntroModal';
 import {
   InitModeSelector,
@@ -70,6 +70,10 @@ import {
   toDetectSource,
 } from '../../modelConfig';
 import { styles as lpStyles } from '../live-pipeline-showcase/LivePipelineShowcaseScreen.styles';
+import {
+  resolveAudioFileDisplayName,
+  toFileSource,
+} from '../../utils/fileSourceFromUri';
 
 const STT_INPUT_SAMPLE_RATE = 16000;
 const PAD_PACK_NAME = 'sherpa_models';
@@ -90,17 +94,6 @@ function normalizeErrorMessage(error: unknown): string {
     if (maybe.message) return maybe.message;
   }
   return 'Unknown error';
-}
-
-function toFileSource(input: string): FileSource {
-  const value = input.trim();
-  if (value.startsWith('content://')) {
-    return { kind: 'contentUri', uri: value };
-  }
-  if (value.startsWith('file://')) {
-    return { kind: 'fs', path: decodeURI(value.replace(/^file:\/\//, '')) };
-  }
-  return { kind: 'fs', path: value };
 }
 
 type StreamingState = 'idle' | 'starting' | 'running' | 'stopping';
@@ -528,7 +521,10 @@ export default function STTStreamingScreen() {
       let fileIngestDone: Promise<unknown> = Promise.resolve();
 
       if (sourceMode === 'file') {
-        const source = toFileSource(selectedFileUri!);
+        const source = toFileSource(
+          selectedFileUri!,
+          selectedFileName ?? undefined
+        );
         const ingest = await ingestFileToLiveAudioBuffer(
           liveAudio.bufferId,
           source,
@@ -602,6 +598,7 @@ export default function STTStreamingScreen() {
     resolveModelPath,
     segConfig,
     selectedFileUri,
+    selectedFileName,
     sourceMode,
     selectedModelFolder,
     stopPolling,
@@ -633,11 +630,15 @@ export default function STTStreamingScreen() {
   const pickFile = useCallback(async () => {
     try {
       const [result] = await DocumentPicker.pick({
-        type: [DocumentPicker.types.audio],
+        type: DECODABLE_AUDIO_PICKER_TYPES,
       });
       if (result) {
+        const resolvedName =
+          resolveAudioFileDisplayName(result.uri, result.name) ??
+          result.name ??
+          result.uri;
         setSelectedFileUri(result.uri);
-        setSelectedFileName(result.name ?? result.uri);
+        setSelectedFileName(resolvedName);
       }
     } catch (pickErr) {
       const isPickCancel =

--- a/example/src/screens/tts/OfflineTTSScreen.tsx
+++ b/example/src/screens/tts/OfflineTTSScreen.tsx
@@ -20,7 +20,7 @@ import {
   type TtsMatchaModelOptions,
   type TtsVitsModelOptions,
 } from 'react-native-sherpa-onnx/tts';
-import { copyFile, shareFile } from 'react-native-sherpa-onnx/fileio';
+import { shareFile } from 'react-native-sherpa-onnx/fileio';
 import { createPcmPlayer, type PcmPlayer } from 'react-native-sherpa-onnx/pcm';
 import type { TtsEngine } from 'react-native-sherpa-onnx/tts';
 import {
@@ -51,12 +51,13 @@ import {
   getModelDisplayName,
   toDetectSource,
 } from '../../modelConfig';
-import {
-  DocumentDirectoryPath,
-  unlink,
-  exists,
-} from '@dr.pogodin/react-native-fs';
+import { DocumentDirectoryPath, exists } from '@dr.pogodin/react-native-fs';
 import * as DocumentPicker from '@react-native-documents/picker';
+import { DECODABLE_AUDIO_PICKER_TYPES } from '../../utils/decodableAudioPickerTypes';
+import {
+  resolveAudioFileDisplayName,
+  toFileSource,
+} from '../../utils/fileSourceFromUri';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
 import { styles } from './OfflineTTSScreen.styles';
 import { setPipelineAudioRoutePreference } from 'react-native-sherpa-onnx/audio';
@@ -105,7 +106,6 @@ type ReferenceAudioState = {
   buffer: OfflineAudioBufferRef;
   sampleRate: number;
   numSamples: number;
-  ownedTempPath: string | null;
 };
 
 export default function OfflineTTSScreen() {
@@ -416,9 +416,6 @@ export default function OfflineTTSScreen() {
       await releasePipelineAudioBuffer(refAudio.buffer.bufferId).catch(
         () => {}
       );
-      if (refAudio.ownedTempPath) {
-        await unlink(refAudio.ownedTempPath).catch(() => {});
-      }
     },
     []
   );
@@ -448,9 +445,6 @@ export default function OfflineTTSScreen() {
       referenceAudioRef.current = null;
       if (refAudio) {
         releasePipelineAudioBuffer(refAudio.buffer.bufferId).catch(() => {});
-        if (refAudio.ownedTempPath) {
-          unlink(refAudio.ownedTempPath).catch(() => {});
-        }
       }
       const buffersToRelease = offlineAudioBuffersRef.current;
       offlineAudioBuffersRef.current = [];
@@ -464,38 +458,26 @@ export default function OfflineTTSScreen() {
     setError(null);
     try {
       const picked = await DocumentPicker.pick({
-        type: [DocumentPicker.types.audio],
+        type: DECODABLE_AUDIO_PICKER_TYPES,
       });
       const file = Array.isArray(picked) ? picked[0] : picked;
       const uri = file?.uri ?? (file as { fileUri?: string })?.fileUri ?? '';
-      const name = file?.name ?? uri?.split('/')?.pop() ?? 'reference.wav';
+      const name =
+        resolveAudioFileDisplayName(uri, file?.name) ??
+        file?.name?.trim() ??
+        uri?.split('/')?.pop() ??
+        'reference.wav';
       if (!uri) {
         setError('Could not get file URI from picker');
         return;
       }
-      let path = uri.replace(/^file:\/\//, '');
-      let ownedTempPath: string | null = null;
-      if (uri.startsWith('content://')) {
-        const result = await copyFile(
-          { kind: 'contentUri', uri },
-          { kind: 'app', base: 'cache', path: `tts_ref_${Date.now()}.wav` }
-        );
-        path =
-          result.output.kind === 'fs' ? result.output.path : result.output.uri;
-        ownedTempPath = path;
-      }
 
-      const refBuffer = await createOfflineAudioBufferFromFile({
-        kind: 'fs',
-        path,
-      });
+      const source = toFileSource(uri, name);
+      const refBuffer = await createOfflineAudioBufferFromFile(source);
       const info = await getPipelineAudioBufferInfo(refBuffer.bufferId);
       const numSamples = info.numSamples ?? 0;
       if (numSamples <= 0 || info.sampleRate <= 0) {
         await releasePipelineAudioBuffer(refBuffer.bufferId).catch(() => {});
-        if (ownedTempPath) {
-          await unlink(ownedTempPath).catch(() => {});
-        }
         setError('Reference audio is empty or invalid');
         return;
       }
@@ -504,7 +486,6 @@ export default function OfflineTTSScreen() {
         buffer: refBuffer,
         sampleRate: info.sampleRate,
         numSamples,
-        ownedTempPath,
       };
       const previousRef = referenceAudioRef.current;
       referenceAudioRef.current = nextRef;

--- a/example/src/screens/vad/VADScreen.tsx
+++ b/example/src/screens/vad/VADScreen.tsx
@@ -10,7 +10,12 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as DocumentPicker from '@react-native-documents/picker';
+import { DECODABLE_AUDIO_PICKER_TYPES } from '../../utils/decodableAudioPickerTypes';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
+import {
+  resolveAudioFileDisplayName,
+  toFileSource,
+} from '../../utils/fileSourceFromUri';
 import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 import { listAssetModels } from 'react-native-sherpa-onnx/utils';
 import {
@@ -129,17 +134,6 @@ function normalizeErrorMessage(error: unknown): string {
     }
   }
   return 'Unknown error';
-}
-
-function toFileSource(pathOrUri: string): FileSource {
-  const trimmed = pathOrUri.trim();
-  if (trimmed.startsWith('content://')) {
-    return { kind: 'contentUri', uri: trimmed };
-  }
-  if (trimmed.startsWith('file://')) {
-    return { kind: 'fs', path: decodeURI(trimmed.replace(/^file:\/\//, '')) };
-  }
-  return { kind: 'fs', path: trimmed };
 }
 
 export default function VADScreen() {
@@ -548,7 +542,7 @@ export default function VADScreen() {
   const pickLiveFile = useCallback(async () => {
     try {
       const picked = await DocumentPicker.pick({
-        type: [DocumentPicker.types.audio],
+        type: DECODABLE_AUDIO_PICKER_TYPES,
       });
       const file = Array.isArray(picked) ? picked[0] : picked;
       const uri =
@@ -557,10 +551,13 @@ export default function VADScreen() {
         (file as any).localUri ??
         (file as any).nativeUri;
       if (!uri) throw new Error('Could not resolve a file URI from picker.');
+      const resolvedName =
+        resolveAudioFileDisplayName(uri, file.name) ??
+        file.name?.trim() ??
+        uri.split('/').pop() ??
+        'audio-file';
       setSelectedLiveFileUri(uri);
-      setSelectedLiveFileName(
-        file.name || uri.split('/').pop() || 'audio-file'
-      );
+      setSelectedLiveFileName(resolvedName);
       setStatus('Live input file selected.');
     } catch (pickErr: any) {
       const isCancel =
@@ -741,7 +738,7 @@ export default function VADScreen() {
         );
         const ingest = await ingestFileToLiveAudioBuffer(
           liveAudio,
-          toFileSource(selectedLiveFileUri),
+          toFileSource(selectedLiveFileUri, selectedLiveFileName ?? undefined),
           {
             // Deterministic template flow: user explicitly finishes the pipeline.
             autoFinalize: false,

--- a/example/src/utils/audioFilePcmPlayback.ts
+++ b/example/src/utils/audioFilePcmPlayback.ts
@@ -17,9 +17,9 @@ type PcmFilePlaybackOptions = {
 export async function startPcmFilePlayback(
   pathOrUri: string,
   onPlaybackEnded?: () => void,
-  options?: PcmFilePlaybackOptions
+  options?: PcmFilePlaybackOptions & { displayName?: string }
 ): Promise<ActivePcmFilePlayback> {
-  const source = toFileSource(pathOrUri);
+  const source = toFileSource(pathOrUri, options?.displayName);
   const audioBuffer = await createOfflineAudioBufferFromFile(source, {
     forceMono: true,
   });

--- a/example/src/utils/decodableAudioPickerTypes.ts
+++ b/example/src/utils/decodableAudioPickerTypes.ts
@@ -1,0 +1,15 @@
+import { types } from '@react-native-documents/picker';
+
+/**
+ * Document-picker filter for SDK-decodable inputs (see audioConfig CODEC_ASSET_ENTRIES).
+ *
+ * `types.audio` alone is insufficient on Android: MKV/WebM are often exposed as
+ * video/* (e.g. video/x-matroska, video/webm), not audio/*.
+ */
+export const DECODABLE_AUDIO_PICKER_TYPES: string[] = [
+  types.audio,
+  types.video,
+  'audio/webm',
+  'video/webm',
+  'video/x-matroska',
+];

--- a/example/src/utils/fileSourceFromUri.ts
+++ b/example/src/utils/fileSourceFromUri.ts
@@ -1,6 +1,9 @@
 import { Platform } from 'react-native';
 import type { FileSource } from 'react-native-sherpa-onnx/fileio';
 
+const AUDIO_EXT_RE =
+  /\.(aac|m4a|mp3|wav|flac|ogg|opus|wma|caf|aiff?|webm|mkv)$/i;
+
 /** decodeURI that never throws (malformed % sequences from pickers). */
 function safeDecodeUri(encoded: string): string {
   try {
@@ -10,12 +13,54 @@ function safeDecodeUri(encoded: string): string {
   }
 }
 
-/** Map a filesystem path or content URI to a {@link FileSource}. */
-export function toFileSource(pathOrUri: string): FileSource {
+function basenameFromUri(uri: string): string {
+  const withoutQuery = (uri.split('?')[0] ?? uri).trim();
+  const segments = withoutQuery.split(/[/\\]/);
+  return segments[segments.length - 1] ?? withoutQuery;
+}
+
+function hasAudioExtension(name: string): boolean {
+  return AUDIO_EXT_RE.test(name);
+}
+
+/**
+ * Best display name for native decode: picker hint, then URI basename if it has
+ * a known audio extension. Omit extensionless hints so Android ContentResolver
+ * can supply DISPLAY_NAME.
+ */
+export function resolveAudioFileDisplayName(
+  uri: string,
+  displayNameHint?: string | null,
+  fallback = 'audio'
+): string | undefined {
+  const trimmedHint = displayNameHint?.trim();
+  if (trimmedHint && hasAudioExtension(trimmedHint)) {
+    return trimmedHint;
+  }
+  const fromUri = basenameFromUri(uri);
+  if (hasAudioExtension(fromUri)) {
+    return fromUri;
+  }
+  const loose = trimmedHint || fromUri || fallback;
+  return hasAudioExtension(loose) ? loose : undefined;
+}
+
+/**
+ * Map a filesystem path or content URI to a {@link FileSource}.
+ * Pass `displayName` from the document picker (e.g. `file.name`) so native
+ * decode can select the correct FFmpeg demuxer for extensionless URIs/paths.
+ */
+export function toFileSource(
+  pathOrUri: string,
+  displayName?: string
+): FileSource {
   const trimmed = pathOrUri.trim();
+  const resolvedName = resolveAudioFileDisplayName(trimmed, displayName);
 
   if (trimmed.startsWith('content://')) {
-    return { kind: 'contentUri', uri: trimmed };
+    return resolvedName != null
+      ? { kind: 'contentUri', uri: trimmed, displayName: resolvedName }
+      : { kind: 'contentUri', uri: trimmed };
   }
 
   if (trimmed.startsWith('file://')) {
@@ -58,12 +103,17 @@ export function describeFileSource(source: FileSource): string {
     case 'contentUri': {
       const tail =
         source.uri.length > 48 ? `…${source.uri.slice(-40)}` : source.uri;
-      return `contentUri: ${tail}`;
+      const name =
+        'displayName' in source && source.displayName
+          ? ` (${source.displayName})`
+          : '';
+      return `contentUri: ${tail}${name}`;
     }
     case 'securityScoped': {
       const tail =
         source.uri.length > 48 ? `…${source.uri.slice(-40)}` : source.uri;
-      return `securityScoped: ${tail}`;
+      const name = source.displayName ? ` (${source.displayName})` : '';
+      return `securityScoped: ${tail}${name}`;
     }
     case 'pad':
       return `pad: ${source.packName}/${source.path}`;

--- a/example/src/utils/separationCustomInitFill.ts
+++ b/example/src/utils/separationCustomInitFill.ts
@@ -1,0 +1,146 @@
+import { exists, readDir } from '@dr.pogodin/react-native-fs';
+import {
+  getCustomModelPathRequirements,
+  requiredCustomModelPathFieldKeys,
+  resolveFileSourceForModelInit,
+} from 'react-native-sherpa-onnx/detect';
+import {
+  detectSeparationModel,
+  type SeparationConcreteModelType,
+} from 'react-native-sherpa-onnx/separation';
+import type { FileSource } from 'react-native-sherpa-onnx/fileio';
+import type { SeparationCustomPathKey } from './separationCustomInitLabels';
+
+export type FillSeparationCustomConfigResult = {
+  modelType: SeparationConcreteModelType;
+  customConfig: Partial<Record<SeparationCustomPathKey, FileSource>>;
+  missingKeys: readonly string[];
+  modelDir: string;
+};
+
+function basename(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1] ?? path;
+}
+
+async function listFilesRecursive(dir: string): Promise<string[]> {
+  if (!(await exists(dir))) {
+    return [];
+  }
+  const entries = await readDir(dir);
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      files.push(...(await listFilesRecursive(entry.path)));
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(entry.path);
+    }
+  }
+  return files;
+}
+
+function findOnnxByTokens(files: string[], tokens: string[]): string {
+  const onnxFiles = files.filter((file) =>
+    file.toLowerCase().endsWith('.onnx')
+  );
+  const matches = onnxFiles.filter((file) => {
+    const lower = basename(file).toLowerCase();
+    return tokens.some((token) => lower.includes(token.toLowerCase()));
+  });
+  return matches[0] ?? '';
+}
+
+function toFsSource(path: string | undefined): FileSource | undefined {
+  const trimmed = path?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return { kind: 'fs', path: trimmed };
+}
+
+function isConcreteSeparationModelType(
+  value: string
+): value is SeparationConcreteModelType {
+  return value === 'spleeter' || value === 'uvr';
+}
+
+function scanPathForKey(files: string[], key: SeparationCustomPathKey): string {
+  if (key === 'vocals') {
+    return (
+      findOnnxByTokens(files, ['vocal']) || findOnnxByTokens(files, ['vocals'])
+    );
+  }
+  if (key === 'accompaniment') {
+    return (
+      findOnnxByTokens(files, ['accompaniment', 'accomp', 'instrumental']) ||
+      findOnnxByTokens(files, ['no_vocals', 'other'])
+    );
+  }
+  return (
+    findOnnxByTokens(files, ['uvr', 'mdx', 'model']) ||
+    files.find((file) => file.toLowerCase().endsWith('.onnx')) ||
+    ''
+  );
+}
+
+export async function fillSeparationCustomConfigFromModelFolder(
+  modelSource: FileSource,
+  options?: { modelTypeOverride?: SeparationConcreteModelType }
+): Promise<FillSeparationCustomConfigResult> {
+  const detectResult = await detectSeparationModel(modelSource, {
+    modelType: options?.modelTypeOverride ?? 'auto',
+  });
+  if (!detectResult.success) {
+    throw new Error(
+      detectResult.error?.trim() || 'Model detection failed for fill helper'
+    );
+  }
+
+  const rawType =
+    options?.modelTypeOverride ??
+    (detectResult.modelType &&
+    isConcreteSeparationModelType(detectResult.modelType)
+      ? detectResult.modelType
+      : detectResult.detectedModels[0]?.type);
+
+  if (!rawType || !isConcreteSeparationModelType(rawType)) {
+    throw new Error(
+      'Could not determine a concrete separation model type for fill'
+    );
+  }
+
+  const modelType = rawType;
+  const modelDir = await resolveFileSourceForModelInit(modelSource);
+  const files = await listFilesRecursive(modelDir);
+  const detectPaths = detectResult.paths;
+
+  const schema = await getCustomModelPathRequirements('separation', modelType);
+  const customConfig: Partial<Record<SeparationCustomPathKey, FileSource>> = {};
+  for (const field of schema.fields) {
+    const key = field.key as SeparationCustomPathKey;
+    const fromDetect =
+      key === 'vocals'
+        ? detectPaths?.vocals
+        : key === 'accompaniment'
+        ? detectPaths?.accompaniment
+        : detectPaths?.model;
+    const scanned = scanPathForKey(files, key);
+    const source = toFsSource(fromDetect) ?? toFsSource(scanned);
+    if (source) {
+      customConfig[key] = source;
+    }
+  }
+
+  const missingKeys = requiredCustomModelPathFieldKeys(schema).filter(
+    (key) => customConfig[key as SeparationCustomPathKey] == null
+  );
+
+  return {
+    modelType,
+    customConfig,
+    missingKeys,
+    modelDir,
+  };
+}

--- a/example/src/utils/separationCustomInitLabels.ts
+++ b/example/src/utils/separationCustomInitLabels.ts
@@ -1,0 +1,22 @@
+import type {
+  SpleeterCustomPathKey,
+  UvrCustomPathKey,
+} from 'react-native-sherpa-onnx/separation';
+
+export type SeparationCustomPathKey = SpleeterCustomPathKey | UvrCustomPathKey;
+
+/** Human-readable labels for separation custom init path keys (example app UI). */
+export const SEPARATION_CUSTOM_PATH_LABELS: Record<
+  SeparationCustomPathKey,
+  string
+> = {
+  vocals: 'Vocals stem (.onnx)',
+  accompaniment: 'Accompaniment stem (.onnx)',
+  model: 'Separation model (.onnx)',
+};
+
+export function labelForSeparationCustomPathKey(
+  key: SeparationCustomPathKey
+): string {
+  return SEPARATION_CUSTOM_PATH_LABELS[key] ?? key;
+}

--- a/ios/separation/bridge/SherpaOnnx+SeparationOffline.mm
+++ b/ios/separation/bridge/SherpaOnnx+SeparationOffline.mm
@@ -2,7 +2,7 @@
 #import <React/RCTLog.h>
 
 #include "../../audio/pipeline/SherpaOnnx+PipelineAudioGlobals.h"
-#include "../sherpa-onnx-separation-wrapper.h"
+#include "sherpa-onnx-separation-wrapper.h"
 #include "../core/SeparationBridgeState.h"
 #include "../SeparationOfflineLivePipelineWorker.h"
 #include "../../segmentbuffer/core/SherpaOnnx+SegmentBufferGlobals.h"

--- a/ios/separation/core/SeparationBridgeState.mm
+++ b/ios/separation/core/SeparationBridgeState.mm
@@ -1,5 +1,5 @@
 #include "SeparationBridgeState.h"
-#include "../sherpa-onnx-separation-wrapper.h"
+#include "sherpa-onnx-separation-wrapper.h"
 
 namespace sherpaonnx {
 namespace separation {

--- a/src/audiobuffer/index.ts
+++ b/src/audiobuffer/index.ts
@@ -700,6 +700,12 @@ export function createOfflineAudioBufferFromSamples(
 export function createOfflineAudioBufferFromSamples(
   samples: Float32Array,
   inputSampleRateHz: number,
+  channelCount: number,
+  options: OfflineFromSamplesOptions
+): OfflineAudioBufferRef;
+export function createOfflineAudioBufferFromSamples(
+  samples: Float32Array,
+  inputSampleRateHz: number,
   channelCountOrOptions?: number | OfflineFromSamplesOptions,
   options?: OfflineFromSamplesOptions
 ): OfflineAudioBufferRef {

--- a/src/pipeline/offlineOrchestrator.ts
+++ b/src/pipeline/offlineOrchestrator.ts
@@ -698,7 +698,8 @@ async function runOfflineAudioSegmentLoop(
           tempIn = createOfflineAudioBufferFromSamples(
             segSamples,
             inputInfo.sampleRate,
-            inputInfo.channelCount
+            inputInfo.channelCount,
+            { targetSampleRateHz: 0 }
           );
           tempOuts = [];
           for (let o = 0; o < outputCount; o++) {
@@ -1601,7 +1602,8 @@ export async function runOfflineAudioToTextPipeline(
           tempIn = createOfflineAudioBufferFromSamples(
             segSamples,
             info.sampleRate,
-            info.channelCount
+            info.channelCount,
+            { targetSampleRateHz: 0 }
           );
           tempOut = await createEmptyOfflineTextBuffer();
 

--- a/src/separation/__tests__/createSeparation.test.ts
+++ b/src/separation/__tests__/createSeparation.test.ts
@@ -43,6 +43,7 @@ jest.mock('../../model-languages', () => ({
 }));
 
 jest.mock('../../audiobuffer', () => ({
+  getPipelineAudioBufferInfo: jest.fn(),
   releasePipelineAudioBuffer: jest.fn(),
   resolvePipelineAudioBufferId: jest.fn((value: unknown) => String(value)),
 }));
@@ -53,7 +54,10 @@ jest.mock('../orchestrate', () => ({
 }));
 
 import SherpaOnnx from '../../NativeSherpaOnnx';
-import { releasePipelineAudioBuffer } from '../../audiobuffer';
+import {
+  getPipelineAudioBufferInfo,
+  releasePipelineAudioBuffer,
+} from '../../audiobuffer';
 import { createSeparation } from '../index';
 import {
   runOfflineSeparationDirect,
@@ -86,6 +90,15 @@ describe('createSeparation', () => {
     native.populateOfflineAudioBufferIfEmpty.mockResolvedValue(null);
     native.getSeparationSampleRate.mockResolvedValue(44100);
     native.getSeparationNumStems.mockResolvedValue(2);
+    (getPipelineAudioBufferInfo as jest.Mock).mockResolvedValue({
+      bufferId: 'off_input',
+      kind: 'offlinePcmBuffer',
+      state: 'immutable',
+      sampleRate: 44100,
+      channelCount: 1,
+      numSamples: 44100,
+      durationMs: 1000,
+    });
     (runOfflineSeparationDirect as jest.Mock).mockResolvedValue(undefined);
     (releasePipelineAudioBuffer as jest.Mock).mockResolvedValue(undefined);
   });
@@ -230,6 +243,31 @@ describe('createSeparation', () => {
 
     expect(result.status).toBe('partial');
     expect(result.failedSegment?.segmentId).toBe('speech_1');
+  });
+
+  it('rejects segmented separation when input sample rate differs from model', async () => {
+    (getPipelineAudioBufferInfo as jest.Mock).mockResolvedValue({
+      bufferId: 'off_input',
+      kind: 'offlinePcmBuffer',
+      state: 'immutable',
+      sampleRate: 16000,
+      channelCount: 1,
+      numSamples: 16000,
+      durationMs: 1000,
+    });
+
+    const sep = await createSeparation({
+      modelSource: { kind: 'fs', path: '/models/separation' },
+    });
+
+    await expect(
+      sep.separate('off_input', ['off_vocals', 'off_accomp'], {
+        segmentation: { mode: 'auto' },
+      })
+    ).rejects.toThrow(
+      `${SeparationErrorCode.INVALID_ARGUMENT}: Input sample rate (16000 Hz) must match separation model sample rate (44100 Hz) when using segmentation.`
+    );
+    expect(runOfflineSeparationPipeline).not.toHaveBeenCalled();
   });
 
   it('validates output buffer count against numStems', async () => {

--- a/src/separation/index.ts
+++ b/src/separation/index.ts
@@ -18,6 +18,7 @@ import {
   type DetectionSource,
 } from '../types/modelDetect';
 import {
+  getPipelineAudioBufferInfo,
   resolvePipelineAudioBufferId,
   releasePipelineAudioBuffer,
   subscribeLiveAudioBufferEvents,
@@ -337,9 +338,24 @@ export async function createSeparation(
         );
       }
 
-      resolvePipelineAudioBufferId(audioIn);
+      const inId = resolvePipelineAudioBufferId(audioIn);
       for (const out of audioOuts) {
         resolvePipelineAudioBufferId(out);
+      }
+
+      if (mode !== 'off') {
+        const inInfo = await getPipelineAudioBufferInfo(inId);
+        const modelSampleRateHz = await SherpaOnnx.getSeparationSampleRate(
+          instanceId
+        );
+        if (
+          inInfo.kind === 'offlinePcmBuffer' &&
+          inInfo.sampleRate !== modelSampleRateHz
+        ) {
+          throw new Error(
+            `${SeparationErrorCode.INVALID_ARGUMENT}: Input sample rate (${inInfo.sampleRate} Hz) must match separation model sample rate (${modelSampleRateHz} Hz) when using segmentation. Decode or resample the input before separate().`
+          );
+        }
       }
 
       if (mode === 'off') {


### PR DESCRIPTION
This pull request refactors and enhances the separation inference JNI integration for the Android build, improves logging for better diagnostics, and cleans up the build configuration. The main changes include renaming and reorganizing separation detection wrapper files, adding shared separation core sources, updating CMake and CocoaPods configurations, and introducing detailed logging in the JNI layer.

**Separation JNI and Wrapper Refactor:**
- Renamed `sherpa-onnx-separation-wrapper.cpp/h` to `sherpa-onnx-separation-detect-wrapper.cpp/h` in `jni/model_detect/separation` to clarify their role as detection wrappers. All includes and references have been updated accordingly. [[1]](diffhunk://#diff-f5845ee50e143cdc3119745f5a1e90d4811a59074a1c864496c23d045d91d933L1-R1) [[2]](diffhunk://#diff-f80036b8877422fb090af89ee57f435be4849fdfb535eccb849a656ff011d047L1-R2) [[3]](diffhunk://#diff-f80036b8877422fb090af89ee57f435be4849fdfb535eccb849a656ff011d047L17-R17) [[4]](diffhunk://#diff-61e15669749497d86e340d32b09005e7c4e6c1e2493aa7073a6c256dee7ed3c6L25-R25)
- Added new shared separation core files (`separation/sherpa-onnx-separation-wrapper.cpp/h`) and JNI bridge (`jni/separation/sherpa-onnx-separation-jni.cpp`) to the project and build configuration. [[1]](diffhunk://#diff-717bf771205b889224abf6dcec473d2231190138b9763c644c58544f79b03f32L50-R53) [[2]](diffhunk://#diff-717bf771205b889224abf6dcec473d2231190138b9763c644c58544f79b03f32L65-R69) [[3]](diffhunk://#diff-717bf771205b889224abf6dcec473d2231190138b9763c644c58544f79b03f32L76-R81)

**Build System Updates:**
- Updated `CMakeLists.txt` to use the new file locations, remove obsolete iOS includes, and add the new shared separation directory to the include paths. [[1]](diffhunk://#diff-9c2798aa7ffaf63cbae7c421481a846035dd9078e8d0a84a856382150070a227L117-R118) [[2]](diffhunk://#diff-9c2798aa7ffaf63cbae7c421481a846035dd9078e8d0a84a856382150070a227R243) [[3]](diffhunk://#diff-9c2798aa7ffaf63cbae7c421481a846035dd9078e8d0a84a856382150070a227L252)
- Updated `SherpaOnnx.podspec` to include the new separation sources and headers, and to reference the new separation directory for both source files and header search paths. [[1]](diffhunk://#diff-717bf771205b889224abf6dcec473d2231190138b9763c644c58544f79b03f32L50-R53) [[2]](diffhunk://#diff-717bf771205b889224abf6dcec473d2231190138b9763c644c58544f79b03f32L65-R69) [[3]](diffhunk://#diff-717bf771205b889224abf6dcec473d2231190138b9763c644c58544f79b03f32L76-R81) [[4]](diffhunk://#diff-717bf771205b889224abf6dcec473d2231190138b9763c644c58544f79b03f32R145)

**JNI Logging Improvements:**
- Introduced `LOGI`, `LOGW`, and `LOGE` macros for consistent Android logging in `jni/separation/sherpa-onnx-separation-jni.cpp`.
- Added detailed info and error logs to all JNI entry points for initialization, processing, and release, improving traceability and debugging of JNI operations. [[1]](diffhunk://#diff-e4097f8f6efa57d23550d28de981f87cf20cd5abdfbadb718252373a31ccdc4cR129-R136) [[2]](diffhunk://#diff-e4097f8f6efa57d23550d28de981f87cf20cd5abdfbadb718252373a31ccdc4cR154-R166) [[3]](diffhunk://#diff-e4097f8f6efa57d23550d28de981f87cf20cd5abdfbadb718252373a31ccdc4cR193-R199) [[4]](diffhunk://#diff-e4097f8f6efa57d23550d28de981f87cf20cd5abdfbadb718252373a31ccdc4cR217-R229) [[5]](diffhunk://#diff-e4097f8f6efa57d23550d28de981f87cf20cd5abdfbadb718252373a31ccdc4cL204-R279) [[6]](diffhunk://#diff-e4097f8f6efa57d23550d28de981f87cf20cd5abdfbadb718252373a31ccdc4cR334)