### PR TITLE
Perf/fix sid bridge roundtrip bottlenecks

### DIFF
--- a/android/src/main/cpp/jni/diarization/sherpa-onnx-diarization-jni.cpp
+++ b/android/src/main/cpp/jni/diarization/sherpa-onnx-diarization-jni.cpp
@@ -20,8 +20,16 @@
 namespace {
 
 std::mutex g_diarization_mutex;
-std::unordered_map<std::string, std::unique_ptr<sherpaonnx::DiarizationWrapper>>
+std::unordered_map<std::string, std::shared_ptr<sherpaonnx::DiarizationWrapper>>
     g_diarization_instances;
+
+std::shared_ptr<sherpaonnx::DiarizationWrapper> LookupDiarization(
+    const std::string& id) {
+  std::lock_guard<std::mutex> lock(g_diarization_mutex);
+  auto it = g_diarization_instances.find(id);
+  if (it == g_diarization_instances.end() || !it->second) return nullptr;
+  return it->second;
+}
 
 std::string CopyRequiredJstring(JNIEnv* env, jstring value) {
   if (value == nullptr) return {};
@@ -240,12 +248,8 @@ Java_com_sherpaonnx_diarization_facade_SherpaOnnxDiarizationHelper_nativeInitial
   sherpaonnx::DiarizationInitializeResult result;
   {
     std::lock_guard<std::mutex> lock(g_diarization_mutex);
-    auto& inst = g_diarization_instances[instanceIdStr];
-    if (inst == nullptr) {
-      inst = std::make_unique<sherpaonnx::DiarizationWrapper>();
-    } else {
-      inst->release();
-    }
+    // Replace the map entry so in-flight shared_ptrs keep the old wrapper.
+    auto inst = std::make_shared<sherpaonnx::DiarizationWrapper>();
     result = inst->initialize(
         segmentationPath,
         embeddingPath,
@@ -267,6 +271,7 @@ Java_com_sherpaonnx_diarization_facade_SherpaOnnxDiarizationHelper_nativeInitial
       );
       g_diarization_instances.erase(instanceIdStr);
     } else {
+      g_diarization_instances[instanceIdStr] = std::move(inst);
       LOGI(
           "nativeInitializeDiarization ok: instanceId=%s sampleRate=%d",
           instanceIdStr.c_str(),
@@ -315,19 +320,14 @@ Java_com_sherpaonnx_diarization_facade_SherpaOnnxDiarizationHelper_nativeProcess
   env->GetFloatArrayRegion(samples, 0, n, input.data());
 
   // Unlock during process so nativeCancelDiarization can interrupt.
-  sherpaonnx::DiarizationWrapper* wrapper = nullptr;
-  {
-    std::lock_guard<std::mutex> lock(g_diarization_mutex);
-    auto it = g_diarization_instances.find(instanceIdStr);
-    if (it == g_diarization_instances.end() || it->second == nullptr) {
-      LOGE("nativeProcessDiarization: instance not found: %s", instanceIdStr.c_str());
-      sherpaonnx::DiarizationProcessResult missing;
-      missing.success = false;
-      missing.errorCode = "DIARIZATION_NOT_INITIALIZED";
-      missing.error = "Diarization instance not found: " + instanceIdStr;
-      return DiarizationProcessResultToJava(env, missing);
-    }
-    wrapper = it->second.get();
+  auto wrapper = LookupDiarization(instanceIdStr);
+  if (!wrapper) {
+    LOGE("nativeProcessDiarization: instance not found: %s", instanceIdStr.c_str());
+    sherpaonnx::DiarizationProcessResult missing;
+    missing.success = false;
+    missing.errorCode = "DIARIZATION_NOT_INITIALIZED";
+    missing.error = "Diarization instance not found: " + instanceIdStr;
+    return DiarizationProcessResultToJava(env, missing);
   }
 
   sherpaonnx::DiarizationProcessResult result =
@@ -366,17 +366,14 @@ Java_com_sherpaonnx_diarization_facade_SherpaOnnxDiarizationHelper_nativeReclust
   );
 
   sherpaonnx::DiarizationProcessResult result;
-  {
-    std::lock_guard<std::mutex> lock(g_diarization_mutex);
-    auto it = g_diarization_instances.find(instanceIdStr);
-    if (it == g_diarization_instances.end() || it->second == nullptr) {
-      result.success = false;
-      result.errorCode = "DIARIZATION_NOT_INITIALIZED";
-      result.error = "Diarization instance not found: " + instanceIdStr;
-      return DiarizationProcessResultToJava(env, result);
-    }
-    result = it->second->recluster(numClusters, threshold);
+  auto wrapper = LookupDiarization(instanceIdStr);
+  if (!wrapper) {
+    result.success = false;
+    result.errorCode = "DIARIZATION_NOT_INITIALIZED";
+    result.error = "Diarization instance not found: " + instanceIdStr;
+    return DiarizationProcessResultToJava(env, result);
   }
+  result = wrapper->recluster(numClusters, threshold);
   return DiarizationProcessResultToJava(env, result);
 }
 
@@ -389,15 +386,12 @@ Java_com_sherpaonnx_diarization_facade_SherpaOnnxDiarizationHelper_nativeGetClus
   const std::string instanceIdStr = CopyRequiredJstring(env, instanceId);
 
   std::vector<sherpaonnx::DiarizationClusterEmbeddingDto> embeddings;
-  {
-    std::lock_guard<std::mutex> lock(g_diarization_mutex);
-    auto it = g_diarization_instances.find(instanceIdStr);
-    if (it == g_diarization_instances.end() || it->second == nullptr) {
-      LOGW("nativeGetClusterEmbeddings: instance not found: %s", instanceIdStr.c_str());
-      embeddings.clear();
-    } else {
-      embeddings = it->second->getClusterEmbeddings();
-    }
+  auto wrapper = LookupDiarization(instanceIdStr);
+  if (!wrapper) {
+    LOGW("nativeGetClusterEmbeddings: instance not found: %s", instanceIdStr.c_str());
+    embeddings.clear();
+  } else {
+    embeddings = wrapper->getClusterEmbeddings();
   }
 
   jclass listClass = env->FindClass("java/util/ArrayList");
@@ -461,10 +455,9 @@ Java_com_sherpaonnx_diarization_facade_SherpaOnnxDiarizationHelper_nativeCancelD
 ) {
   const std::string instanceIdStr = CopyRequiredJstring(env, instanceId);
   LOGI("nativeCancelDiarization: instanceId=%s", instanceIdStr.c_str());
-  std::lock_guard<std::mutex> lock(g_diarization_mutex);
-  auto it = g_diarization_instances.find(instanceIdStr);
-  if (it != g_diarization_instances.end() && it->second != nullptr) {
-    it->second->cancel();
+  auto wrapper = LookupDiarization(instanceIdStr);
+  if (wrapper) {
+    wrapper->cancel();
   }
 }
 
@@ -476,15 +469,19 @@ Java_com_sherpaonnx_diarization_facade_SherpaOnnxDiarizationHelper_nativeUnloadD
 ) {
   const std::string instanceIdStr = CopyRequiredJstring(env, instanceId);
   LOGI("nativeUnloadDiarization: instanceId=%s", instanceIdStr.c_str());
-  std::lock_guard<std::mutex> lock(g_diarization_mutex);
-  auto it = g_diarization_instances.find(instanceIdStr);
-  if (it != g_diarization_instances.end()) {
-    if (it->second != nullptr) {
-      it->second->cancel();
-      it->second->release();
+  std::shared_ptr<sherpaonnx::DiarizationWrapper> doomed;
+  {
+    std::lock_guard<std::mutex> lock(g_diarization_mutex);
+    auto it = g_diarization_instances.find(instanceIdStr);
+    if (it != g_diarization_instances.end()) {
+      if (it->second) {
+        it->second->cancel();
+      }
+      doomed = std::move(it->second);
+      g_diarization_instances.erase(it);
     }
-    g_diarization_instances.erase(it);
   }
+  // Destructor releases when last shared_ptr drops (after in-flight process).
 }
 
 }  // extern "C"

--- a/android/src/main/cpp/jni/speaker-embedding/sherpa-onnx-speaker-embedding-jni.cpp
+++ b/android/src/main/cpp/jni/speaker-embedding/sherpa-onnx-speaker-embedding-jni.cpp
@@ -20,11 +20,11 @@
 namespace {
 
 std::mutex g_speaker_embedding_mutex;
-std::unordered_map<std::string,
-                   std::unique_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper>>
+std::unordered_map<
+    std::string, std::shared_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper>>
     g_extractors;
 std::unordered_map<std::string,
-                   std::unique_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper>>
+                   std::shared_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper>>
     g_managers;
 
 std::string CopyRequiredJstring(JNIEnv* env, jstring value) {
@@ -111,6 +111,22 @@ jobject OkMap(JNIEnv* env, bool ok) {
   return map;
 }
 
+std::shared_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper> LookupExtractor(
+    const std::string& id) {
+  std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
+  auto it = g_extractors.find(id);
+  if (it == g_extractors.end() || !it->second) return nullptr;
+  return it->second;
+}
+
+std::shared_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper> LookupManager(
+    const std::string& id) {
+  std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
+  auto it = g_managers.find(id);
+  if (it == g_managers.end() || !it->second) return nullptr;
+  return it->second;
+}
+
 }  // namespace
 
 extern "C" {
@@ -127,12 +143,9 @@ Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nat
   sherpaonnx::SpeakerEmbeddingInitializeResult result;
   {
     std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-    auto& inst = g_extractors[id];
-    if (inst == nullptr) {
-      inst = std::make_unique<sherpaonnx::SpeakerEmbeddingExtractorWrapper>();
-    } else {
-      inst->release();
-    }
+    // Replace the map entry so in-flight shared_ptrs keep the old wrapper.
+    auto inst =
+        std::make_shared<sherpaonnx::SpeakerEmbeddingExtractorWrapper>();
     result = inst->initialize(dir, type.empty() ? "auto" : type,
                               numThreads > 0 ? numThreads : 1, providerOpt,
                               debug == JNI_TRUE);
@@ -141,6 +154,7 @@ Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nat
            result.errorCode.c_str());
       g_extractors.erase(id);
     } else {
+      g_extractors[id] = std::move(inst);
       LOGI("nativeInitializeExtractorAuto ok: id=%s dim=%d", id.c_str(),
            result.dim);
     }
@@ -163,17 +177,15 @@ Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nat
   sherpaonnx::SpeakerEmbeddingInitializeResult result;
   {
     std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-    auto& inst = g_extractors[id];
-    if (inst == nullptr) {
-      inst = std::make_unique<sherpaonnx::SpeakerEmbeddingExtractorWrapper>();
-    } else {
-      inst->release();
-    }
+    auto inst =
+        std::make_shared<sherpaonnx::SpeakerEmbeddingExtractorWrapper>();
     result = inst->initializeCustom(type, paths, numThreads > 0 ? numThreads : 1,
                                     providerOpt, debug == JNI_TRUE);
     if (!result.success) {
       LOGE("nativeInitializeExtractorCustom failed: %s", result.error.c_str());
       g_extractors.erase(id);
+    } else {
+      g_extractors[id] = std::move(inst);
     }
   }
   return InitResultToJava(env, result);
@@ -202,28 +214,25 @@ Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nat
     env->GetFloatArrayRegion(samples, 0, n, input.data());
   }
 
+  auto extractor = LookupExtractor(id);
   std::vector<float> embedding;
   std::string error;
   std::string errorCode;
   bool ok = false;
-  {
-    std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-    auto it = g_extractors.find(id);
-    if (it == g_extractors.end() || it->second == nullptr) {
-      error = "Speaker embedding extractor not found: " + id;
-      errorCode = "SPEAKER_EMBEDDING_NOT_INITIALIZED";
+  if (!extractor) {
+    error = "Speaker embedding extractor not found: " + id;
+    errorCode = "SPEAKER_EMBEDDING_NOT_INITIALIZED";
+  } else {
+    embedding = extractor->computeFromSamples(input, sampleRate);
+    if (embedding.empty()) {
+      error = extractor->lastError().empty()
+                  ? "Speaker embedding compute failed"
+                  : extractor->lastError();
+      errorCode = extractor->lastErrorCode().empty()
+                      ? "SPEAKER_EMBEDDING_COMPUTE_ERROR"
+                      : extractor->lastErrorCode();
     } else {
-      embedding = it->second->computeFromSamples(input, sampleRate);
-      if (embedding.empty()) {
-        error = it->second->lastError().empty()
-                    ? "Speaker embedding compute failed"
-                    : it->second->lastError();
-        errorCode = it->second->lastErrorCode().empty()
-                        ? "SPEAKER_EMBEDDING_COMPUTE_ERROR"
-                        : it->second->lastErrorCode();
-      } else {
-        ok = true;
-      }
+      ok = true;
     }
   }
 
@@ -253,12 +262,16 @@ JNIEXPORT void JNICALL
 Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nativeUnloadExtractor(
     JNIEnv* env, jclass /* clazz */, jstring instanceId) {
   const std::string id = CopyRequiredJstring(env, instanceId);
-  std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-  auto it = g_extractors.find(id);
-  if (it != g_extractors.end()) {
-    if (it->second) it->second->release();
-    g_extractors.erase(it);
+  std::shared_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper> doomed;
+  {
+    std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
+    auto it = g_extractors.find(id);
+    if (it != g_extractors.end()) {
+      doomed = std::move(it->second);
+      g_extractors.erase(it);
+    }
   }
+  // Destructor releases when last shared_ptr drops (after in-flight compute).
 }
 
 JNIEXPORT jobject JNICALL
@@ -272,15 +285,12 @@ Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nat
   bool ok = false;
   {
     std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-    auto& inst = g_managers[id];
-    if (inst == nullptr) {
-      inst = std::make_unique<sherpaonnx::SpeakerEmbeddingManagerWrapper>();
-    } else {
-      inst->release();
-    }
+    auto inst = std::make_shared<sherpaonnx::SpeakerEmbeddingManagerWrapper>();
     ok = inst->create(dim);
     if (!ok) {
       g_managers.erase(id);
+    } else {
+      g_managers[id] = std::move(inst);
     }
   }
   sherpaonnx::PutBoolean(env, map, mapPut, "success", ok);
@@ -305,12 +315,9 @@ Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nat
     env->GetFloatArrayRegion(embeddings, 0, n, flat.data());
   }
   bool ok = false;
-  {
-    std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-    auto it = g_managers.find(id);
-    if (it != g_managers.end() && it->second) {
-      ok = it->second->add(nameStr, flat, count);
-    }
+  auto manager = LookupManager(id);
+  if (manager) {
+    ok = manager->add(nameStr, flat, count);
   }
   return OkMap(env, ok);
 }
@@ -321,12 +328,9 @@ Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nat
   const std::string id = CopyRequiredJstring(env, managerId);
   const std::string nameStr = CopyRequiredJstring(env, name);
   bool ok = false;
-  {
-    std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-    auto it = g_managers.find(id);
-    if (it != g_managers.end() && it->second) {
-      ok = it->second->remove(nameStr);
-    }
+  auto manager = LookupManager(id);
+  if (manager) {
+    ok = manager->remove(nameStr);
   }
   return OkMap(env, ok);
 }
@@ -342,12 +346,9 @@ Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nat
     env->GetFloatArrayRegion(embedding, 0, n, emb.data());
   }
   std::string name;
-  {
-    std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-    auto it = g_managers.find(id);
-    if (it != g_managers.end() && it->second) {
-      name = it->second->search(emb, threshold);
-    }
+  auto manager = LookupManager(id);
+  if (manager) {
+    name = manager->search(emb, threshold);
   }
   jmethodID mapPut = nullptr;
   jobject map = NewHashMap(env, &mapPut);
@@ -368,12 +369,9 @@ Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nat
     env->GetFloatArrayRegion(embedding, 0, n, emb.data());
   }
   bool ok = false;
-  {
-    std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-    auto it = g_managers.find(id);
-    if (it != g_managers.end() && it->second) {
-      ok = it->second->verify(nameStr, emb, threshold);
-    }
+  auto manager = LookupManager(id);
+  if (manager) {
+    ok = manager->verify(nameStr, emb, threshold);
   }
   return OkMap(env, ok);
 }
@@ -384,12 +382,9 @@ Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nat
   const std::string id = CopyRequiredJstring(env, managerId);
   const std::string nameStr = CopyRequiredJstring(env, name);
   bool ok = false;
-  {
-    std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-    auto it = g_managers.find(id);
-    if (it != g_managers.end() && it->second) {
-      ok = it->second->contains(nameStr);
-    }
+  auto manager = LookupManager(id);
+  if (manager) {
+    ok = manager->contains(nameStr);
   }
   return OkMap(env, ok);
 }
@@ -398,10 +393,9 @@ JNIEXPORT jint JNICALL
 Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nativeManagerNumSpeakers(
     JNIEnv* env, jclass /* clazz */, jstring managerId) {
   const std::string id = CopyRequiredJstring(env, managerId);
-  std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-  auto it = g_managers.find(id);
-  if (it == g_managers.end() || !it->second) return 0;
-  return it->second->numSpeakers();
+  auto manager = LookupManager(id);
+  if (!manager) return 0;
+  return manager->numSpeakers();
 }
 
 JNIEXPORT jobject JNICALL
@@ -409,12 +403,9 @@ Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nat
     JNIEnv* env, jclass /* clazz */, jstring managerId) {
   const std::string id = CopyRequiredJstring(env, managerId);
   std::vector<std::string> names;
-  {
-    std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-    auto it = g_managers.find(id);
-    if (it != g_managers.end() && it->second) {
-      names = it->second->allSpeakers();
-    }
+  auto manager = LookupManager(id);
+  if (manager) {
+    names = manager->allSpeakers();
   }
   jmethodID mapPut = nullptr;
   jobject map = NewHashMap(env, &mapPut);
@@ -447,26 +438,34 @@ JNIEXPORT void JNICALL
 Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nativeDestroyManager(
     JNIEnv* env, jclass /* clazz */, jstring managerId) {
   const std::string id = CopyRequiredJstring(env, managerId);
-  std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-  auto it = g_managers.find(id);
-  if (it != g_managers.end()) {
-    if (it->second) it->second->release();
-    g_managers.erase(it);
+  std::shared_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper> doomed;
+  {
+    std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
+    auto it = g_managers.find(id);
+    if (it != g_managers.end()) {
+      doomed = std::move(it->second);
+      g_managers.erase(it);
+    }
   }
 }
 
 JNIEXPORT void JNICALL
 Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nativeShutdownAll(
     JNIEnv* /* env */, jclass /* clazz */) {
-  std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-  for (auto& kv : g_extractors) {
-    if (kv.second) kv.second->release();
+  std::unordered_map<
+      std::string,
+      std::shared_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper>>
+      extractors;
+  std::unordered_map<
+      std::string, std::shared_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper>>
+      managers;
+  {
+    std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
+    extractors.swap(g_extractors);
+    managers.swap(g_managers);
   }
-  g_extractors.clear();
-  for (auto& kv : g_managers) {
-    if (kv.second) kv.second->release();
-  }
-  g_managers.clear();
+  // Drop map ownership outside the global lock; in-flight shared_ptrs keep
+  // wrappers alive until compute/search finish.
 }
 
 }  // extern "C"

--- a/android/src/main/cpp/jni/speaker-embedding/sherpa-onnx-speaker-embedding-jni.cpp
+++ b/android/src/main/cpp/jni/speaker-embedding/sherpa-onnx-speaker-embedding-jni.cpp
@@ -234,35 +234,18 @@ Java_com_sherpaonnx_speakerembedding_facade_SherpaOnnxSpeakerEmbeddingHelper_nat
     return map;
   }
 
-  jclass listClass = env->FindClass("java/util/ArrayList");
-  jclass floatClass = env->FindClass("java/lang/Float");
-  if (!listClass || !floatClass) {
-    if (listClass) env->DeleteLocalRef(listClass);
-    if (floatClass) env->DeleteLocalRef(floatClass);
-    return map;
-  }
-  jmethodID listInit = env->GetMethodID(listClass, "<init>", "()V");
-  jmethodID listAdd =
-      env->GetMethodID(listClass, "add", "(Ljava/lang/Object;)Z");
-  jmethodID floatValueOf =
-      env->GetStaticMethodID(floatClass, "valueOf", "(F)Ljava/lang/Float;");
-  jobject arr = env->NewObject(listClass, listInit);
-  if (arr && listAdd && floatValueOf) {
-    for (float v : embedding) {
-      jobject boxed =
-          env->CallStaticObjectMethod(floatClass, floatValueOf, v);
-      if (boxed) {
-        env->CallBooleanMethod(arr, listAdd, boxed);
-        env->DeleteLocalRef(boxed);
-      }
+  jfloatArray embArray =
+      env->NewFloatArray(static_cast<jsize>(embedding.size()));
+  if (embArray) {
+    if (!embedding.empty()) {
+      env->SetFloatArrayRegion(
+          embArray, 0, static_cast<jsize>(embedding.size()), embedding.data());
     }
     jstring key = env->NewStringUTF("embedding");
-    env->CallObjectMethod(map, mapPut, key, arr);
+    env->CallObjectMethod(map, mapPut, key, embArray);
     env->DeleteLocalRef(key);
+    env->DeleteLocalRef(embArray);
   }
-  if (arr) env->DeleteLocalRef(arr);
-  env->DeleteLocalRef(listClass);
-  env->DeleteLocalRef(floatClass);
   return map;
 }
 

--- a/android/src/main/cpp/speaker-embedding/sherpa-onnx-speaker-embedding-wrapper.cpp
+++ b/android/src/main/cpp/speaker-embedding/sherpa-onnx-speaker-embedding-wrapper.cpp
@@ -2,6 +2,7 @@
 
 #include "sherpa-onnx-validate-speaker-embedding.h"
 
+#include <mutex>
 #include <utility>
 
 namespace sherpaonnx {
@@ -214,6 +215,7 @@ void SpeakerEmbeddingExtractorWrapper::release() {
 
 class SpeakerEmbeddingManagerWrapper::Impl {
  public:
+  mutable std::mutex mu;
   speaker_embedding::SpeakerEmbeddingManagerCore core;
 };
 
@@ -223,50 +225,63 @@ SpeakerEmbeddingManagerWrapper::SpeakerEmbeddingManagerWrapper()
 SpeakerEmbeddingManagerWrapper::~SpeakerEmbeddingManagerWrapper() { release(); }
 
 bool SpeakerEmbeddingManagerWrapper::create(int32_t dim) {
+  std::lock_guard<std::mutex> lock(pImpl->mu);
   return pImpl->core.Create(dim).ok;
 }
 
 bool SpeakerEmbeddingManagerWrapper::add(const std::string& name,
                                          const std::vector<float>& flattened,
                                          int32_t count) {
+  std::lock_guard<std::mutex> lock(pImpl->mu);
   return pImpl->core.Add(name, flattened, count).ok;
 }
 
 bool SpeakerEmbeddingManagerWrapper::remove(const std::string& name) {
+  std::lock_guard<std::mutex> lock(pImpl->mu);
   return pImpl->core.Remove(name).ok;
 }
 
 std::string SpeakerEmbeddingManagerWrapper::search(
     const std::vector<float>& embedding, float threshold) {
+  std::lock_guard<std::mutex> lock(pImpl->mu);
   return pImpl->core.Search(embedding, threshold);
 }
 
 bool SpeakerEmbeddingManagerWrapper::verify(
     const std::string& name, const std::vector<float>& embedding,
     float threshold) {
+  std::lock_guard<std::mutex> lock(pImpl->mu);
   return pImpl->core.Verify(name, embedding, threshold);
 }
 
 bool SpeakerEmbeddingManagerWrapper::contains(const std::string& name) {
+  std::lock_guard<std::mutex> lock(pImpl->mu);
   return pImpl->core.Contains(name);
 }
 
 int32_t SpeakerEmbeddingManagerWrapper::numSpeakers() const {
+  std::lock_guard<std::mutex> lock(pImpl->mu);
   return pImpl->core.NumSpeakers();
 }
 
 std::vector<std::string> SpeakerEmbeddingManagerWrapper::allSpeakers() const {
+  std::lock_guard<std::mutex> lock(pImpl->mu);
   return pImpl->core.AllSpeakers();
 }
 
 int32_t SpeakerEmbeddingManagerWrapper::dim() const {
+  std::lock_guard<std::mutex> lock(pImpl->mu);
   return pImpl->core.dim();
 }
 
 bool SpeakerEmbeddingManagerWrapper::isInitialized() const {
+  std::lock_guard<std::mutex> lock(pImpl->mu);
   return pImpl->core.isReady();
 }
 
-void SpeakerEmbeddingManagerWrapper::release() { pImpl->core.Release(); }
+void SpeakerEmbeddingManagerWrapper::release() {
+  std::lock_guard<std::mutex> lock(pImpl->mu);
+  pImpl->core.Release();
+}
 
 }  // namespace sherpaonnx

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -29,6 +29,7 @@ import com.sherpaonnx.download.ForegroundDownloader
 import com.sherpaonnx.enhancement.facade.SherpaOnnxEnhancementHelper
 import com.sherpaonnx.separation.facade.SherpaOnnxSeparationHelper
 import com.sherpaonnx.speakerembedding.facade.SherpaOnnxSpeakerEmbeddingHelper
+import com.sherpaonnx.speakeridentification.facade.SherpaOnnxSpeakerIdentificationLivePipelineHelper
 import com.sherpaonnx.diarization.facade.SherpaOnnxDiarizationHelper
 import com.sherpaonnx.punctuation.facade.SherpaOnnxOfflinePunctuationLivePipelineHelper
 import com.sherpaonnx.punctuation.facade.SherpaOnnxOnlinePunctuationHelper
@@ -216,6 +217,12 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
       Companion.nativeDetectSpeakerEmbeddingModel(modelDir, assetName, modelType)
     }
   )
+  private val speakerIdentificationLivePipelineHelper =
+    SherpaOnnxSpeakerIdentificationLivePipelineHelper(
+      reactApplicationContext,
+      speakerEmbeddingHelper,
+      NAME,
+    )
   private val diarizationHelper = SherpaOnnxDiarizationHelper(
     reactApplicationContext,
     { modelDir, assetName, modelType ->
@@ -4849,6 +4856,24 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     promise: Promise
   ) {
     speakerEmbeddingHelper.computeSpeakerEmbeddingOffline(instanceId, audioBufferId, promise)
+  }
+
+  override fun startSpeakerIdentificationOfflineLivePipeline(
+    instanceId: String,
+    managerId: String,
+    audioInLiveBufferId: String,
+    segmentsOutLiveBufferId: String,
+    options: ReadableMap,
+    promise: Promise,
+  ) {
+    speakerIdentificationLivePipelineHelper.startSpeakerIdentificationOfflineLivePipeline(
+      instanceId = instanceId,
+      managerId = managerId,
+      audioInLiveBufferId = audioInLiveBufferId,
+      segmentsOutLiveBufferId = segmentsOutLiveBufferId,
+      options = options,
+      promise = promise,
+    )
   }
 
   override fun unloadSpeakerEmbeddingExtractor(instanceId: String, promise: Promise) {

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -4810,12 +4810,14 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
   override fun diarizeOffline(
     instanceId: String,
     audioInBufferId: String,
+    segmentsOutBufferId: String,
     includeOverlap: Boolean?,
     promise: Promise
   ) {
     diarizationHelper.diarizeOffline(
       instanceId,
       audioInBufferId,
+      segmentsOutBufferId,
       includeOverlap == true,
       promise,
     )

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -4908,6 +4908,26 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     )
   }
 
+  override fun enrollSpeakerOffline(
+    instanceId: String,
+    managerId: String,
+    name: String,
+    audioBufferIds: ReadableArray,
+    startSamples: ReadableArray?,
+    endSamples: ReadableArray?,
+    promise: Promise,
+  ) {
+    speakerEmbeddingHelper.enrollSpeakerOffline(
+      instanceId,
+      managerId,
+      name,
+      audioBufferIds,
+      startSamples,
+      endSamples,
+      promise,
+    )
+  }
+
   override fun startSpeakerIdentificationOfflineLivePipeline(
     instanceId: String,
     managerId: String,

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -4866,6 +4866,26 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     )
   }
 
+  override fun identifySpeakerOffline(
+    instanceId: String,
+    managerId: String,
+    audioBufferId: String,
+    threshold: Double,
+    startSample: Double?,
+    endSample: Double?,
+    promise: Promise
+  ) {
+    speakerEmbeddingHelper.identifySpeakerOffline(
+      instanceId,
+      managerId,
+      audioBufferId,
+      threshold,
+      startSample,
+      endSample,
+      promise,
+    )
+  }
+
   override fun startSpeakerIdentificationOfflineLivePipeline(
     instanceId: String,
     managerId: String,

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -4886,6 +4886,28 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     )
   }
 
+  override fun verifySpeakerOffline(
+    instanceId: String,
+    managerId: String,
+    audioBufferId: String,
+    name: String,
+    threshold: Double,
+    startSample: Double?,
+    endSample: Double?,
+    promise: Promise
+  ) {
+    speakerEmbeddingHelper.verifySpeakerOffline(
+      instanceId,
+      managerId,
+      audioBufferId,
+      name,
+      threshold,
+      startSample,
+      endSample,
+      promise,
+    )
+  }
+
   override fun startSpeakerIdentificationOfflineLivePipeline(
     instanceId: String,
     managerId: String,

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -4853,9 +4853,17 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
   override fun computeSpeakerEmbeddingOffline(
     instanceId: String,
     audioBufferId: String,
+    startSample: Double?,
+    endSample: Double?,
     promise: Promise
   ) {
-    speakerEmbeddingHelper.computeSpeakerEmbeddingOffline(instanceId, audioBufferId, promise)
+    speakerEmbeddingHelper.computeSpeakerEmbeddingOffline(
+      instanceId,
+      audioBufferId,
+      startSample,
+      endSample,
+      promise,
+    )
   }
 
   override fun startSpeakerIdentificationOfflineLivePipeline(

--- a/android/src/main/java/com/sherpaonnx/diarization/facade/SherpaOnnxDiarizationHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/diarization/facade/SherpaOnnxDiarizationHelper.kt
@@ -8,6 +8,9 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
 import com.sherpaonnx.audio.pipeline.PipelineAudioRegistry
 import com.sherpaonnx.diarization.core.DiarizationErrorCodes
+import com.sherpaonnx.segment.pipeline.SegmentPipelineException
+import com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry
+import com.sherpaonnx.segment.pipeline.SegmentRecord
 import java.util.concurrent.Executors
 
 internal class SherpaOnnxDiarizationHelper(
@@ -137,6 +140,7 @@ internal class SherpaOnnxDiarizationHelper(
   fun diarizeOffline(
     instanceId: String,
     audioInBufferId: String,
+    segmentsOutBufferId: String,
     includeOverlap: Boolean,
     promise: Promise,
   ) {
@@ -155,6 +159,13 @@ internal class SherpaOnnxDiarizationHelper(
       promise.reject(
         DiarizationErrorCodes.DIARIZATION_ERROR,
         "Expected offline audio buffer (off_*) for audioIn, got: $audioInBufferId",
+      )
+      return
+    }
+    if (segmentsOutBufferId.isBlank() || !segmentsOutBufferId.startsWith("seg_off_")) {
+      promise.reject(
+        DiarizationErrorCodes.DIARIZATION_ERROR,
+        "Expected empty offline segment buffer (seg_off_*) for segmentsOut, got: $segmentsOutBufferId",
       )
       return
     }
@@ -177,9 +188,26 @@ internal class SherpaOnnxDiarizationHelper(
           return@execute
         }
 
+        val offlineOut = SegmentPipelineRegistry.getOffline(segmentsOutBufferId)
+        if (offlineOut == null) {
+          promise.reject(
+            DiarizationErrorCodes.DIARIZATION_BUFFER_NOT_FOUND,
+            "Offline segment buffer not found: $segmentsOutBufferId",
+          )
+          return@execute
+        }
+        if (offlineOut.snapshotSegments().isNotEmpty()) {
+          promise.reject(
+            DiarizationErrorCodes.DIARIZATION_ERROR,
+            "segmentOut must be an empty offline segment buffer",
+          )
+          return@execute
+        }
+
         Log.i(
           DiarizationErrorCodes.TAG,
           "diarizeOffline: instanceId=$instanceId audioIn=$audioInBufferId " +
+            "segmentsOut=$segmentsOutBufferId " +
             "numSamples=${audioInEntry.numSamples} sampleRate=${audioInEntry.sampleRate}",
         )
         val inputSamples = audioInEntry.readAllSamples()
@@ -215,7 +243,60 @@ internal class SherpaOnnxDiarizationHelper(
           )
           return@execute
         }
-        promise.resolve(processResultToWritable(result))
+
+        val sampleRate =
+          (result["sampleRate"] as? Number)?.toInt()?.takeIf { it > 0 }
+            ?: audioInEntry.sampleRate
+        @Suppress("UNCHECKED_CAST")
+        val segments =
+          result["segments"] as? ArrayList<HashMap<String, Any>> ?: arrayListOf()
+        val records = ArrayList<SegmentRecord>(segments.size)
+        for (seg in segments) {
+          val startSec = (seg["start"] as? Number)?.toDouble() ?: 0.0
+          val endSec = (seg["end"] as? Number)?.toDouble() ?: 0.0
+          val speaker = (seg["speaker"] as? Number)?.toInt() ?: 0
+          val startSample =
+            kotlin.math
+              .round(startSec * sampleRate)
+              .toInt()
+              .coerceAtLeast(0)
+          val endSample =
+            kotlin.math
+              .round(endSec * sampleRate)
+              .toInt()
+              .coerceAtLeast(startSample)
+          val durationMs =
+            if (sampleRate > 0) {
+              ((endSample - startSample) * 1000) / sampleRate
+            } else {
+              0
+            }
+          records.add(
+            SegmentRecord(
+              id = "seg_off_${startSample}_${endSample}",
+              kind = "diarization",
+              sourceAudioBufferId = audioInBufferId,
+              startSample = startSample,
+              endSample = endSample,
+              sampleRate = sampleRate,
+              durationMs = durationMs,
+              confidence = null,
+              payloadJson = """{"source":"diarization","speaker":$speaker}""",
+            ),
+          )
+        }
+        try {
+          offlineOut.populate(records)
+        } catch (e: SegmentPipelineException) {
+          promise.reject(
+            e.code,
+            e.message ?: "Failed to populate offline segment buffer",
+            e,
+          )
+          return@execute
+        }
+
+        promise.resolve(processResultToWritableWritten(result, records.size, sampleRate))
       } catch (e: Exception) {
         Log.e(DiarizationErrorCodes.TAG, "diarizeOffline failed", e)
         promise.reject(
@@ -404,6 +485,39 @@ internal class SherpaOnnxDiarizationHelper(
     val numSpeakers = (result["numSpeakers"] as? Number)?.toInt() ?: 0
     map.putInt("numSpeakers", numSpeakers)
     val sampleRate = (result["sampleRate"] as? Number)?.toInt() ?: 0
+    map.putInt("sampleRate", sampleRate)
+
+    @Suppress("UNCHECKED_CAST")
+    val spf = result["speakersPerFrame"] as? ArrayList<*>
+    if (!spf.isNullOrEmpty()) {
+      val spfArr = Arguments.createArray()
+      for (entry in spf) {
+        val v = (entry as? Number)?.toInt() ?: continue
+        spfArr.pushInt(v)
+      }
+      if (spfArr.size() > 0) {
+        map.putArray("speakersPerFrame", spfArr)
+      }
+    }
+    return map
+  }
+
+  /** Product diarize path: segments already written to segmentsOut; omit timeline array. */
+  private fun processResultToWritableWritten(
+    result: HashMap<String, Any>,
+    segmentCount: Int,
+    sampleRate: Int,
+  ): WritableMap {
+    val map = Arguments.createMap()
+    map.putBoolean("success", result["success"] as? Boolean ?: false)
+    val error = result["error"] as? String
+    if (!error.isNullOrBlank()) map.putString("error", error)
+    val errorCode = result["errorCode"] as? String
+    if (!errorCode.isNullOrBlank()) map.putString("errorCode", errorCode)
+    map.putArray("segments", Arguments.createArray())
+    map.putInt("segmentCount", segmentCount)
+    val numSpeakers = (result["numSpeakers"] as? Number)?.toInt() ?: 0
+    map.putInt("numSpeakers", numSpeakers)
     map.putInt("sampleRate", sampleRate)
 
     @Suppress("UNCHECKED_CAST")

--- a/android/src/main/java/com/sherpaonnx/livePipeline/OfflineLivePipelineWorker.kt
+++ b/android/src/main/java/com/sherpaonnx/livePipeline/OfflineLivePipelineWorker.kt
@@ -24,6 +24,7 @@ sealed class CommittedSegmentRef {
     val segmentId: String,
     val segmentIndex: Int,
     val payloadJson: String?,
+    val confidence: Double? = null,
   ) : CommittedSegmentRef()
 
   data class Text(
@@ -253,6 +254,7 @@ internal abstract class OfflineLivePipelineWorker(
             segmentId = next.segmentId,
             segmentIndex = next.segmentIndex,
             payloadJson = record.payloadJson,
+            confidence = record.confidence,
           ),
           unitsRead = (record.endSample - record.startSample).coerceAtLeast(0).toLong(),
         )

--- a/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
+++ b/android/src/main/java/com/sherpaonnx/segment/pipeline/LiveSegmentEntry.kt
@@ -88,6 +88,7 @@ class LiveSegmentEntry(
     annotationReason: String? = null,
     annotationSource: String? = null,
     annotationCreatedAtMs: Long? = null,
+    forceEmitAppendedEvent: Boolean = false,
   ): Pair<String, Int> {
     val normalizedKind = kind.trim().ifEmpty { "speech" }
     if (!ALLOWED_KINDS.contains(normalizedKind)) {
@@ -171,9 +172,13 @@ class LiveSegmentEntry(
       )
     }
 
-    if (emitSegmentAppendedEvents) {
+    if (emitSegmentAppendedEvents || forceEmitAppendedEvent) {
       val now = System.currentTimeMillis()
-      if (segmentEventMinIntervalMs <= 0L || now - lastSegmentEventEmitAtMs >= segmentEventMinIntervalMs) {
+      if (
+        forceEmitAppendedEvent ||
+        segmentEventMinIntervalMs <= 0L ||
+        now - lastSegmentEventEmitAtMs >= segmentEventMinIntervalMs
+      ) {
         lastSegmentEventEmitAtMs = now
         try {
           SegmentBufferEventBridge.emitSegmentAppended?.invoke(

--- a/android/src/main/java/com/sherpaonnx/speakerembedding/facade/SherpaOnnxSpeakerEmbeddingHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/speakerembedding/facade/SherpaOnnxSpeakerEmbeddingHelper.kt
@@ -155,6 +155,8 @@ internal class SherpaOnnxSpeakerEmbeddingHelper(
   fun computeSpeakerEmbeddingOffline(
     instanceId: String,
     audioBufferId: String,
+    startSample: Double?,
+    endSample: Double?,
     promise: Promise,
   ) {
     if (!audioBufferId.startsWith("off_")) {
@@ -173,8 +175,43 @@ internal class SherpaOnnxSpeakerEmbeddingHelper(
       promise.reject(BUFFER_EMPTY, "Input offline audio buffer is empty: $audioBufferId")
       return
     }
+
+    val hasStart = startSample != null
+    val hasEnd = endSample != null
+    if (hasStart != hasEnd) {
+      promise.reject(
+        INVALID_ARGUMENT,
+        "startSample and endSample must both be provided or both omitted",
+      )
+      return
+    }
+
     try {
-      val inputSamples = audioInEntry.readAllSamples()
+      val inputSamples: FloatArray
+      if (!hasStart) {
+        inputSamples = audioInEntry.readAllSamples()
+      } else {
+        val start =
+          kotlin.math
+            .floor(startSample!!)
+            .toInt()
+            .coerceAtLeast(0)
+        val endRaw =
+          kotlin.math
+            .floor(endSample!!)
+            .toInt()
+            .coerceAtLeast(start)
+        val end = endRaw.coerceAtMost(audioInEntry.numSamples)
+        val frameCount = (end - start).coerceAtLeast(0)
+        if (frameCount == 0) {
+          val out = Arguments.createMap()
+          out.putArray("embedding", Arguments.createArray())
+          promise.resolve(out)
+          return
+        }
+        inputSamples = audioInEntry.readSlice(start, frameCount)
+      }
+
       val result = nativeComputeEmbedding(
         instanceId,
         inputSamples,
@@ -465,6 +502,7 @@ internal class SherpaOnnxSpeakerEmbeddingHelper(
     private const val BUFFER_KIND_MISMATCH = "SPEAKER_EMBEDDING_BUFFER_KIND_MISMATCH"
     private const val BUFFER_NOT_FOUND = "SPEAKER_EMBEDDING_BUFFER_NOT_FOUND"
     private const val BUFFER_EMPTY = "SPEAKER_EMBEDDING_BUFFER_EMPTY"
+    private const val INVALID_ARGUMENT = "SPEAKER_EMBEDDING_INVALID_ARGUMENT"
     private val SUPPORTED_TYPES = setOf("wespeaker", "3d-speaker", "nemo")
 
     @JvmStatic

--- a/android/src/main/java/com/sherpaonnx/speakerembedding/facade/SherpaOnnxSpeakerEmbeddingHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/speakerembedding/facade/SherpaOnnxSpeakerEmbeddingHelper.kt
@@ -419,6 +419,172 @@ internal class SherpaOnnxSpeakerEmbeddingHelper(
     }
   }
 
+  fun enrollSpeakerOffline(
+    instanceId: String,
+    managerId: String,
+    name: String,
+    audioBufferIds: ReadableArray,
+    startSamples: ReadableArray?,
+    endSamples: ReadableArray?,
+    promise: Promise,
+  ) {
+    if (instanceId.isBlank()) {
+      promise.reject(COMPUTE_ERROR, "instanceId is required")
+      return
+    }
+    if (managerId.isBlank()) {
+      promise.reject(MANAGER_ERROR, "managerId is required")
+      return
+    }
+    if (name.isBlank()) {
+      promise.reject(MANAGER_ERROR, "name is required")
+      return
+    }
+    val countIds = audioBufferIds.size()
+    if (countIds <= 0) {
+      promise.reject(INVALID_ARGUMENT, "audioBufferIds must contain at least one buffer id")
+      return
+    }
+
+    val hasStarts = startSamples != null
+    val hasEnds = endSamples != null
+    if (hasStarts != hasEnds) {
+      promise.reject(
+        INVALID_ARGUMENT,
+        "startSamples and endSamples must both be provided or both omitted",
+      )
+      return
+    }
+    if (hasStarts) {
+      if (startSamples!!.size() != countIds || endSamples!!.size() != countIds) {
+        promise.reject(
+          INVALID_ARGUMENT,
+          "startSamples and endSamples must match audioBufferIds length",
+        )
+        return
+      }
+    }
+
+    try {
+      val embeddings = ArrayList<FloatArray>()
+      for (i in 0 until countIds) {
+        val audioBufferId = audioBufferIds.getString(i)
+        if (audioBufferId.isNullOrBlank()) {
+          promise.reject(INVALID_ARGUMENT, "audioBufferIds[$i] is required")
+          return
+        }
+        if (!audioBufferId.startsWith("off_")) {
+          promise.reject(
+            BUFFER_KIND_MISMATCH,
+            "Expected offline audio buffer (off_*) , got: $audioBufferId",
+          )
+          return
+        }
+        val audioInEntry = PipelineAudioRegistry.getOffline(audioBufferId)
+        if (audioInEntry == null) {
+          promise.reject(BUFFER_NOT_FOUND, "Offline audio buffer not found: $audioBufferId")
+          return
+        }
+        if (audioInEntry.numSamples <= 0 || audioInEntry.sampleRate <= 0) {
+          promise.reject(BUFFER_EMPTY, "Input offline audio buffer is empty: $audioBufferId")
+          return
+        }
+
+        val inputSamples: FloatArray
+        if (!hasStarts) {
+          inputSamples = audioInEntry.readAllSamples()
+        } else {
+          val startIsNull = startSamples!!.isNull(i)
+          val endIsNull = endSamples!!.isNull(i)
+          if (startIsNull != endIsNull) {
+            promise.reject(
+              INVALID_ARGUMENT,
+              "startSamples[$i] and endSamples[$i] must both be provided or both null",
+            )
+            return
+          }
+          if (startIsNull) {
+            inputSamples = audioInEntry.readAllSamples()
+          } else {
+            val start =
+              kotlin.math
+                .floor(startSamples.getDouble(i))
+                .toInt()
+                .coerceAtLeast(0)
+            val endRaw =
+              kotlin.math
+                .floor(endSamples.getDouble(i))
+                .toInt()
+                .coerceAtLeast(start)
+            val end = endRaw.coerceAtMost(audioInEntry.numSamples)
+            val frameCount = (end - start).coerceAtLeast(0)
+            if (frameCount == 0) {
+              continue
+            }
+            inputSamples = audioInEntry.readSlice(start, frameCount)
+          }
+        }
+        if (inputSamples.isEmpty()) {
+          continue
+        }
+        embeddings.add(
+          computeEmbeddingFromSamples(
+            instanceId,
+            inputSamples,
+            audioInEntry.sampleRate,
+          ),
+        )
+      }
+
+      if (embeddings.isEmpty()) {
+        val out = Arguments.createMap()
+        out.putBoolean("ok", false)
+        out.putArray("embeddings", Arguments.createArray())
+        promise.resolve(out)
+        return
+      }
+
+      val dim = embeddings[0].size
+      val flat = FloatArray(dim * embeddings.size)
+      var offset = 0
+      for (emb in embeddings) {
+        if (emb.size != dim) {
+          promise.reject(COMPUTE_ERROR, "Speaker embedding dimension mismatch during enroll")
+          return
+        }
+        System.arraycopy(emb, 0, flat, offset, dim)
+        offset += dim
+      }
+
+      val addResult = nativeManagerAdd(managerId, name, flat, embeddings.size)
+      val ok = addResult?.get("ok") as? Boolean == true
+      val embArr = Arguments.createArray()
+      for (v in flat) {
+        embArr.pushDouble(v.toDouble())
+      }
+      val out = Arguments.createMap()
+      out.putBoolean("ok", ok)
+      out.putArray("embeddings", embArr)
+      promise.resolve(out)
+    } catch (e: Exception) {
+      Log.e(TAG, "Speaker enroll offline failed", e)
+      val message = e.message.orEmpty()
+      val code =
+        when {
+          message.startsWith("SPEAKER_EMBEDDING_") ->
+            message.substringBefore(':').trim().ifBlank { COMPUTE_ERROR }
+          else -> COMPUTE_ERROR
+        }
+      val detail =
+        when {
+          message.contains(':') -> message.substringAfter(':').trim()
+          message.isNotBlank() -> message
+          else -> "Speaker enroll offline failed"
+        }
+      promise.reject(code, detail, e)
+    }
+  }
+
   fun unloadSpeakerEmbeddingExtractor(instanceId: String, promise: Promise) {
     nativeUnloadExtractor(instanceId)
     promise.resolve(null)

--- a/android/src/main/java/com/sherpaonnx/speakerembedding/facade/SherpaOnnxSpeakerEmbeddingHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/speakerembedding/facade/SherpaOnnxSpeakerEmbeddingHelper.kt
@@ -241,6 +241,97 @@ internal class SherpaOnnxSpeakerEmbeddingHelper(
     }
   }
 
+  fun identifySpeakerOffline(
+    instanceId: String,
+    managerId: String,
+    audioBufferId: String,
+    threshold: Double,
+    startSample: Double?,
+    endSample: Double?,
+    promise: Promise,
+  ) {
+    if (!audioBufferId.startsWith("off_")) {
+      promise.reject(
+        BUFFER_KIND_MISMATCH,
+        "Expected offline audio buffer (off_*) , got: $audioBufferId",
+      )
+      return
+    }
+    val audioInEntry = PipelineAudioRegistry.getOffline(audioBufferId)
+    if (audioInEntry == null) {
+      promise.reject(BUFFER_NOT_FOUND, "Offline audio buffer not found: $audioBufferId")
+      return
+    }
+    if (audioInEntry.numSamples <= 0 || audioInEntry.sampleRate <= 0) {
+      promise.reject(BUFFER_EMPTY, "Input offline audio buffer is empty: $audioBufferId")
+      return
+    }
+
+    val hasStart = startSample != null
+    val hasEnd = endSample != null
+    if (hasStart != hasEnd) {
+      promise.reject(
+        INVALID_ARGUMENT,
+        "startSample and endSample must both be provided or both omitted",
+      )
+      return
+    }
+
+    try {
+      val inputSamples: FloatArray
+      if (!hasStart) {
+        inputSamples = audioInEntry.readAllSamples()
+      } else {
+        val start =
+          kotlin.math
+            .floor(startSample!!)
+            .toInt()
+            .coerceAtLeast(0)
+        val endRaw =
+          kotlin.math
+            .floor(endSample!!)
+            .toInt()
+            .coerceAtLeast(start)
+        val end = endRaw.coerceAtMost(audioInEntry.numSamples)
+        val frameCount = (end - start).coerceAtLeast(0)
+        if (frameCount == 0) {
+          val out = Arguments.createMap()
+          out.putString("name", "")
+          promise.resolve(out)
+          return
+        }
+        inputSamples = audioInEntry.readSlice(start, frameCount)
+      }
+
+      val embedding =
+        computeEmbeddingFromSamples(
+          instanceId,
+          inputSamples,
+          audioInEntry.sampleRate,
+        )
+      val name = searchSpeaker(managerId, embedding, threshold.toFloat())
+      val out = Arguments.createMap()
+      out.putString("name", name)
+      promise.resolve(out)
+    } catch (e: Exception) {
+      Log.e(TAG, "Speaker identify offline failed", e)
+      val message = e.message.orEmpty()
+      val code =
+        when {
+          message.startsWith("SPEAKER_EMBEDDING_") ->
+            message.substringBefore(':').trim().ifBlank { COMPUTE_ERROR }
+          else -> COMPUTE_ERROR
+        }
+      val detail =
+        when {
+          message.contains(':') -> message.substringAfter(':').trim()
+          message.isNotBlank() -> message
+          else -> "Speaker identify offline failed"
+        }
+      promise.reject(code, detail, e)
+    }
+  }
+
   fun unloadSpeakerEmbeddingExtractor(instanceId: String, promise: Promise) {
     nativeUnloadExtractor(instanceId)
     promise.resolve(null)

--- a/android/src/main/java/com/sherpaonnx/speakerembedding/facade/SherpaOnnxSpeakerEmbeddingHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/speakerembedding/facade/SherpaOnnxSpeakerEmbeddingHelper.kt
@@ -356,6 +356,43 @@ internal class SherpaOnnxSpeakerEmbeddingHelper(
     promise.resolve(null)
   }
 
+  /**
+   * Synchronous compute for offline-live workers (worker thread; not Promise/TM).
+   */
+  fun computeEmbeddingFromSamples(
+    instanceId: String,
+    samples: FloatArray,
+    sampleRate: Int,
+  ): FloatArray {
+    val result = nativeComputeEmbedding(instanceId, samples, sampleRate)
+      ?: throw IllegalStateException("Speaker embedding compute returned null")
+    if (result["success"] as? Boolean != true) {
+      val code =
+        (result["errorCode"] as? String)?.takeIf { it.isNotBlank() } ?: COMPUTE_ERROR
+      val error =
+        (result["error"] as? String)?.takeIf { it.isNotBlank() }
+          ?: "Speaker embedding compute failed"
+      throw IllegalStateException("$code: $error")
+    }
+    @Suppress("UNCHECKED_CAST")
+    val embedding = result["embedding"] as? ArrayList<Float>
+      ?: throw IllegalStateException("Speaker embedding compute missing embedding")
+    return FloatArray(embedding.size) { i -> embedding[i] }
+  }
+
+  /**
+   * Synchronous search for offline-live workers (worker thread; not Promise/TM).
+   * Returns empty string when no match.
+   */
+  fun searchSpeaker(
+    managerId: String,
+    embedding: FloatArray,
+    threshold: Float,
+  ): String {
+    val result = nativeManagerSearch(managerId, embedding, threshold)
+    return (result?.get("name") as? String).orEmpty()
+  }
+
   private fun okMap(ok: Boolean): WritableMap {
     val out = Arguments.createMap()
     out.putBoolean("ok", ok)

--- a/android/src/main/java/com/sherpaonnx/speakerembedding/facade/SherpaOnnxSpeakerEmbeddingHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/speakerembedding/facade/SherpaOnnxSpeakerEmbeddingHelper.kt
@@ -226,8 +226,7 @@ internal class SherpaOnnxSpeakerEmbeddingHelper(
         promise.reject(code, error)
         return
       }
-      @Suppress("UNCHECKED_CAST")
-      val embedding = result["embedding"] as? ArrayList<Float> ?: arrayListOf()
+      val embedding = result["embedding"] as? FloatArray ?: floatArrayOf()
       val arr = Arguments.createArray()
       for (v in embedding) {
         arr.pushDouble(v.toDouble())
@@ -327,6 +326,94 @@ internal class SherpaOnnxSpeakerEmbeddingHelper(
           message.contains(':') -> message.substringAfter(':').trim()
           message.isNotBlank() -> message
           else -> "Speaker identify offline failed"
+        }
+      promise.reject(code, detail, e)
+    }
+  }
+
+  fun verifySpeakerOffline(
+    instanceId: String,
+    managerId: String,
+    audioBufferId: String,
+    name: String,
+    threshold: Double,
+    startSample: Double?,
+    endSample: Double?,
+    promise: Promise,
+  ) {
+    if (!audioBufferId.startsWith("off_")) {
+      promise.reject(
+        BUFFER_KIND_MISMATCH,
+        "Expected offline audio buffer (off_*) , got: $audioBufferId",
+      )
+      return
+    }
+    val audioInEntry = PipelineAudioRegistry.getOffline(audioBufferId)
+    if (audioInEntry == null) {
+      promise.reject(BUFFER_NOT_FOUND, "Offline audio buffer not found: $audioBufferId")
+      return
+    }
+    if (audioInEntry.numSamples <= 0 || audioInEntry.sampleRate <= 0) {
+      promise.reject(BUFFER_EMPTY, "Input offline audio buffer is empty: $audioBufferId")
+      return
+    }
+
+    val hasStart = startSample != null
+    val hasEnd = endSample != null
+    if (hasStart != hasEnd) {
+      promise.reject(
+        INVALID_ARGUMENT,
+        "startSample and endSample must both be provided or both omitted",
+      )
+      return
+    }
+
+    try {
+      val inputSamples: FloatArray
+      if (!hasStart) {
+        inputSamples = audioInEntry.readAllSamples()
+      } else {
+        val start =
+          kotlin.math
+            .floor(startSample!!)
+            .toInt()
+            .coerceAtLeast(0)
+        val endRaw =
+          kotlin.math
+            .floor(endSample!!)
+            .toInt()
+            .coerceAtLeast(start)
+        val end = endRaw.coerceAtMost(audioInEntry.numSamples)
+        val frameCount = (end - start).coerceAtLeast(0)
+        if (frameCount == 0) {
+          promise.resolve(okMap(false))
+          return
+        }
+        inputSamples = audioInEntry.readSlice(start, frameCount)
+      }
+
+      val embedding =
+        computeEmbeddingFromSamples(
+          instanceId,
+          inputSamples,
+          audioInEntry.sampleRate,
+        )
+      val ok = verifySpeaker(managerId, name, embedding, threshold.toFloat())
+      promise.resolve(okMap(ok))
+    } catch (e: Exception) {
+      Log.e(TAG, "Speaker verify offline failed", e)
+      val message = e.message.orEmpty()
+      val code =
+        when {
+          message.startsWith("SPEAKER_EMBEDDING_") ->
+            message.substringBefore(':').trim().ifBlank { COMPUTE_ERROR }
+          else -> COMPUTE_ERROR
+        }
+      val detail =
+        when {
+          message.contains(':') -> message.substringAfter(':').trim()
+          message.isNotBlank() -> message
+          else -> "Speaker verify offline failed"
         }
       promise.reject(code, detail, e)
     }
@@ -502,10 +589,9 @@ internal class SherpaOnnxSpeakerEmbeddingHelper(
           ?: "Speaker embedding compute failed"
       throw IllegalStateException("$code: $error")
     }
-    @Suppress("UNCHECKED_CAST")
-    val embedding = result["embedding"] as? ArrayList<Float>
+    val embedding = result["embedding"] as? FloatArray
       ?: throw IllegalStateException("Speaker embedding compute missing embedding")
-    return FloatArray(embedding.size) { i -> embedding[i] }
+    return embedding
   }
 
   /**
@@ -519,6 +605,19 @@ internal class SherpaOnnxSpeakerEmbeddingHelper(
   ): String {
     val result = nativeManagerSearch(managerId, embedding, threshold)
     return (result?.get("name") as? String).orEmpty()
+  }
+
+  /**
+   * Synchronous verify for combined offline verify (worker / Helper; not Promise/TM).
+   */
+  fun verifySpeaker(
+    managerId: String,
+    name: String,
+    embedding: FloatArray,
+    threshold: Float,
+  ): Boolean {
+    val result = nativeManagerVerify(managerId, name, embedding, threshold)
+    return result?.get("ok") as? Boolean == true
   }
 
   private fun okMap(ok: Boolean): WritableMap {

--- a/android/src/main/java/com/sherpaonnx/speakeridentification/facade/SherpaOnnxSpeakerIdentificationLivePipelineHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/speakeridentification/facade/SherpaOnnxSpeakerIdentificationLivePipelineHelper.kt
@@ -1,0 +1,150 @@
+package com.sherpaonnx.speakeridentification.facade
+
+import android.util.Log
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.sherpaonnx.audio.pipeline.PipelineAudioRegistry
+import com.sherpaonnx.audio.pipeline.StreamingPipelineCompletion
+import com.sherpaonnx.audio.pipeline.StreamingPipelineRegistry
+import com.sherpaonnx.livePipeline.OfflineLivePipelineWorker
+import com.sherpaonnx.segment.pipeline.SegmentPipelineRegistry
+import com.sherpaonnx.speakerembedding.facade.SherpaOnnxSpeakerEmbeddingHelper
+import com.sherpaonnx.speakeridentification.pipeline.SpeakerIdentificationOfflineLivePipelineWorker
+
+internal class SherpaOnnxSpeakerIdentificationLivePipelineHelper(
+  private val context: ReactApplicationContext,
+  private val embeddingHelper: SherpaOnnxSpeakerEmbeddingHelper,
+  private val logTag: String,
+) {
+
+  fun startSpeakerIdentificationOfflineLivePipeline(
+    instanceId: String,
+    managerId: String,
+    audioInLiveBufferId: String,
+    segmentsOutLiveBufferId: String,
+    options: ReadableMap,
+    promise: Promise,
+  ) {
+    try {
+      if (instanceId.isBlank()) {
+        promise.reject(ERR_INVALID, "instanceId is required")
+        return
+      }
+      if (managerId.isBlank()) {
+        promise.reject(ERR_INVALID, "managerId is required")
+        return
+      }
+
+      val audioEntry = PipelineAudioRegistry.getLive(audioInLiveBufferId)
+      if (audioEntry == null) {
+        promise.reject(
+          ERR_AUDIO_NOT_FOUND,
+          "Input live audio buffer not found: $audioInLiveBufferId",
+        )
+        return
+      }
+
+      val segmentsOutEntry = SegmentPipelineRegistry.getLive(segmentsOutLiveBufferId)
+      if (segmentsOutEntry == null) {
+        promise.reject(
+          ERR_SEGMENT_NOT_FOUND,
+          "Output live segment buffer not found: $segmentsOutLiveBufferId",
+        )
+        return
+      }
+
+      val attachedSegmentationEngineId =
+        options.getString("attachedSegmentationEngineId")?.trim().orEmpty()
+      if (attachedSegmentationEngineId.isEmpty()) {
+        promise.reject(ERR_INVALID, "attachedSegmentationEngineId is required")
+        return
+      }
+
+      val segmentLiveBufferId =
+        options.getString("segmentLiveBufferId")?.trim().orEmpty()
+      if (segmentLiveBufferId.isEmpty()) {
+        promise.reject(ERR_INVALID, "segmentLiveBufferId is required")
+        return
+      }
+
+      val segmentEntry = SegmentPipelineRegistry.getLive(segmentLiveBufferId)
+      if (segmentEntry == null) {
+        promise.reject(
+          ERR_SEGMENT_NOT_FOUND,
+          "Input live segment buffer not found: $segmentLiveBufferId",
+        )
+        return
+      }
+
+      if (!options.hasKey("threshold") || options.isNull("threshold")) {
+        promise.reject(ERR_INVALID, "threshold is required")
+        return
+      }
+      val threshold = options.getDouble("threshold").toFloat()
+      if (!threshold.isFinite()) {
+        promise.reject(ERR_INVALID, "threshold must be a finite number")
+        return
+      }
+
+      val pipelineId = "sid_live_" + java.util.UUID.randomUUID().toString()
+      val worker = SpeakerIdentificationOfflineLivePipelineWorker(
+        pipelineId = pipelineId,
+        attachedSegmentationEngineId = attachedSegmentationEngineId,
+        audioInputRef = OfflineLivePipelineWorker.AudioInput(
+          liveAudioEntry = audioEntry,
+          liveSegmentEntry = segmentEntry,
+        ),
+        audioInBufferId = audioInLiveBufferId,
+        embeddingHelper = embeddingHelper,
+        instanceId = instanceId,
+        managerId = managerId,
+        threshold = threshold,
+        segmentsOutEntry = segmentsOutEntry,
+      )
+
+      val registeredId = StreamingPipelineRegistry.registerAndStart(worker) { completion ->
+        emitPipelineCompletedEvent(completion)
+      }
+
+      val out = Arguments.createMap()
+      out.putString("pipelineId", registeredId)
+      promise.resolve(out)
+    } catch (e: Exception) {
+      Log.e(logTag, "startSpeakerIdentificationOfflineLivePipeline failed: ${e.message}", e)
+      promise.reject(ERR_START_FAILED, "live SID failed: ${e.message}", e)
+    }
+  }
+
+  private fun emitPipelineCompletedEvent(completion: StreamingPipelineCompletion) {
+    try {
+      val payload = Arguments.createMap().apply {
+        putString("pipelineId", completion.pipelineId)
+        putString("reason", completion.reason)
+        putDouble("chunksProcessed", completion.chunksProcessed.toDouble())
+        putDouble("unitsRead", completion.unitsRead.toDouble())
+        putDouble("unitsWritten", completion.unitsWritten.toDouble())
+        if (completion.error != null) {
+          putString("error", completion.error)
+        } else {
+          putNull("error")
+        }
+      }
+
+      context
+        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+        .emit("streamingPipelineCompleted", payload)
+    } catch (_: Exception) {
+      // JS bridge might already be shutting down.
+    }
+  }
+
+  companion object {
+    private const val ERR_INVALID = "SID_INVALID_ARGUMENT"
+    private const val ERR_AUDIO_NOT_FOUND = "SID_PIPELINE_AUDIO_BUFFER_NOT_FOUND"
+    private const val ERR_SEGMENT_NOT_FOUND = "SID_PIPELINE_SEGMENT_BUFFER_NOT_FOUND"
+    private const val ERR_START_FAILED = "SID_LABEL_FAILED"
+  }
+}

--- a/android/src/main/java/com/sherpaonnx/speakeridentification/pipeline/SpeakerIdentificationOfflineLivePipelineWorker.kt
+++ b/android/src/main/java/com/sherpaonnx/speakeridentification/pipeline/SpeakerIdentificationOfflineLivePipelineWorker.kt
@@ -1,0 +1,89 @@
+package com.sherpaonnx.speakeridentification.pipeline
+
+import android.util.Log
+import com.sherpaonnx.livePipeline.CommittedSegmentRef
+import com.sherpaonnx.livePipeline.OfflineLivePipelineWorker
+import com.sherpaonnx.segment.pipeline.LiveSegmentEntry
+import com.sherpaonnx.speakerembedding.facade.SherpaOnnxSpeakerEmbeddingHelper
+import org.json.JSONObject
+
+internal class SpeakerIdentificationOfflineLivePipelineWorker(
+  pipelineId: String,
+  attachedSegmentationEngineId: String,
+  private val audioInputRef: AudioInput,
+  private val audioInBufferId: String,
+  private val embeddingHelper: SherpaOnnxSpeakerEmbeddingHelper,
+  private val instanceId: String,
+  private val managerId: String,
+  private val threshold: Float,
+  private val segmentsOutEntry: LiveSegmentEntry,
+) : OfflineLivePipelineWorker(
+  pipelineId = pipelineId,
+  attachedSegmentationEngineId = attachedSegmentationEngineId,
+  audioInput = audioInputRef,
+  textInput = null,
+) {
+
+  override fun onSegmentCommitted(segment: CommittedSegmentRef) {
+    val speech = segment as? CommittedSegmentRef.Speech ?: return
+    val frameCount = (speech.endSample - speech.startSample).coerceAtLeast(0)
+    if (frameCount == 0) return
+
+    val samples = audioInputRef.liveAudioEntry.getSamplesSlice(
+      startFrame = speech.startSample,
+      frameCount = frameCount,
+    )
+    if (samples.isEmpty()) return
+
+    Log.d(
+      TAG,
+      "label span start=${speech.startSample} end=${speech.endSample} frames=${samples.size} sr=${speech.sampleRate}",
+    )
+
+    val embedding = embeddingHelper.computeEmbeddingFromSamples(
+      instanceId = instanceId,
+      samples = samples,
+      sampleRate = speech.sampleRate,
+    )
+    val matched = embeddingHelper.searchSpeaker(
+      managerId = managerId,
+      embedding = embedding,
+      threshold = threshold,
+    ).trim()
+    val speakerName = matched.ifEmpty { null }
+
+    Log.d(
+      TAG,
+      "search result speaker=${speakerName ?: "null"} dim=${embedding.size} threshold=$threshold",
+    )
+
+    val payloadJson = JSONObject().apply {
+      put("source", "sid")
+      if (speakerName == null) {
+        put("speakerName", JSONObject.NULL)
+      } else {
+        put("speakerName", speakerName)
+      }
+    }.toString()
+
+    val sourceAudioBufferId =
+      speech.sourceAudioBufferId.ifBlank { audioInBufferId }
+
+    segmentsOutEntry.appendSegment(
+      kind = "speech",
+      sourceAudioBufferId = sourceAudioBufferId,
+      startSample = speech.startSample,
+      endSample = speech.endSample,
+      sampleRate = speech.sampleRate,
+      durationMs = speech.durationMs,
+      confidence = speech.confidence,
+      payloadJson = payloadJson,
+      forceEmitAppendedEvent = true,
+    )
+    addUnitsWritten(1)
+  }
+
+  companion object {
+    private const val TAG = "SherpaOnnx:sid-live"
+  }
+}

--- a/docs/diarization-offline.md
+++ b/docs/diarization-offline.md
@@ -84,8 +84,8 @@ Detects `pyannote` / `reverb` packs (prefers `model.onnx` over `model.int8.onnx`
 
 ### `engine.diarize(audioIn, segmentOut, options?)`
 
-Runs the full pipeline and materializes `{start,end,speaker}` into `segmentOut`
-(`kind: 'diarization'`, payload `{ source: 'diarization', speaker }`).
+Runs the full pipeline and writes `{start,end,speaker}` into `segmentOut`
+natively (`kind: 'diarization'`, payload `{ source: 'diarization', speaker }`).
 
 `segmentOut` must be an **empty** offline segment buffer.
 

--- a/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
+++ b/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
@@ -1,14 +1,16 @@
 # Speaker embedding / SID: bridge roundtrip bottlenecks (future work)
 
-**Status:** Findings 1–5 **done**. Optional follow-ups: iOS TM mutex narrowing (same pattern), embedding JSI for raw-vector apps.  
-**Scope:** TurboModule / JS orchestration costs on the **speaker-embedding** and **speaker-identification** paths after the shared C++ `SpeakerEmbeddingRunner` / `SpeakerEmbeddingManager` migration.  
-**Motivation:** Align SID with the live-overload target architecture already used by STT/TTS (and punctuation / enhancement / separation): **one native start**, per-utterance work stays in-process, no PCM or embedding vectors bouncing through JS.
+**Status:** Findings 1–5 and **§10** **done**. Open follow-ups: **§6–§9** (diarization lifetime, iOS mutex parity, enroll without JS embeddings, diarization native segment write). Optional later: embedding JSI.  
+**Scope:** TurboModule / JS orchestration costs on the **speaker-embedding**, **speaker-identification**, and **diarization** paths after the shared C++ `SpeakerEmbeddingRunner` / `SpeakerEmbeddingManager` migration.  
+**Motivation:** Align SID (and keep diarization) with the live-overload target architecture already used by STT/TTS (and punctuation / enhancement / separation): **one native start**, per-utterance / batch work stays in-process, no PCM or embedding vectors bouncing through JS on product hot paths.
 
 **Related (today):**
 
 - [speaker-embedding-foundation.md](../internal/speaker-embedding-foundation.md) — shared C++ core, SID vs diarization ownership
 - [live-overload.md §11](../internal/live-overload.md#11-speaker-identification-live-overload-native-worker) — SID live native worker (Finding 1 done)
 - [speaker-identification-live.md](../speaker-identification-live.md) — public `labelLiveSegments` contract
+- [speaker-identification-offline.md](../speaker-identification-offline.md) — offline SID (identify/verify combined TMs)
+- [diarization-offline.md](../diarization-offline.md) — offline diarization (shipped; compute→cluster in-process)
 - [speaker-embedding-sharing-verification.md](../internal/speaker-embedding-sharing-verification.md) — device logcat weight-sharing check
 - Audio JSI baseline: [liveaudiobuffer-internal.md](../internal/liveaudiobuffer-internal.md), `src/audiobuffer/jsi.ts`
 
@@ -18,18 +20,36 @@
 
 | Layer | Verdict |
 |-------|---------|
-| Shared C++ `SpeakerEmbeddingRunner` / `ManagerCore` | **Not** the bottleneck. Diarization already uses the same core **without** JS and is the target pattern. |
+| Shared C++ `SpeakerEmbeddingRunner` / `ManagerCore` | **Not** the bottleneck. Diarization already uses the same core **without** JS between embed and cluster — still the target pattern for compute. |
 | C++ registry weight sharing | **Win** (fewer ONNX loads). Orthogonal to transport cost. |
-| TurboModule `number[]` embeddings + JS live drain | **Real** cost — pre-dates the migration in shape; migration replaced only the last inference hop (Kotlin AAR / iOS cxx-API → our JNI/C++). |
+| TurboModule `number[]` embeddings + JS live drain | **Was** the real cost on SID; Findings 1–5 closed product hot paths. Residuals: enroll, low-level extract, diarization post-result JS materialization, lifetime/mutex parity. |
 
-**Hop count from JS did not increase.** Findings 1–5 address live orchestration, range extract, combined identify/verify, Android embedding unbox, and JNI lock narrowing. Optional later: embedding JSI; iOS TM mutex parity.
+**Hop count from JS did not increase** at the shared-Runner migration. Findings 1–5 fixed live orchestration, range extract, combined identify/verify, Android embedding unbox, and Android JNI lock narrowing.
 
 ```text
 STT / TTS / Punctuation / Enhancement / Separation / SID live
   JS: attach segmentation → start*OfflineLivePipeline once
   Native worker: read seg_live_* + PCM → infer → write outputs
-  ✅ Target architecture
+  ✅ Target architecture (SID live met)
+
+Diarization offline compute
+  JS: buffer ids → diarizeOffline once
+  Native: PCM → embed → cluster → timeline
+  ✅ Compute path met; segment materialization still JS (Finding 9)
 ```
+
+### Post–Finding 1–5 audit snapshot
+
+| Path | vs target |
+|------|-----------|
+| SID live / identify / verify | **Met** (no PCM/embedding through JS) |
+| SID enroll | **Partial** — no JS PCM; embeddings still cross JS for `manager.add` + mirror |
+| Diarization compute→cluster | **Met** (in-process) |
+| Diarization result → offline segments | **Gap** — JS live-append materialize loop |
+| Android SID JNI lifetime | **Met** (`shared_ptr` + narrow map lock) |
+| Diarization JNI lifetime | **Gap** — raw pointer after unlock (Finding 6) |
+| iOS SID TM mutex | **Gap** — still coarse on TurboModule paths (Finding 7) |
+| Internal docs / cursor rule | **Met** (Finding 10) |
 
 ---
 
@@ -120,7 +140,7 @@ Empty `name` = no match. Range rules match Finding 2. Combined `verifySpeakerOff
 
 ## 4. Finding — Embedding transport as `number[]` / boxed floats (MEDIUM) — **DONE**
 
-**Status:** Implemented (path D). Offline `verify` / `verifyOfflineSegments` call `verifySpeakerOffline` (compute + manager verify in one TM → `{ ok }`). Android `nativeComputeEmbedding` returns `jfloatArray` instead of boxed `ArrayList&lt;Float&gt;`. **No** embedding JSI in this finding; enroll and low-level extract still use TurboModule `number[]` (infrequent / app-facing). Optional later: JSI `ArrayBuffer` if apps need faster raw-vector pull.
+**Status:** Implemented (path D). Offline `verify` / `verifyOfflineSegments` call `verifySpeakerOffline` (compute + manager verify in one TM → `{ ok }`). Android `nativeComputeEmbedding` returns `jfloatArray` instead of boxed `ArrayList&lt;Float&gt;`. **No** embedding JSI in this finding; enroll and low-level extract still use TurboModule `number[]` (see Finding 8). Optional later: JSI `ArrayBuffer` if apps need faster raw-vector pull.
 
 ### Problem (historical)
 
@@ -150,7 +170,7 @@ Zero-length range → `{ ok: false }` without ONNX. Android compute JNI uses `Ne
 
 ## 5. Finding — Coarse Android JNI mutex (LOW–MEDIUM) — **DONE**
 
-**Status:** Implemented. Android `g_speaker_embedding_mutex` is now registry lookup/mutate only. Extractor/manager maps hold `shared_ptr` so unload during compute cannot UAF. Hot paths (`nativeComputeEmbedding`, manager add/remove/search/verify/contains/numSpeakers/allSpeakers) copy the pointer out and run outside the global lock. `SpeakerEmbeddingManagerWrapper` has a per-manager mutex around C-API ops. Runner `compute_mutex` unchanged. iOS TurboModule coarse bridge mutex is an optional parity follow-up (iOS live already unlocks after pinning).
+**Status:** Implemented. Android `g_speaker_embedding_mutex` is now registry lookup/mutate only. Extractor/manager maps hold `shared_ptr` so unload during compute cannot UAF. Hot paths (`nativeComputeEmbedding`, manager add/remove/search/verify/contains/numSpeakers/allSpeakers) copy the pointer out and run outside the global lock. `SpeakerEmbeddingManagerWrapper` has a per-manager mutex around C-API ops. Runner `compute_mutex` unchanged. iOS TurboModule coarse bridge mutex remains open as Finding 7 (iOS live already unlocks after pinning).
 
 ### Problem (historical)
 
@@ -164,27 +184,152 @@ Zero-length range → `{ ok: false }` without ONNX. Android compute JNI uses `Ne
 
 ---
 
-## 6. Suggested implementation order
+## 6. Finding — Diarization JNI lifetime (raw pointer after unlock) (MEDIUM)
 
-| Step | Finding | Effort | Impact | Status |
-|------|---------|--------|--------|--------|
-| C | §1 native SID live pipeline | Medium–large | Matches STT/TTS target architecture | **Done** |
-| A | §2 native extract-by-range | Small | Removes JS PCM staging for offline/range | **Done** |
-| B | §3 combined identify (or in-worker search) | Small–medium | Drops embedding roundtrip on identify APIs that still cross JS | **Done** |
-| D | §4 combined verify + Android unbox (path D) | Small–medium | Residual verify path + JNI boxing hygiene | **Done** |
-| E | §5 JNI lock narrowing | Small | Contention hygiene | **Done** |
+### Problem
+
+Diarization already unlocks `g_diarization_mutex` before `processMonoSamples` (good for cancel). The instance is held as a **raw pointer** copied under the lock. Unload / destroy while a process is running can UAF. SID Finding 5 fixed the analogous bug with `shared_ptr` map entries.
+
+Android: `android/.../jni/diarization/sherpa-onnx-diarization-jni.cpp`  
+iOS: same pattern under diarization bridge state.
+
+### Direction
+
+- Store diarization sessions as `shared_ptr` in the registry map.
+- Lookup → copy `shared_ptr` → unlock → `processMonoSamples` / recluster / get embeddings.
+- Unload erases the map entry only; in-flight holders keep the session alive until process finishes.
+- Re-init replaces the map entry (do not `release()` in place while others may hold the pointer).
+
+**Priority:** Medium (correctness / concurrency hygiene). Small–medium effort. Do **before** larger diarization bridge refactors (Finding 9).
 
 ---
 
-## 7. Measurement checklist (before / after)
+## 7. Finding — iOS SID TurboModule mutex still coarse (LOW–MEDIUM)
 
-Instrument with a stable tag (e.g. `[SherpaOnnx:sid-live]` / `[SherpaOnnx:sid-bridge]`) and compare Android logcat first:
+### Problem
+
+iOS `g_speaker_embedding_mutex` (TurboModule path in `SherpaOnnx+SpeakerEmbeddingInference.mm`) still spans compute / identify / verify / manager C-API calls. iOS **live** already pins pointers then works unlocked. Android Finding 5 already narrowed the JNI map lock.
+
+### Direction
+
+Mirror Finding 5 on iOS TM:
+
+- Keep map lock for init / create / unload / destroy / short lookup.
+- Copy `shared_ptr` (or equivalent strong refs) out; run `computeFromSamples` / manager ops outside the global bridge mutex.
+- Rely on Runner `compute_mutex` + existing ManagerWrapper per-manager mutex.
+
+**Priority:** Low–medium. Small once Finding 5 patterns are copied. Independent of enroll / diarization segment write.
+
+---
+
+## 8. Finding — SID enroll still marshals embeddings through JS (MEDIUM)
+
+### Problem
+
+`enroll` / `enrollOfflineSegments` still:
+
+1. `computeSpeakerEmbeddingOffline` → embedding `number[]` → JS `Float32Array`
+2. Flatten → `speakerEmbeddingManagerAdd` with `number[]`
+
+No PCM through JS (Finding 2), but the last product path that **needs** vectors for `manager.add` + the JS enrollment mirror still crosses the bridge twice per utterance. Infrequent vs live label, but still the only SID product embedding gap after Findings 3–4.
+
+### Direction
+
+Combined native enroll API, e.g.:
+
+```ts
+enrollSpeakerOffline(
+  instanceId: string,
+  managerId: string,
+  name: string,
+  audioBufferId: string,
+  startSample?: number | null,
+  endSample?: number | null
+): Promise<{ ok: boolean; embedding?: number[] }>
+```
+
+Or multi-buffer variant for `enroll(name, buffers[])` / per-span enroll.
+
+- Native: slice/full → compute → `manager.add` in-process → `{ ok }`.
+- If the JS enrollment mirror must stay: return embedding once (or a compact transfer) **only for mirror**, not a second add roundtrip — or extend native export later ([speaker-embedding-manager-upstream-export-import.md](speaker-embedding-manager-upstream-export-import.md)).
+- Keep low-level `compute` / `manager.add` for apps that need raw vectors.
+
+**Priority:** Medium. Medium effort. After lifetime/mutex hygiene (§6–§7) so enroll hot path lands on stable locks.
+
+---
+
+## 9. Finding — Diarization result materialization still in JS (MEDIUM)
+
+### Problem
+
+`diarizeOffline` returns a timeline `{ start, end, speaker }[]`. JS then materializes into the offline segment buffer via a live-append → finalize → populate loop (`materializeSegmentsIntoOfflineBuffer` in `src/diarization/index.ts`). Compute→cluster never left C++ (correct), but the **result write** is many small TurboModule hops — same class of “orchestration in JS” as pre-Finding-1 SID live, without PCM/embedding cost.
+
+### Direction
+
+Native write into the empty `segmentsOut` offline segment buffer (or one TM that accepts `audioIn` + `segmentsOut` and fills diarization segments with `kind: 'diarization'`), so JS only awaits completion / counts.
+
+Public `diarize(audioIn, segmentsOut)` shape can stay; internal swap only.
+
+**Priority:** Medium. Medium–large effort. After Finding 6 (lifetime) so process + write share safe session ownership.
+
+---
+
+## 10. Finding — Stale foundation / cursor docs vs shipped diarization (LOW) — **DONE**
+
+**Status:** Implemented. Foundation status/phase table, `.cursor/rules/separation-diarization-pre-1.0.mdc`, and SID offline cross-links describe offline diarization as **shipped**. Backlog points at §6–§9 / live diarization / pyannote evaluator — not greenfield native.
+
+### Problem (historical)
+
+Offline diarization was shipped, but some internal docs still read as Phase-2-planned / “native fehlt”:
+
+- [speaker-embedding-foundation.md](../internal/speaker-embedding-foundation.md) header / phase table lagged §8–§10 reality
+- `.cursor/rules/separation-diarization-pre-1.0.mdc` implied diarization native was missing
+- Related cross-links called diarization planned/stub
+
+### What shipped
+
+- Foundation: Phase 2 offline **Done**; Phase-2 checklist items marked; related links → offline guide
+- Cursor rule: Separation **and** Diarization native shipped; detect checklist done
+- SID offline docs: diarization available (not “planned”)
+- This file: step F / Finding 10 marked done
+
+---
+
+## 11. Suggested implementation order
+
+Findings 1–5 and §10 are **done**. Recommended order for the remaining open follow-ups (safety before larger API moves):
+
+| Step | Finding | Effort | Impact | Status | Why this order |
+|------|---------|--------|--------|--------|----------------|
+| C | §1 native SID live pipeline | Medium–large | Matches STT/TTS target architecture | **Done** | — |
+| A | §2 native extract-by-range | Small | Removes JS PCM staging for offline/range | **Done** | — |
+| B | §3 combined identify | Small–medium | Drops embedding roundtrip on identify | **Done** | — |
+| D | §4 combined verify + Android unbox | Small–medium | Residual verify path + JNI boxing | **Done** | — |
+| E | §5 Android JNI lock narrowing | Small | Contention / lifetime hygiene | **Done** | — |
+| F | §10 docs sync (foundation + cursor rule) | Small | Stops stale “diarization missing” planning | **Done** | Cheap; clear mental model before more work |
+| G | §6 diarization `shared_ptr` lifetime | Small–medium | Unload-during-process safety | Open | Same pattern as §5; prerequisite for §9 |
+| H | §7 iOS SID TM mutex parity | Small | Contention hygiene parity with Android | Open | Independent of enroll / segment write |
+| I | §8 combined enroll (no JS embedding add) | Medium | Closes last SID product embedding gap | Open | Builds on stable locks (§5/§7) |
+| J | §9 diarization native `segmentsOut` write | Medium–large | Drops JS materialize loop | Open | After §6 lifetime |
+| K | Optional embedding JSI | Small–medium | Faster raw-vector apps only | Deferred | Only if enroll/low-level still hot in profiles |
+
+**Recommendation summary:** next `G → H → I → J` (diarization lifetime → iOS mutex → enroll TM → diarization segment write). Defer embedding JSI unless profiling shows enroll/low-level extract as a real cost.
+
+Draft an **explicit implementation plan per open finding** in that order (one finding at a time), same style as Findings 1–5.
+
+---
+
+## 12. Measurement checklist (before / after)
+
+Instrument with a stable tag (e.g. `[SherpaOnnx:sid-live]` / `[SherpaOnnx:sid-bridge]` / `[SherpaOnnx:diarization]`) and compare Android logcat first:
 
 | Probe | What to log |
 |-------|-------------|
 | Live span (native worker) | `startSample`, `endSample`, frame count, compute/search/append |
 | Offline range extract | native slice + compute only (no JS staging) |
 | Extract/search TM (low-level APIs) | wall ms, dim |
+| Enroll (after §8) | one combined TM; no compute→add embedding bounce |
+| Diarize (after §9) | one native fill of `segmentsOut`; no per-segment JS append |
 
 Success criteria for §1 (met): **no** PCM `Float32Array` in JS on the live label hot path; one `startSpeakerIdentificationOfflineLivePipeline` call per session; embedding vectors stay native unless the app calls low-level extract.
 
@@ -192,14 +337,27 @@ Success criteria for §2 (met): ranged `extractFromOfflineAudio` calls `computeS
 
 Success criteria for §3 (met): offline `identify` / `labelOfflineSegments` use `identifySpeakerOffline` only (no compute→JS→search); empty name maps to `null` in SID TS.
 
-Success criteria for §4 path D (met): offline `verify` / `verifyOfflineSegments` use `verifySpeakerOffline` only; Android compute returns `jfloatArray` (no `ArrayList&lt;Float&gt;` boxing). JSI embedding transport remains optional later.
+Success criteria for §4 path D (met): offline `verify` / `verifyOfflineSegments` use `verifySpeakerOffline` only; Android compute returns `jfloatArray` (no `ArrayList&lt;Float&gt;` boxing).
 
 Success criteria for §5 (met): Android JNI does not hold `g_speaker_embedding_mutex` across ONNX compute or manager C-API ops; maps use `shared_ptr`; ManagerWrapper serializes C-API calls.
 
+Success criteria for §6: diarization process holds a `shared_ptr` session; unload during process does not UAF.
+
+Success criteria for §7: iOS TM compute/identify/verify/manager ops do not hold `g_speaker_embedding_mutex` across ONNX / C-API work.
+
+Success criteria for §8: `enroll` / `enrollOfflineSegments` do not call separate compute + `manager.add` with embedding `number[]` on the product path (mirror policy documented).
+
+Success criteria for §9: `diarize` fills `segmentsOut` natively (no JS per-segment materialize loop).
+
+Success criteria for §10 (met): foundation status + cursor rule describe diarization offline as shipped; backlog points at §6–§9 / live diarization — not greenfield native.
+
 ---
-## 8. Non-goals
+
+## 13. Non-goals
 
 - Reverting the shared C++ Runner/Manager migration
-- Changing public `labelLiveSegments` / offline SID API shapes (internal swap only)
+- Changing public `labelLiveSegments` / offline SID / offline diarization API shapes (internal swap only)
 - Moving diarization clustering through JS (already correct in-process)
 - Host CI linking full sherpa C-API for Runner gtests (optional later; registry-key tests remain)
+- True streaming / live diarization (separate track)
+- Replacing the JS enrollment mirror without a native export story ([speaker-embedding-manager-upstream-export-import.md](speaker-embedding-manager-upstream-export-import.md))

--- a/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
+++ b/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
@@ -1,6 +1,6 @@
 # Speaker embedding / SID: bridge roundtrip bottlenecks (future work)
 
-**Status:** Findings 1–5, **§6**, and **§10** **done**. Open follow-ups: **§7–§9** (iOS mutex parity, enroll without JS embeddings, diarization native segment write). Optional later: embedding JSI.  
+**Status:** Findings 1–5, **§6–§7**, and **§10** **done**. Open follow-ups: **§8–§9** (enroll without JS embeddings, diarization native segment write). Optional later: embedding JSI.  
 **Scope:** TurboModule / JS orchestration costs on the **speaker-embedding**, **speaker-identification**, and **diarization** paths after the shared C++ `SpeakerEmbeddingRunner` / `SpeakerEmbeddingManager` migration.  
 **Motivation:** Align SID (and keep diarization) with the live-overload target architecture already used by STT/TTS (and punctuation / enhancement / separation): **one native start**, per-utterance / batch work stays in-process, no PCM or embedding vectors bouncing through JS on product hot paths.
 
@@ -22,7 +22,7 @@
 |-------|---------|
 | Shared C++ `SpeakerEmbeddingRunner` / `ManagerCore` | **Not** the bottleneck. Diarization already uses the same core **without** JS between embed and cluster — still the target pattern for compute. |
 | C++ registry weight sharing | **Win** (fewer ONNX loads). Orthogonal to transport cost. |
-| TurboModule `number[]` embeddings + JS live drain | **Was** the real cost on SID; Findings 1–5 closed product hot paths. Residuals: enroll, low-level extract, diarization post-result JS materialization, lifetime/mutex parity. |
+| TurboModule `number[]` embeddings + JS live drain | **Was** the real cost on SID; Findings 1–5 closed product hot paths. Residuals: enroll, low-level extract, diarization post-result JS materialization. |
 
 **Hop count from JS did not increase** at the shared-Runner migration. Findings 1–5 fixed live orchestration, range extract, combined identify/verify, Android embedding unbox, and Android JNI lock narrowing.
 
@@ -48,7 +48,7 @@ Diarization offline compute
 | Diarization result → offline segments | **Gap** — JS live-append materialize loop |
 | Android SID JNI lifetime | **Met** (`shared_ptr` + narrow map lock) |
 | Diarization JNI lifetime | **Met** (`shared_ptr` + narrow map lock; Finding 6) |
-| iOS SID TM mutex | **Gap** — still coarse on TurboModule paths (Finding 7) |
+| iOS SID TM mutex | **Met** (`shared_ptr` + narrow map lock; Finding 7) |
 | Internal docs / cursor rule | **Met** (Finding 10) |
 
 ---
@@ -170,7 +170,7 @@ Zero-length range → `{ ok: false }` without ONNX. Android compute JNI uses `Ne
 
 ## 5. Finding — Coarse Android JNI mutex (LOW–MEDIUM) — **DONE**
 
-**Status:** Implemented. Android `g_speaker_embedding_mutex` is now registry lookup/mutate only. Extractor/manager maps hold `shared_ptr` so unload during compute cannot UAF. Hot paths (`nativeComputeEmbedding`, manager add/remove/search/verify/contains/numSpeakers/allSpeakers) copy the pointer out and run outside the global lock. `SpeakerEmbeddingManagerWrapper` has a per-manager mutex around C-API ops. Runner `compute_mutex` unchanged. iOS TurboModule coarse bridge mutex remains open as Finding 7 (iOS live already unlocks after pinning).
+**Status:** Implemented. Android `g_speaker_embedding_mutex` is now registry lookup/mutate only. Extractor/manager maps hold `shared_ptr` so unload during compute cannot UAF. Hot paths (`nativeComputeEmbedding`, manager add/remove/search/verify/contains/numSpeakers/allSpeakers) copy the pointer out and run outside the global lock. `SpeakerEmbeddingManagerWrapper` has a per-manager mutex around C-API ops. Runner `compute_mutex` unchanged. iOS TurboModule mutex narrowed in Finding 7.
 
 ### Problem (historical)
 
@@ -202,21 +202,21 @@ Diarization already unlocked `g_diarization_mutex` before `processMonoSamples` (
 
 ---
 
-## 7. Finding — iOS SID TurboModule mutex still coarse (LOW–MEDIUM)
+## 7. Finding — iOS SID TurboModule mutex still coarse (LOW–MEDIUM) — **DONE**
 
-### Problem
+**Status:** Implemented. iOS `g_speaker_embedding_extractors` / `g_speaker_embedding_managers` hold `shared_ptr` wrappers (State shells removed). Hot paths (`computeSpeakerEmbeddingOffline`, `identifySpeakerOffline`, `verifySpeakerOffline`, manager add/remove/search/verify/contains/numSpeakers/allSpeakers) use `LookupExtractor` / `LookupManager` then run outside the map lock. Init/create replace map entries; unload/destroy move-out. SID live worker holds `shared_ptr` extractor + manager (no raw `.get()` pins). Matches Android Finding 5.
 
-iOS `g_speaker_embedding_mutex` (TurboModule path in `SherpaOnnx+SpeakerEmbeddingInference.mm`) still spans compute / identify / verify / manager C-API calls. iOS **live** already pins pointers then works unlocked. Android Finding 5 already narrowed the JNI map lock.
+### Problem (historical)
 
-### Direction
+iOS `g_speaker_embedding_mutex` (TurboModule path in `SherpaOnnx+SpeakerEmbeddingInference.mm`) spanned compute / identify / verify / manager C-API calls. Live unlocked after pinning but used raw pointers.
 
-Mirror Finding 5 on iOS TM:
+### What shipped
 
-- Keep map lock for init / create / unload / destroy / short lookup.
-- Copy `shared_ptr` (or equivalent strong refs) out; run `computeFromSamples` / manager ops outside the global bridge mutex.
-- Rely on Runner `compute_mutex` + existing ManagerWrapper per-manager mutex.
+- Flattened maps to `shared_ptr` wrappers + Lookup helpers
+- Map lock: init / create / unload / destroy / short lookup only
+- Live worker strong refs via `shared_ptr`
 
-**Priority:** Low–medium. Small once Finding 5 patterns are copied. Independent of enroll / diarization segment write.
+**Priority:** Low–medium — **met**.
 
 ---
 
@@ -274,7 +274,7 @@ Public `diarize(audioIn, segmentsOut)` shape can stay; internal swap only.
 
 ## 10. Finding — Stale foundation / cursor docs vs shipped diarization (LOW) — **DONE**
 
-**Status:** Implemented. Foundation status/phase table, `.cursor/rules/separation-diarization-pre-1.0.mdc`, and SID offline cross-links describe offline diarization as **shipped**. Backlog points at §7–§9 / live diarization / pyannote evaluator — not greenfield native.
+**Status:** Implemented. Foundation status/phase table, `.cursor/rules/separation-diarization-pre-1.0.mdc`, and SID offline cross-links describe offline diarization as **shipped**. Backlog points at §8–§9 / live diarization / pyannote evaluator — not greenfield native.
 
 ### Problem (historical)
 
@@ -295,7 +295,7 @@ Offline diarization was shipped, but some internal docs still read as Phase-2-pl
 
 ## 11. Suggested implementation order
 
-Findings 1–5, §6, and §10 are **done**. Recommended order for the remaining open follow-ups (safety before larger API moves):
+Findings 1–5, §6–§7, and §10 are **done**. Recommended order for the remaining open follow-ups (safety before larger API moves):
 
 | Step | Finding | Effort | Impact | Status | Why this order |
 |------|---------|--------|--------|--------|----------------|
@@ -306,12 +306,12 @@ Findings 1–5, §6, and §10 are **done**. Recommended order for the remaining 
 | E | §5 Android JNI lock narrowing | Small | Contention / lifetime hygiene | **Done** | — |
 | F | §10 docs sync (foundation + cursor rule) | Small | Stops stale “diarization missing” planning | **Done** | Cheap; clear mental model before more work |
 | G | §6 diarization `shared_ptr` lifetime | Small–medium | Unload-during-process safety | **Done** | Same pattern as §5; prerequisite for §9 |
-| H | §7 iOS SID TM mutex parity | Small | Contention hygiene parity with Android | Open | Independent of enroll / segment write |
+| H | §7 iOS SID TM mutex parity | Small | Contention hygiene parity with Android | **Done** | Independent of enroll / segment write |
 | I | §8 combined enroll (no JS embedding add) | Medium | Closes last SID product embedding gap | Open | Builds on stable locks (§5/§7) |
 | J | §9 diarization native `segmentsOut` write | Medium–large | Drops JS materialize loop | Open | After §6 lifetime |
 | K | Optional embedding JSI | Small–medium | Faster raw-vector apps only | Deferred | Only if enroll/low-level still hot in profiles |
 
-**Recommendation summary:** next `H → I → J` (iOS mutex → enroll TM → diarization segment write). Defer embedding JSI unless profiling shows enroll/low-level extract as a real cost.
+**Recommendation summary:** next `I → J` (enroll TM → diarization segment write). Defer embedding JSI unless profiling shows enroll/low-level extract as a real cost.
 
 Draft an **explicit implementation plan per open finding** in that order (one finding at a time), same style as Findings 1–5.
 
@@ -341,13 +341,13 @@ Success criteria for §5 (met): Android JNI does not hold `g_speaker_embedding_m
 
 Success criteria for §6 (met): diarization process holds a `shared_ptr` session; unload during process does not UAF.
 
-Success criteria for §7: iOS TM compute/identify/verify/manager ops do not hold `g_speaker_embedding_mutex` across ONNX / C-API work.
+Success criteria for §7 (met): iOS TM compute/identify/verify/manager ops do not hold `g_speaker_embedding_mutex` across ONNX / C-API work.
 
 Success criteria for §8: `enroll` / `enrollOfflineSegments` do not call separate compute + `manager.add` with embedding `number[]` on the product path (mirror policy documented).
 
 Success criteria for §9: `diarize` fills `segmentsOut` natively (no JS per-segment materialize loop).
 
-Success criteria for §10 (met): foundation status + cursor rule describe diarization offline as shipped; backlog points at §7–§9 / live diarization — not greenfield native.
+Success criteria for §10 (met): foundation status + cursor rule describe diarization offline as shipped; backlog points at §8–§9 / live diarization — not greenfield native.
 
 ---
 

--- a/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
+++ b/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
@@ -1,6 +1,6 @@
 # Speaker embedding / SID: bridge roundtrip bottlenecks (future work)
 
-**Status:** Findings 1–5, **§6–§7**, and **§10** **done**. Open follow-ups: **§8–§9** (enroll without JS embeddings, diarization native segment write). Optional later: embedding JSI.  
+**Status:** Findings 1–5, **§6–§8**, and **§10** **done**. Open follow-up: **§9** (diarization native segment write). Optional later: embedding JSI.  
 **Scope:** TurboModule / JS orchestration costs on the **speaker-embedding**, **speaker-identification**, and **diarization** paths after the shared C++ `SpeakerEmbeddingRunner` / `SpeakerEmbeddingManager` migration.  
 **Motivation:** Align SID (and keep diarization) with the live-overload target architecture already used by STT/TTS (and punctuation / enhancement / separation): **one native start**, per-utterance / batch work stays in-process, no PCM or embedding vectors bouncing through JS on product hot paths.
 
@@ -22,7 +22,7 @@
 |-------|---------|
 | Shared C++ `SpeakerEmbeddingRunner` / `ManagerCore` | **Not** the bottleneck. Diarization already uses the same core **without** JS between embed and cluster — still the target pattern for compute. |
 | C++ registry weight sharing | **Win** (fewer ONNX loads). Orthogonal to transport cost. |
-| TurboModule `number[]` embeddings + JS live drain | **Was** the real cost on SID; Findings 1–5 closed product hot paths. Residuals: enroll, low-level extract, diarization post-result JS materialization. |
+| TurboModule `number[]` embeddings + JS live drain | **Was** the real cost on SID; Findings 1–5 and §8 closed product hot paths. Residuals: low-level extract, diarization post-result JS materialization. |
 
 **Hop count from JS did not increase** at the shared-Runner migration. Findings 1–5 fixed live orchestration, range extract, combined identify/verify, Android embedding unbox, and Android JNI lock narrowing.
 
@@ -43,7 +43,7 @@ Diarization offline compute
 | Path | vs target |
 |------|-----------|
 | SID live / identify / verify | **Met** (no PCM/embedding through JS) |
-| SID enroll | **Partial** — no JS PCM; embeddings still cross JS for `manager.add` + mirror |
+| SID enroll | **Met** (`enrollSpeakerOffline` compute+add; mirror from returned flats) |
 | Diarization compute→cluster | **Met** (in-process) |
 | Diarization result → offline segments | **Gap** — JS live-append materialize loop |
 | Android SID JNI lifetime | **Met** (`shared_ptr` + narrow map lock) |
@@ -140,7 +140,7 @@ Empty `name` = no match. Range rules match Finding 2. Combined `verifySpeakerOff
 
 ## 4. Finding — Embedding transport as `number[]` / boxed floats (MEDIUM) — **DONE**
 
-**Status:** Implemented (path D). Offline `verify` / `verifyOfflineSegments` call `verifySpeakerOffline` (compute + manager verify in one TM → `{ ok }`). Android `nativeComputeEmbedding` returns `jfloatArray` instead of boxed `ArrayList&lt;Float&gt;`. **No** embedding JSI in this finding; enroll and low-level extract still use TurboModule `number[]` (see Finding 8). Optional later: JSI `ArrayBuffer` if apps need faster raw-vector pull.
+**Status:** Implemented (path D). Offline `verify` / `verifyOfflineSegments` call `verifySpeakerOffline` (compute + manager verify in one TM → `{ ok }`). Android `nativeComputeEmbedding` returns `jfloatArray` instead of boxed `ArrayList&lt;Float&gt;`. **No** embedding JSI in this finding; enroll closed later in Finding 8; low-level extract still uses TurboModule `number[]`. Optional later: JSI `ArrayBuffer` if apps need faster raw-vector pull.
 
 ### Problem (historical)
 
@@ -220,39 +220,21 @@ iOS `g_speaker_embedding_mutex` (TurboModule path in `SherpaOnnx+SpeakerEmbeddin
 
 ---
 
-## 8. Finding — SID enroll still marshals embeddings through JS (MEDIUM)
+## 8. Finding — SID enroll still marshals embeddings through JS (MEDIUM) — **DONE**
 
-### Problem
+**Status:** Implemented. Product `enroll` / `enrollOfflineSegments` call `enrollSpeakerOffline` (batch buffer ids + optional per-item ranges → compute → `manager.add` in one TM). Returns flattened embeddings once for the JS enrollment mirror. Low-level `compute` / `manager.add` unchanged for apps / `importEnrollments`.
 
-`enroll` / `enrollOfflineSegments` still:
+### Problem (historical)
 
-1. `computeSpeakerEmbeddingOffline` → embedding `number[]` → JS `Float32Array`
-2. Flatten → `speakerEmbeddingManagerAdd` with `number[]`
+`enroll` / `enrollOfflineSegments` did `computeSpeakerEmbeddingOffline` → embedding `number[]` → JS → `speakerEmbeddingManagerAdd`.
 
-No PCM through JS (Finding 2), but the last product path that **needs** vectors for `manager.add` + the JS enrollment mirror still crosses the bridge twice per utterance. Infrequent vs live label, but still the only SID product embedding gap after Findings 3–4.
+### What shipped
 
-### Direction
+- Spec + Android Helper/Module + iOS Inference: `enrollSpeakerOffline`
+- Multi-buffer / multi-span same-name enroll is one native add (`count > 1`)
+- Unit tests expect combined TM only on enroll paths
 
-Combined native enroll API, e.g.:
-
-```ts
-enrollSpeakerOffline(
-  instanceId: string,
-  managerId: string,
-  name: string,
-  audioBufferId: string,
-  startSample?: number | null,
-  endSample?: number | null
-): Promise<{ ok: boolean; embedding?: number[] }>
-```
-
-Or multi-buffer variant for `enroll(name, buffers[])` / per-span enroll.
-
-- Native: slice/full → compute → `manager.add` in-process → `{ ok }`.
-- If the JS enrollment mirror must stay: return embedding once (or a compact transfer) **only for mirror**, not a second add roundtrip — or extend native export later ([speaker-embedding-manager-upstream-export-import.md](speaker-embedding-manager-upstream-export-import.md)).
-- Keep low-level `compute` / `manager.add` for apps that need raw vectors.
-
-**Priority:** Medium. Medium effort. After lifetime/mutex hygiene (§6–§7) so enroll hot path lands on stable locks.
+**Priority:** Medium — **met**.
 
 ---
 
@@ -274,7 +256,7 @@ Public `diarize(audioIn, segmentsOut)` shape can stay; internal swap only.
 
 ## 10. Finding — Stale foundation / cursor docs vs shipped diarization (LOW) — **DONE**
 
-**Status:** Implemented. Foundation status/phase table, `.cursor/rules/separation-diarization-pre-1.0.mdc`, and SID offline cross-links describe offline diarization as **shipped**. Backlog points at §8–§9 / live diarization / pyannote evaluator — not greenfield native.
+**Status:** Implemented. Foundation status/phase table, `.cursor/rules/separation-diarization-pre-1.0.mdc`, and SID offline cross-links describe offline diarization as **shipped**. Backlog points at §9 / live diarization / pyannote evaluator — not greenfield native.
 
 ### Problem (historical)
 
@@ -295,7 +277,7 @@ Offline diarization was shipped, but some internal docs still read as Phase-2-pl
 
 ## 11. Suggested implementation order
 
-Findings 1–5, §6–§7, and §10 are **done**. Recommended order for the remaining open follow-ups (safety before larger API moves):
+Findings 1–5, §6–§8, and §10 are **done**. Remaining open follow-up:
 
 | Step | Finding | Effort | Impact | Status | Why this order |
 |------|---------|--------|--------|--------|----------------|
@@ -307,11 +289,11 @@ Findings 1–5, §6–§7, and §10 are **done**. Recommended order for the rema
 | F | §10 docs sync (foundation + cursor rule) | Small | Stops stale “diarization missing” planning | **Done** | Cheap; clear mental model before more work |
 | G | §6 diarization `shared_ptr` lifetime | Small–medium | Unload-during-process safety | **Done** | Same pattern as §5; prerequisite for §9 |
 | H | §7 iOS SID TM mutex parity | Small | Contention hygiene parity with Android | **Done** | Independent of enroll / segment write |
-| I | §8 combined enroll (no JS embedding add) | Medium | Closes last SID product embedding gap | Open | Builds on stable locks (§5/§7) |
+| I | §8 combined enroll (no JS embedding add) | Medium | Closes last SID product embedding gap | **Done** | Builds on stable locks (§5/§7) |
 | J | §9 diarization native `segmentsOut` write | Medium–large | Drops JS materialize loop | Open | After §6 lifetime |
-| K | Optional embedding JSI | Small–medium | Faster raw-vector apps only | Deferred | Only if enroll/low-level still hot in profiles |
+| K | Optional embedding JSI | Small–medium | Faster raw-vector apps only | Deferred | Only if low-level extract still hot in profiles |
 
-**Recommendation summary:** next `I → J` (enroll TM → diarization segment write). Defer embedding JSI unless profiling shows enroll/low-level extract as a real cost.
+**Recommendation summary:** next **J** (diarization native `segmentsOut` write). Defer embedding JSI unless profiling shows low-level extract as a real cost.
 
 Draft an **explicit implementation plan per open finding** in that order (one finding at a time), same style as Findings 1–5.
 
@@ -343,11 +325,11 @@ Success criteria for §6 (met): diarization process holds a `shared_ptr` session
 
 Success criteria for §7 (met): iOS TM compute/identify/verify/manager ops do not hold `g_speaker_embedding_mutex` across ONNX / C-API work.
 
-Success criteria for §8: `enroll` / `enrollOfflineSegments` do not call separate compute + `manager.add` with embedding `number[]` on the product path (mirror policy documented).
+Success criteria for §8 (met): `enroll` / `enrollOfflineSegments` do not call separate compute + `manager.add` with embedding `number[]` on the product path (mirror policy documented).
 
 Success criteria for §9: `diarize` fills `segmentsOut` natively (no JS per-segment materialize loop).
 
-Success criteria for §10 (met): foundation status + cursor rule describe diarization offline as shipped; backlog points at §8–§9 / live diarization — not greenfield native.
+Success criteria for §10 (met): foundation status + cursor rule describe diarization offline as shipped; backlog points at §9 / live diarization — not greenfield native.
 
 ---
 

--- a/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
+++ b/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
@@ -1,6 +1,6 @@
 # Speaker embedding / SID: bridge roundtrip bottlenecks (future work)
 
-**Status:** Findings 1–4 **done**. Finding 5 remains open.  
+**Status:** Findings 1–5 **done**. Optional follow-ups: iOS TM mutex narrowing (same pattern), embedding JSI for raw-vector apps.  
 **Scope:** TurboModule / JS orchestration costs on the **speaker-embedding** and **speaker-identification** paths after the shared C++ `SpeakerEmbeddingRunner` / `SpeakerEmbeddingManager` migration.  
 **Motivation:** Align SID with the live-overload target architecture already used by STT/TTS (and punctuation / enhancement / separation): **one native start**, per-utterance work stays in-process, no PCM or embedding vectors bouncing through JS.
 
@@ -22,7 +22,7 @@
 | C++ registry weight sharing | **Win** (fewer ONNX loads). Orthogonal to transport cost. |
 | TurboModule `number[]` embeddings + JS live drain | **Real** cost — pre-dates the migration in shape; migration replaced only the last inference hop (Kotlin AAR / iOS cxx-API → our JNI/C++). |
 
-**Hop count from JS did not increase.** Marshalling quality (e.g. Android `ArrayList<Float>` boxing) and live orchestration remain the issues to fix.
+**Hop count from JS did not increase.** Findings 1–5 address live orchestration, range extract, combined identify/verify, Android embedding unbox, and JNI lock narrowing. Optional later: embedding JSI; iOS TM mutex parity.
 
 ```text
 STT / TTS / Punctuation / Enhancement / Separation / SID live
@@ -148,21 +148,19 @@ Zero-length range → `{ ok: false }` without ONNX. Android compute JNI uses `Ne
 
 ---
 
-## 5. Finding — Coarse Android JNI mutex (LOW–MEDIUM)
+## 5. Finding — Coarse Android JNI mutex (LOW–MEDIUM) — **DONE**
 
-### Problem
+**Status:** Implemented. Android `g_speaker_embedding_mutex` is now registry lookup/mutate only. Extractor/manager maps hold `shared_ptr` so unload during compute cannot UAF. Hot paths (`nativeComputeEmbedding`, manager add/remove/search/verify/contains/numSpeakers/allSpeakers) copy the pointer out and run outside the global lock. `SpeakerEmbeddingManagerWrapper` has a per-manager mutex around C-API ops. Runner `compute_mutex` unchanged. iOS TurboModule coarse bridge mutex is an optional parity follow-up (iOS live already unlocks after pinning).
 
-`android/.../jni/speaker-embedding/sherpa-onnx-speaker-embedding-jni.cpp` uses a process-wide `g_speaker_embedding_mutex` around extractor/manager operations. The shared Runner already has a **per-extractor** `compute_mutex`. The global lock serializes **all** SID instances and can contend with other JNI entry points that touch the same maps under concurrent SID + diarization / multi-session use.
+### Problem (historical)
 
-This is contention risk more than copy cost; listed for completeness after the transport findings.
+`android/.../jni/speaker-embedding/sherpa-onnx-speaker-embedding-jni.cpp` used a process-wide `g_speaker_embedding_mutex` around extractor/manager operations, including ONNX compute and C-API search/verify. That serialized **all** SID instances even though Runner already has a per-extractor `compute_mutex`.
 
-### Direction
+### What shipped
 
-- Narrow the global lock to **registry map** mutate/lookup only.
-- Rely on Runner `compute_mutex` (and per-manager locks) for inference.
-- Do not hold the global lock across ONNX `Compute` / C-API search.
-
-**Priority:** After or alongside native live / range work if profiling shows lock wait; not the first knob to turn for PCM roundtrips.
+- Map lock: init / create / unload / destroy / shutdown only (plus short lookup)
+- Inference: Runner `compute_mutex` + ManagerWrapper mutex
+- Lifetime: `shared_ptr` maps; re-init replaces the map entry rather than `release()` in place
 
 ---
 
@@ -174,7 +172,7 @@ This is contention risk more than copy cost; listed for completeness after the t
 | A | §2 native extract-by-range | Small | Removes JS PCM staging for offline/range | **Done** |
 | B | §3 combined identify (or in-worker search) | Small–medium | Drops embedding roundtrip on identify APIs that still cross JS | **Done** |
 | D | §4 combined verify + Android unbox (path D) | Small–medium | Residual verify path + JNI boxing hygiene | **Done** |
-| E | §5 JNI lock narrowing | Small | Contention hygiene | Open |
+| E | §5 JNI lock narrowing | Small | Contention hygiene | **Done** |
 
 ---
 
@@ -195,6 +193,8 @@ Success criteria for §2 (met): ranged `extractFromOfflineAudio` calls `computeS
 Success criteria for §3 (met): offline `identify` / `labelOfflineSegments` use `identifySpeakerOffline` only (no compute→JS→search); empty name maps to `null` in SID TS.
 
 Success criteria for §4 path D (met): offline `verify` / `verifyOfflineSegments` use `verifySpeakerOffline` only; Android compute returns `jfloatArray` (no `ArrayList&lt;Float&gt;` boxing). JSI embedding transport remains optional later.
+
+Success criteria for §5 (met): Android JNI does not hold `g_speaker_embedding_mutex` across ONNX compute or manager C-API ops; maps use `shared_ptr`; ManagerWrapper serializes C-API calls.
 
 ---
 ## 8. Non-goals

--- a/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
+++ b/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
@@ -1,6 +1,6 @@
 # Speaker embedding / SID: bridge roundtrip bottlenecks (future work)
 
-**Status:** Findings 1–5, **§6–§8**, and **§10** **done**. Open follow-up: **§9** (diarization native segment write). Optional later: embedding JSI.  
+**Status:** Findings 1–5, **§6–§10** **done**. Optional later: embedding JSI.  
 **Scope:** TurboModule / JS orchestration costs on the **speaker-embedding**, **speaker-identification**, and **diarization** paths after the shared C++ `SpeakerEmbeddingRunner` / `SpeakerEmbeddingManager` migration.  
 **Motivation:** Align SID (and keep diarization) with the live-overload target architecture already used by STT/TTS (and punctuation / enhancement / separation): **one native start**, per-utterance / batch work stays in-process, no PCM or embedding vectors bouncing through JS on product hot paths.
 
@@ -22,7 +22,7 @@
 |-------|---------|
 | Shared C++ `SpeakerEmbeddingRunner` / `ManagerCore` | **Not** the bottleneck. Diarization already uses the same core **without** JS between embed and cluster — still the target pattern for compute. |
 | C++ registry weight sharing | **Win** (fewer ONNX loads). Orthogonal to transport cost. |
-| TurboModule `number[]` embeddings + JS live drain | **Was** the real cost on SID; Findings 1–5 and §8 closed product hot paths. Residuals: low-level extract, diarization post-result JS materialization. |
+| TurboModule `number[]` embeddings + JS live drain | **Was** the real cost on SID; Findings 1–5 and §8–§9 closed product hot paths. Residual: low-level extract (optional embedding JSI). |
 
 **Hop count from JS did not increase** at the shared-Runner migration. Findings 1–5 fixed live orchestration, range extract, combined identify/verify, Android embedding unbox, and Android JNI lock narrowing.
 
@@ -32,10 +32,10 @@ STT / TTS / Punctuation / Enhancement / Separation / SID live
   Native worker: read seg_live_* + PCM → infer → write outputs
   ✅ Target architecture (SID live met)
 
-Diarization offline compute
-  JS: buffer ids → diarizeOffline once
-  Native: PCM → embed → cluster → timeline
-  ✅ Compute path met; segment materialization still JS (Finding 9)
+Diarization offline
+  JS: buffer ids → diarizeOffline once (audioIn + segmentsOut)
+  Native: PCM → embed → cluster → populate seg_off_*
+  ✅ Target architecture met (Finding 9)
 ```
 
 ### Post–Finding 1–5 audit snapshot
@@ -45,7 +45,7 @@ Diarization offline compute
 | SID live / identify / verify | **Met** (no PCM/embedding through JS) |
 | SID enroll | **Met** (`enrollSpeakerOffline` compute+add; mirror from returned flats) |
 | Diarization compute→cluster | **Met** (in-process) |
-| Diarization result → offline segments | **Gap** — JS live-append materialize loop |
+| Diarization result → offline segments | **Met** (native `segmentsOut` populate; Finding 9) |
 | Android SID JNI lifetime | **Met** (`shared_ptr` + narrow map lock) |
 | Diarization JNI lifetime | **Met** (`shared_ptr` + narrow map lock; Finding 6) |
 | iOS SID TM mutex | **Met** (`shared_ptr` + narrow map lock; Finding 7) |
@@ -238,25 +238,27 @@ iOS `g_speaker_embedding_mutex` (TurboModule path in `SherpaOnnx+SpeakerEmbeddin
 
 ---
 
-## 9. Finding — Diarization result materialization still in JS (MEDIUM)
+## 9. Finding — Diarization result materialization still in JS (MEDIUM) — **DONE**
 
-### Problem
+**Status:** Implemented. Product `diarizeOffline` takes `segmentsOutBufferId`, builds `kind: 'diarization'` records after `processMonoSamples`, and populates the empty offline segment buffer in-process (Android `OfflineSegmentEntry.populate` / iOS `g_seg_offline`). JS no longer live-appends the timeline. Return carries `segmentCount` (timeline array omitted on the write path). `reclusterDiarization` unchanged (cache-only).
 
-`diarizeOffline` returns a timeline `{ start, end, speaker }[]`. JS then materializes into the offline segment buffer via a live-append → finalize → populate loop (`materializeSegmentsIntoOfflineBuffer` in `src/diarization/index.ts`). Compute→cluster never left C++ (correct), but the **result write** is many small TurboModule hops — same class of “orchestration in JS” as pre-Finding-1 SID live, without PCM/embedding cost.
+### Problem (historical)
 
-### Direction
+`diarizeOffline` returned a timeline `{ start, end, speaker }[]`. JS then materialized via live-append → finalize → populate (`materializeSegmentsIntoOfflineBuffer`).
 
-Native write into the empty `segmentsOut` offline segment buffer (or one TM that accepts `audioIn` + `segmentsOut` and fills diarization segments with `kind: 'diarization'`), so JS only awaits completion / counts.
+### What shipped
 
-Public `diarize(audioIn, segmentsOut)` shape can stay; internal swap only.
+- Spec + Android Helper/Module + iOS Offline.mm: `segmentsOut` write
+- TS `diarize` passes `segmentOut` into TM; materialize helper removed
+- Unit tests assert no staging append/populate on success
 
-**Priority:** Medium. Medium–large effort. After Finding 6 (lifetime) so process + write share safe session ownership.
+**Priority:** Medium — **met**.
 
 ---
 
 ## 10. Finding — Stale foundation / cursor docs vs shipped diarization (LOW) — **DONE**
 
-**Status:** Implemented. Foundation status/phase table, `.cursor/rules/separation-diarization-pre-1.0.mdc`, and SID offline cross-links describe offline diarization as **shipped**. Backlog points at §9 / live diarization / pyannote evaluator — not greenfield native.
+**Status:** Implemented. Foundation status/phase table, `.cursor/rules/separation-diarization-pre-1.0.mdc`, and SID offline cross-links describe offline diarization as **shipped**. Backlog points at live diarization / pyannote evaluator / optional embedding JSI — not greenfield native.
 
 ### Problem (historical)
 
@@ -277,7 +279,7 @@ Offline diarization was shipped, but some internal docs still read as Phase-2-pl
 
 ## 11. Suggested implementation order
 
-Findings 1–5, §6–§8, and §10 are **done**. Remaining open follow-up:
+Findings 1–5 and §6–§10 are **done**. Remaining optional work:
 
 | Step | Finding | Effort | Impact | Status | Why this order |
 |------|---------|--------|--------|--------|----------------|
@@ -290,10 +292,10 @@ Findings 1–5, §6–§8, and §10 are **done**. Remaining open follow-up:
 | G | §6 diarization `shared_ptr` lifetime | Small–medium | Unload-during-process safety | **Done** | Same pattern as §5; prerequisite for §9 |
 | H | §7 iOS SID TM mutex parity | Small | Contention hygiene parity with Android | **Done** | Independent of enroll / segment write |
 | I | §8 combined enroll (no JS embedding add) | Medium | Closes last SID product embedding gap | **Done** | Builds on stable locks (§5/§7) |
-| J | §9 diarization native `segmentsOut` write | Medium–large | Drops JS materialize loop | Open | After §6 lifetime |
+| J | §9 diarization native `segmentsOut` write | Medium–large | Drops JS materialize loop | **Done** | After §6 lifetime |
 | K | Optional embedding JSI | Small–medium | Faster raw-vector apps only | Deferred | Only if low-level extract still hot in profiles |
 
-**Recommendation summary:** next **J** (diarization native `segmentsOut` write). Defer embedding JSI unless profiling shows low-level extract as a real cost.
+**Recommendation summary:** bridge roundtrip findings complete. Defer embedding JSI unless profiling shows low-level extract as a real cost.
 
 Draft an **explicit implementation plan per open finding** in that order (one finding at a time), same style as Findings 1–5.
 
@@ -327,9 +329,9 @@ Success criteria for §7 (met): iOS TM compute/identify/verify/manager ops do no
 
 Success criteria for §8 (met): `enroll` / `enrollOfflineSegments` do not call separate compute + `manager.add` with embedding `number[]` on the product path (mirror policy documented).
 
-Success criteria for §9: `diarize` fills `segmentsOut` natively (no JS per-segment materialize loop).
+Success criteria for §9 (met): `diarize` fills `segmentsOut` natively (no JS per-segment materialize loop).
 
-Success criteria for §10 (met): foundation status + cursor rule describe diarization offline as shipped; backlog points at §9 / live diarization — not greenfield native.
+Success criteria for §10 (met): foundation status + cursor rule describe diarization offline as shipped; backlog points at live diarization / optional embedding JSI — not greenfield native.
 
 ---
 

--- a/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
+++ b/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
@@ -1,6 +1,6 @@
 # Speaker embedding / SID: bridge roundtrip bottlenecks (future work)
 
-**Status:** Findings 1–2 **done**. Findings 3–5 remain open.  
+**Status:** Findings 1–3 **done**. Findings 4–5 remain open.  
 **Scope:** TurboModule / JS orchestration costs on the **speaker-embedding** and **speaker-identification** paths after the shared C++ `SpeakerEmbeddingRunner` / `SpeakerEmbeddingManager` migration.  
 **Motivation:** Align SID with the live-overload target architecture already used by STT/TTS (and punctuation / enhancement / separation): **one native start**, per-utterance work stays in-process, no PCM or embedding vectors bouncing through JS.
 
@@ -88,20 +88,20 @@ Half-open `[start, end)`; both omitted = full buffer; exactly one set = reject; 
 
 ---
 
-## 3. Finding — Separate extract + search TurboModule calls (MEDIUM)
+## 3. Finding — Separate extract + search TurboModule calls (MEDIUM) — **DONE**
 
-### Problem
+**Status:** Implemented. Offline `identify` / `labelOfflineSegments` call `identifySpeakerOffline` (one TurboModule: native slice/full → compute → manager search → `{ name }`). Embeddings no longer round-trip through JS on those paths. Low-level `computeSpeakerEmbeddingOffline` / `speakerEmbeddingManagerSearch` remain for enroll and apps that need raw vectors. Live SID already searches in-process (Finding 1).
 
-Every identify does:
+### Problem (historical)
+
+Every identify did:
 
 1. Extract → embedding marshalled to JS (`number[]` → `Float32Array`)
 2. Search → embedding marshalled back to native (`Float32Array` → `number[]` → JNI/`NSArray`)
 
 Two async bridges, two marshallings, and (on Android) the global JNI lock twice. Diarization never leaves C++ between compute and cluster logic.
 
-### Direction
-
-Combined native identify APIs, e.g.:
+### What shipped
 
 ```ts
 identifySpeakerOffline(
@@ -109,14 +109,12 @@ identifySpeakerOffline(
   managerId: string,
   audioBufferId: string,
   threshold: number,
-  startSample?: number,
-  endSample?: number
+  startSample?: number | null,
+  endSample?: number | null
 ): Promise<{ name: string }>
 ```
 
-Keep low-level `compute` / `search` for apps that need raw vectors; hot path (SID label) should not require them.
-
-**Priority:** Medium alone; **high** when bundled with §1 or §2 (native worker or range extract can call Manager in-process without a public combined TM if the worker owns both IDs).
+Empty `name` = no match. Range rules match Finding 2. Combined `verifySpeakerOffline` is still open (verify path unchanged).
 
 ---
 
@@ -166,7 +164,7 @@ This is contention risk more than copy cost; listed for completeness after the t
 |------|---------|--------|--------|--------|
 | C | §1 native SID live pipeline | Medium–large | Matches STT/TTS target architecture | **Done** |
 | A | §2 native extract-by-range | Small | Removes JS PCM staging for offline/range | **Done** |
-| B | §3 combined identify (or in-worker search) | Small–medium | Drops embedding roundtrip on identify APIs that still cross JS | Open |
+| B | §3 combined identify (or in-worker search) | Small–medium | Drops embedding roundtrip on identify APIs that still cross JS | **Done** |
 | D | §4 JSI / unbox embeddings | Small–medium | Residual path for apps that still pull vectors | Open |
 | E | §5 JNI lock narrowing | Small | Contention hygiene | Open |
 
@@ -185,6 +183,8 @@ Instrument with a stable tag (e.g. `[SherpaOnnx:sid-live]` / `[SherpaOnnx:sid-br
 Success criteria for §1 (met): **no** PCM `Float32Array` in JS on the live label hot path; one `startSpeakerIdentificationOfflineLivePipeline` call per session; embedding vectors stay native unless the app calls low-level extract.
 
 Success criteria for §2 (met): ranged `extractFromOfflineAudio` calls `computeSpeakerEmbeddingOffline(..., start, end)` with **no** JSI slice / temp offline buffer.
+
+Success criteria for §3 (met): offline `identify` / `labelOfflineSegments` use `identifySpeakerOffline` only (no compute→JS→search); empty name maps to `null` in SID TS.
 
 ---
 ## 8. Non-goals

--- a/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
+++ b/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
@@ -1,6 +1,6 @@
 # Speaker embedding / SID: bridge roundtrip bottlenecks (future work)
 
-**Status:** Finding 1 (native SID live) **done**. Findings 2–5 remain open.  
+**Status:** Findings 1–2 **done**. Findings 3–5 remain open.  
 **Scope:** TurboModule / JS orchestration costs on the **speaker-embedding** and **speaker-identification** paths after the shared C++ `SpeakerEmbeddingRunner` / `SpeakerEmbeddingManager` migration.  
 **Motivation:** Align SID with the live-overload target architecture already used by STT/TTS (and punctuation / enhancement / separation): **one native start**, per-utterance work stays in-process, no PCM or embedding vectors bouncing through JS.
 
@@ -58,38 +58,33 @@ That was a **triple PCM path** plus two embedding-related bridge calls.
 
 ---
 
-## 2. Finding — No native extract-by-range (HIGH)
+## 2. Finding — No native extract-by-range (HIGH) — **DONE**
 
-### Problem
+**Status:** Implemented. `computeSpeakerEmbeddingOffline(instanceId, bufferId, startSample?, endSample?)` reads an offline slice natively (`OfflineEntry.readSlice` / `pa_get_offline_samples_slice`). `extractFromOfflineAudio(audio, range?)` no longer stages PCM through JS.
 
-`SpeakerEmbeddingRunner` already supports `SampleRange` / ranged `Compute`. The TS engine still emulates ranges by **JS staging** on the **offline** path (`labelOfflineSegments` / `extractFromOfflineAudio` with range):
+### Problem (historical)
+
+The TS engine previously emulated ranges by **JS staging** on the offline path:
 
 ```ts
-// src/speaker-embedding/engine.ts — range path today
 getOfflineAudioBufferSamplesSlice(...)
 createOfflineAudioBufferFromSamples(...)
 computeSpeakerEmbeddingOffline(temp.bufferId)
 releasePipelineAudioBuffer(temp.bufferId)
 ```
 
-(Live labeling no longer uses this path after Finding 1.)
-
-### Direction
-
-Extend the bridge:
+### What shipped
 
 ```ts
 computeSpeakerEmbeddingOffline(
   instanceId: string,
   audioBufferId: string,
-  startSample?: number,
-  endSample?: number
-): Promise<{ embedding: number[] /* or ArrayBuffer — see §4 */ }>
+  startSample?: number | null,
+  endSample?: number | null
+): Promise<{ embedding: number[] }>
 ```
 
-Native side: read `[start, end)` from the offline/live registry (or mmap slice) and call `Runner::Compute` with ranges — **no** PCM through JS.
-
-**Priority:** High for offline label/enroll range paths.
+Half-open `[start, end)`; both omitted = full buffer; exactly one set = reject; zero-length = empty embedding without ONNX.
 
 ---
 
@@ -170,7 +165,7 @@ This is contention risk more than copy cost; listed for completeness after the t
 | Step | Finding | Effort | Impact | Status |
 |------|---------|--------|--------|--------|
 | C | §1 native SID live pipeline | Medium–large | Matches STT/TTS target architecture | **Done** |
-| A | §2 native extract-by-range | Small | Removes JS PCM staging for offline/range | Open |
+| A | §2 native extract-by-range | Small | Removes JS PCM staging for offline/range | **Done** |
 | B | §3 combined identify (or in-worker search) | Small–medium | Drops embedding roundtrip on identify APIs that still cross JS | Open |
 | D | §4 JSI / unbox embeddings | Small–medium | Residual path for apps that still pull vectors | Open |
 | E | §5 JNI lock narrowing | Small | Contention hygiene | Open |
@@ -184,10 +179,12 @@ Instrument with a stable tag (e.g. `[SherpaOnnx:sid-live]` / `[SherpaOnnx:sid-br
 | Probe | What to log |
 |-------|-------------|
 | Live span (native worker) | `startSample`, `endSample`, frame count, compute/search/append |
-| Offline range (until §2) | JSI slice ms, createOffline ms, release ms |
+| Offline range extract | native slice + compute only (no JS staging) |
 | Extract/search TM (low-level APIs) | wall ms, dim |
 
 Success criteria for §1 (met): **no** PCM `Float32Array` in JS on the live label hot path; one `startSpeakerIdentificationOfflineLivePipeline` call per session; embedding vectors stay native unless the app calls low-level extract.
+
+Success criteria for §2 (met): ranged `extractFromOfflineAudio` calls `computeSpeakerEmbeddingOffline(..., start, end)` with **no** JSI slice / temp offline buffer.
 
 ---
 ## 8. Non-goals

--- a/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
+++ b/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
@@ -1,6 +1,6 @@
 # Speaker embedding / SID: bridge roundtrip bottlenecks (future work)
 
-**Status:** Findings 1–5 and **§10** **done**. Open follow-ups: **§6–§9** (diarization lifetime, iOS mutex parity, enroll without JS embeddings, diarization native segment write). Optional later: embedding JSI.  
+**Status:** Findings 1–5, **§6**, and **§10** **done**. Open follow-ups: **§7–§9** (iOS mutex parity, enroll without JS embeddings, diarization native segment write). Optional later: embedding JSI.  
 **Scope:** TurboModule / JS orchestration costs on the **speaker-embedding**, **speaker-identification**, and **diarization** paths after the shared C++ `SpeakerEmbeddingRunner` / `SpeakerEmbeddingManager` migration.  
 **Motivation:** Align SID (and keep diarization) with the live-overload target architecture already used by STT/TTS (and punctuation / enhancement / separation): **one native start**, per-utterance / batch work stays in-process, no PCM or embedding vectors bouncing through JS on product hot paths.
 
@@ -47,7 +47,7 @@ Diarization offline compute
 | Diarization compute→cluster | **Met** (in-process) |
 | Diarization result → offline segments | **Gap** — JS live-append materialize loop |
 | Android SID JNI lifetime | **Met** (`shared_ptr` + narrow map lock) |
-| Diarization JNI lifetime | **Gap** — raw pointer after unlock (Finding 6) |
+| Diarization JNI lifetime | **Met** (`shared_ptr` + narrow map lock; Finding 6) |
 | iOS SID TM mutex | **Gap** — still coarse on TurboModule paths (Finding 7) |
 | Internal docs / cursor rule | **Met** (Finding 10) |
 
@@ -184,23 +184,21 @@ Zero-length range → `{ ok: false }` without ONNX. Android compute JNI uses `Ne
 
 ---
 
-## 6. Finding — Diarization JNI lifetime (raw pointer after unlock) (MEDIUM)
+## 6. Finding — Diarization JNI lifetime (raw pointer after unlock) (MEDIUM) — **DONE**
 
-### Problem
+**Status:** Implemented. Android `g_diarization_instances` and iOS `DiarizationBridgeState` hold `shared_ptr<DiarizationWrapper>`. Hot paths (`process` / `diarizeOffline`, `recluster`, `getClusterEmbeddings`, `cancel`) copy via `LookupDiarization` then run outside the map lock. Init replaces the map entry on success; unload cancels + move-out + erase (no in-place `release()`). Matches SID Finding 5.
 
-Diarization already unlocks `g_diarization_mutex` before `processMonoSamples` (good for cancel). The instance is held as a **raw pointer** copied under the lock. Unload / destroy while a process is running can UAF. SID Finding 5 fixed the analogous bug with `shared_ptr` map entries.
+### Problem (historical)
 
-Android: `android/.../jni/diarization/sherpa-onnx-diarization-jni.cpp`  
-iOS: same pattern under diarization bridge state.
+Diarization already unlocked `g_diarization_mutex` before `processMonoSamples` (good for cancel). The instance was held as a **raw pointer** copied under the lock. Unload / destroy while a process was running could UAF.
 
-### Direction
+### What shipped
 
-- Store diarization sessions as `shared_ptr` in the registry map.
-- Lookup → copy `shared_ptr` → unlock → `processMonoSamples` / recluster / get embeddings.
-- Unload erases the map entry only; in-flight holders keep the session alive until process finishes.
-- Re-init replaces the map entry (do not `release()` in place while others may hold the pointer).
+- Map type: `unique_ptr` → `shared_ptr`
+- `LookupDiarization` on Android JNI + iOS bridge
+- Replace-on-init; move-out unload; cancel still reaches in-flight wrapper
 
-**Priority:** Medium (correctness / concurrency hygiene). Small–medium effort. Do **before** larger diarization bridge refactors (Finding 9).
+**Priority:** Medium (correctness / concurrency hygiene). Prerequisite for Finding 9 — **met**.
 
 ---
 
@@ -276,7 +274,7 @@ Public `diarize(audioIn, segmentsOut)` shape can stay; internal swap only.
 
 ## 10. Finding — Stale foundation / cursor docs vs shipped diarization (LOW) — **DONE**
 
-**Status:** Implemented. Foundation status/phase table, `.cursor/rules/separation-diarization-pre-1.0.mdc`, and SID offline cross-links describe offline diarization as **shipped**. Backlog points at §6–§9 / live diarization / pyannote evaluator — not greenfield native.
+**Status:** Implemented. Foundation status/phase table, `.cursor/rules/separation-diarization-pre-1.0.mdc`, and SID offline cross-links describe offline diarization as **shipped**. Backlog points at §7–§9 / live diarization / pyannote evaluator — not greenfield native.
 
 ### Problem (historical)
 
@@ -297,7 +295,7 @@ Offline diarization was shipped, but some internal docs still read as Phase-2-pl
 
 ## 11. Suggested implementation order
 
-Findings 1–5 and §10 are **done**. Recommended order for the remaining open follow-ups (safety before larger API moves):
+Findings 1–5, §6, and §10 are **done**. Recommended order for the remaining open follow-ups (safety before larger API moves):
 
 | Step | Finding | Effort | Impact | Status | Why this order |
 |------|---------|--------|--------|--------|----------------|
@@ -307,13 +305,13 @@ Findings 1–5 and §10 are **done**. Recommended order for the remaining open f
 | D | §4 combined verify + Android unbox | Small–medium | Residual verify path + JNI boxing | **Done** | — |
 | E | §5 Android JNI lock narrowing | Small | Contention / lifetime hygiene | **Done** | — |
 | F | §10 docs sync (foundation + cursor rule) | Small | Stops stale “diarization missing” planning | **Done** | Cheap; clear mental model before more work |
-| G | §6 diarization `shared_ptr` lifetime | Small–medium | Unload-during-process safety | Open | Same pattern as §5; prerequisite for §9 |
+| G | §6 diarization `shared_ptr` lifetime | Small–medium | Unload-during-process safety | **Done** | Same pattern as §5; prerequisite for §9 |
 | H | §7 iOS SID TM mutex parity | Small | Contention hygiene parity with Android | Open | Independent of enroll / segment write |
 | I | §8 combined enroll (no JS embedding add) | Medium | Closes last SID product embedding gap | Open | Builds on stable locks (§5/§7) |
 | J | §9 diarization native `segmentsOut` write | Medium–large | Drops JS materialize loop | Open | After §6 lifetime |
 | K | Optional embedding JSI | Small–medium | Faster raw-vector apps only | Deferred | Only if enroll/low-level still hot in profiles |
 
-**Recommendation summary:** next `G → H → I → J` (diarization lifetime → iOS mutex → enroll TM → diarization segment write). Defer embedding JSI unless profiling shows enroll/low-level extract as a real cost.
+**Recommendation summary:** next `H → I → J` (iOS mutex → enroll TM → diarization segment write). Defer embedding JSI unless profiling shows enroll/low-level extract as a real cost.
 
 Draft an **explicit implementation plan per open finding** in that order (one finding at a time), same style as Findings 1–5.
 
@@ -341,7 +339,7 @@ Success criteria for §4 path D (met): offline `verify` / `verifyOfflineSegments
 
 Success criteria for §5 (met): Android JNI does not hold `g_speaker_embedding_mutex` across ONNX compute or manager C-API ops; maps use `shared_ptr`; ManagerWrapper serializes C-API calls.
 
-Success criteria for §6: diarization process holds a `shared_ptr` session; unload during process does not UAF.
+Success criteria for §6 (met): diarization process holds a `shared_ptr` session; unload during process does not UAF.
 
 Success criteria for §7: iOS TM compute/identify/verify/manager ops do not hold `g_speaker_embedding_mutex` across ONNX / C-API work.
 
@@ -349,7 +347,7 @@ Success criteria for §8: `enroll` / `enrollOfflineSegments` do not call separat
 
 Success criteria for §9: `diarize` fills `segmentsOut` natively (no JS per-segment materialize loop).
 
-Success criteria for §10 (met): foundation status + cursor rule describe diarization offline as shipped; backlog points at §6–§9 / live diarization — not greenfield native.
+Success criteria for §10 (met): foundation status + cursor rule describe diarization offline as shipped; backlog points at §7–§9 / live diarization — not greenfield native.
 
 ---
 

--- a/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
+++ b/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
@@ -1,13 +1,13 @@
 # Speaker embedding / SID: bridge roundtrip bottlenecks (future work)
 
-**Status:** Design note — analysis complete; not implemented.  
+**Status:** Finding 1 (native SID live) **done**. Findings 2–5 remain open.  
 **Scope:** TurboModule / JS orchestration costs on the **speaker-embedding** and **speaker-identification** paths after the shared C++ `SpeakerEmbeddingRunner` / `SpeakerEmbeddingManager` migration.  
 **Motivation:** Align SID with the live-overload target architecture already used by STT/TTS (and punctuation / enhancement / separation): **one native start**, per-utterance work stays in-process, no PCM or embedding vectors bouncing through JS.
 
 **Related (today):**
 
 - [speaker-embedding-foundation.md](../internal/speaker-embedding-foundation.md) — shared C++ core, SID vs diarization ownership
-- [live-overload.md §11](../internal/live-overload.md#11-speaker-identification-live-overload-js-orchestration) — SID live is still JS-orchestrated
+- [live-overload.md §11](../internal/live-overload.md#11-speaker-identification-live-overload-native-worker) — SID live native worker (Finding 1 done)
 - [speaker-identification-live.md](../speaker-identification-live.md) — public `labelLiveSegments` contract
 - [speaker-embedding-sharing-verification.md](../internal/speaker-embedding-sharing-verification.md) — device logcat weight-sharing check
 - Audio JSI baseline: [liveaudiobuffer-internal.md](../internal/liveaudiobuffer-internal.md), `src/audiobuffer/jsi.ts`
@@ -25,23 +25,21 @@
 **Hop count from JS did not increase.** Marshalling quality (e.g. Android `ArrayList<Float>` boxing) and live orchestration remain the issues to fix.
 
 ```text
-STT / TTS / Punctuation / Enhancement / Separation live
+STT / TTS / Punctuation / Enhancement / Separation / SID live
   JS: attach segmentation → start*OfflineLivePipeline once
   Native worker: read seg_live_* + PCM → infer → write outputs
   ✅ Target architecture
-
-SID labelLiveSegments (today)
-  JS poll loop: slice PCM → temp offline → extract TM → search TM → append
-  ❌ Exception documented in live-overload.md §11
 ```
 
 ---
 
-## 1. Finding — Live SID JS orchestration (HIGH)
+## 1. Finding — Live SID JS orchestration (HIGH) — **DONE**
 
-### Problem
+**Status:** Implemented. `labelLiveSegments` now starts `startSpeakerIdentificationOfflineLivePipeline`; per-utterance work runs in `SpeakerIdentificationOfflineLivePipelineWorker` (Android Kotlin + iOS ObjC++). See [live-overload.md §11](../internal/live-overload.md#11-speaker-identification-live-overload-native-worker).
 
-`labelLiveSegments` (`src/speaker-identification/live.ts`) polls committed speech spans in JS and, per utterance, roughly:
+### Problem (historical)
+
+`labelLiveSegments` previously polled committed speech spans in JS and, per utterance:
 
 1. `getLiveAudioBufferSamplesSlice` (JSI → JS `Float32Array`)
 2. `createOfflineAudioBufferFromSamples` (JSI → temp `off_*`)
@@ -49,22 +47,14 @@ SID labelLiveSegments (today)
 4. `manager.search(embedding)` (TurboModule; embedding as `number[]`)
 5. `appendLiveSegment(...)`
 
-That is a **triple PCM path** for audio that already lived in the live ring, plus two embedding-related bridge calls, plus a ~50 ms poll. Unlike STT/TTS live, there is **no** `startSpeakerIdentificationOfflineLivePipeline`.
+That was a **triple PCM path** plus two embedding-related bridge calls.
 
-### Why it was left this way
+### What shipped
 
-Documented in [live-overload.md §11](../internal/live-overload.md#11-speaker-identification-live-overload-js-orchestration): cheap per-utterance math, existing offline staging building blocks, no prior native worker that writes **segment-buffer labels** with cross-subsystem access to `SpeakerEmbeddingManager`.
-
-### Direction
-
-Keep public `labelLiveSegments` + handle shape; swap the body for a native worker (same pattern as STT):
-
-1. TurboModule `startSpeakerIdentificationOfflineLivePipeline(instanceId, managerId?, audioIn, segmentsOut, { attachedSegmentationEngineId, segmentLiveBufferId, threshold })`
+1. TurboModule `startSpeakerIdentificationOfflineLivePipeline(instanceId, managerId, audioIn, segmentsOut, { attachedSegmentationEngineId, segmentLiveBufferId, threshold })`
 2. Android / iOS `SpeakerIdentificationOfflineLivePipelineWorker` extending `OfflineLivePipelineWorker`
-3. In-process: live ring slice → `SpeakerEmbeddingRunner::Compute` (ranges) → `SpeakerEmbeddingManager::Search` → `appendLiveSegment` with `payload.source: 'sid'`
-4. `completed` / `getStatus` via streaming pipeline registry (drop JS-synthesized handle internals)
-
-**Priority:** Do this **soon** — SID should match the live-overload target architecture; JS orchestration is the dominant cost on the live path.
+3. In-process: live ring slice → embed → manager search → append with `payload.source: 'sid'`
+4. `completed` / `getStatus` via streaming pipeline registry; `onLabeled` via `subscribeLiveSegmentBufferEvents`
 
 ---
 
@@ -72,7 +62,7 @@ Keep public `labelLiveSegments` + handle shape; swap the body for a native worke
 
 ### Problem
 
-`SpeakerEmbeddingRunner` already supports `SampleRange` / ranged `Compute`. The TS engine still emulates ranges by **JS staging**:
+`SpeakerEmbeddingRunner` already supports `SampleRange` / ranged `Compute`. The TS engine still emulates ranges by **JS staging** on the **offline** path (`labelOfflineSegments` / `extractFromOfflineAudio` with range):
 
 ```ts
 // src/speaker-embedding/engine.ts — range path today
@@ -82,7 +72,7 @@ computeSpeakerEmbeddingOffline(temp.bufferId)
 releasePipelineAudioBuffer(temp.bufferId)
 ```
 
-Offline `labelOfflineSegments` pays the same tax per span.
+(Live labeling no longer uses this path after Finding 1.)
 
 ### Direction
 
@@ -99,7 +89,7 @@ computeSpeakerEmbeddingOffline(
 
 Native side: read `[start, end)` from the offline/live registry (or mmap slice) and call `Runner::Compute` with ranges — **no** PCM through JS.
 
-**Priority:** Smallest high-ROI step if native live worker is not immediate; also unblocks a cleaner offline label path and is a building block for §1.
+**Priority:** High for offline label/enroll range paths.
 
 ---
 
@@ -177,34 +167,29 @@ This is contention risk more than copy cost; listed for completeness after the t
 
 ## 6. Suggested implementation order
 
-| Step | Finding | Effort | Impact |
-|------|---------|--------|--------|
-| A | §2 native extract-by-range | Small | Removes JS PCM staging for offline/range + simplifies live interim |
-| B | §3 combined identify (or in-worker search) | Small–medium | Drops embedding roundtrip on identify |
-| C | §1 native SID live pipeline | Medium–large | Matches STT/TTS target architecture; removes poll + triple PCM |
-| D | §4 JSI / unbox embeddings | Small–medium | Residual path for apps that still pull vectors |
-| E | §5 JNI lock narrowing | Small | Contention hygiene |
-
-**Product priority stated for this note:** §1 (native live) should be **pulled forward soon** so SID matches the live-overload Zielbild; A/B are useful stepping stones and reduce risk when C lands.
+| Step | Finding | Effort | Impact | Status |
+|------|---------|--------|--------|--------|
+| C | §1 native SID live pipeline | Medium–large | Matches STT/TTS target architecture | **Done** |
+| A | §2 native extract-by-range | Small | Removes JS PCM staging for offline/range | Open |
+| B | §3 combined identify (or in-worker search) | Small–medium | Drops embedding roundtrip on identify APIs that still cross JS | Open |
+| D | §4 JSI / unbox embeddings | Small–medium | Residual path for apps that still pull vectors | Open |
+| E | §5 JNI lock narrowing | Small | Contention hygiene | Open |
 
 ---
 
 ## 7. Measurement checklist (before / after)
 
-Instrument with a stable tag (e.g. `[SherpaOnnx:sid-bridge]`) and compare Android logcat first:
+Instrument with a stable tag (e.g. `[SherpaOnnx:sid-live]` / `[SherpaOnnx:sid-bridge]`) and compare Android logcat first:
 
 | Probe | What to log |
 |-------|-------------|
-| Live span start/end | `startSample`, `endSample`, frame count |
-| Staging | JSI slice ms, createOffline ms, release ms |
-| Extract TM | wall ms, sample count into JNI, dim out |
-| Search TM | wall ms |
-| Native worker (after §1) | span → compute → search → append ms **without** JS staging markers |
+| Live span (native worker) | `startSample`, `endSample`, frame count, compute/search/append |
+| Offline range (until §2) | JSI slice ms, createOffline ms, release ms |
+| Extract/search TM (low-level APIs) | wall ms, dim |
 
-Success criteria for §1: **no** PCM `Float32Array` in JS on the live label hot path; one `start*OfflineLivePipeline`-style bridge call per session; embedding vectors never enter JS unless the app explicitly calls low-level extract.
+Success criteria for §1 (met): **no** PCM `Float32Array` in JS on the live label hot path; one `startSpeakerIdentificationOfflineLivePipeline` call per session; embedding vectors stay native unless the app calls low-level extract.
 
 ---
-
 ## 8. Non-goals
 
 - Reverting the shared C++ Runner/Manager migration

--- a/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
+++ b/docs/future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md
@@ -1,6 +1,6 @@
 # Speaker embedding / SID: bridge roundtrip bottlenecks (future work)
 
-**Status:** Findings 1–3 **done**. Findings 4–5 remain open.  
+**Status:** Findings 1–4 **done**. Finding 5 remains open.  
 **Scope:** TurboModule / JS orchestration costs on the **speaker-embedding** and **speaker-identification** paths after the shared C++ `SpeakerEmbeddingRunner` / `SpeakerEmbeddingManager` migration.  
 **Motivation:** Align SID with the live-overload target architecture already used by STT/TTS (and punctuation / enhancement / separation): **one native start**, per-utterance work stays in-process, no PCM or embedding vectors bouncing through JS.
 
@@ -114,29 +114,37 @@ identifySpeakerOffline(
 ): Promise<{ name: string }>
 ```
 
-Empty `name` = no match. Range rules match Finding 2. Combined `verifySpeakerOffline` is still open (verify path unchanged).
+Empty `name` = no match. Range rules match Finding 2. Combined `verifySpeakerOffline` shipped in Finding 4.
 
 ---
 
-## 4. Finding — Embedding transport as `number[]` / boxed floats (MEDIUM)
+## 4. Finding — Embedding transport as `number[]` / boxed floats (MEDIUM) — **DONE**
 
-### Problem
+**Status:** Implemented (path D). Offline `verify` / `verifyOfflineSegments` call `verifySpeakerOffline` (compute + manager verify in one TM → `{ ok }`). Android `nativeComputeEmbedding` returns `jfloatArray` instead of boxed `ArrayList&lt;Float&gt;`. **No** embedding JSI in this finding; enroll and low-level extract still use TurboModule `number[]` (infrequent / app-facing). Optional later: JSI `ArrayBuffer` if apps need faster raw-vector pull.
+
+### Problem (historical)
 
 Return path (Android sketch):
 
-`std::vector<float>` → `ArrayList<Float>` (boxed) → `WritableArray` of doubles → JS `number[]` → TS `Float32Array`
+`std::vector<float>` → `ArrayList&lt;Float&gt;` (boxed) → `WritableArray` of doubles → JS `number[]` → TS `Float32Array`
 
-Inbound search/verify reverses a similar chain. Dim is small (~192–512) vs PCM, but live multiplies extract+search roundtrips. Audio already has JSI `ArrayBuffer` transport; embeddings do not.
+Inbound search/verify reversed a similar chain. Dim is small (~192–512) vs PCM; after Findings 1–3 the remaining product path that still crossed JS was verify.
 
-### Direction (pick one or combine)
+### What shipped
 
-1. **Prefer not crossing JS** for hot paths (§1 / §3) — best fix.
-2. If JS must see vectors: return / accept **`ArrayBuffer` / `Float32Array` via JSI** (extend `__SherpaOnnxJSI` or a dedicated embedding transfer id), same spirit as `getOfflineAudioBufferSamplesSlice`.
-3. On Android JNI interim: prefer `jfloatArray` (or fill `WritableArray` from `float*` without `ArrayList<Float>` boxing).
+```ts
+verifySpeakerOffline(
+  instanceId: string,
+  managerId: string,
+  audioBufferId: string,
+  name: string,
+  threshold: number,
+  startSample?: number | null,
+  endSample?: number | null
+): Promise<{ ok: boolean }>
+```
 
-Enrollment `manager.add` flatten to `number[]` is **low** priority (infrequent).
-
-**Priority:** Medium; collapses if §1/§3 land first.
+Zero-length range → `{ ok: false }` without ONNX. Android compute JNI uses `NewFloatArray` / `SetFloatArrayRegion` (same spirit as diarization).
 
 ---
 
@@ -165,7 +173,7 @@ This is contention risk more than copy cost; listed for completeness after the t
 | C | §1 native SID live pipeline | Medium–large | Matches STT/TTS target architecture | **Done** |
 | A | §2 native extract-by-range | Small | Removes JS PCM staging for offline/range | **Done** |
 | B | §3 combined identify (or in-worker search) | Small–medium | Drops embedding roundtrip on identify APIs that still cross JS | **Done** |
-| D | §4 JSI / unbox embeddings | Small–medium | Residual path for apps that still pull vectors | Open |
+| D | §4 combined verify + Android unbox (path D) | Small–medium | Residual verify path + JNI boxing hygiene | **Done** |
 | E | §5 JNI lock narrowing | Small | Contention hygiene | Open |
 
 ---
@@ -185,6 +193,8 @@ Success criteria for §1 (met): **no** PCM `Float32Array` in JS on the live labe
 Success criteria for §2 (met): ranged `extractFromOfflineAudio` calls `computeSpeakerEmbeddingOffline(..., start, end)` with **no** JSI slice / temp offline buffer.
 
 Success criteria for §3 (met): offline `identify` / `labelOfflineSegments` use `identifySpeakerOffline` only (no compute→JS→search); empty name maps to `null` in SID TS.
+
+Success criteria for §4 path D (met): offline `verify` / `verifyOfflineSegments` use `verifySpeakerOffline` only; Android compute returns `jfloatArray` (no `ArrayList&lt;Float&gt;` boxing). JSI embedding transport remains optional later.
 
 ---
 ## 8. Non-goals

--- a/docs/internal/live-overload.md
+++ b/docs/internal/live-overload.md
@@ -383,4 +383,4 @@ Public API: `createSpeakerIdentification().labelLiveSegments(LiveAudio, LiveSegm
 
 `onLabeled` is wired like STT `onSegment`: `subscribeLiveSegmentBufferEvents(segmentsOut)` mapping `payload.source === 'sid'`.
 
-Remaining bridge follow-ups (JNI mutex; optional embedding JSI): [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md).
+Optional bridge follow-ups (iOS TM mutex narrowing; embedding JSI): [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md).

--- a/docs/internal/live-overload.md
+++ b/docs/internal/live-overload.md
@@ -317,7 +317,7 @@ Both buffers must be live **or** both offline. Mixed calls throw `*_INVALID_ARGU
 | **Punctuation** | ✅ `punctuate(LiveText, LiveText, { segmentation })` | Implemented |
 | **Enhancement** | ✅ `enhance(LiveAudio, LiveAudio, { segmentation: continuous_frames })` | Implemented (restricted) |
 | **Separation** | ✅ `separate(LiveAudio, LiveAudio[], { segmentation: continuous_frames })` | Implemented (restricted; N stem outputs) |
-| **Speaker identification** | ✅ `labelLiveSegments(LiveAudio, LiveSegment, { segmentation })` | Implemented — **JS orchestration** (see §11); no native `start*OfflineLivePipeline` yet |
+| **Speaker identification** | ✅ `labelLiveSegments(LiveAudio, LiveSegment, { segmentation })` | Implemented — native `startSpeakerIdentificationOfflineLivePipeline` (see §11) |
 | VAD | ❌ | N/A — VAD **is** the segmentation primitive; `createStreamingVAD.process()` already accepts both buffer families |
 | Alignment | ❌ | Structurally incompatible (closed, bounded problem) |
 | Diarization | ❌ | Placeholder — revisit at implementation time |
@@ -369,32 +369,18 @@ flowchart LR
 
 ---
 
-## 11. Speaker Identification live overload (JS orchestration)
+## 11. Speaker Identification live overload (native worker)
 
 Public API: `createSpeakerIdentification().labelLiveSegments(LiveAudio, LiveSegment, options)` — see [speaker-identification-live.md](../speaker-identification-live.md) for the consumer contract.
 
-### Why JS (not a native worker)
+### Implementation (STT Zielbild)
 
-SID live inference is a cheap per-utterance embedding extract + cosine search. Every building block already exists (`labelOfflineSegments` staging pattern, `getLiveAudioBufferSamplesSlice`, temp offline buffer → `extractFromOfflineAudio`, `manager.search`, `appendLiveSegment` with `payload.source: 'sid'`). A native `OfflineLivePipelineWorker` subclass would be precedent-less for **segment-buffer label output** and would need cross-subsystem access to the `SpeakerEmbeddingManager`. Design note: [speaker-embedding-foundation.md](speaker-embedding-foundation.md).
+1. JS: `validateLiveOfflinePipelineOptions` (`speech_energy_silence` | `speech_vad_model`) → `attachSegmentationEngine` → internal `seg_live_*`
+2. TurboModule `startSpeakerIdentificationOfflineLivePipeline(instanceId, managerId, audioIn, segmentsOut, { attachedSegmentationEngineId, segmentLiveBufferId, threshold })`
+3. Android / iOS `SpeakerIdentificationOfflineLivePipelineWorker` extends `OfflineLivePipelineWorker`
+4. Per committed speech span (native): live ring slice → embed → manager search → `appendSegment` with `payload: { source: 'sid', speakerName }` (force-emit `pipelineLiveSegmentAppended` for `onLabeled`)
+5. Handle via `createStreamingPipelineCompletionPromise` + streaming pipeline registry; JS still detaches segmentation and finalizes `segmentsOut` on terminal
 
-### Current drain loop (`src/speaker-identification/live.ts`)
+`onLabeled` is wired like STT `onSegment`: `subscribeLiveSegmentBufferEvents(segmentsOut)` mapping `payload.source === 'sid'`.
 
-1. `validateLiveOfflinePipelineOptions` (`speech_energy_silence` | `speech_vad_model`)
-2. `attachSegmentationEngine(audioIn, { policy })` → internal `seg_live_*`
-3. JS poll/cursor over `getLiveSegmentBufferSegmentCount` / `getLiveSegmentBufferSegments`
-4. Per speech span: live PCM slice → temp offline buffer → extract → search → `appendLiveSegment(segmentsOut, { payload: { source: 'sid', speakerName } })` → `onLabeled`
-5. Handle (`SpeakerIdentificationPipelineHandle`) synthesizes `stop` / `flush` / `reset` / `getStatus` / `completed` in JS (not via `StreamingPipelineRegistry` / `streamingPipelineCompleted`)
-
-`finalizeLiveAudioBuffer(audioIn)` → detach with `flushFinal: true` → drain tail → finalize `segmentsOut` → `completed` with `reason: 'completed'`.
-
-### Possible native migration (same public API)
-
-Keep `labelLiveSegments` signature + handle shape; swap the body for:
-
-1. TurboModule `startSpeakerIdentificationOfflineLivePipeline(instanceId, audioIn, segmentsOut, { attachedSegmentationEngineId, segmentLiveBufferId, threshold })`
-2. Kotlin / iOS `SpeakerIdentificationOfflineLivePipelineWorker` extending `OfflineLivePipelineWorker`
-3. `completed` / `getStatus` via `createStreamingPipelineCompletionPromise` + native streaming pipeline registry
-
-No public API change required.
-
-Full bottleneck analysis (live JS drain, range extract staging, extract+search roundtrips, embedding `number[]` marshalling, JNI mutex) and suggested order: [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md).
+Remaining bridge follow-ups (offline range extract, combined identify TM, embedding marshalling): [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md).

--- a/docs/internal/live-overload.md
+++ b/docs/internal/live-overload.md
@@ -383,4 +383,4 @@ Public API: `createSpeakerIdentification().labelLiveSegments(LiveAudio, LiveSegm
 
 `onLabeled` is wired like STT `onSegment`: `subscribeLiveSegmentBufferEvents(segmentsOut)` mapping `payload.source === 'sid'`.
 
-Remaining bridge follow-ups (offline range extract, combined identify TM, embedding marshalling): [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md).
+Remaining bridge follow-ups (embedding marshalling, JNI mutex; combined verify still open): [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md).

--- a/docs/internal/live-overload.md
+++ b/docs/internal/live-overload.md
@@ -383,4 +383,4 @@ Public API: `createSpeakerIdentification().labelLiveSegments(LiveAudio, LiveSegm
 
 `onLabeled` is wired like STT `onSegment`: `subscribeLiveSegmentBufferEvents(segmentsOut)` mapping `payload.source === 'sid'`.
 
-Remaining bridge follow-ups (embedding marshalling, JNI mutex; combined verify still open): [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md).
+Remaining bridge follow-ups (JNI mutex; optional embedding JSI): [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md).

--- a/docs/internal/speaker-embedding-foundation.md
+++ b/docs/internal/speaker-embedding-foundation.md
@@ -198,7 +198,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - True streaming diarization (no upstream API)
 - Spoken Language Identification
 - Native embedding dump / Upstream `GetEmbedding` (SID export uses a JS mirror) — tracked in [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md)
-- Remaining SID bridge roundtrip fixes (combined identify, embedding marshalling, JNI mutex) — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–2 **done**)
+- Remaining SID bridge roundtrip fixes (embedding marshalling, JNI mutex; combined verify still open) — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–3 **done**)
 
 ---
 
@@ -221,7 +221,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - [speaker-identification-offline.md](../speaker-identification-offline.md)
 - [speaker-identification-live.md](../speaker-identification-live.md)
 - [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md) — upstream `GetEmbedding` / optional Save·Load
-- [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) — bridge costs; Finding 1 (native live) done
+- [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) — bridge costs; Findings 1–3 done
 - [speaker-embedding-sharing-verification.md](./speaker-embedding-sharing-verification.md) — device logcat sharing check
 - [diarization.md](../diarization.md) — public stub (to replace when Phase 2 ships)
 - [sdk-feature-support-matrix.md](./sdk-feature-support-matrix.md)

--- a/docs/internal/speaker-embedding-foundation.md
+++ b/docs/internal/speaker-embedding-foundation.md
@@ -5,7 +5,7 @@
 > **Strategy:** Ship **Speaker Identification (SID)** first on a shared **Extractor + Manager** layer designed so **Speaker Diarization** can reuse the same embedding engine without rework.
 > **User request:** [Discussion #113 — Speaker Identification](https://github.com/XDcobra/react-native-sherpa-onnx/discussions/113)
 >
-> Live-overload implementation details (JS drain loop, native migration notes): [live-overload.md §11](live-overload.md#11-speaker-identification-live-overload-js-orchestration).
+> Live-overload implementation details: [live-overload.md §11](live-overload.md#11-speaker-identification-live-overload-native-worker).
 
 ---
 
@@ -81,7 +81,7 @@ engine.destroy(): Promise<void>
 
 **Persistence:** Thin SID helpers `exportEnrollments` / `importEnrollments` return/accept a versioned embeddings JSON bundle (`SpeakerEnrollmentBundle`). The SDK does not write files — the app stores the object. Export is fed by a JS enrollment mirror (native manager cannot read embeddings back). Diarization does not need persistence.
 
-**Live SID:** Offline embedding weights + mandatory speech segmentation + per-utterance extract/search. Public handle matches other live overloads. Drain loop is JS orchestration — see [live-overload.md §11](live-overload.md#11-speaker-identification-live-overload-js-orchestration).
+**Live SID:** Offline embedding weights + mandatory speech segmentation + per-utterance extract/search in a native `OfflineLivePipelineWorker`. Public handle matches other live overloads — see [live-overload.md §11](live-overload.md#11-speaker-identification-live-overload-native-worker).
 
 ### 2.3 `src/diarization/` (Phase 2 — replace placeholder)
 
@@ -198,7 +198,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - True streaming diarization (no upstream API)
 - Spoken Language Identification
 - Native embedding dump / Upstream `GetEmbedding` (SID export uses a JS mirror) — tracked in [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md)
-- Native SID live worker + bridge roundtrip fixes (JS orchestration ships today) — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md); see also [live-overload.md §11](live-overload.md#11-speaker-identification-live-overload-js-orchestration)
+- Remaining SID bridge roundtrip fixes (range extract, combined identify, embedding marshalling) — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Finding 1 native live **done**)
 
 ---
 
@@ -210,7 +210,8 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - [x] Manager holds **names**, not diarization cluster indices.
 - [x] Weight sharing is C++ registry only (JS `engineCache` removed).
 - [x] Do not extend the old placeholder API (`initializeDiarization` / `diarizeAudio(path)`).
-- [x] Document that SID “live” = segment orchestration, not a streaming model family (native live worker still future work).
+- [x] Document that SID “live” = segment orchestration, not a streaming model family.
+- [x] SID live uses native `OfflineLivePipelineWorker` (same Zielbild as STT/TTS).
 
 ---
 
@@ -220,7 +221,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - [speaker-identification-offline.md](../speaker-identification-offline.md)
 - [speaker-identification-live.md](../speaker-identification-live.md)
 - [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md) — upstream `GetEmbedding` / optional Save·Load
-- [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) — native live + range extract + identify bridge costs
+- [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) — bridge costs; Finding 1 (native live) done
 - [speaker-embedding-sharing-verification.md](./speaker-embedding-sharing-verification.md) — device logcat sharing check
 - [diarization.md](../diarization.md) — public stub (to replace when Phase 2 ships)
 - [sdk-feature-support-matrix.md](./sdk-feature-support-matrix.md)

--- a/docs/internal/speaker-embedding-foundation.md
+++ b/docs/internal/speaker-embedding-foundation.md
@@ -191,7 +191,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - True streaming diarization (no upstream API)
 - Spoken Language Identification
 - Native embedding dump / Upstream `GetEmbedding` (SID export uses a JS mirror) — tracked in [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md)
-- Bridge follow-ups §7–§9 (iOS TM mutex, combined enroll, native `segmentsOut` write) + optional embedding JSI — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–5, §6, and §10 **done**)
+- Bridge follow-ups §8–§9 (combined enroll, native `segmentsOut` write) + optional embedding JSI — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–5, §6–§7, and §10 **done**)
 
 ---
 

--- a/docs/internal/speaker-embedding-foundation.md
+++ b/docs/internal/speaker-embedding-foundation.md
@@ -191,7 +191,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - True streaming diarization (no upstream API)
 - Spoken Language Identification
 - Native embedding dump / Upstream `GetEmbedding` (SID export uses a JS mirror) — tracked in [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md)
-- Bridge follow-ups §6–§9 (diarization lifetime, iOS TM mutex, combined enroll, native `segmentsOut` write) + optional embedding JSI — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–5 and §10 **done**)
+- Bridge follow-ups §7–§9 (iOS TM mutex, combined enroll, native `segmentsOut` write) + optional embedding JSI — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–5, §6, and §10 **done**)
 
 ---
 

--- a/docs/internal/speaker-embedding-foundation.md
+++ b/docs/internal/speaker-embedding-foundation.md
@@ -198,7 +198,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - True streaming diarization (no upstream API)
 - Spoken Language Identification
 - Native embedding dump / Upstream `GetEmbedding` (SID export uses a JS mirror) — tracked in [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md)
-- Remaining SID bridge roundtrip fixes (range extract, combined identify, embedding marshalling) — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Finding 1 native live **done**)
+- Remaining SID bridge roundtrip fixes (combined identify, embedding marshalling, JNI mutex) — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–2 **done**)
 
 ---
 

--- a/docs/internal/speaker-embedding-foundation.md
+++ b/docs/internal/speaker-embedding-foundation.md
@@ -191,7 +191,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - True streaming diarization (no upstream API)
 - Spoken Language Identification
 - Native embedding dump / Upstream `GetEmbedding` (SID export uses a JS mirror) — tracked in [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md)
-- Bridge follow-ups §8–§9 (combined enroll, native `segmentsOut` write) + optional embedding JSI — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–5, §6–§7, and §10 **done**)
+- Bridge follow-up §9 (native `segmentsOut` write) + optional embedding JSI — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–5, §6–§8, and §10 **done**)
 
 ---
 

--- a/docs/internal/speaker-embedding-foundation.md
+++ b/docs/internal/speaker-embedding-foundation.md
@@ -198,7 +198,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - True streaming diarization (no upstream API)
 - Spoken Language Identification
 - Native embedding dump / Upstream `GetEmbedding` (SID export uses a JS mirror) — tracked in [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md)
-- Remaining SID bridge roundtrip fixes (JNI mutex; optional embedding JSI for raw-vector apps) — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–4 **done**)
+- Optional SID bridge follow-ups (iOS TM mutex narrowing; embedding JSI for raw-vector apps) — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–5 **done**)
 
 ---
 
@@ -221,7 +221,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - [speaker-identification-offline.md](../speaker-identification-offline.md)
 - [speaker-identification-live.md](../speaker-identification-live.md)
 - [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md) — upstream `GetEmbedding` / optional Save·Load
-- [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) — bridge costs; Findings 1–4 done
+- [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) — bridge costs; Findings 1–5 done
 - [speaker-embedding-sharing-verification.md](./speaker-embedding-sharing-verification.md) — device logcat sharing check
 - [diarization.md](../diarization.md) — public stub (to replace when Phase 2 ships)
 - [sdk-feature-support-matrix.md](./sdk-feature-support-matrix.md)

--- a/docs/internal/speaker-embedding-foundation.md
+++ b/docs/internal/speaker-embedding-foundation.md
@@ -1,6 +1,6 @@
 # Speaker embedding foundation — Internal design
 
-> **Status:** Phase 1 (SID) **shipped** — shared extractor/manager + offline SID + live `labelLiveSegments`. Phase 2 offline diarization **shipped** — shared `SpeakerEmbeddingRunner` + `createDiarization` / `diarize` (see [diarization-offline.md](../diarization-offline.md) and [§10](#10-diarization-core-design-phase-2--decisions)). Remaining: live/streaming diarization (out of scope upstream), pyannote segmentation-engine evaluator, bridge follow-ups §6–§9 in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md).
+> **Status:** Phase 1 (SID) **shipped** — shared extractor/manager + offline SID + live `labelLiveSegments`. Phase 2 offline diarization **shipped** — shared `SpeakerEmbeddingRunner` + `createDiarization` / `diarize` (see [diarization-offline.md](../diarization-offline.md) and [§10](#10-diarization-core-design-phase-2--decisions)). Remaining: live/streaming diarization (out of scope upstream), pyannote segmentation-engine evaluator, optional embedding JSI in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md).
 > **Audience:** SDK maintainers.
 > **Strategy:** Ship **Speaker Identification (SID)** first on a shared **Extractor + Manager** layer designed so **Speaker Diarization** can reuse the same embedding engine without rework.
 > **User request:** [Discussion #113 — Speaker Identification](https://github.com/XDcobra/react-native-sherpa-onnx/discussions/113)
@@ -191,7 +191,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - True streaming diarization (no upstream API)
 - Spoken Language Identification
 - Native embedding dump / Upstream `GetEmbedding` (SID export uses a JS mirror) — tracked in [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md)
-- Bridge follow-up §9 (native `segmentsOut` write) + optional embedding JSI — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–5, §6–§8, and §10 **done**)
+- Optional embedding JSI — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–5 and §6–§10 **done**)
 
 ---
 
@@ -214,7 +214,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - [speaker-identification-offline.md](../speaker-identification-offline.md)
 - [speaker-identification-live.md](../speaker-identification-live.md)
 - [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md) — upstream `GetEmbedding` / optional Save·Load
-- [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) — bridge costs; Findings 1–5 + §10 done; §6–§9 open
+- [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) — bridge costs; Findings 1–5 and §6–§10 done; optional embedding JSI deferred
 - [speaker-embedding-sharing-verification.md](./speaker-embedding-sharing-verification.md) — device logcat sharing check
 - [diarization.md](../diarization.md) — overview → [diarization-offline.md](../diarization-offline.md) (offline shipped)
 - [sdk-feature-support-matrix.md](./sdk-feature-support-matrix.md)

--- a/docs/internal/speaker-embedding-foundation.md
+++ b/docs/internal/speaker-embedding-foundation.md
@@ -198,7 +198,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - True streaming diarization (no upstream API)
 - Spoken Language Identification
 - Native embedding dump / Upstream `GetEmbedding` (SID export uses a JS mirror) — tracked in [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md)
-- Remaining SID bridge roundtrip fixes (embedding marshalling, JNI mutex; combined verify still open) — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–3 **done**)
+- Remaining SID bridge roundtrip fixes (JNI mutex; optional embedding JSI for raw-vector apps) — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–4 **done**)
 
 ---
 
@@ -221,7 +221,7 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - [speaker-identification-offline.md](../speaker-identification-offline.md)
 - [speaker-identification-live.md](../speaker-identification-live.md)
 - [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md) — upstream `GetEmbedding` / optional Save·Load
-- [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) — bridge costs; Findings 1–3 done
+- [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) — bridge costs; Findings 1–4 done
 - [speaker-embedding-sharing-verification.md](./speaker-embedding-sharing-verification.md) — device logcat sharing check
 - [diarization.md](../diarization.md) — public stub (to replace when Phase 2 ships)
 - [sdk-feature-support-matrix.md](./sdk-feature-support-matrix.md)

--- a/docs/internal/speaker-embedding-foundation.md
+++ b/docs/internal/speaker-embedding-foundation.md
@@ -1,6 +1,6 @@
 # Speaker embedding foundation — Internal design
 
-> **Status:** Phase 1 (SID) **shipped** — shared extractor/manager + offline SID + live `labelLiveSegments`. Phase 2 (diarization) still planned; **core native design decided** — see [§10](#10-diarization-core-design-phase-2--decisions). Example screen for SID is the remaining Phase‑1 demo item.
+> **Status:** Phase 1 (SID) **shipped** — shared extractor/manager + offline SID + live `labelLiveSegments`. Phase 2 offline diarization **shipped** — shared `SpeakerEmbeddingRunner` + `createDiarization` / `diarize` (see [diarization-offline.md](../diarization-offline.md) and [§10](#10-diarization-core-design-phase-2--decisions)). Remaining: live/streaming diarization (out of scope upstream), pyannote segmentation-engine evaluator, bridge follow-ups §6–§9 in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md).
 > **Audience:** SDK maintainers.
 > **Strategy:** Ship **Speaker Identification (SID)** first on a shared **Extractor + Manager** layer designed so **Speaker Diarization** can reuse the same embedding engine without rework.
 > **User request:** [Discussion #113 — Speaker Identification](https://github.com/XDcobra/react-native-sherpa-onnx/discussions/113)
@@ -16,7 +16,7 @@ Implement speaker features in two phases without building the embedding stack tw
 | Phase | Public module | Uses shared layer | Status |
 |-------|---------------|-------------------|--------|
 | **1** | `speaker-identification/` | Extractor + Manager | **Done** (offline + live overload) |
-| **2** | `diarization/` (replaces placeholder) | Same Extractor + `OfflineSpeakerDiarization` native | Planned |
+| **2** | `diarization/` | Same Runner registry + shared C++ diarization session | **Done** (offline batch); live streaming still out of scope |
 
 **Principle:** The embedding extractor knows only **audio → vector**. It does not know enrollment, clustering, or timeline output. The manager is for **named speakers** (SID). Diarization uses **anonymous cluster indices** and must not overload the manager for clustering.
 
@@ -83,21 +83,15 @@ engine.destroy(): Promise<void>
 
 **Live SID:** Offline embedding weights + mandatory speech segmentation + per-utterance extract/search in a native `OfflineLivePipelineWorker`. Public handle matches other live overloads — see [live-overload.md §11](live-overload.md#11-speaker-identification-live-overload-native-worker).
 
-### 2.3 `src/diarization/` (Phase 2 — replace placeholder)
+### 2.3 `src/diarization/` (Phase 2 — offline shipped)
 
-Replace `src/diarization/index.ts` (file-path throws) with a real module that:
+Public module: `createDiarization` / `detectDiarizationModel` / `diarize(audioIn, segmentsOut)` with `kind: 'diarization'` segments. Shared C++ session acquires `SpeakerEmbeddingRunner` from the same registry as SID — see [diarization-offline.md](../diarization-offline.md) and [§10](#10-diarization-core-design-phase-2--decisions).
 
-1. Accepts optional **`embeddingEngine: SpeakerEmbeddingEngine`** (shared) **or** embedding model path (creates/caches engine).
-2. Runs the diarization pipeline via a **shared C++ core** (not Kotlin+`.mm`) — see [§10](#10-diarization-core-design-phase-2--decisions) for the native strategy decision.
-3. Returns timeline segments: `{ startSec, endSec, speakerIndex }`.
+**Do not** store cluster labels in `SpeakerEmbeddingManager`. Apps map anonymous clusters to names via `getClusterEmbeddings()` + SID search.
 
-**Do not** store cluster labels in `SpeakerEmbeddingManager`.
-
-> **Native strategy note:** the initial diarization core wraps the sherpa-onnx
-> **whole-block** C API (`SherpaOnnxCreateOfflineSpeakerDiarization` / `...Process`)
-> in shared C++. That block loads **its own** embedding model from a path and does
-> **not** reuse an already-loaded SID `SpeakerEmbeddingEngine` instance, and does
-> **not** expose pyannote overlap/powerset add-on info. Full rationale, constraints,
+> **Native strategy note (historical):** early design considered the sherpa-onnx
+> whole-block C API; the shipped core is the **decomposed** pipeline (pyannote
+> segmentation + Runner embed + fast clustering) in shared C++. Full rationale
 > and the additive "pyannote as a segmentation-engine mode" track are in [§10](#10-diarization-core-design-phase-2--decisions).
 
 ---
@@ -146,7 +140,7 @@ createDiarization({
 | Feature | Offline models | Streaming models (ASR-style) | “Live” UX in product |
 |---------|----------------|------------------------------|----------------------|
 | **Speaker ID** | Yes (embedding ONNX) | **No separate class** | Yes — live overload / segment orchestration + extract/search |
-| **Speaker Diarization** | Yes (`OfflineSpeakerDiarization`) | **No** | Deferred — full-file offline first |
+| **Speaker Diarization** | Yes (offline session) | **No** | Deferred — full-file offline first (shipped); no live worker yet |
 
 **SDK implication:** Treat SID as **offline embedding inference**. Live SID = orchestration, **not** a second model class.
 
@@ -183,22 +177,21 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 ### Phase 2 — Diarization
 
 > Detailed decisions, C API surface, build wiring, and the pyannote segmentation-engine
-> track are in [§10](#10-diarization-core-design-phase-2--decisions). Ordering:
-> **collect + license** (see plan) → **detect** → **core** (below).
+> track are in [§10](#10-diarization-core-design-phase-2--decisions).
 
-1. Collect + license for `speaker-segmentation-models` (fixtures + CSV + `licenses.ts`)
+1. [x] Collect + license for `speaker-segmentation-models` (fixtures + CSV + `licenses.ts`)
 2. [x] Model detect wiring (`CATEGORY_BY_NATIVE`, `CATALOG_DETECT_CATEGORIES`, native detect)
-3. **Shared C++** diarization wrapper over the C API (Separation pattern) — one core, thin JNI + thin `.mm`
-4. Replace diarization placeholder; buffer-in timeline-out API (`{ startSec, endSec, speakerIndex }`)
-5. Example diarization screen
-6. Additive: `speech_pyannote_segmentation` evaluator in the segmentation engine (simple spans + opt-in overlap/powerset add-on)
+3. [x] Shared C++ diarization session over Runner + clustering (thin JNI + thin `.mm`)
+4. [x] Buffer-in timeline-out public API (`createDiarization` / `diarize` → `kind: 'diarization'`)
+5. [x] Example diarization screen
+6. Additive: `speech_pyannote_segmentation` evaluator in the segmentation engine (simple spans + opt-in overlap/powerset add-on) — **open**
 
 ### Out of scope for initial phases
 
 - True streaming diarization (no upstream API)
 - Spoken Language Identification
 - Native embedding dump / Upstream `GetEmbedding` (SID export uses a JS mirror) — tracked in [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md)
-- Optional SID bridge follow-ups (iOS TM mutex narrowing; embedding JSI for raw-vector apps) — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–5 **done**)
+- Bridge follow-ups §6–§9 (diarization lifetime, iOS TM mutex, combined enroll, native `segmentsOut` write) + optional embedding JSI — tracked in [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) (Findings 1–5 and §10 **done**)
 
 ---
 
@@ -221,9 +214,9 @@ Rule unchanged: Android inference uses `com.k2fsa.sherpa.onnx` Kotlin classes; i
 - [speaker-identification-offline.md](../speaker-identification-offline.md)
 - [speaker-identification-live.md](../speaker-identification-live.md)
 - [speaker-embedding-manager-upstream-export-import.md](../future-work/speaker-embedding-manager-upstream-export-import.md) — upstream `GetEmbedding` / optional Save·Load
-- [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) — bridge costs; Findings 1–5 done
+- [speaker-embedding-sid-bridge-roundtrips-future-work.md](../future-work/speaker-embedding-sid-bridge-roundtrips-future-work.md) — bridge costs; Findings 1–5 + §10 done; §6–§9 open
 - [speaker-embedding-sharing-verification.md](./speaker-embedding-sharing-verification.md) — device logcat sharing check
-- [diarization.md](../diarization.md) — public stub (to replace when Phase 2 ships)
+- [diarization.md](../diarization.md) — overview → [diarization-offline.md](../diarization-offline.md) (offline shipped)
 - [sdk-feature-support-matrix.md](./sdk-feature-support-matrix.md)
 - [Diarization core design](#10-diarization-core-design-phase-2--decisions) — this doc, §10
 - Upstream: `third_party/sherpa-onnx/sherpa-onnx/kotlin-api/Speaker.kt`, `OfflineSpeakerDiarization.kt` (Kotlin API — **not** used for diarization; see §10.2)

--- a/docs/speaker-identification-live.md
+++ b/docs/speaker-identification-live.md
@@ -2,13 +2,14 @@
 
 > **Live overload** — not a streaming SID model.
 >
-> This guide uses the **same offline** speaker-embedding weights as [speaker-identification-offline.md](speaker-identification-offline.md). Live audio is sliced by a mandatory **segmentation policy**; each committed utterance is labeled with offline extract + search. There is **no** separate online/streaming speaker-ID model family in sherpa-onnx.
+> This guide uses the **same offline** speaker-embedding weights as [speaker-identification-offline.md](speaker-identification-offline.md). Live audio is sliced by a mandatory **segmentation policy**; each committed utterance is labeled **natively** (offline extract + search inside an `OfflineLivePipelineWorker`). There is **no** separate online/streaming speaker-ID model family in sherpa-onnx.
 >
 > Contrast with features that have a **true streaming** engine (e.g. [stt-streaming.md](stt-streaming.md), [vad-streaming.md](vad-streaming.md), [enhancement-streaming.md](enhancement-streaming.md) via `createStreaming*`), which use streaming-capable models and native online workers.
 
 ## Introduction
 
-On-device **named-speaker labeling** over a live audio stream. SID owns speech segmentation, extracts an embedding per committed utterance, searches the enrolled manager, and appends labeled speech segments (`payload.source: 'sid'`) to a live segment Out buffer.
+On-device **named-speaker labeling** over a live audio stream. SID owns speech segmentation; a native live worker extracts an embedding per committed utterance, searches the enrolled manager, and appends labeled speech segments (`payload.source: 'sid'`) to a live segment Out buffer. Public API matches other live overloads (attach segmentation → start pipeline → handle).
+
 
 | Role | Type | Notes |
 | --- | --- | --- |

--- a/docs/speaker-identification-offline.md
+++ b/docs/speaker-identification-offline.md
@@ -272,8 +272,8 @@ interface SpeakerIdentificationEngine {
 | `identify` | Extract → search; `name` is `null` when below threshold / unknown. Default `threshold` is `0.5`. |
 | `labelOfflineSegments` | Per speech span: native `identifySpeakerOffline` (extract+search in one call) → append `{ source: 'sid', speakerName }` into staging → populate empty `segmentsOut`. `speakerName == null` increments `unknownCount`. Optional `onProgress` + `onLabeled`. |
 | `labelLiveSegments` | Live overload: attach speech segmentation, label each committed utterance into a live segment Out. See [speaker-identification-live.md](speaker-identification-live.md). |
-| `verify` | Cosine check against one enrolled name (whole buffer). |
-| `verifyOfflineSegments` | Per speech span: extract → verify. `string`: same name on every span. `string[]`: one expected name per speech span (length must match). Returns `{ matchCount, mismatchCount, matches }`. Optional `onProgress` + `onVerified`. No segment Out buffer. |
+| `verify` | Native `verifySpeakerOffline` cosine check against one enrolled name (whole buffer). |
+| `verifyOfflineSegments` | Per speech span: native `verifySpeakerOffline` (extract+verify in one call). `string`: same name on every span. `string[]`: one expected name per speech span (length must match). Returns `{ matchCount, mismatchCount, matches }`. Optional `onProgress` + `onVerified`. No segment Out buffer. |
 | `exportEnrollments` / `importEnrollments` | Cross-session enrollment snapshot — see [Persistence](#persistence). |
 | `destroy` | Releases manager + drops extractor ref-count. |
 
@@ -325,7 +325,7 @@ await sid.labelOfflineSegments(audio, vadSegs, labeledOut, {
 
 ### `onVerified` (per-span result — `verifyOfflineSegments` only)
 
-Fires **after** extract + cosine verify for each speech span. Fields match `onLabeled` ranges, plus `expectedName` (the name checked for that span) and `matched: boolean`. Order: `onProgress` → extract/verify → `onVerified`. Non-function / throwing `onVerified` → `SID_INVALID_OPTIONS` / abort.
+Fires **after** native verify for each speech span. Fields match `onLabeled` ranges, plus `expectedName` (the name checked for that span) and `matched: boolean`. Order: `onProgress` → verify → `onVerified`. Non-function / throwing `onVerified` → `SID_INVALID_OPTIONS` / abort.
 
 ```ts
 const { matchCount, mismatchCount, matches } = await sid.verifyOfflineSegments(
@@ -373,7 +373,7 @@ SID does **not** invent the name list; the app supplies who each span belongs to
 
 ### Buffer-first embeddings
 
-PCM stays native via buffer ids. Only the compact embedding (`dim` floats, typically ~256) crosses the TurboModule for enroll/search — not the full waveform.
+PCM stays native via buffer ids. Identify / label / verify use combined native TMs (`identifySpeakerOffline` / `verifySpeakerOffline`) so embeddings stay off the JS hot path. Only enroll (and low-level extract/search) still move compact `dim` floats (~256) across the TurboModule — not the full waveform.
 
 ### Persistence
 

--- a/docs/speaker-identification-offline.md
+++ b/docs/speaker-identification-offline.md
@@ -270,7 +270,7 @@ interface SpeakerIdentificationEngine {
 | `enroll` | Extract embedding(s) from whole buffer(s); native manager averages multiple clips (L2-normalized). Fails if the name already exists. |
 | `enrollOfflineSegments` | Speech spans → embeddings. `string`: average all under one name. `string[]`: one name per speech span (length must match); duplicate names are grouped and averaged. Optional `onProgress`. |
 | `identify` | Extract → search; `name` is `null` when below threshold / unknown. Default `threshold` is `0.5`. |
-| `labelOfflineSegments` | Per speech span: extract → search → append `{ source: 'sid', speakerName }` into staging → populate empty `segmentsOut`. `speakerName == null` increments `unknownCount`. Optional `onProgress` + `onLabeled`. |
+| `labelOfflineSegments` | Per speech span: native `identifySpeakerOffline` (extract+search in one call) → append `{ source: 'sid', speakerName }` into staging → populate empty `segmentsOut`. `speakerName == null` increments `unknownCount`. Optional `onProgress` + `onLabeled`. |
 | `labelLiveSegments` | Live overload: attach speech segmentation, label each committed utterance into a live segment Out. See [speaker-identification-live.md](speaker-identification-live.md). |
 | `verify` | Cosine check against one enrolled name (whole buffer). |
 | `verifyOfflineSegments` | Per speech span: extract → verify. `string`: same name on every span. `string[]`: one expected name per speech span (length must match). Returns `{ matchCount, mismatchCount, matches }`. Optional `onProgress` + `onVerified`. No segment Out buffer. |
@@ -307,7 +307,7 @@ Fires **after** search + successful staging append for each speech span:
 | `startSample` / `endSample` / `sampleRate` / `durationMs` | Span range |
 | `speakerName` | Matched enrolled name, or `null` if below threshold / unknown |
 
-Order per span: `onProgress` → extract/search/append → `onLabeled`. Enroll paths have **no** `onLabeled`. Non-function / throwing `onLabeled` behaves like `onProgress` (`SID_INVALID_OPTIONS` / abort + staging cleanup).
+Order per span: `onProgress` → identify/append → `onLabeled`. Enroll paths have **no** `onLabeled`. Non-function / throwing `onLabeled` behaves like `onProgress` (`SID_INVALID_OPTIONS` / abort + staging cleanup).
 
 ```ts
 await sid.labelOfflineSegments(audio, vadSegs, labeledOut, {

--- a/docs/speaker-identification-offline.md
+++ b/docs/speaker-identification-offline.md
@@ -267,8 +267,8 @@ interface SpeakerIdentificationEngine {
 
 | Method | Behavior |
 | --- | --- |
-| `enroll` | Extract embedding(s) from whole buffer(s); native manager averages multiple clips (L2-normalized). Fails if the name already exists. |
-| `enrollOfflineSegments` | Speech spans → embeddings. `string`: average all under one name. `string[]`: one name per speech span (length must match); duplicate names are grouped and averaged. Optional `onProgress`. |
+| `enroll` | Combined `enrollSpeakerOffline` (whole buffer(s) → compute + manager.add). Fails if the name already exists. |
+| `enrollOfflineSegments` | Combined `enrollSpeakerOffline` per name group (speech spans → embeddings + add). `string`: average all under one name. `string[]`: one name per speech span (length must match); duplicate names are grouped and averaged. Optional `onProgress`. |
 | `identify` | Extract → search; `name` is `null` when below threshold / unknown. Default `threshold` is `0.5`. |
 | `labelOfflineSegments` | Per speech span: native `identifySpeakerOffline` (extract+search in one call) → append `{ source: 'sid', speakerName }` into staging → populate empty `segmentsOut`. `speakerName == null` increments `unknownCount`. Optional `onProgress` + `onLabeled`. |
 | `labelLiveSegments` | Live overload: attach speech segmentation, label each committed utterance into a live segment Out. See [speaker-identification-live.md](speaker-identification-live.md). |
@@ -373,11 +373,11 @@ SID does **not** invent the name list; the app supplies who each span belongs to
 
 ### Buffer-first embeddings
 
-PCM stays native via buffer ids. Identify / label / verify use combined native TMs (`identifySpeakerOffline` / `verifySpeakerOffline`) so embeddings stay off the JS hot path. Only enroll (and low-level extract/search) still move compact `dim` floats (~256) across the TurboModule — not the full waveform.
+PCM stays native via buffer ids. Identify / label / verify / enroll use combined native TMs (`identifySpeakerOffline` / `verifySpeakerOffline` / `enrollSpeakerOffline`) so embeddings stay off the JS product hot path. Low-level extract/search still move compact `dim` floats (~256) across the TurboModule when apps need raw vectors — not the full waveform.
 
 ### Persistence
 
-The native manager cannot read embeddings back by name. SID keeps a **JS mirror** of vectors passed to `manager.add` on `enroll` / `enrollOfflineSegments` / `importEnrollments`, and clears it on `removeSpeaker` / `destroy`.
+The native manager cannot read embeddings back by name. SID keeps a **JS mirror** of vectors returned once from `enrollSpeakerOffline` (and from `importEnrollments`), and clears it on `removeSpeaker` / `destroy`. Product enroll does **not** call a separate `manager.add` with embedding arrays.
 
 ```ts
 // After enroll…

--- a/docs/speaker-identification-offline.md
+++ b/docs/speaker-identification-offline.md
@@ -14,7 +14,7 @@ Import path: **`react-native-sherpa-onnx/speaker-identification`**.
 
 Model detect is available on the SID package (`detectSpeakerEmbeddingModel`) and on **`react-native-sherpa-onnx/speaker-embedding`** (shared foundation). Most embedding internals stay package-local; apps use the SID surface for enrollment and search.
 
-SID answers **who** spoke against an enrolled name list. It does **not** invent anonymous clusters — that is [Speaker Diarization](diarization.md) (planned). VAD still answers **when** speech happens; the app decides which spans belong together for enroll (for example every other interview turn).
+SID answers **who** spoke against an enrolled name list. It does **not** invent anonymous clusters — that is [Speaker Diarization](diarization.md) (offline available). VAD still answers **when** speech happens; the app decides which spans belong together for enroll (for example every other interview turn).
 
 Live labeling is available via **`labelLiveSegments`** — see [speaker-identification-live.md](speaker-identification-live.md). Enrollment remains offline (`enroll` / `enrollOfflineSegments`).
 
@@ -192,7 +192,7 @@ function createSpeakerIdentification(
 
 `SpeakerIdentificationOptions` is the same union as speaker-embedding init (`initMode: 'auto' | 'custom'`, `modelSource` / `customConfig`, `numThreads`, `provider`, `debug`).
 
-The extractor is **ref-counted** so a future diarization engine can share the same weights. Each SID instance still owns its own **named-speaker manager**.
+The extractor is **ref-counted** so diarization can share the same weights via the C++ `SpeakerEmbeddingRunner` registry. Each SID instance still owns its own **named-speaker manager**.
 
 ### Engine methods
 
@@ -430,7 +430,7 @@ await sid.importEnrollments(restored, { replaceExisting: true });
 | Identify result | `{ name: string \| null }` | Whole-buffer `identify` — no segment Out. |
 | Labeled timeline | `OfflineSegmentBuffer` (`seg_off_*`) | Empty `segmentsOut` filled with `payload.source: 'sid'`. |
 | UI / export | Segment metadata | Read via `getOfflineSegmentBufferSegments(...)`. |
-| Future diarization | Shared embedding engine | Same weights via extractor cache; anonymous clusters are **not** SID — see [diarization.md](diarization.md). |
+| Diarization | Shared embedding Runner | Same weights via C++ registry; anonymous clusters are **not** SID — see [diarization.md](diarization.md). |
 
 ```mermaid
 flowchart LR
@@ -525,7 +525,7 @@ JS-side SID guards (message match, not always a native `code`): empty speaker na
 - [Pipeline segment buffers — offline](segmentbuffer-offline.md) — speech payload `sid`
 - [VAD streaming](vad-streaming.md) — speech boundaries (when)
 - [Speaker Identification (live overload)](speaker-identification-live.md) — `labelLiveSegments`
-- [Speaker diarization](diarization.md) — anonymous clustering (planned; shared embedding foundation)
+- [Speaker diarization](diarization.md) — anonymous clustering (offline shipped; shared embedding foundation)
 - [Feature pipelines](feature-pipelines.md)
 - [Model detect](model-detect.md)
 - [Model setup](model-setup.md)

--- a/ios/diarization/bridge/SherpaOnnx+DiarizationOffline.mm
+++ b/ios/diarization/bridge/SherpaOnnx+DiarizationOffline.mm
@@ -120,12 +120,8 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
   dispatch_async(DiarizationSerialQueue(), ^{
     @try {
       std::lock_guard<std::mutex> lock(sherpaonnx::diarization::bridge::g_diarization_mutex);
-      auto &inst = sherpaonnx::diarization::bridge::g_diarization_instances[instanceIdStr];
-      if (inst == nullptr) {
-        inst = std::make_unique<sherpaonnx::DiarizationWrapper>();
-      } else {
-        inst->release();
-      }
+      // Replace the map entry so in-flight shared_ptrs keep the old wrapper.
+      auto inst = std::make_shared<sherpaonnx::DiarizationWrapper>();
 
       sherpaonnx::DiarizationInitializeResult result = inst->initialize(
           std::string([segmentationModel UTF8String]),
@@ -151,6 +147,9 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
         reject(errorCode, errorMsg, nil);
         return;
       }
+
+      sherpaonnx::diarization::bridge::g_diarization_instances[instanceIdStr] =
+          std::move(inst);
 
       NSMutableDictionary *out = [@{
         @"success": @YES,
@@ -224,18 +223,13 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
         return;
       }
 
-      sherpaonnx::DiarizationWrapper *wrapper = nullptr;
-      {
-        std::lock_guard<std::mutex> lock(sherpaonnx::diarization::bridge::g_diarization_mutex);
-        auto it = sherpaonnx::diarization::bridge::g_diarization_instances.find(instanceIdStr);
-        if (it == sherpaonnx::diarization::bridge::g_diarization_instances.end() ||
-            it->second == nullptr) {
-          reject(@"DIARIZATION_NOT_INITIALIZED",
-                 [NSString stringWithFormat:@"Diarization instance not found: %@", instanceId],
-                 nil);
-          return;
-        }
-        wrapper = it->second.get();
+      auto wrapper =
+          sherpaonnx::diarization::bridge::LookupDiarization(instanceIdStr);
+      if (!wrapper) {
+        reject(@"DIARIZATION_NOT_INITIALIZED",
+               [NSString stringWithFormat:@"Diarization instance not found: %@", instanceId],
+               nil);
+        return;
       }
 
       sherpaonnx::DiarizationProcessResult result =
@@ -271,20 +265,17 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
   std::string instanceIdStr = [instanceId UTF8String];
   dispatch_async(DiarizationSerialQueue(), ^{
     @try {
-      sherpaonnx::DiarizationProcessResult result;
-      {
-        std::lock_guard<std::mutex> lock(sherpaonnx::diarization::bridge::g_diarization_mutex);
-        auto it = sherpaonnx::diarization::bridge::g_diarization_instances.find(instanceIdStr);
-        if (it == sherpaonnx::diarization::bridge::g_diarization_instances.end() ||
-            it->second == nullptr) {
-          reject(@"DIARIZATION_NOT_INITIALIZED",
-                 [NSString stringWithFormat:@"Diarization instance not found: %@", instanceId],
-                 nil);
-          return;
-        }
-        result = it->second->recluster(static_cast<int32_t>(numClusters),
-                                       static_cast<float>(threshold));
+      auto wrapper =
+          sherpaonnx::diarization::bridge::LookupDiarization(instanceIdStr);
+      if (!wrapper) {
+        reject(@"DIARIZATION_NOT_INITIALIZED",
+               [NSString stringWithFormat:@"Diarization instance not found: %@", instanceId],
+               nil);
+        return;
       }
+      sherpaonnx::DiarizationProcessResult result =
+          wrapper->recluster(static_cast<int32_t>(numClusters),
+                             static_cast<float>(threshold));
       if (!result.success) {
         reject(RejectCodeForProcess(result),
                result.error.empty()
@@ -314,19 +305,16 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
   std::string instanceIdStr = [instanceId UTF8String];
   dispatch_async(DiarizationSerialQueue(), ^{
     @try {
-      std::vector<sherpaonnx::DiarizationClusterEmbeddingDto> embeddings;
-      {
-        std::lock_guard<std::mutex> lock(sherpaonnx::diarization::bridge::g_diarization_mutex);
-        auto it = sherpaonnx::diarization::bridge::g_diarization_instances.find(instanceIdStr);
-        if (it == sherpaonnx::diarization::bridge::g_diarization_instances.end() ||
-            it->second == nullptr) {
-          reject(@"DIARIZATION_NOT_INITIALIZED",
-                 [NSString stringWithFormat:@"Diarization instance not found: %@", instanceId],
-                 nil);
-          return;
-        }
-        embeddings = it->second->getClusterEmbeddings();
+      auto wrapper =
+          sherpaonnx::diarization::bridge::LookupDiarization(instanceIdStr);
+      if (!wrapper) {
+        reject(@"DIARIZATION_NOT_INITIALIZED",
+               [NSString stringWithFormat:@"Diarization instance not found: %@", instanceId],
+               nil);
+        return;
       }
+      std::vector<sherpaonnx::DiarizationClusterEmbeddingDto> embeddings =
+          wrapper->getClusterEmbeddings();
 
       NSMutableArray *out = [NSMutableArray arrayWithCapacity:embeddings.size()];
       for (const auto &entry : embeddings) {
@@ -359,11 +347,10 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
   }
   const std::string instanceIdStr = [instanceId UTF8String];
   @try {
-    std::lock_guard<std::mutex> lock(sherpaonnx::diarization::bridge::g_diarization_mutex);
-    auto it = sherpaonnx::diarization::bridge::g_diarization_instances.find(instanceIdStr);
-    if (it != sherpaonnx::diarization::bridge::g_diarization_instances.end() &&
-        it->second != nullptr) {
-      it->second->cancel();
+    auto wrapper =
+        sherpaonnx::diarization::bridge::LookupDiarization(instanceIdStr);
+    if (wrapper) {
+      wrapper->cancel();
     }
     resolve(nil);
   } @catch (NSException *exception) {
@@ -384,15 +371,19 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
   const std::string instanceIdStr = [instanceId UTF8String];
   dispatch_async(DiarizationSerialQueue(), ^{
     @try {
-      std::lock_guard<std::mutex> lock(sherpaonnx::diarization::bridge::g_diarization_mutex);
-      auto it = sherpaonnx::diarization::bridge::g_diarization_instances.find(instanceIdStr);
-      if (it != sherpaonnx::diarization::bridge::g_diarization_instances.end()) {
-        if (it->second != nullptr) {
-          it->second->cancel();
-          it->second->release();
+      std::shared_ptr<sherpaonnx::DiarizationWrapper> doomed;
+      {
+        std::lock_guard<std::mutex> lock(sherpaonnx::diarization::bridge::g_diarization_mutex);
+        auto it = sherpaonnx::diarization::bridge::g_diarization_instances.find(instanceIdStr);
+        if (it != sherpaonnx::diarization::bridge::g_diarization_instances.end()) {
+          if (it->second) {
+            it->second->cancel();
+          }
+          doomed = std::move(it->second);
+          sherpaonnx::diarization::bridge::g_diarization_instances.erase(it);
         }
-        sherpaonnx::diarization::bridge::g_diarization_instances.erase(it);
       }
+      // Destructor releases when last shared_ptr drops (after in-flight process).
       resolve(nil);
     } @catch (NSException *exception) {
       reject(@"DIARIZATION_ERROR",

--- a/ios/diarization/bridge/SherpaOnnx+DiarizationOffline.mm
+++ b/ios/diarization/bridge/SherpaOnnx+DiarizationOffline.mm
@@ -2,10 +2,12 @@
 #import <React/RCTLog.h>
 
 #include "../../audio/pipeline/SherpaOnnx+PipelineAudioGlobals.h"
+#include "../../segmentbuffer/core/SherpaOnnx+SegmentBufferGlobals.h"
 #include "sherpa-onnx-diarization-wrapper.h"
 #include "../core/DiarizationBridgeState.h"
 
 #include <algorithm>
+#include <cmath>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -54,6 +56,35 @@ NSDictionary *ProcessResultToDict(const sherpaonnx::DiarizationProcessResult &re
     @"segments": segments,
     @"numSpeakers": @(result.numSpeakers),
     @"sampleRate": @(result.sampleRate),
+  } mutableCopy];
+
+  if (!result.error.empty()) {
+    out[@"error"] = [NSString stringWithUTF8String:result.error.c_str()];
+  }
+  if (!result.errorCode.empty()) {
+    out[@"errorCode"] = [NSString stringWithUTF8String:result.errorCode.c_str()];
+  }
+  if (!result.speakersPerFrame.empty()) {
+    NSMutableArray *spf = [NSMutableArray arrayWithCapacity:result.speakersPerFrame.size()];
+    for (int32_t v : result.speakersPerFrame) {
+      [spf addObject:@(v)];
+    }
+    out[@"speakersPerFrame"] = spf;
+  }
+  return out;
+}
+
+/** Product diarize path: segments already written to segmentsOut; omit timeline array. */
+NSDictionary *ProcessResultToDictWritten(
+    const sherpaonnx::DiarizationProcessResult &result,
+    NSUInteger segmentCount,
+    int sampleRate) {
+  NSMutableDictionary *out = [@{
+    @"success": @(result.success),
+    @"segments": @[],
+    @"segmentCount": @(segmentCount),
+    @"numSpeakers": @(result.numSpeakers),
+    @"sampleRate": @(sampleRate),
   } mutableCopy];
 
   if (!result.error.empty()) {
@@ -172,6 +203,7 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
 
 - (void)diarizeOffline:(NSString *)instanceId
        audioInBufferId:(NSString *)audioInBufferId
+  segmentsOutBufferId:(NSString *)segmentsOutBufferId
         includeOverlap:(BOOL)includeOverlap
                resolve:(RCTPromiseResolveBlock)resolve
                 reject:(RCTPromiseRejectBlock)reject
@@ -184,9 +216,19 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
     reject(@"DIARIZATION_BUFFER_NOT_FOUND", @"audioInBufferId is required", nil);
     return;
   }
+  if (segmentsOutBufferId == nil || [segmentsOutBufferId length] == 0 ||
+      ![segmentsOutBufferId hasPrefix:@"seg_off_"]) {
+    reject(@"DIARIZATION_ERROR",
+           [NSString stringWithFormat:
+               @"Expected empty offline segment buffer (seg_off_*) for segmentsOut, got: %@",
+               segmentsOutBufferId ?: @"(null)"],
+           nil);
+    return;
+  }
 
   std::string instanceIdStr = [instanceId UTF8String];
   std::string audioInId = [audioInBufferId UTF8String];
+  std::string segmentsOutId = [segmentsOutBufferId UTF8String];
   if (audioInId.find("off_") != 0) {
     reject(@"DIARIZATION_ERROR",
            [NSString stringWithFormat:@"Expected offline audio buffer (off_*) for audioIn, got: %@",
@@ -210,6 +252,24 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
            [NSString stringWithFormat:@"Input offline audio buffer is empty: %@", audioInBufferId],
            nil);
     return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(g_seg_mutex);
+    auto it = g_seg_offline.find(segmentsOutId);
+    if (it == g_seg_offline.end() || !it->second) {
+      reject(@"DIARIZATION_BUFFER_NOT_FOUND",
+             [NSString stringWithFormat:@"Offline segment buffer not found: %@",
+                                        segmentsOutBufferId],
+             nil);
+      return;
+    }
+    if (!it->second->segments.empty()) {
+      reject(@"DIARIZATION_ERROR",
+             @"segmentOut must be an empty offline segment buffer",
+             nil);
+      return;
+    }
   }
 
   dispatch_async(DiarizationSerialQueue(), ^{
@@ -242,7 +302,53 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
                nil);
         return;
       }
-      resolve(ProcessResultToDict(result));
+
+      const int sampleRate =
+          result.sampleRate > 0 ? result.sampleRate : inSampleRate;
+      std::vector<SegRecord> records;
+      records.reserve(result.segments.size());
+      for (const auto &seg : result.segments) {
+        const int startSample =
+            std::max(0, static_cast<int>(std::lround(seg.start * sampleRate)));
+        const int endSample =
+            std::max(startSample, static_cast<int>(std::lround(seg.end * sampleRate)));
+        const int durationMs =
+            sampleRate > 0 ? ((endSample - startSample) * 1000) / sampleRate : 0;
+        SegRecord r;
+        r.id = "seg_off_" + std::to_string(startSample) + "_" + std::to_string(endSample);
+        r.kind = "diarization";
+        r.sourceAudioBufferId = audioInId;
+        r.startSample = startSample;
+        r.endSample = endSample;
+        r.sampleRate = sampleRate;
+        r.durationMs = durationMs;
+        r.hasConfidence = false;
+        r.payloadJson =
+            std::string("{\"source\":\"diarization\",\"speaker\":") +
+            std::to_string(seg.speaker) + "}";
+        records.push_back(std::move(r));
+      }
+
+      {
+        std::lock_guard<std::mutex> lock(g_seg_mutex);
+        auto it = g_seg_offline.find(segmentsOutId);
+        if (it == g_seg_offline.end() || !it->second) {
+          reject(@"DIARIZATION_BUFFER_NOT_FOUND",
+                 [NSString stringWithFormat:@"Offline segment buffer not found: %@",
+                                            segmentsOutBufferId],
+                 nil);
+          return;
+        }
+        if (!it->second->segments.empty()) {
+          reject(@"DIARIZATION_ERROR",
+                 @"segmentOut must be an empty offline segment buffer",
+                 nil);
+          return;
+        }
+        it->second->segments = std::move(records);
+      }
+
+      resolve(ProcessResultToDictWritten(result, result.segments.size(), sampleRate));
     } @catch (NSException *exception) {
       reject(@"DIARIZATION_ERROR",
              [NSString stringWithFormat:@"Diarization process failed: %@", exception.reason],

--- a/ios/diarization/core/DiarizationBridgeState.h
+++ b/ios/diarization/core/DiarizationBridgeState.h
@@ -15,9 +15,13 @@ namespace sherpaonnx {
 namespace diarization {
 namespace bridge {
 
-extern std::unordered_map<std::string, std::unique_ptr<sherpaonnx::DiarizationWrapper>>
+extern std::unordered_map<std::string, std::shared_ptr<sherpaonnx::DiarizationWrapper>>
     g_diarization_instances;
 extern std::mutex g_diarization_mutex;
+
+/** Copy a strong ref under the map lock; caller uses it outside the lock. */
+std::shared_ptr<sherpaonnx::DiarizationWrapper> LookupDiarization(
+    const std::string& id);
 
 }  // namespace bridge
 }  // namespace diarization

--- a/ios/diarization/core/DiarizationBridgeState.mm
+++ b/ios/diarization/core/DiarizationBridgeState.mm
@@ -5,9 +5,17 @@ namespace sherpaonnx {
 namespace diarization {
 namespace bridge {
 
-std::unordered_map<std::string, std::unique_ptr<sherpaonnx::DiarizationWrapper>>
+std::unordered_map<std::string, std::shared_ptr<sherpaonnx::DiarizationWrapper>>
     g_diarization_instances;
 std::mutex g_diarization_mutex;
+
+std::shared_ptr<sherpaonnx::DiarizationWrapper> LookupDiarization(
+    const std::string& id) {
+  std::lock_guard<std::mutex> lock(g_diarization_mutex);
+  auto it = g_diarization_instances.find(id);
+  if (it == g_diarization_instances.end() || !it->second) return nullptr;
+  return it->second;
+}
 
 }  // namespace bridge
 }  // namespace diarization

--- a/ios/livePipeline/OfflineLivePipelineWorker.h
+++ b/ios/livePipeline/OfflineLivePipelineWorker.h
@@ -24,6 +24,8 @@ struct CommittedSegmentSpeech {
   std::string segmentId;
   int segmentIndex = 0;
   std::string payloadJson;
+  bool hasConfidence = false;
+  double confidence = 0.0;
 };
 
 struct CommittedSegmentText {

--- a/ios/livePipeline/OfflineLivePipelineWorker.mm
+++ b/ios/livePipeline/OfflineLivePipelineWorker.mm
@@ -239,6 +239,8 @@ bool OfflineLivePipelineWorker::drainNextSegment(DrainedSegment *out) {
         record.id,
         startIndex,
         record.payloadJson,
+        record.hasConfidence,
+        record.confidence,
       };
       out->unitsRead = std::max(0, record.endSample - record.startSample);
       return true;

--- a/ios/speaker-embedding/bridge/SherpaOnnx+SpeakerEmbeddingInference.mm
+++ b/ios/speaker-embedding/bridge/SherpaOnnx+SpeakerEmbeddingInference.mm
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
@@ -109,26 +110,11 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
   const SpeakerEmbeddingInitScalars scalars = ParseSpeakerEmbeddingInitScalars(options);
 
   @try {
-    std::lock_guard<std::mutex> lock(
-        sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-    auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors
-                  .find(instanceIdStr);
-    if (it ==
-        sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors.end()) {
-      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors[instanceIdStr] =
-          std::make_unique<
-              sherpaonnx::speaker_embedding::bridge::SpeakerEmbeddingExtractorState>();
-    }
-
-    auto *inst =
-        sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors[instanceIdStr]
-            .get();
-    if (inst->wrapper == nullptr) {
-      inst->wrapper =
-          std::make_unique<sherpaonnx::SpeakerEmbeddingExtractorWrapper>();
-    }
-
-    sherpaonnx::SpeakerEmbeddingInitializeResult result;
+    // Validate custom/auto args before allocating a wrapper under the map lock.
+    sherpaonnx::SpeakerEmbeddingModelPaths customPaths;
+    std::string customModelType;
+    std::string autoModelDir;
+    std::string autoModelType;
     if (isCustomInit) {
       NSString *modelType = options.modelType();
       if (modelType == nil || [modelType length] == 0 ||
@@ -143,14 +129,8 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
                @"custom init requires modelPaths", nil);
         return;
       }
-      sherpaonnx::SpeakerEmbeddingModelPaths paths;
-      FillSpeakerEmbeddingModelPathsFromDict((NSDictionary *)modelPathsObj, paths);
-      result = inst->wrapper->initializeCustom(
-          std::string([modelType UTF8String]),
-          paths,
-          scalars.numThreads,
-          scalars.provider,
-          scalars.debug);
+      customModelType = std::string([modelType UTF8String]);
+      FillSpeakerEmbeddingModelPathsFromDict((NSDictionary *)modelPathsObj, customPaths);
     } else {
       NSString *modelDir = options.modelDir();
       if (modelDir == nil || [modelDir length] == 0) {
@@ -158,24 +138,45 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
                @"modelDir is required for initMode auto", nil);
         return;
       }
-      NSString *modelType = options.modelType();
-      std::string modelTypeStr =
-          sherpaonnx::speaker_embedding::bridge::ModelTypeOrAuto(modelType);
-      result = inst->wrapper->initialize(
-          std::string([modelDir UTF8String]),
-          modelTypeStr,
+      autoModelDir = std::string([modelDir UTF8String]);
+      autoModelType = sherpaonnx::speaker_embedding::bridge::ModelTypeOrAuto(
+          options.modelType());
+    }
+
+    std::lock_guard<std::mutex> lock(
+        sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
+    // Replace the map entry so in-flight shared_ptrs keep the old wrapper.
+    auto inst = std::make_shared<sherpaonnx::SpeakerEmbeddingExtractorWrapper>();
+
+    sherpaonnx::SpeakerEmbeddingInitializeResult result;
+    if (isCustomInit) {
+      result = inst->initializeCustom(
+          customModelType,
+          customPaths,
+          scalars.numThreads,
+          scalars.provider,
+          scalars.debug);
+    } else {
+      result = inst->initialize(
+          autoModelDir,
+          autoModelType,
           scalars.numThreads,
           scalars.provider,
           scalars.debug);
     }
 
     if (!result.success) {
+      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors.erase(
+          instanceIdStr);
       NSString *errorMsg = result.error.empty()
           ? @"Failed to initialize speaker embedding extractor"
           : [NSString stringWithUTF8String:result.error.c_str()];
       reject(@"SPEAKER_EMBEDDING_INIT_ERROR", errorMsg, nil);
       return;
     }
+
+    sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors[instanceIdStr] =
+        std::move(inst);
 
     resolve(@{
       @"success": @YES,
@@ -275,31 +276,19 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
       }
     }
 
-    std::vector<float> embedding;
-    std::string computeError;
-    std::string computeErrorCode;
-    {
-      std::lock_guard<std::mutex> lock(
-          sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-      auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors
-                    .find(instanceIdStr);
-      if (it ==
-              sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors
-                  .end() ||
-          it->second == nullptr || it->second->wrapper == nullptr ||
-          !it->second->wrapper->isInitialized()) {
-        reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR",
-               [NSString stringWithFormat:@"Speaker embedding extractor not found: %@", instanceId],
-               nil);
-        return;
-      }
-      embedding = it->second->wrapper->computeFromSamples(inputSamples, inputSr);
-      if (embedding.empty()) {
-        computeError = it->second->wrapper->lastError();
-        computeErrorCode = it->second->wrapper->lastErrorCode();
-      }
+    auto extractor =
+        sherpaonnx::speaker_embedding::bridge::LookupExtractor(instanceIdStr);
+    if (!extractor || !extractor->isInitialized()) {
+      reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR",
+             [NSString stringWithFormat:@"Speaker embedding extractor not found: %@", instanceId],
+             nil);
+      return;
     }
+    std::vector<float> embedding =
+        extractor->computeFromSamples(inputSamples, inputSr);
     if (embedding.empty()) {
+      const std::string &computeError = extractor->lastError();
+      const std::string &computeErrorCode = extractor->lastErrorCode();
       NSString *code = computeErrorCode.empty()
           ? @"SPEAKER_EMBEDDING_COMPUTE_ERROR"
           : [NSString stringWithUTF8String:computeErrorCode.c_str()];
@@ -411,52 +400,27 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
       }
     }
 
-    std::string matchedName;
-    std::string computeError;
-    std::string computeErrorCode;
-    bool computeFailed = false;
-    bool managerMissing = false;
-    {
-      std::lock_guard<std::mutex> lock(
-          sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-      auto extractorIt = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors
-                             .find(instanceIdStr);
-      if (extractorIt ==
-              sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors
-                  .end() ||
-          extractorIt->second == nullptr || extractorIt->second->wrapper == nullptr ||
-          !extractorIt->second->wrapper->isInitialized()) {
-        reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR",
-               [NSString stringWithFormat:@"Speaker embedding extractor not found: %@", instanceId],
-               nil);
-        return;
-      }
-      auto managerIt = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
-                           .find(managerIdStr);
-      if (managerIt ==
-              sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end() ||
-          managerIt->second == nullptr || managerIt->second->wrapper == nullptr) {
-        managerMissing = true;
-      } else {
-        std::vector<float> embedding =
-            extractorIt->second->wrapper->computeFromSamples(inputSamples, inputSr);
-        if (embedding.empty()) {
-          computeFailed = true;
-          computeError = extractorIt->second->wrapper->lastError();
-          computeErrorCode = extractorIt->second->wrapper->lastErrorCode();
-        } else {
-          matchedName =
-              managerIt->second->wrapper->search(embedding, static_cast<float>(threshold));
-        }
-      }
+    auto extractor =
+        sherpaonnx::speaker_embedding::bridge::LookupExtractor(instanceIdStr);
+    if (!extractor || !extractor->isInitialized()) {
+      reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR",
+             [NSString stringWithFormat:@"Speaker embedding extractor not found: %@", instanceId],
+             nil);
+      return;
     }
-    if (managerMissing) {
+    auto manager =
+        sherpaonnx::speaker_embedding::bridge::LookupManager(managerIdStr);
+    if (!manager) {
       reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
              [NSString stringWithFormat:@"Speaker embedding manager not found: %@", managerId],
              nil);
       return;
     }
-    if (computeFailed) {
+    std::vector<float> embedding =
+        extractor->computeFromSamples(inputSamples, inputSr);
+    if (embedding.empty()) {
+      const std::string &computeError = extractor->lastError();
+      const std::string &computeErrorCode = extractor->lastErrorCode();
       NSString *code = computeErrorCode.empty()
           ? @"SPEAKER_EMBEDDING_COMPUTE_ERROR"
           : [NSString stringWithUTF8String:computeErrorCode.c_str()];
@@ -466,6 +430,8 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
       reject(code, msg, nil);
       return;
     }
+    std::string matchedName =
+        manager->search(embedding, static_cast<float>(threshold));
 
     resolve(@{
       @"name": [NSString stringWithUTF8String:matchedName.c_str()] ?: @""
@@ -576,52 +542,27 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
       }
     }
 
-    bool verified = false;
-    std::string computeError;
-    std::string computeErrorCode;
-    bool computeFailed = false;
-    bool managerMissing = false;
-    {
-      std::lock_guard<std::mutex> lock(
-          sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-      auto extractorIt = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors
-                             .find(instanceIdStr);
-      if (extractorIt ==
-              sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors
-                  .end() ||
-          extractorIt->second == nullptr || extractorIt->second->wrapper == nullptr ||
-          !extractorIt->second->wrapper->isInitialized()) {
-        reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR",
-               [NSString stringWithFormat:@"Speaker embedding extractor not found: %@", instanceId],
-               nil);
-        return;
-      }
-      auto managerIt = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
-                           .find(managerIdStr);
-      if (managerIt ==
-              sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end() ||
-          managerIt->second == nullptr || managerIt->second->wrapper == nullptr) {
-        managerMissing = true;
-      } else {
-        std::vector<float> embedding =
-            extractorIt->second->wrapper->computeFromSamples(inputSamples, inputSr);
-        if (embedding.empty()) {
-          computeFailed = true;
-          computeError = extractorIt->second->wrapper->lastError();
-          computeErrorCode = extractorIt->second->wrapper->lastErrorCode();
-        } else {
-          verified = managerIt->second->wrapper->verify(
-              nameStr, embedding, static_cast<float>(threshold));
-        }
-      }
+    auto extractor =
+        sherpaonnx::speaker_embedding::bridge::LookupExtractor(instanceIdStr);
+    if (!extractor || !extractor->isInitialized()) {
+      reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR",
+             [NSString stringWithFormat:@"Speaker embedding extractor not found: %@", instanceId],
+             nil);
+      return;
     }
-    if (managerMissing) {
+    auto manager =
+        sherpaonnx::speaker_embedding::bridge::LookupManager(managerIdStr);
+    if (!manager) {
       reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
              [NSString stringWithFormat:@"Speaker embedding manager not found: %@", managerId],
              nil);
       return;
     }
-    if (computeFailed) {
+    std::vector<float> embedding =
+        extractor->computeFromSamples(inputSamples, inputSr);
+    if (embedding.empty()) {
+      const std::string &computeError = extractor->lastError();
+      const std::string &computeErrorCode = extractor->lastErrorCode();
       NSString *code = computeErrorCode.empty()
           ? @"SPEAKER_EMBEDDING_COMPUTE_ERROR"
           : [NSString stringWithUTF8String:computeErrorCode.c_str()];
@@ -631,6 +572,8 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
       reject(code, msg, nil);
       return;
     }
+    bool verified =
+        manager->verify(nameStr, embedding, static_cast<float>(threshold));
 
     resolve(@{ @"ok": @(verified) });
   } @catch (NSException *exception) {
@@ -649,17 +592,19 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
     return;
   }
   const std::string instanceIdStr = [instanceId UTF8String];
-  std::lock_guard<std::mutex> lock(
-      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-  auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors
-                .find(instanceIdStr);
-  if (it !=
-      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors.end()) {
-    if (it->second != nullptr && it->second->wrapper != nullptr) {
-      it->second->wrapper->release();
+  std::shared_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper> doomed;
+  {
+    std::lock_guard<std::mutex> lock(
+        sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
+    auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors
+                  .find(instanceIdStr);
+    if (it !=
+        sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors.end()) {
+      doomed = std::move(it->second);
+      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors.erase(it);
     }
-    sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors.erase(it);
   }
+  // Destructor releases when last shared_ptr drops (after in-flight compute).
   resolve(nil);
 }
 
@@ -682,27 +627,17 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
   @try {
     std::lock_guard<std::mutex> lock(
         sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-    auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
-                  .find(managerIdStr);
-    if (it ==
-        sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end()) {
-      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers[managerIdStr] =
-          std::make_unique<
-              sherpaonnx::speaker_embedding::bridge::SpeakerEmbeddingManagerState>();
-    }
-    auto *inst =
-        sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers[managerIdStr]
-            .get();
-    if (inst->wrapper == nullptr) {
-      inst->wrapper = std::make_unique<sherpaonnx::SpeakerEmbeddingManagerWrapper>();
-    } else {
-      inst->wrapper->release();
-    }
-    if (!inst->wrapper->create(dimInt)) {
+    // Replace the map entry so in-flight shared_ptrs keep the old wrapper.
+    auto inst = std::make_shared<sherpaonnx::SpeakerEmbeddingManagerWrapper>();
+    if (!inst->create(dimInt)) {
+      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.erase(
+          managerIdStr);
       reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
              @"Failed to create speaker embedding manager", nil);
       return;
     }
+    sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers[managerIdStr] =
+        std::move(inst);
     resolve(@{ @"success": @YES });
   } @catch (NSException *exception) {
     reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
@@ -726,20 +661,15 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
   const int32_t countInt = (int32_t)count;
   auto flat = NSArrayToFloatVector(embeddings);
 
-  std::lock_guard<std::mutex> lock(
-      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-  auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
-                .find(managerIdStr);
-  if (it == sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end() ||
-      it->second == nullptr || it->second->wrapper == nullptr ||
-      !it->second->wrapper->isInitialized()) {
+  auto manager =
+      sherpaonnx::speaker_embedding::bridge::LookupManager(managerIdStr);
+  if (!manager || !manager->isInitialized()) {
     reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
            [NSString stringWithFormat:@"Speaker embedding manager not found: %@", managerId],
            nil);
     return;
   }
-  bool ok = it->second->wrapper->add(
-      std::string([name UTF8String]), flat, countInt);
+  bool ok = manager->add(std::string([name UTF8String]), flat, countInt);
   resolve(@{ @"ok": @(ok) });
 }
 
@@ -753,18 +683,15 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
     return;
   }
   const std::string managerIdStr = [managerId UTF8String];
-  std::lock_guard<std::mutex> lock(
-      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-  auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
-                .find(managerIdStr);
-  if (it == sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end() ||
-      it->second == nullptr || it->second->wrapper == nullptr) {
+  auto manager =
+      sherpaonnx::speaker_embedding::bridge::LookupManager(managerIdStr);
+  if (!manager) {
     reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
            [NSString stringWithFormat:@"Speaker embedding manager not found: %@", managerId],
            nil);
     return;
   }
-  bool ok = it->second->wrapper->remove(std::string([name UTF8String]));
+  bool ok = manager->remove(std::string([name UTF8String]));
   resolve(@{ @"ok": @(ok) });
 }
 
@@ -780,19 +707,16 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
   }
   const std::string managerIdStr = [managerId UTF8String];
   auto emb = NSArrayToFloatVector(embedding);
-  std::lock_guard<std::mutex> lock(
-      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-  auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
-                .find(managerIdStr);
-  if (it == sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end() ||
-      it->second == nullptr || it->second->wrapper == nullptr) {
+  auto manager =
+      sherpaonnx::speaker_embedding::bridge::LookupManager(managerIdStr);
+  if (!manager) {
     reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
            [NSString stringWithFormat:@"Speaker embedding manager not found: %@", managerId],
            nil);
     return;
   }
   std::string name =
-      it->second->wrapper->search(emb, static_cast<float>(threshold));
+      manager->search(emb, static_cast<float>(threshold));
   resolve(@{
     @"name": [NSString stringWithUTF8String:name.c_str()] ?: @""
   });
@@ -811,18 +735,15 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
   }
   const std::string managerIdStr = [managerId UTF8String];
   auto emb = NSArrayToFloatVector(embedding);
-  std::lock_guard<std::mutex> lock(
-      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-  auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
-                .find(managerIdStr);
-  if (it == sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end() ||
-      it->second == nullptr || it->second->wrapper == nullptr) {
+  auto manager =
+      sherpaonnx::speaker_embedding::bridge::LookupManager(managerIdStr);
+  if (!manager) {
     reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
            [NSString stringWithFormat:@"Speaker embedding manager not found: %@", managerId],
            nil);
     return;
   }
-  bool ok = it->second->wrapper->verify(
+  bool ok = manager->verify(
       std::string([name UTF8String]), emb, static_cast<float>(threshold));
   resolve(@{ @"ok": @(ok) });
 }
@@ -837,18 +758,15 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
     return;
   }
   const std::string managerIdStr = [managerId UTF8String];
-  std::lock_guard<std::mutex> lock(
-      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-  auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
-                .find(managerIdStr);
-  if (it == sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end() ||
-      it->second == nullptr || it->second->wrapper == nullptr) {
+  auto manager =
+      sherpaonnx::speaker_embedding::bridge::LookupManager(managerIdStr);
+  if (!manager) {
     reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
            [NSString stringWithFormat:@"Speaker embedding manager not found: %@", managerId],
            nil);
     return;
   }
-  bool ok = it->second->wrapper->contains(std::string([name UTF8String]));
+  bool ok = manager->contains(std::string([name UTF8String]));
   resolve(@{ @"ok": @(ok) });
 }
 
@@ -861,18 +779,15 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
     return;
   }
   const std::string managerIdStr = [managerId UTF8String];
-  std::lock_guard<std::mutex> lock(
-      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-  auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
-                .find(managerIdStr);
-  if (it == sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end() ||
-      it->second == nullptr || it->second->wrapper == nullptr) {
+  auto manager =
+      sherpaonnx::speaker_embedding::bridge::LookupManager(managerIdStr);
+  if (!manager) {
     reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
            [NSString stringWithFormat:@"Speaker embedding manager not found: %@", managerId],
            nil);
     return;
   }
-  resolve(@(it->second->wrapper->numSpeakers()));
+  resolve(@(manager->numSpeakers()));
 }
 
 - (void)speakerEmbeddingManagerAllSpeakerNames:(NSString *)managerId
@@ -884,18 +799,15 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
     return;
   }
   const std::string managerIdStr = [managerId UTF8String];
-  std::lock_guard<std::mutex> lock(
-      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-  auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
-                .find(managerIdStr);
-  if (it == sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end() ||
-      it->second == nullptr || it->second->wrapper == nullptr) {
+  auto manager =
+      sherpaonnx::speaker_embedding::bridge::LookupManager(managerIdStr);
+  if (!manager) {
     reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
            [NSString stringWithFormat:@"Speaker embedding manager not found: %@", managerId],
            nil);
     return;
   }
-  auto names = it->second->wrapper->allSpeakers();
+  auto names = manager->allSpeakers();
   NSMutableArray *arr = [NSMutableArray arrayWithCapacity:names.size()];
   for (const auto &n : names) {
     [arr addObject:[NSString stringWithUTF8String:n.c_str()] ?: @""];
@@ -912,17 +824,19 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
     return;
   }
   const std::string managerIdStr = [managerId UTF8String];
-  std::lock_guard<std::mutex> lock(
-      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
-  auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
-                .find(managerIdStr);
-  if (it !=
-      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end()) {
-    if (it->second != nullptr && it->second->wrapper != nullptr) {
-      it->second->wrapper->release();
+  std::shared_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper> doomed;
+  {
+    std::lock_guard<std::mutex> lock(
+        sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
+    auto it = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
+                  .find(managerIdStr);
+    if (it !=
+        sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end()) {
+      doomed = std::move(it->second);
+      sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.erase(it);
     }
-    sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.erase(it);
   }
+  // Destructor releases when last shared_ptr drops (after in-flight manager ops).
   resolve(nil);
 }
 

--- a/ios/speaker-embedding/bridge/SherpaOnnx+SpeakerEmbeddingInference.mm
+++ b/ios/speaker-embedding/bridge/SherpaOnnx+SpeakerEmbeddingInference.mm
@@ -477,6 +477,169 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
   }
 }
 
+- (void)verifySpeakerOffline:(NSString *)instanceId
+                   managerId:(NSString *)managerId
+               audioBufferId:(NSString *)audioBufferId
+                        name:(NSString *)name
+                   threshold:(double)threshold
+                 startSample:(NSNumber *)startSample
+                   endSample:(NSNumber *)endSample
+                     resolve:(RCTPromiseResolveBlock)resolve
+                      reject:(RCTPromiseRejectBlock)reject
+{
+  if (instanceId == nil || [instanceId length] == 0) {
+    reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR", @"instanceId is required", nil);
+    return;
+  }
+  if (managerId == nil || [managerId length] == 0) {
+    reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR", @"managerId is required", nil);
+    return;
+  }
+  if (name == nil || [name length] == 0) {
+    reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR", @"name is required", nil);
+    return;
+  }
+  if (audioBufferId == nil || [audioBufferId length] == 0) {
+    reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR", @"audioBufferId is required", nil);
+    return;
+  }
+
+  const bool hasStart = startSample != nil;
+  const bool hasEnd = endSample != nil;
+  if (hasStart != hasEnd) {
+    reject(@"SPEAKER_EMBEDDING_INVALID_ARGUMENT",
+           @"startSample and endSample must both be provided or both omitted",
+           nil);
+    return;
+  }
+
+  const std::string instanceIdStr = [instanceId UTF8String];
+  const std::string managerIdStr = [managerId UTF8String];
+  const std::string nameStr = [name UTF8String];
+  const std::string audioInId = [audioBufferId UTF8String];
+  if (audioInId.find("off_") != 0) {
+    reject(@"SPEAKER_EMBEDDING_BUFFER_KIND_MISMATCH",
+           [NSString stringWithFormat:@"Expected offline audio buffer (off_*), got: %@", audioBufferId],
+           nil);
+    return;
+  }
+
+  int inSampleRate = 0;
+  int inNumSamples = 0;
+  std::string errCode;
+  std::string errMsg;
+  if (!pa_get_offline_metadata(audioInId, &inSampleRate, &inNumSamples, &errCode, &errMsg)) {
+    reject(@"SPEAKER_EMBEDDING_BUFFER_NOT_FOUND",
+           [NSString stringWithFormat:@"Offline audio buffer not found: %@", audioBufferId],
+           nil);
+    return;
+  }
+  if (inSampleRate <= 0 || inNumSamples <= 0) {
+    reject(@"SPEAKER_EMBEDDING_BUFFER_EMPTY",
+           [NSString stringWithFormat:@"Input offline audio buffer is empty: %@", audioBufferId],
+           nil);
+    return;
+  }
+
+  @try {
+    std::vector<float> inputSamples;
+    int inputSr = inSampleRate;
+
+    if (!hasStart) {
+      if (!pa_read_offline_samples(audioInId, &inputSamples, &inputSr) || inputSamples.empty()) {
+        reject(@"SPEAKER_EMBEDDING_BUFFER_EMPTY",
+               [NSString stringWithFormat:@"Input offline audio buffer is empty: %@", audioBufferId],
+               nil);
+        return;
+      }
+    } else {
+      const int start = std::max(0, static_cast<int>(std::floor([startSample doubleValue])));
+      const int endRaw = std::max(start, static_cast<int>(std::floor([endSample doubleValue])));
+      const int end = std::min(endRaw, inNumSamples);
+      const int frameCount = std::max(0, end - start);
+      if (frameCount == 0) {
+        resolve(@{ @"ok": @NO });
+        return;
+      }
+      std::string sliceErrCode;
+      std::string sliceErrMsg;
+      if (!pa_get_offline_samples_slice(
+              audioInId, start, frameCount, &inputSamples, &sliceErrCode, &sliceErrMsg)) {
+        NSString *code = sliceErrCode.empty()
+            ? @"SPEAKER_EMBEDDING_COMPUTE_ERROR"
+            : [NSString stringWithUTF8String:sliceErrCode.c_str()];
+        NSString *msg = sliceErrMsg.empty()
+            ? @"Failed to read offline audio slice"
+            : [NSString stringWithUTF8String:sliceErrMsg.c_str()];
+        reject(code, msg, nil);
+        return;
+      }
+    }
+
+    bool verified = false;
+    std::string computeError;
+    std::string computeErrorCode;
+    bool computeFailed = false;
+    bool managerMissing = false;
+    {
+      std::lock_guard<std::mutex> lock(
+          sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
+      auto extractorIt = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors
+                             .find(instanceIdStr);
+      if (extractorIt ==
+              sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors
+                  .end() ||
+          extractorIt->second == nullptr || extractorIt->second->wrapper == nullptr ||
+          !extractorIt->second->wrapper->isInitialized()) {
+        reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR",
+               [NSString stringWithFormat:@"Speaker embedding extractor not found: %@", instanceId],
+               nil);
+        return;
+      }
+      auto managerIt = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
+                           .find(managerIdStr);
+      if (managerIt ==
+              sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end() ||
+          managerIt->second == nullptr || managerIt->second->wrapper == nullptr) {
+        managerMissing = true;
+      } else {
+        std::vector<float> embedding =
+            extractorIt->second->wrapper->computeFromSamples(inputSamples, inputSr);
+        if (embedding.empty()) {
+          computeFailed = true;
+          computeError = extractorIt->second->wrapper->lastError();
+          computeErrorCode = extractorIt->second->wrapper->lastErrorCode();
+        } else {
+          verified = managerIt->second->wrapper->verify(
+              nameStr, embedding, static_cast<float>(threshold));
+        }
+      }
+    }
+    if (managerMissing) {
+      reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
+             [NSString stringWithFormat:@"Speaker embedding manager not found: %@", managerId],
+             nil);
+      return;
+    }
+    if (computeFailed) {
+      NSString *code = computeErrorCode.empty()
+          ? @"SPEAKER_EMBEDDING_COMPUTE_ERROR"
+          : [NSString stringWithUTF8String:computeErrorCode.c_str()];
+      NSString *msg = computeError.empty()
+          ? @"Speaker embedding compute failed"
+          : [NSString stringWithUTF8String:computeError.c_str()];
+      reject(code, msg, nil);
+      return;
+    }
+
+    resolve(@{ @"ok": @(verified) });
+  } @catch (NSException *exception) {
+    reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR",
+           [NSString stringWithFormat:@"Speaker verify offline failed: %@", exception.reason],
+           nil);
+  }
+}
+
 - (void)unloadSpeakerEmbeddingExtractor:(NSString *)instanceId
                                 resolve:(RCTPromiseResolveBlock)resolve
                                  reject:(RCTPromiseRejectBlock)reject

--- a/ios/speaker-embedding/bridge/SherpaOnnx+SpeakerEmbeddingInference.mm
+++ b/ios/speaker-embedding/bridge/SherpaOnnx+SpeakerEmbeddingInference.mm
@@ -8,6 +8,8 @@
 
 #include "sherpa-onnx-model-path-fill.h"
 
+#include <algorithm>
+#include <cmath>
 #include <map>
 #include <mutex>
 #include <optional>
@@ -189,6 +191,8 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
 
 - (void)computeSpeakerEmbeddingOffline:(NSString *)instanceId
                         audioBufferId:(NSString *)audioBufferId
+                          startSample:(NSNumber *)startSample
+                            endSample:(NSNumber *)endSample
                               resolve:(RCTPromiseResolveBlock)resolve
                                reject:(RCTPromiseRejectBlock)reject
 {
@@ -198,6 +202,15 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
   }
   if (audioBufferId == nil || [audioBufferId length] == 0) {
     reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR", @"audioBufferId is required", nil);
+    return;
+  }
+
+  const bool hasStart = startSample != nil;
+  const bool hasEnd = endSample != nil;
+  if (hasStart != hasEnd) {
+    reject(@"SPEAKER_EMBEDDING_INVALID_ARGUMENT",
+           @"startSample and endSample must both be provided or both omitted",
+           nil);
     return;
   }
 
@@ -229,12 +242,37 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
 
   @try {
     std::vector<float> inputSamples;
-    int inputSr = 0;
-    if (!pa_read_offline_samples(audioInId, &inputSamples, &inputSr) || inputSamples.empty()) {
-      reject(@"SPEAKER_EMBEDDING_BUFFER_EMPTY",
-             [NSString stringWithFormat:@"Input offline audio buffer is empty: %@", audioBufferId],
-             nil);
-      return;
+    int inputSr = inSampleRate;
+
+    if (!hasStart) {
+      if (!pa_read_offline_samples(audioInId, &inputSamples, &inputSr) || inputSamples.empty()) {
+        reject(@"SPEAKER_EMBEDDING_BUFFER_EMPTY",
+               [NSString stringWithFormat:@"Input offline audio buffer is empty: %@", audioBufferId],
+               nil);
+        return;
+      }
+    } else {
+      const int start = std::max(0, static_cast<int>(std::floor([startSample doubleValue])));
+      const int endRaw = std::max(start, static_cast<int>(std::floor([endSample doubleValue])));
+      const int end = std::min(endRaw, inNumSamples);
+      const int frameCount = std::max(0, end - start);
+      if (frameCount == 0) {
+        resolve(@{ @"embedding": @[] });
+        return;
+      }
+      std::string sliceErrCode;
+      std::string sliceErrMsg;
+      if (!pa_get_offline_samples_slice(
+              audioInId, start, frameCount, &inputSamples, &sliceErrCode, &sliceErrMsg)) {
+        NSString *code = sliceErrCode.empty()
+            ? @"SPEAKER_EMBEDDING_COMPUTE_ERROR"
+            : [NSString stringWithUTF8String:sliceErrCode.c_str()];
+        NSString *msg = sliceErrMsg.empty()
+            ? @"Failed to read offline audio slice"
+            : [NSString stringWithUTF8String:sliceErrMsg.c_str()];
+        reject(code, msg, nil);
+        return;
+      }
     }
 
     std::vector<float> embedding;

--- a/ios/speaker-embedding/bridge/SherpaOnnx+SpeakerEmbeddingInference.mm
+++ b/ios/speaker-embedding/bridge/SherpaOnnx+SpeakerEmbeddingInference.mm
@@ -318,6 +318,165 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
   }
 }
 
+- (void)identifySpeakerOffline:(NSString *)instanceId
+                     managerId:(NSString *)managerId
+                 audioBufferId:(NSString *)audioBufferId
+                     threshold:(double)threshold
+                   startSample:(NSNumber *)startSample
+                     endSample:(NSNumber *)endSample
+                       resolve:(RCTPromiseResolveBlock)resolve
+                        reject:(RCTPromiseRejectBlock)reject
+{
+  if (instanceId == nil || [instanceId length] == 0) {
+    reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR", @"instanceId is required", nil);
+    return;
+  }
+  if (managerId == nil || [managerId length] == 0) {
+    reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR", @"managerId is required", nil);
+    return;
+  }
+  if (audioBufferId == nil || [audioBufferId length] == 0) {
+    reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR", @"audioBufferId is required", nil);
+    return;
+  }
+
+  const bool hasStart = startSample != nil;
+  const bool hasEnd = endSample != nil;
+  if (hasStart != hasEnd) {
+    reject(@"SPEAKER_EMBEDDING_INVALID_ARGUMENT",
+           @"startSample and endSample must both be provided or both omitted",
+           nil);
+    return;
+  }
+
+  const std::string instanceIdStr = [instanceId UTF8String];
+  const std::string managerIdStr = [managerId UTF8String];
+  const std::string audioInId = [audioBufferId UTF8String];
+  if (audioInId.find("off_") != 0) {
+    reject(@"SPEAKER_EMBEDDING_BUFFER_KIND_MISMATCH",
+           [NSString stringWithFormat:@"Expected offline audio buffer (off_*), got: %@", audioBufferId],
+           nil);
+    return;
+  }
+
+  int inSampleRate = 0;
+  int inNumSamples = 0;
+  std::string errCode;
+  std::string errMsg;
+  if (!pa_get_offline_metadata(audioInId, &inSampleRate, &inNumSamples, &errCode, &errMsg)) {
+    reject(@"SPEAKER_EMBEDDING_BUFFER_NOT_FOUND",
+           [NSString stringWithFormat:@"Offline audio buffer not found: %@", audioBufferId],
+           nil);
+    return;
+  }
+  if (inSampleRate <= 0 || inNumSamples <= 0) {
+    reject(@"SPEAKER_EMBEDDING_BUFFER_EMPTY",
+           [NSString stringWithFormat:@"Input offline audio buffer is empty: %@", audioBufferId],
+           nil);
+    return;
+  }
+
+  @try {
+    std::vector<float> inputSamples;
+    int inputSr = inSampleRate;
+
+    if (!hasStart) {
+      if (!pa_read_offline_samples(audioInId, &inputSamples, &inputSr) || inputSamples.empty()) {
+        reject(@"SPEAKER_EMBEDDING_BUFFER_EMPTY",
+               [NSString stringWithFormat:@"Input offline audio buffer is empty: %@", audioBufferId],
+               nil);
+        return;
+      }
+    } else {
+      const int start = std::max(0, static_cast<int>(std::floor([startSample doubleValue])));
+      const int endRaw = std::max(start, static_cast<int>(std::floor([endSample doubleValue])));
+      const int end = std::min(endRaw, inNumSamples);
+      const int frameCount = std::max(0, end - start);
+      if (frameCount == 0) {
+        resolve(@{ @"name": @"" });
+        return;
+      }
+      std::string sliceErrCode;
+      std::string sliceErrMsg;
+      if (!pa_get_offline_samples_slice(
+              audioInId, start, frameCount, &inputSamples, &sliceErrCode, &sliceErrMsg)) {
+        NSString *code = sliceErrCode.empty()
+            ? @"SPEAKER_EMBEDDING_COMPUTE_ERROR"
+            : [NSString stringWithUTF8String:sliceErrCode.c_str()];
+        NSString *msg = sliceErrMsg.empty()
+            ? @"Failed to read offline audio slice"
+            : [NSString stringWithUTF8String:sliceErrMsg.c_str()];
+        reject(code, msg, nil);
+        return;
+      }
+    }
+
+    std::string matchedName;
+    std::string computeError;
+    std::string computeErrorCode;
+    bool computeFailed = false;
+    bool managerMissing = false;
+    {
+      std::lock_guard<std::mutex> lock(
+          sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_mutex);
+      auto extractorIt = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors
+                             .find(instanceIdStr);
+      if (extractorIt ==
+              sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_extractors
+                  .end() ||
+          extractorIt->second == nullptr || extractorIt->second->wrapper == nullptr ||
+          !extractorIt->second->wrapper->isInitialized()) {
+        reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR",
+               [NSString stringWithFormat:@"Speaker embedding extractor not found: %@", instanceId],
+               nil);
+        return;
+      }
+      auto managerIt = sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers
+                           .find(managerIdStr);
+      if (managerIt ==
+              sherpaonnx::speaker_embedding::bridge::g_speaker_embedding_managers.end() ||
+          managerIt->second == nullptr || managerIt->second->wrapper == nullptr) {
+        managerMissing = true;
+      } else {
+        std::vector<float> embedding =
+            extractorIt->second->wrapper->computeFromSamples(inputSamples, inputSr);
+        if (embedding.empty()) {
+          computeFailed = true;
+          computeError = extractorIt->second->wrapper->lastError();
+          computeErrorCode = extractorIt->second->wrapper->lastErrorCode();
+        } else {
+          matchedName =
+              managerIt->second->wrapper->search(embedding, static_cast<float>(threshold));
+        }
+      }
+    }
+    if (managerMissing) {
+      reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
+             [NSString stringWithFormat:@"Speaker embedding manager not found: %@", managerId],
+             nil);
+      return;
+    }
+    if (computeFailed) {
+      NSString *code = computeErrorCode.empty()
+          ? @"SPEAKER_EMBEDDING_COMPUTE_ERROR"
+          : [NSString stringWithUTF8String:computeErrorCode.c_str()];
+      NSString *msg = computeError.empty()
+          ? @"Speaker embedding compute failed"
+          : [NSString stringWithUTF8String:computeError.c_str()];
+      reject(code, msg, nil);
+      return;
+    }
+
+    resolve(@{
+      @"name": [NSString stringWithUTF8String:matchedName.c_str()] ?: @""
+    });
+  } @catch (NSException *exception) {
+    reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR",
+           [NSString stringWithFormat:@"Speaker identify offline failed: %@", exception.reason],
+           nil);
+  }
+}
+
 - (void)unloadSpeakerEmbeddingExtractor:(NSString *)instanceId
                                 resolve:(RCTPromiseResolveBlock)resolve
                                  reject:(RCTPromiseRejectBlock)reject

--- a/ios/speaker-embedding/bridge/SherpaOnnx+SpeakerEmbeddingInference.mm
+++ b/ios/speaker-embedding/bridge/SherpaOnnx+SpeakerEmbeddingInference.mm
@@ -583,6 +583,223 @@ NSArray *FloatVectorToNSArray(const std::vector<float> &values) {
   }
 }
 
+- (void)enrollSpeakerOffline:(NSString *)instanceId
+                   managerId:(NSString *)managerId
+                        name:(NSString *)name
+              audioBufferIds:(NSArray *)audioBufferIds
+                startSamples:(NSArray *)startSamples
+                  endSamples:(NSArray *)endSamples
+                     resolve:(RCTPromiseResolveBlock)resolve
+                      reject:(RCTPromiseRejectBlock)reject
+{
+  if (instanceId == nil || [instanceId length] == 0) {
+    reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR", @"instanceId is required", nil);
+    return;
+  }
+  if (managerId == nil || [managerId length] == 0) {
+    reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR", @"managerId is required", nil);
+    return;
+  }
+  if (name == nil || [name length] == 0) {
+    reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR", @"name is required", nil);
+    return;
+  }
+  if (audioBufferIds == nil || ![audioBufferIds isKindOfClass:[NSArray class]] ||
+      [audioBufferIds count] == 0) {
+    reject(@"SPEAKER_EMBEDDING_INVALID_ARGUMENT",
+           @"audioBufferIds must contain at least one buffer id", nil);
+    return;
+  }
+
+  const NSUInteger countIds = [audioBufferIds count];
+  const bool hasStarts = startSamples != nil && ![startSamples isEqual:[NSNull null]];
+  const bool hasEnds = endSamples != nil && ![endSamples isEqual:[NSNull null]];
+  if (hasStarts != hasEnds) {
+    reject(@"SPEAKER_EMBEDDING_INVALID_ARGUMENT",
+           @"startSamples and endSamples must both be provided or both omitted",
+           nil);
+    return;
+  }
+  if (hasStarts) {
+    if (![startSamples isKindOfClass:[NSArray class]] ||
+        ![endSamples isKindOfClass:[NSArray class]] ||
+        [startSamples count] != countIds || [endSamples count] != countIds) {
+      reject(@"SPEAKER_EMBEDDING_INVALID_ARGUMENT",
+             @"startSamples and endSamples must match audioBufferIds length",
+             nil);
+      return;
+    }
+  }
+
+  const std::string instanceIdStr = [instanceId UTF8String];
+  const std::string managerIdStr = [managerId UTF8String];
+  const std::string nameStr = [name UTF8String];
+
+  @try {
+    auto extractor =
+        sherpaonnx::speaker_embedding::bridge::LookupExtractor(instanceIdStr);
+    if (!extractor || !extractor->isInitialized()) {
+      reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR",
+             [NSString stringWithFormat:@"Speaker embedding extractor not found: %@", instanceId],
+             nil);
+      return;
+    }
+    auto manager =
+        sherpaonnx::speaker_embedding::bridge::LookupManager(managerIdStr);
+    if (!manager || !manager->isInitialized()) {
+      reject(@"SPEAKER_EMBEDDING_MANAGER_ERROR",
+             [NSString stringWithFormat:@"Speaker embedding manager not found: %@", managerId],
+             nil);
+      return;
+    }
+
+    std::vector<std::vector<float>> embeddings;
+    embeddings.reserve(countIds);
+
+    for (NSUInteger i = 0; i < countIds; i++) {
+      id idObj = audioBufferIds[i];
+      if (![idObj isKindOfClass:[NSString class]] || [(NSString *)idObj length] == 0) {
+        reject(@"SPEAKER_EMBEDDING_INVALID_ARGUMENT",
+               [NSString stringWithFormat:@"audioBufferIds[%lu] is required", (unsigned long)i],
+               nil);
+        return;
+      }
+      NSString *audioBufferId = (NSString *)idObj;
+      const std::string audioInId = [audioBufferId UTF8String];
+      if (audioInId.find("off_") != 0) {
+        reject(@"SPEAKER_EMBEDDING_BUFFER_KIND_MISMATCH",
+               [NSString stringWithFormat:@"Expected offline audio buffer (off_*), got: %@",
+                                          audioBufferId],
+               nil);
+        return;
+      }
+
+      int inSampleRate = 0;
+      int inNumSamples = 0;
+      std::string errCode;
+      std::string errMsg;
+      if (!pa_get_offline_metadata(audioInId, &inSampleRate, &inNumSamples, &errCode, &errMsg)) {
+        reject(@"SPEAKER_EMBEDDING_BUFFER_NOT_FOUND",
+               [NSString stringWithFormat:@"Offline audio buffer not found: %@", audioBufferId],
+               nil);
+        return;
+      }
+      if (inSampleRate <= 0 || inNumSamples <= 0) {
+        reject(@"SPEAKER_EMBEDDING_BUFFER_EMPTY",
+               [NSString stringWithFormat:@"Input offline audio buffer is empty: %@", audioBufferId],
+               nil);
+        return;
+      }
+
+      std::vector<float> inputSamples;
+      int inputSr = inSampleRate;
+      bool useFull = !hasStarts;
+      if (hasStarts) {
+        id startObj = startSamples[i];
+        id endObj = endSamples[i];
+        const bool startNull = startObj == nil || startObj == [NSNull null];
+        const bool endNull = endObj == nil || endObj == [NSNull null];
+        if (startNull != endNull) {
+          reject(@"SPEAKER_EMBEDDING_INVALID_ARGUMENT",
+                 [NSString stringWithFormat:
+                     @"startSamples[%lu] and endSamples[%lu] must both be provided or both null",
+                     (unsigned long)i, (unsigned long)i],
+                 nil);
+          return;
+        }
+        if (startNull) {
+          useFull = true;
+        } else {
+          if (![startObj isKindOfClass:[NSNumber class]] ||
+              ![endObj isKindOfClass:[NSNumber class]]) {
+            reject(@"SPEAKER_EMBEDDING_INVALID_ARGUMENT",
+                   [NSString stringWithFormat:
+                       @"startSamples[%lu] and endSamples[%lu] must be numbers or null",
+                       (unsigned long)i, (unsigned long)i],
+                   nil);
+            return;
+          }
+          const int start =
+              std::max(0, static_cast<int>(std::floor([(NSNumber *)startObj doubleValue])));
+          const int endRaw =
+              std::max(start, static_cast<int>(std::floor([(NSNumber *)endObj doubleValue])));
+          const int end = std::min(endRaw, inNumSamples);
+          const int frameCount = std::max(0, end - start);
+          if (frameCount == 0) {
+            continue;
+          }
+          std::string sliceErrCode;
+          std::string sliceErrMsg;
+          if (!pa_get_offline_samples_slice(
+                  audioInId, start, frameCount, &inputSamples, &sliceErrCode, &sliceErrMsg)) {
+            NSString *code = sliceErrCode.empty()
+                ? @"SPEAKER_EMBEDDING_COMPUTE_ERROR"
+                : [NSString stringWithUTF8String:sliceErrCode.c_str()];
+            NSString *msg = sliceErrMsg.empty()
+                ? @"Failed to read offline audio slice"
+                : [NSString stringWithUTF8String:sliceErrMsg.c_str()];
+            reject(code, msg, nil);
+            return;
+          }
+        }
+      }
+      if (useFull) {
+        if (!pa_read_offline_samples(audioInId, &inputSamples, &inputSr) ||
+            inputSamples.empty()) {
+          continue;
+        }
+      }
+      if (inputSamples.empty()) {
+        continue;
+      }
+
+      std::vector<float> embedding =
+          extractor->computeFromSamples(inputSamples, inputSr);
+      if (embedding.empty()) {
+        const std::string &computeError = extractor->lastError();
+        const std::string &computeErrorCode = extractor->lastErrorCode();
+        NSString *code = computeErrorCode.empty()
+            ? @"SPEAKER_EMBEDDING_COMPUTE_ERROR"
+            : [NSString stringWithUTF8String:computeErrorCode.c_str()];
+        NSString *msg = computeError.empty()
+            ? @"Speaker embedding compute failed"
+            : [NSString stringWithUTF8String:computeError.c_str()];
+        reject(code, msg, nil);
+        return;
+      }
+      embeddings.push_back(std::move(embedding));
+    }
+
+    if (embeddings.empty()) {
+      resolve(@{ @"ok": @NO, @"embeddings": @[] });
+      return;
+    }
+
+    const size_t dim = embeddings[0].size();
+    std::vector<float> flat;
+    flat.reserve(dim * embeddings.size());
+    for (const auto &emb : embeddings) {
+      if (emb.size() != dim) {
+        reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR",
+               @"Speaker embedding dimension mismatch during enroll", nil);
+        return;
+      }
+      flat.insert(flat.end(), emb.begin(), emb.end());
+    }
+
+    const bool ok =
+        manager->add(nameStr, flat, static_cast<int32_t>(embeddings.size()));
+    resolve(@{
+      @"ok": @(ok),
+      @"embeddings": FloatVectorToNSArray(flat),
+    });
+  } @catch (NSException *exception) {
+    reject(@"SPEAKER_EMBEDDING_COMPUTE_ERROR",
+           [NSString stringWithFormat:@"Speaker enroll offline failed: %@", exception.reason],
+           nil);
+  }
+}
+
 - (void)unloadSpeakerEmbeddingExtractor:(NSString *)instanceId
                                 resolve:(RCTPromiseResolveBlock)resolve
                                  reject:(RCTPromiseRejectBlock)reject

--- a/ios/speaker-embedding/core/SpeakerEmbeddingBridgeState.h
+++ b/ios/speaker-embedding/core/SpeakerEmbeddingBridgeState.h
@@ -16,19 +16,19 @@ namespace sherpaonnx {
 namespace speaker_embedding {
 namespace bridge {
 
-struct SpeakerEmbeddingExtractorState {
-  std::unique_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper> wrapper;
-};
-
-struct SpeakerEmbeddingManagerState {
-  std::unique_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper> wrapper;
-};
-
-extern std::unordered_map<std::string, std::unique_ptr<SpeakerEmbeddingExtractorState>>
+extern std::unordered_map<std::string,
+                          std::shared_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper>>
     g_speaker_embedding_extractors;
-extern std::unordered_map<std::string, std::unique_ptr<SpeakerEmbeddingManagerState>>
+extern std::unordered_map<std::string,
+                          std::shared_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper>>
     g_speaker_embedding_managers;
 extern std::mutex g_speaker_embedding_mutex;
+
+/** Copy a strong ref under the map lock; caller uses it outside the lock. */
+std::shared_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper> LookupExtractor(
+    const std::string& id);
+std::shared_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper> LookupManager(
+    const std::string& id);
 
 }  // namespace bridge
 }  // namespace speaker_embedding

--- a/ios/speaker-embedding/core/SpeakerEmbeddingBridgeState.mm
+++ b/ios/speaker-embedding/core/SpeakerEmbeddingBridgeState.mm
@@ -1,15 +1,33 @@
 #include "SpeakerEmbeddingBridgeState.h"
-#include "../native/sherpa-onnx-speaker-embedding-wrapper.h"
+#include "sherpa-onnx-speaker-embedding-wrapper.h"
 
 namespace sherpaonnx {
 namespace speaker_embedding {
 namespace bridge {
 
-std::unordered_map<std::string, std::unique_ptr<SpeakerEmbeddingExtractorState>>
+std::unordered_map<std::string,
+                   std::shared_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper>>
     g_speaker_embedding_extractors;
-std::unordered_map<std::string, std::unique_ptr<SpeakerEmbeddingManagerState>>
+std::unordered_map<std::string,
+                   std::shared_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper>>
     g_speaker_embedding_managers;
 std::mutex g_speaker_embedding_mutex;
+
+std::shared_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper> LookupExtractor(
+    const std::string& id) {
+  std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
+  auto it = g_speaker_embedding_extractors.find(id);
+  if (it == g_speaker_embedding_extractors.end() || !it->second) return nullptr;
+  return it->second;
+}
+
+std::shared_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper> LookupManager(
+    const std::string& id) {
+  std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
+  auto it = g_speaker_embedding_managers.find(id);
+  if (it == g_speaker_embedding_managers.end() || !it->second) return nullptr;
+  return it->second;
+}
 
 }  // namespace bridge
 }  // namespace speaker_embedding

--- a/ios/speaker-identification/bridge/SherpaOnnx+SpeakerIdentificationLive.mm
+++ b/ios/speaker-identification/bridge/SherpaOnnx+SpeakerIdentificationLive.mm
@@ -1,0 +1,160 @@
+#import "../../SherpaOnnx.h"
+#import <React/RCTLog.h>
+
+#include "../../audio/pipeline/SherpaOnnx+PipelineAudioGlobals.h"
+#include "../../pipeline/bridge/SherpaOnnx+StreamingPipelineCompletion.h"
+#include "../../pipeline/core/SherpaOnnx+StreamingPipeline.h"
+#include "../../segmentbuffer/core/SherpaOnnx+SegmentBufferGlobals.h"
+#include "../../speaker-embedding/core/SpeakerEmbeddingBridgeState.h"
+#include "../pipeline/SpeakerIdentificationOfflineLivePipelineWorker.h"
+#include "sherpa-onnx-speaker-embedding-wrapper.h"
+
+#include <cmath>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+
+@implementation SherpaOnnx (SpeakerIdentificationLive)
+
+- (void)startSpeakerIdentificationOfflineLivePipeline:(NSString *)instanceId
+                                            managerId:(NSString *)managerId
+                                  audioInLiveBufferId:(NSString *)audioInLiveBufferId
+                              segmentsOutLiveBufferId:(NSString *)segmentsOutLiveBufferId
+                                              options:(JS::NativeSherpaOnnx::SpecStartSpeakerIdentificationOfflineLivePipelineOptions &)options
+                                              resolve:(RCTPromiseResolveBlock)resolve
+                                               reject:(RCTPromiseRejectBlock)reject
+{
+  if (instanceId == nil || [instanceId length] == 0) {
+    reject(@"SID_INVALID_ARGUMENT", @"instanceId is required", nil);
+    return;
+  }
+  if (managerId == nil || [managerId length] == 0) {
+    reject(@"SID_INVALID_ARGUMENT", @"managerId is required", nil);
+    return;
+  }
+  if (audioInLiveBufferId == nil || [audioInLiveBufferId length] == 0) {
+    reject(@"SID_INVALID_ARGUMENT", @"audioInLiveBufferId is required", nil);
+    return;
+  }
+  if (segmentsOutLiveBufferId == nil || [segmentsOutLiveBufferId length] == 0) {
+    reject(@"SID_INVALID_ARGUMENT", @"segmentsOutLiveBufferId is required", nil);
+    return;
+  }
+
+  NSString *attachedSegmentationEngineId = options.attachedSegmentationEngineId();
+  if (attachedSegmentationEngineId == nil || [attachedSegmentationEngineId length] == 0) {
+    reject(@"SID_INVALID_ARGUMENT", @"options.attachedSegmentationEngineId is required", nil);
+    return;
+  }
+
+  NSString *segmentLiveBufferId = options.segmentLiveBufferId();
+  if (segmentLiveBufferId == nil || [segmentLiveBufferId length] == 0) {
+    reject(@"SID_INVALID_ARGUMENT", @"options.segmentLiveBufferId is required", nil);
+    return;
+  }
+
+  const float threshold = static_cast<float>(options.threshold());
+  if (!std::isfinite(threshold)) {
+    reject(@"SID_INVALID_ARGUMENT", @"options.threshold must be a finite number", nil);
+    return;
+  }
+
+  std::string instanceIdStr = [instanceId UTF8String];
+  std::string managerIdStr = [managerId UTF8String];
+  std::string audioInIdStr = [audioInLiveBufferId UTF8String];
+  std::string segmentsOutIdStr = [segmentsOutLiveBufferId UTF8String];
+  std::string attachedEngineIdStr = [attachedSegmentationEngineId UTF8String];
+  std::string segmentBufferIdStr = [segmentLiveBufferId UTF8String];
+
+  sherpaonnx::SpeakerEmbeddingExtractorWrapper *extractor = nullptr;
+  sherpaonnx::SpeakerEmbeddingManagerWrapper *manager = nullptr;
+  {
+    using namespace sherpaonnx::speaker_embedding::bridge;
+    std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
+    auto eit = g_speaker_embedding_extractors.find(instanceIdStr);
+    if (eit == g_speaker_embedding_extractors.end() ||
+        eit->second == nullptr ||
+        eit->second->wrapper == nullptr ||
+        !eit->second->wrapper->isInitialized()) {
+      reject(@"SID_INSTANCE_NOT_FOUND", @"Speaker embedding extractor not initialized", nil);
+      return;
+    }
+    auto mit = g_speaker_embedding_managers.find(managerIdStr);
+    if (mit == g_speaker_embedding_managers.end() ||
+        mit->second == nullptr ||
+        mit->second->wrapper == nullptr ||
+        !mit->second->wrapper->isInitialized()) {
+      reject(@"SID_MANAGER_NOT_FOUND", @"Speaker embedding manager not found", nil);
+      return;
+    }
+    extractor = eit->second->wrapper.get();
+    manager = mit->second->wrapper.get();
+  }
+
+  auto inputEntry = pa_get_live_entry(audioInIdStr);
+  if (!inputEntry) {
+    reject(
+      @"SID_PIPELINE_AUDIO_BUFFER_NOT_FOUND",
+      [NSString stringWithFormat:@"Input live audio buffer not found: %@", audioInLiveBufferId],
+      nil
+    );
+    return;
+  }
+
+  auto segmentsOutEntry = seg_get_live_entry(segmentsOutIdStr);
+  if (!segmentsOutEntry) {
+    reject(
+      @"SID_PIPELINE_SEGMENT_BUFFER_NOT_FOUND",
+      [NSString stringWithFormat:@"Output live segment buffer not found: %@", segmentsOutLiveBufferId],
+      nil
+    );
+    return;
+  }
+  (void)segmentsOutEntry;
+
+  auto segmentInputEntry = seg_get_live_entry(segmentBufferIdStr);
+  if (!segmentInputEntry) {
+    reject(
+      @"SID_PIPELINE_SEGMENT_BUFFER_NOT_FOUND",
+      [NSString stringWithFormat:@"Input live segment buffer not found: %@", segmentLiveBufferId],
+      nil
+    );
+    return;
+  }
+  (void)segmentInputEntry;
+
+  try {
+    std::string pipelineId =
+      std::string("sid_live_") +
+      std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+
+    auto worker = std::make_shared<SpeakerIdentificationOfflineLivePipelineWorker>(
+      pipelineId,
+      attachedEngineIdStr,
+      inputEntry,
+      segmentBufferIdStr,
+      audioInIdStr,
+      segmentsOutIdStr,
+      extractor,
+      manager,
+      threshold
+    );
+
+    {
+      std::lock_guard<std::mutex> lock(g_streaming_pipeline_mutex);
+      g_streaming_pipelines[pipelineId] = worker;
+    }
+
+    worker->start();
+    so_start_streaming_pipeline_completion_watcher(self, pipelineId, worker);
+
+    resolve(@{ @"pipelineId": [NSString stringWithUTF8String:pipelineId.c_str()] ?: @"" });
+  } catch (const std::exception &e) {
+    reject(@"SID_LABEL_FAILED", [NSString stringWithUTF8String:e.what()], nil);
+  } catch (...) {
+    reject(@"SID_LABEL_FAILED", @"Failed to start SID live pipeline", nil);
+  }
+}
+
+@end

--- a/ios/speaker-identification/bridge/SherpaOnnx+SpeakerIdentificationLive.mm
+++ b/ios/speaker-identification/bridge/SherpaOnnx+SpeakerIdentificationLive.mm
@@ -67,29 +67,17 @@
   std::string attachedEngineIdStr = [attachedSegmentationEngineId UTF8String];
   std::string segmentBufferIdStr = [segmentLiveBufferId UTF8String];
 
-  sherpaonnx::SpeakerEmbeddingExtractorWrapper *extractor = nullptr;
-  sherpaonnx::SpeakerEmbeddingManagerWrapper *manager = nullptr;
-  {
-    using namespace sherpaonnx::speaker_embedding::bridge;
-    std::lock_guard<std::mutex> lock(g_speaker_embedding_mutex);
-    auto eit = g_speaker_embedding_extractors.find(instanceIdStr);
-    if (eit == g_speaker_embedding_extractors.end() ||
-        eit->second == nullptr ||
-        eit->second->wrapper == nullptr ||
-        !eit->second->wrapper->isInitialized()) {
-      reject(@"SID_INSTANCE_NOT_FOUND", @"Speaker embedding extractor not initialized", nil);
-      return;
-    }
-    auto mit = g_speaker_embedding_managers.find(managerIdStr);
-    if (mit == g_speaker_embedding_managers.end() ||
-        mit->second == nullptr ||
-        mit->second->wrapper == nullptr ||
-        !mit->second->wrapper->isInitialized()) {
-      reject(@"SID_MANAGER_NOT_FOUND", @"Speaker embedding manager not found", nil);
-      return;
-    }
-    extractor = eit->second->wrapper.get();
-    manager = mit->second->wrapper.get();
+  auto extractor =
+      sherpaonnx::speaker_embedding::bridge::LookupExtractor(instanceIdStr);
+  if (!extractor || !extractor->isInitialized()) {
+    reject(@"SID_INSTANCE_NOT_FOUND", @"Speaker embedding extractor not initialized", nil);
+    return;
+  }
+  auto manager =
+      sherpaonnx::speaker_embedding::bridge::LookupManager(managerIdStr);
+  if (!manager || !manager->isInitialized()) {
+    reject(@"SID_MANAGER_NOT_FOUND", @"Speaker embedding manager not found", nil);
+    return;
   }
 
   auto inputEntry = pa_get_live_entry(audioInIdStr);
@@ -136,8 +124,8 @@
       segmentBufferIdStr,
       audioInIdStr,
       segmentsOutIdStr,
-      extractor,
-      manager,
+      std::move(extractor),
+      std::move(manager),
       threshold
     );
 

--- a/ios/speaker-identification/pipeline/SpeakerIdentificationOfflineLivePipelineWorker.h
+++ b/ios/speaker-identification/pipeline/SpeakerIdentificationOfflineLivePipelineWorker.h
@@ -15,8 +15,8 @@ public:
     std::string audioSegmentInputBufferId,
     std::string audioInBufferId,
     std::string segmentsOutBufferId,
-    sherpaonnx::SpeakerEmbeddingExtractorWrapper *extractor,
-    sherpaonnx::SpeakerEmbeddingManagerWrapper *manager,
+    std::shared_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper> extractor,
+    std::shared_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper> manager,
     float threshold
   );
 
@@ -27,7 +27,7 @@ private:
   std::shared_ptr<PaLiveEntry> audioInput_;
   std::string audioInBufferId_;
   std::string segmentsOutBufferId_;
-  sherpaonnx::SpeakerEmbeddingExtractorWrapper *extractor_ = nullptr;
-  sherpaonnx::SpeakerEmbeddingManagerWrapper *manager_ = nullptr;
+  std::shared_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper> extractor_;
+  std::shared_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper> manager_;
   float threshold_ = 0.5f;
 };

--- a/ios/speaker-identification/pipeline/SpeakerIdentificationOfflineLivePipelineWorker.h
+++ b/ios/speaker-identification/pipeline/SpeakerIdentificationOfflineLivePipelineWorker.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "../../livePipeline/OfflineLivePipelineWorker.h"
+#include "sherpa-onnx-speaker-embedding-wrapper.h"
+
+#include <memory>
+#include <string>
+
+class SpeakerIdentificationOfflineLivePipelineWorker : public OfflineLivePipelineWorker {
+public:
+  SpeakerIdentificationOfflineLivePipelineWorker(
+    std::string pipelineId,
+    std::string attachedSegmentationEngineId,
+    std::shared_ptr<PaLiveEntry> audioInput,
+    std::string audioSegmentInputBufferId,
+    std::string audioInBufferId,
+    std::string segmentsOutBufferId,
+    sherpaonnx::SpeakerEmbeddingExtractorWrapper *extractor,
+    sherpaonnx::SpeakerEmbeddingManagerWrapper *manager,
+    float threshold
+  );
+
+protected:
+  void onSegmentCommitted(const CommittedSegmentRef &segment) override;
+
+private:
+  std::shared_ptr<PaLiveEntry> audioInput_;
+  std::string audioInBufferId_;
+  std::string segmentsOutBufferId_;
+  sherpaonnx::SpeakerEmbeddingExtractorWrapper *extractor_ = nullptr;
+  sherpaonnx::SpeakerEmbeddingManagerWrapper *manager_ = nullptr;
+  float threshold_ = 0.5f;
+};

--- a/ios/speaker-identification/pipeline/SpeakerIdentificationOfflineLivePipelineWorker.mm
+++ b/ios/speaker-identification/pipeline/SpeakerIdentificationOfflineLivePipelineWorker.mm
@@ -33,8 +33,8 @@ SpeakerIdentificationOfflineLivePipelineWorker::SpeakerIdentificationOfflineLive
   std::string audioSegmentInputBufferId,
   std::string audioInBufferId,
   std::string segmentsOutBufferId,
-  sherpaonnx::SpeakerEmbeddingExtractorWrapper *extractor,
-  sherpaonnx::SpeakerEmbeddingManagerWrapper *manager,
+  std::shared_ptr<sherpaonnx::SpeakerEmbeddingExtractorWrapper> extractor,
+  std::shared_ptr<sherpaonnx::SpeakerEmbeddingManagerWrapper> manager,
   float threshold
 )
   : OfflineLivePipelineWorker(
@@ -47,8 +47,8 @@ SpeakerIdentificationOfflineLivePipelineWorker::SpeakerIdentificationOfflineLive
     audioInput_(std::move(audioInput)),
     audioInBufferId_(std::move(audioInBufferId)),
     segmentsOutBufferId_(std::move(segmentsOutBufferId)),
-    extractor_(extractor),
-    manager_(manager),
+    extractor_(std::move(extractor)),
+    manager_(std::move(manager)),
     threshold_(threshold)
 {}
 

--- a/ios/speaker-identification/pipeline/SpeakerIdentificationOfflineLivePipelineWorker.mm
+++ b/ios/speaker-identification/pipeline/SpeakerIdentificationOfflineLivePipelineWorker.mm
@@ -1,0 +1,121 @@
+#include "SpeakerIdentificationOfflineLivePipelineWorker.h"
+
+#include "../../segmentbuffer/core/SherpaOnnx+SegmentBufferGlobals.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+std::string BuildSidPayloadJson(const std::string &speakerNameOrEmpty) {
+  if (speakerNameOrEmpty.empty()) {
+    return "{\"source\":\"sid\",\"speakerName\":null}";
+  }
+  std::string escaped;
+  escaped.reserve(speakerNameOrEmpty.size());
+  for (char c : speakerNameOrEmpty) {
+    if (c == '\\' || c == '"') {
+      escaped.push_back('\\');
+    }
+    escaped.push_back(c);
+  }
+  return std::string("{\"source\":\"sid\",\"speakerName\":\"") + escaped + "\"}";
+}
+
+}  // namespace
+
+SpeakerIdentificationOfflineLivePipelineWorker::SpeakerIdentificationOfflineLivePipelineWorker(
+  std::string pipelineId,
+  std::string attachedSegmentationEngineId,
+  std::shared_ptr<PaLiveEntry> audioInput,
+  std::string audioSegmentInputBufferId,
+  std::string audioInBufferId,
+  std::string segmentsOutBufferId,
+  sherpaonnx::SpeakerEmbeddingExtractorWrapper *extractor,
+  sherpaonnx::SpeakerEmbeddingManagerWrapper *manager,
+  float threshold
+)
+  : OfflineLivePipelineWorker(
+      std::move(pipelineId),
+      std::move(attachedSegmentationEngineId),
+      audioInput,
+      std::move(audioSegmentInputBufferId),
+      nullptr
+    ),
+    audioInput_(std::move(audioInput)),
+    audioInBufferId_(std::move(audioInBufferId)),
+    segmentsOutBufferId_(std::move(segmentsOutBufferId)),
+    extractor_(extractor),
+    manager_(manager),
+    threshold_(threshold)
+{}
+
+void SpeakerIdentificationOfflineLivePipelineWorker::onSegmentCommitted(
+  const CommittedSegmentRef &segment
+) {
+  if (!std::holds_alternative<CommittedSegmentSpeech>(segment)) return;
+  if (!audioInput_ || !extractor_ || !manager_) {
+    throw std::runtime_error("Invalid SID live pipeline worker state");
+  }
+
+  const auto &speech = std::get<CommittedSegmentSpeech>(segment);
+  const int frameCount = std::max(0, speech.endSample - speech.startSample);
+  if (frameCount <= 0) return;
+
+  auto samples = audioInput_->getSamplesSlice(speech.startSample, frameCount);
+  if (samples.empty()) return;
+
+  auto embedding = extractor_->computeFromSamples(
+    samples,
+    static_cast<int32_t>(speech.sampleRate)
+  );
+  if (embedding.empty()) {
+    const std::string err = extractor_->lastError();
+    throw std::runtime_error(
+      err.empty() ? "Speaker embedding compute failed" : err
+    );
+  }
+
+  std::string matched = manager_->search(embedding, threshold_);
+  // Trim whitespace
+  while (!matched.empty() && (matched.back() == ' ' || matched.back() == '\t' || matched.back() == '\n')) {
+    matched.pop_back();
+  }
+  size_t start = 0;
+  while (start < matched.size() && (matched[start] == ' ' || matched[start] == '\t' || matched[start] == '\n')) {
+    start++;
+  }
+  if (start > 0) matched = matched.substr(start);
+
+  const std::string payloadJson = BuildSidPayloadJson(matched);
+  const std::string sourceAudioBufferId =
+    speech.sourceAudioBufferId.empty() ? audioInBufferId_ : speech.sourceAudioBufferId;
+
+  std::string segmentId;
+  int segmentIndex = -1;
+  std::string error;
+  const bool ok = seg_live_append_segment(
+    segmentsOutBufferId_,
+    "speech",
+    sourceAudioBufferId,
+    speech.startSample,
+    speech.endSample,
+    speech.sampleRate,
+    speech.durationMs,
+    speech.hasConfidence,
+    speech.confidence,
+    payloadJson,
+    &segmentId,
+    &segmentIndex,
+    &error
+  );
+  if (!ok) {
+    throw std::runtime_error(
+      error.empty() ? "Failed to append SID labeled segment" : error
+    );
+  }
+
+  addUnitsWritten(1);
+}

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -1625,6 +1625,22 @@ export interface Spec extends TurboModule {
     audioBufferId: string
   ): Promise<{ embedding: number[] }>;
 
+  /**
+   * Start a live-offline Speaker Identification pipeline.
+   * Labels committed speech spans into a live segment buffer (payload.source = sid).
+   */
+  startSpeakerIdentificationOfflineLivePipeline(
+    instanceId: string,
+    managerId: string,
+    audioInLiveBufferId: string,
+    segmentsOutLiveBufferId: string,
+    options: {
+      attachedSegmentationEngineId: string;
+      segmentLiveBufferId: string;
+      threshold: number;
+    }
+  ): Promise<{ pipelineId: string }>;
+
   unloadSpeakerEmbeddingExtractor(instanceId: string): Promise<void>;
 
   createSpeakerEmbeddingManager(

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -1655,6 +1655,20 @@ export interface Spec extends TurboModule {
   ): Promise<{ ok: boolean }>;
 
   /**
+   * Compute embeddings from one or more offline buffers (optional per-item ranges)
+   * and `manager.add` in one native call. Returns flattened embeddings (`dim * count`)
+   * for the JS enrollment mirror only — not for a second add roundtrip.
+   */
+  enrollSpeakerOffline(
+    instanceId: string,
+    managerId: string,
+    name: string,
+    audioBufferIds: string[],
+    startSamples?: Array<number | null> | null,
+    endSamples?: Array<number | null> | null
+  ): Promise<{ ok: boolean; embeddings: number[] }>;
+
+  /**
    * Start a live-offline Speaker Identification pipeline.
    * Labels committed speech spans into a live segment buffer (payload.source = sid).
    */

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -1641,6 +1641,20 @@ export interface Spec extends TurboModule {
   ): Promise<{ name: string }>;
 
   /**
+   * Compute embedding from an offline buffer (optional range) and verify against
+   * a named enrollment in one native call.
+   */
+  verifySpeakerOffline(
+    instanceId: string,
+    managerId: string,
+    audioBufferId: string,
+    name: string,
+    threshold: number,
+    startSample?: number | null,
+    endSample?: number | null
+  ): Promise<{ ok: boolean }>;
+
+  /**
    * Start a live-offline Speaker Identification pipeline.
    * Labels committed speech spans into a live segment buffer (payload.source = sid).
    */

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -1628,6 +1628,19 @@ export interface Spec extends TurboModule {
   ): Promise<{ embedding: number[] }>;
 
   /**
+   * Compute embedding from an offline buffer (optional range) and search the
+   * manager in one native call. Empty `name` means no match above threshold.
+   */
+  identifySpeakerOffline(
+    instanceId: string,
+    managerId: string,
+    audioBufferId: string,
+    threshold: number,
+    startSample?: number | null,
+    endSample?: number | null
+  ): Promise<{ name: string }>;
+
+  /**
    * Start a live-offline Speaker Identification pipeline.
    * Labels committed speech spans into a live segment buffer (payload.source = sid).
    */

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -1622,7 +1622,9 @@ export interface Spec extends TurboModule {
 
   computeSpeakerEmbeddingOffline(
     instanceId: string,
-    audioBufferId: string
+    audioBufferId: string,
+    startSample?: number | null,
+    endSample?: number | null
   ): Promise<{ embedding: number[] }>;
 
   /**

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -155,7 +155,14 @@ export type DiarizationProcessNativeResult = {
   success: boolean;
   error?: string;
   errorCode?: string;
-  segments: Array<{ start: number; end: number; speaker: number }>;
+  /**
+   * Timeline in seconds. Returned by `reclusterDiarization`.
+   * Product `diarizeOffline` writes `segmentsOut` natively and may omit this
+   * (prefer `segmentCount`).
+   */
+  segments?: Array<{ start: number; end: number; speaker: number }>;
+  /** Number of segments written to `segmentsOut` (product `diarizeOffline`). */
+  segmentCount?: number;
   numSpeakers: number;
   sampleRate: number;
   speakersPerFrame?: number[];
@@ -1593,6 +1600,7 @@ export interface Spec extends TurboModule {
   diarizeOffline(
     instanceId: string,
     audioInBufferId: string,
+    segmentsOutBufferId: string,
     includeOverlap?: boolean
   ): Promise<DiarizationProcessNativeResult>;
 

--- a/src/diarization/__tests__/createDiarization.test.ts
+++ b/src/diarization/__tests__/createDiarization.test.ts
@@ -59,6 +59,7 @@ jest.mock('../../segmentbuffer', () => ({
 }));
 
 import SherpaOnnx from '../../NativeSherpaOnnx';
+import * as segmentbuffer from '../../segmentbuffer';
 import { createDiarization, DiarizationErrorCode } from '../index';
 
 describe('createDiarization', () => {
@@ -80,10 +81,7 @@ describe('createDiarization', () => {
     native.unloadDiarization.mockResolvedValue(undefined);
     native.diarizeOffline.mockResolvedValue({
       success: true,
-      segments: [
-        { start: 0, end: 1, speaker: 0 },
-        { start: 1.5, end: 2.5, speaker: 1 },
-      ],
+      segmentCount: 2,
       numSpeakers: 2,
       sampleRate: 16000,
     });
@@ -118,8 +116,14 @@ describe('createDiarization', () => {
     expect(native.diarizeOffline).toHaveBeenCalledWith(
       engine.instanceId,
       'off_audio',
+      'seg_off_out',
       false
     );
+    expect(segmentbuffer.createLiveSegmentBuffer).not.toHaveBeenCalled();
+    expect(segmentbuffer.appendLiveSegment).not.toHaveBeenCalled();
+    expect(
+      segmentbuffer.populateOfflineSegmentBufferIfEmpty
+    ).not.toHaveBeenCalled();
 
     await engine.destroy();
     expect(native.unloadDiarization).toHaveBeenCalledWith(engine.instanceId);
@@ -166,7 +170,7 @@ describe('createDiarization', () => {
       controller.abort();
       return {
         success: true,
-        segments: [],
+        segmentCount: 0,
         numSpeakers: 0,
         sampleRate: 16000,
       };

--- a/src/diarization/index.ts
+++ b/src/diarization/index.ts
@@ -17,21 +17,11 @@ import {
   getPipelineAudioBufferInfo,
   resolvePipelineAudioBufferId,
 } from '../audiobuffer';
-import type { OfflineAudioBufferIdSource } from '../audiobuffer/types';
 import {
-  appendLiveSegment,
-  createLiveSegmentBuffer,
-  finalizeLiveSegmentBuffer,
   getPipelineSegmentBufferInfo,
-  populateOfflineSegmentBufferIfEmpty,
-  releasePipelineSegmentBuffer,
   resolveOfflineSegmentBufferId,
 } from '../segmentbuffer';
-import type {
-  OfflineSegmentBufferIdSource,
-  OfflineSegmentBufferInfo,
-  OfflineSegmentBufferRef,
-} from '../segmentbuffer/types';
+import type { OfflineSegmentBufferInfo } from '../segmentbuffer/types';
 import type { OrchestrationProgress } from '../pipeline/offlineOrchestrator';
 import { isDetectionSource } from './types';
 import type {
@@ -174,51 +164,77 @@ export async function detectDiarizationModel(
   };
 }
 
-async function materializeSegmentsIntoOfflineBuffer(params: {
-  audioInBufferId: string;
-  segmentOutBufferId: string;
-  sampleRate: number;
-  segments: Array<{ start: number; end: number; speaker: number }>;
-}): Promise<number> {
-  const live = await createLiveSegmentBuffer({
-    sourceAudioBufferId: params.audioInBufferId,
-  });
-  try {
-    for (const seg of params.segments) {
-      const startSample = Math.max(
-        0,
-        Math.round(seg.start * params.sampleRate)
-      );
-      const endSample = Math.max(
-        startSample,
-        Math.round(seg.end * params.sampleRate)
-      );
-      const durationMs =
-        params.sampleRate > 0
-          ? ((endSample - startSample) / params.sampleRate) * 1000
-          : 0;
-      await appendLiveSegment(live.bufferId, {
-        kind: 'diarization',
-        sourceAudioBufferId: params.audioInBufferId,
-        startSample,
-        endSample,
-        sampleRate: params.sampleRate,
-        durationMs,
-        payload: {
-          source: 'diarization',
-          speaker: seg.speaker,
-        },
-      });
+async function finishDiarizeResult(params: {
+  nativeResult: {
+    success: boolean;
+    error?: string;
+    errorCode?: string;
+    segments?: Array<{ start: number; end: number; speaker: number }>;
+    segmentCount?: number;
+    numSpeakers: number;
+    sampleRate: number;
+    speakersPerFrame?: number[];
+  };
+  startedAtMs: number;
+  engineSampleRate: number;
+  diarizeOptions?: DiarizeOptions;
+}): Promise<DiarizeResult> {
+  const { nativeResult, startedAtMs, engineSampleRate, diarizeOptions } =
+    params;
+
+  if (!nativeResult.success) {
+    const code =
+      typeof nativeResult.errorCode === 'string' &&
+      nativeResult.errorCode.length > 0
+        ? nativeResult.errorCode
+        : DiarizationErrorCode.INVALID_ARGUMENT;
+    if (
+      code === DiarizationErrorCode.CANCELLED ||
+      code === 'DIARIZATION_CANCELLED'
+    ) {
+      return {
+        status: 'cancelled',
+        numSpeakers: 0,
+        segmentCount: 0,
+        sampleRate: nativeResult.sampleRate || engineSampleRate,
+        processingTimeMs: Date.now() - startedAtMs,
+      };
     }
-    await finalizeLiveSegmentBuffer(live.bufferId);
-    await populateOfflineSegmentBufferIfEmpty(
-      params.segmentOutBufferId,
-      live.bufferId
+    throw new Error(
+      `${code}: ${nativeResult.error?.trim() || 'diarization failed'}`
     );
-  } finally {
-    await releasePipelineSegmentBuffer(live.bufferId).catch(() => undefined);
   }
-  return params.segments.length;
+
+  const sr =
+    nativeResult.sampleRate > 0 ? nativeResult.sampleRate : engineSampleRate;
+  const count =
+    typeof nativeResult.segmentCount === 'number' &&
+    Number.isFinite(nativeResult.segmentCount)
+      ? Math.max(0, nativeResult.segmentCount)
+      : nativeResult.segments?.length ?? 0;
+
+  if (diarizeOptions?.onProgress) {
+    const progress: OrchestrationProgress = {
+      currentSegment: Math.max(1, count),
+      totalSegments: Math.max(1, count),
+      fraction: 1,
+      currentSegmentDurationMs: 0,
+      elapsedMs: Date.now() - startedAtMs,
+    };
+    diarizeOptions.onProgress(progress);
+  }
+
+  return {
+    status: 'complete',
+    numSpeakers: nativeResult.numSpeakers ?? 0,
+    segmentCount: count,
+    sampleRate: sr,
+    processingTimeMs: Date.now() - startedAtMs,
+    ...(diarizeOptions?.includeOverlap &&
+    Array.isArray(nativeResult.speakersPerFrame)
+      ? { speakersPerFrame: nativeResult.speakersPerFrame }
+      : {}),
+  };
 }
 
 export async function createDiarization(
@@ -256,95 +272,6 @@ export async function createDiarization(
     }
   };
 
-  const runMaterialize = async (
-    audioIn: OfflineAudioBufferIdSource,
-    segmentOut: OfflineSegmentBufferIdSource | OfflineSegmentBufferRef,
-    nativeResult: {
-      success: boolean;
-      error?: string;
-      errorCode?: string;
-      segments: Array<{ start: number; end: number; speaker: number }>;
-      numSpeakers: number;
-      sampleRate: number;
-      speakersPerFrame?: number[];
-    },
-    startedAtMs: number,
-    materializeOptions?: DiarizeOptions
-  ): Promise<DiarizeResult> => {
-    if (!nativeResult.success) {
-      const code =
-        typeof nativeResult.errorCode === 'string' &&
-        nativeResult.errorCode.length > 0
-          ? nativeResult.errorCode
-          : DiarizationErrorCode.INVALID_ARGUMENT;
-      if (
-        code === DiarizationErrorCode.CANCELLED ||
-        code === 'DIARIZATION_CANCELLED'
-      ) {
-        return {
-          status: 'cancelled',
-          numSpeakers: 0,
-          segmentCount: 0,
-          sampleRate: nativeResult.sampleRate || sampleRate,
-          processingTimeMs: Date.now() - startedAtMs,
-        };
-      }
-      throw new Error(
-        `${code}: ${nativeResult.error?.trim() || 'diarization failed'}`
-      );
-    }
-
-    const audioInBufferId = resolvePipelineAudioBufferId(audioIn);
-    const segmentOutBufferId = resolveOfflineSegmentBufferId(segmentOut);
-    const audioInfo = await getPipelineAudioBufferInfo(audioInBufferId);
-    if (audioInfo.kind !== 'offlinePcmBuffer') {
-      throw new Error(
-        `${DiarizationErrorCode.INVALID_ARGUMENT}: audioIn must be an offline audio buffer`
-      );
-    }
-    const segmentOutInfo = asOfflineSegmentBufferInfo(
-      await getPipelineSegmentBufferInfo(segmentOutBufferId),
-      'segmentOut'
-    );
-    if ((segmentOutInfo.segmentCount ?? 0) > 0) {
-      throw new Error(
-        `${DiarizationErrorCode.INVALID_ARGUMENT}: segmentOut must be an empty offline segment buffer`
-      );
-    }
-
-    const sr =
-      nativeResult.sampleRate > 0 ? nativeResult.sampleRate : sampleRate;
-    const count = await materializeSegmentsIntoOfflineBuffer({
-      audioInBufferId,
-      segmentOutBufferId,
-      sampleRate: sr,
-      segments: nativeResult.segments ?? [],
-    });
-
-    if (materializeOptions?.onProgress) {
-      const progress: OrchestrationProgress = {
-        currentSegment: Math.max(1, count),
-        totalSegments: Math.max(1, count),
-        fraction: 1,
-        currentSegmentDurationMs: 0,
-        elapsedMs: Date.now() - startedAtMs,
-      };
-      materializeOptions.onProgress(progress);
-    }
-
-    return {
-      status: 'complete',
-      numSpeakers: nativeResult.numSpeakers ?? 0,
-      segmentCount: count,
-      sampleRate: sr,
-      processingTimeMs: Date.now() - startedAtMs,
-      ...(materializeOptions?.includeOverlap &&
-      Array.isArray(nativeResult.speakersPerFrame)
-        ? { speakersPerFrame: nativeResult.speakersPerFrame }
-        : {}),
-    };
-  };
-
   return {
     instanceId,
     sampleRate,
@@ -362,6 +289,23 @@ export async function createDiarization(
 
       const startedAtMs = Date.now();
       const audioInBufferId = resolvePipelineAudioBufferId(audioIn);
+      const segmentOutBufferId = resolveOfflineSegmentBufferId(segmentOut);
+
+      const audioInfo = await getPipelineAudioBufferInfo(audioInBufferId);
+      if (audioInfo.kind !== 'offlinePcmBuffer') {
+        throw new Error(
+          `${DiarizationErrorCode.INVALID_ARGUMENT}: audioIn must be an offline audio buffer`
+        );
+      }
+      const segmentOutInfo = asOfflineSegmentBufferInfo(
+        await getPipelineSegmentBufferInfo(segmentOutBufferId),
+        'segmentOut'
+      );
+      if ((segmentOutInfo.segmentCount ?? 0) > 0) {
+        throw new Error(
+          `${DiarizationErrorCode.INVALID_ARGUMENT}: segmentOut must be an empty offline segment buffer`
+        );
+      }
 
       let abortHandler: (() => void) | null = null;
       try {
@@ -372,7 +316,9 @@ export async function createDiarization(
             });
           }
           abortHandler = () => {
-            SherpaOnnx.cancelDiarization(instanceId).catch(() => undefined);
+            Promise.resolve(SherpaOnnx.cancelDiarization(instanceId)).catch(
+              () => undefined
+            );
           };
           diarizeOptions.signal.addEventListener('abort', abortHandler);
         }
@@ -380,15 +326,15 @@ export async function createDiarization(
         const nativeResult = await SherpaOnnx.diarizeOffline(
           instanceId,
           audioInBufferId,
+          segmentOutBufferId,
           diarizeOptions?.includeOverlap === true
         );
-        return runMaterialize(
-          audioIn,
-          segmentOut,
+        return finishDiarizeResult({
           nativeResult,
           startedAtMs,
-          diarizeOptions
-        );
+          engineSampleRate: sampleRate,
+          diarizeOptions,
+        });
       } finally {
         if (abortHandler && diarizeOptions?.signal) {
           diarizeOptions.signal.removeEventListener('abort', abortHandler);

--- a/src/segmentbuffer/index.ts
+++ b/src/segmentbuffer/index.ts
@@ -691,6 +691,21 @@ function registerLiveSegmentBufferCallbacks(
   };
 }
 
+/**
+ * Subscribe to live segment-buffer events without creating a new buffer.
+ * Used by SID live `onLabeled` (native worker → segmentAppended → JS).
+ */
+export function subscribeLiveSegmentBufferEvents(
+  liveBufferId: LiveSegmentBufferIdSource,
+  callbacks: {
+    onSegmentAppended?: (event: LiveSegmentBufferSegmentAppendedEvent) => void;
+    onError?: (event: LiveSegmentBufferErrorEvent) => void;
+  }
+): () => void {
+  const id = resolveLiveSegmentBufferId(liveBufferId);
+  return registerLiveSegmentBufferCallbacks(id, callbacks);
+}
+
 export async function createLiveSegmentBuffer(
   options: CreateLiveSegmentBufferOptions = {}
 ): Promise<LiveSegmentBufferRef> {

--- a/src/speaker-embedding/__tests__/engine.extractFromOfflineAudio.test.ts
+++ b/src/speaker-embedding/__tests__/engine.extractFromOfflineAudio.test.ts
@@ -1,0 +1,92 @@
+jest.mock('../../NativeSherpaOnnx', () => ({
+  __esModule: true,
+  default: {
+    initializeSpeakerEmbeddingExtractor: jest.fn(),
+    unloadSpeakerEmbeddingExtractor: jest.fn(),
+    computeSpeakerEmbeddingOffline: jest.fn(),
+  },
+}));
+
+jest.mock('../../detect/resolveModelInput', () => ({
+  resolveFileSourceForModelInit: jest.fn(
+    async () => '/models/speaker-embedding'
+  ),
+}));
+
+const mockCreateOfflineAudioBufferFromSamples = jest.fn();
+const mockGetOfflineAudioBufferSamplesSlice = jest.fn();
+const mockGetPipelineAudioBufferInfo = jest.fn();
+const mockReleasePipelineAudioBuffer = jest.fn();
+
+jest.mock('../../audiobuffer', () => ({
+  createOfflineAudioBufferFromSamples: (...args: unknown[]) =>
+    mockCreateOfflineAudioBufferFromSamples(...args),
+  getOfflineAudioBufferSamplesSlice: (...args: unknown[]) =>
+    mockGetOfflineAudioBufferSamplesSlice(...args),
+  getPipelineAudioBufferInfo: (...args: unknown[]) =>
+    mockGetPipelineAudioBufferInfo(...args),
+  releasePipelineAudioBuffer: (...args: unknown[]) =>
+    mockReleasePipelineAudioBuffer(...args),
+  resolvePipelineAudioBufferId: jest.fn((value: unknown) => String(value)),
+}));
+
+import SherpaOnnx from '../../NativeSherpaOnnx';
+import { createSpeakerEmbeddingEngine } from '../engine';
+
+describe('createSpeakerEmbeddingEngine extractFromOfflineAudio', () => {
+  const native = SherpaOnnx as unknown as {
+    initializeSpeakerEmbeddingExtractor: jest.Mock;
+    unloadSpeakerEmbeddingExtractor: jest.Mock;
+    computeSpeakerEmbeddingOffline: jest.Mock;
+  };
+
+  const emb = [0.1, 0.2, 0.3, 0.4];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    native.initializeSpeakerEmbeddingExtractor.mockResolvedValue({
+      success: true,
+      dim: 4,
+      modelType: 'wespeaker',
+    });
+    native.unloadSpeakerEmbeddingExtractor.mockResolvedValue(null);
+    native.computeSpeakerEmbeddingOffline.mockResolvedValue({ embedding: emb });
+  });
+
+  it('full extract calls compute without range args', async () => {
+    const engine = await createSpeakerEmbeddingEngine({
+      modelSource: { kind: 'fs', path: '/models/speaker-embedding' },
+    });
+
+    const result = await engine.extractFromOfflineAudio('off_audio');
+    expect(result).toEqual(Float32Array.from(emb));
+    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenCalledWith(
+      engine.instanceId,
+      'off_audio'
+    );
+    expect(mockGetOfflineAudioBufferSamplesSlice).not.toHaveBeenCalled();
+    expect(mockCreateOfflineAudioBufferFromSamples).not.toHaveBeenCalled();
+  });
+
+  it('range extract passes start/end to native compute (no JS staging)', async () => {
+    const engine = await createSpeakerEmbeddingEngine({
+      modelSource: { kind: 'fs', path: '/models/speaker-embedding' },
+    });
+
+    const result = await engine.extractFromOfflineAudio('off_audio', {
+      startSample: 100.7,
+      endSample: 1600.2,
+    });
+    expect(result).toEqual(Float32Array.from(emb));
+    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenCalledWith(
+      engine.instanceId,
+      'off_audio',
+      100,
+      1600
+    );
+    expect(mockGetOfflineAudioBufferSamplesSlice).not.toHaveBeenCalled();
+    expect(mockCreateOfflineAudioBufferFromSamples).not.toHaveBeenCalled();
+    expect(mockGetPipelineAudioBufferInfo).not.toHaveBeenCalled();
+    expect(mockReleasePipelineAudioBuffer).not.toHaveBeenCalled();
+  });
+});

--- a/src/speaker-embedding/engine.ts
+++ b/src/speaker-embedding/engine.ts
@@ -1,11 +1,5 @@
 import SherpaOnnx from '../NativeSherpaOnnx';
-import {
-  createOfflineAudioBufferFromSamples,
-  getOfflineAudioBufferSamplesSlice,
-  getPipelineAudioBufferInfo,
-  releasePipelineAudioBuffer,
-  resolvePipelineAudioBufferId,
-} from '../audiobuffer';
+import { resolvePipelineAudioBufferId } from '../audiobuffer';
 import type { OfflineAudioBufferIdSource } from '../audiobuffer/types';
 import { buildSpeakerEmbeddingInitBridgeOptions } from './speakerEmbeddingNativeBridge';
 import type {
@@ -89,27 +83,13 @@ export async function createSpeakerEmbeddingEngine(
 
       const start = Math.max(0, Math.floor(range.startSample));
       const end = Math.max(start, Math.floor(range.endSample));
-      const frameCount = end - start;
-      const info = await getPipelineAudioBufferInfo(bufferId);
-      const samples =
-        frameCount > 0
-          ? getOfflineAudioBufferSamplesSlice(audio, start, frameCount)
-          : new Float32Array(0);
-      const temp = createOfflineAudioBufferFromSamples(
-        samples,
-        info.sampleRate,
-        info.channelCount,
-        { targetSampleRateHz: 0 }
+      const result = await SherpaOnnx.computeSpeakerEmbeddingOffline(
+        instanceId,
+        bufferId,
+        start,
+        end
       );
-      try {
-        const result = await SherpaOnnx.computeSpeakerEmbeddingOffline(
-          instanceId,
-          temp.bufferId
-        );
-        return embeddingArrayToFloat32(result.embedding ?? []);
-      } finally {
-        await releasePipelineAudioBuffer(temp.bufferId);
-      }
+      return embeddingArrayToFloat32(result.embedding ?? []);
     },
     async destroy(): Promise<void> {
       if (destroyed) return;

--- a/src/speaker-identification/__tests__/createSpeakerIdentification.test.ts
+++ b/src/speaker-identification/__tests__/createSpeakerIdentification.test.ts
@@ -6,6 +6,7 @@ jest.mock('../../NativeSherpaOnnx', () => ({
     computeSpeakerEmbeddingOffline: jest.fn(),
     identifySpeakerOffline: jest.fn(),
     verifySpeakerOffline: jest.fn(),
+    enrollSpeakerOffline: jest.fn(),
     createSpeakerEmbeddingManager: jest.fn(),
     destroySpeakerEmbeddingManager: jest.fn(),
     speakerEmbeddingManagerAdd: jest.fn(),
@@ -61,6 +62,7 @@ describe('createSpeakerIdentification', () => {
     computeSpeakerEmbeddingOffline: jest.Mock;
     identifySpeakerOffline: jest.Mock;
     verifySpeakerOffline: jest.Mock;
+    enrollSpeakerOffline: jest.Mock;
     createSpeakerEmbeddingManager: jest.Mock;
     destroySpeakerEmbeddingManager: jest.Mock;
     speakerEmbeddingManagerAdd: jest.Mock;
@@ -99,6 +101,20 @@ describe('createSpeakerIdentification', () => {
     native.computeSpeakerEmbeddingOffline.mockResolvedValue({ embedding: emb });
     native.identifySpeakerOffline.mockResolvedValue({ name: 'alice' });
     native.verifySpeakerOffline.mockResolvedValue({ ok: true });
+    native.enrollSpeakerOffline.mockImplementation(
+      async (
+        _instanceId: string,
+        _managerId: string,
+        _name: string,
+        audioBufferIds: string[]
+      ) => ({
+        ok: true,
+        embeddings: Array.from(
+          { length: Math.max(1, audioBufferIds.length) },
+          () => emb
+        ).flat(),
+      })
+    );
     native.createSpeakerEmbeddingManager.mockResolvedValue({ success: true });
     native.destroySpeakerEmbeddingManager.mockResolvedValue(null);
     native.speakerEmbeddingManagerAdd.mockResolvedValue({ ok: true });
@@ -145,13 +161,17 @@ describe('createSpeakerIdentification', () => {
     );
 
     await sid.enroll('alice', ['off_a', 'off_b']);
-    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenCalledTimes(2);
-    expect(native.speakerEmbeddingManagerAdd).toHaveBeenCalledWith(
+    expect(native.enrollSpeakerOffline).toHaveBeenCalledTimes(1);
+    expect(native.enrollSpeakerOffline).toHaveBeenCalledWith(
+      sid.instanceId,
       sid.managerId,
       'alice',
-      [...emb, ...emb],
-      2
+      ['off_a', 'off_b'],
+      null,
+      null
     );
+    expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
+    expect(native.speakerEmbeddingManagerAdd).not.toHaveBeenCalled();
 
     const identified = await sid.identify('off_query', { threshold: 0.6 });
     expect(identified).toEqual({ name: 'alice' });
@@ -161,7 +181,7 @@ describe('createSpeakerIdentification', () => {
       'off_query',
       0.6
     );
-    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenCalledTimes(2);
+    expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
     expect(native.speakerEmbeddingManagerSearch).not.toHaveBeenCalled();
 
     await expect(sid.verify('alice', 'off_query')).resolves.toBe(true);
@@ -173,7 +193,7 @@ describe('createSpeakerIdentification', () => {
       0.5
     );
     expect(native.speakerEmbeddingManagerVerify).not.toHaveBeenCalled();
-    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenCalledTimes(2);
+    expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
 
     await expect(sid.listSpeakers()).resolves.toEqual(['alice']);
     native.speakerEmbeddingManagerContains.mockResolvedValue({ ok: true });
@@ -220,6 +240,7 @@ describe('createSpeakerIdentification', () => {
     await expect(sid.enroll('alice', 'off_a')).rejects.toThrow(
       /already enrolled/
     );
+    expect(native.enrollSpeakerOffline).not.toHaveBeenCalled();
     expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
     expect(native.speakerEmbeddingManagerAdd).not.toHaveBeenCalled();
   });
@@ -242,11 +263,12 @@ describe('createSpeakerIdentification', () => {
     await expect(
       sid.enrollOfflineSegments('alice', AUDIO_ID, SEGS_IN)
     ).rejects.toThrow(/already enrolled/);
+    expect(native.enrollSpeakerOffline).not.toHaveBeenCalled();
     expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
     expect(native.speakerEmbeddingManagerAdd).not.toHaveBeenCalled();
   });
 
-  it('enrollOfflineSegments extracts each speech span then manager.add', async () => {
+  it('enrollOfflineSegments enrolls speech spans via enrollSpeakerOffline', async () => {
     segs.getOfflineSegmentBufferSegments.mockResolvedValue([
       {
         id: 'a',
@@ -298,33 +320,23 @@ describe('createSpeakerIdentification', () => {
     await sid.enrollOfflineSegments('alice', AUDIO_ID, SEGS_IN);
 
     expect(segs.getOfflineSegmentBufferSegments).toHaveBeenCalledWith(SEGS_IN);
-    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenCalledTimes(2);
-    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenNthCalledWith(
-      1,
+    expect(native.enrollSpeakerOffline).toHaveBeenCalledTimes(1);
+    expect(native.enrollSpeakerOffline).toHaveBeenCalledWith(
       sid.instanceId,
-      AUDIO_ID,
-      0,
-      1600
+      sid.managerId,
+      'alice',
+      [AUDIO_ID, AUDIO_ID],
+      [0, 3200],
+      [1600, 4800]
     );
-    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenNthCalledWith(
-      2,
-      sid.instanceId,
-      AUDIO_ID,
-      3200,
-      4800
-    );
+    expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
+    expect(native.speakerEmbeddingManagerAdd).not.toHaveBeenCalled();
     expect(
       audiobuffer.getOfflineAudioBufferSamplesSlice
     ).not.toHaveBeenCalled();
     expect(
       audiobuffer.createOfflineAudioBufferFromSamples
     ).not.toHaveBeenCalled();
-    expect(native.speakerEmbeddingManagerAdd).toHaveBeenCalledWith(
-      sid.managerId,
-      'alice',
-      [...emb, ...emb],
-      2
-    );
   });
 
   it('enrollOfflineSegments rejects when no speech spans', async () => {
@@ -382,36 +394,27 @@ describe('createSpeakerIdentification', () => {
 
     await sid.enrollOfflineSegments(['alice', 'bob'], AUDIO_ID, SEGS_IN);
 
-    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenCalledTimes(2);
-    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenNthCalledWith(
+    expect(native.enrollSpeakerOffline).toHaveBeenCalledTimes(2);
+    expect(native.enrollSpeakerOffline).toHaveBeenNthCalledWith(
       1,
       sid.instanceId,
-      AUDIO_ID,
-      0,
-      1600
-    );
-    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenNthCalledWith(
-      2,
-      sid.instanceId,
-      AUDIO_ID,
-      3200,
-      4800
-    );
-    expect(native.speakerEmbeddingManagerAdd).toHaveBeenCalledTimes(2);
-    expect(native.speakerEmbeddingManagerAdd).toHaveBeenNthCalledWith(
-      1,
       sid.managerId,
       'alice',
-      emb,
-      1
+      [AUDIO_ID],
+      [0],
+      [1600]
     );
-    expect(native.speakerEmbeddingManagerAdd).toHaveBeenNthCalledWith(
+    expect(native.enrollSpeakerOffline).toHaveBeenNthCalledWith(
       2,
+      sid.instanceId,
       sid.managerId,
       'bob',
-      emb,
-      1
+      [AUDIO_ID],
+      [3200],
+      [4800]
     );
+    expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
+    expect(native.speakerEmbeddingManagerAdd).not.toHaveBeenCalled();
   });
 
   it('enrollOfflineSegments name list groups duplicate names into one add', async () => {
@@ -455,19 +458,24 @@ describe('createSpeakerIdentification', () => {
       SEGS_IN
     );
 
-    expect(native.speakerEmbeddingManagerAdd).toHaveBeenCalledTimes(2);
-    expect(native.speakerEmbeddingManagerAdd).toHaveBeenCalledWith(
+    expect(native.enrollSpeakerOffline).toHaveBeenCalledTimes(2);
+    expect(native.enrollSpeakerOffline).toHaveBeenCalledWith(
+      sid.instanceId,
       sid.managerId,
       'alice',
-      [...emb, ...emb],
-      2
+      [AUDIO_ID, AUDIO_ID],
+      [0, 4000],
+      [1600, 5600]
     );
-    expect(native.speakerEmbeddingManagerAdd).toHaveBeenCalledWith(
+    expect(native.enrollSpeakerOffline).toHaveBeenCalledWith(
+      sid.instanceId,
       sid.managerId,
       'bob',
-      emb,
-      1
+      [AUDIO_ID],
+      [2000],
+      [3600]
     );
+    expect(native.speakerEmbeddingManagerAdd).not.toHaveBeenCalled();
   });
 
   it('enrollOfflineSegments rejects name list length mismatch before extract', async () => {
@@ -501,6 +509,7 @@ describe('createSpeakerIdentification', () => {
     ).rejects.toThrow(
       /name list length \(1\) must match speech span count \(2\)/
     );
+    expect(native.enrollSpeakerOffline).not.toHaveBeenCalled();
     expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
     expect(native.speakerEmbeddingManagerAdd).not.toHaveBeenCalled();
   });
@@ -525,6 +534,7 @@ describe('createSpeakerIdentification', () => {
     await expect(
       sid.enrollOfflineSegments(['  '], AUDIO_ID, SEGS_IN)
     ).rejects.toThrow(/names\[0\] must be a non-empty string/);
+    expect(native.enrollSpeakerOffline).not.toHaveBeenCalled();
     expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
   });
 
@@ -560,6 +570,7 @@ describe('createSpeakerIdentification', () => {
     await expect(
       sid.enrollOfflineSegments(['alice', 'bob'], AUDIO_ID, SEGS_IN)
     ).rejects.toThrow(/Speaker 'bob' is already enrolled/);
+    expect(native.enrollSpeakerOffline).not.toHaveBeenCalled();
     expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
     expect(native.speakerEmbeddingManagerAdd).not.toHaveBeenCalled();
   });

--- a/src/speaker-identification/__tests__/createSpeakerIdentification.test.ts
+++ b/src/speaker-identification/__tests__/createSpeakerIdentification.test.ts
@@ -4,6 +4,7 @@ jest.mock('../../NativeSherpaOnnx', () => ({
     initializeSpeakerEmbeddingExtractor: jest.fn(),
     unloadSpeakerEmbeddingExtractor: jest.fn(),
     computeSpeakerEmbeddingOffline: jest.fn(),
+    identifySpeakerOffline: jest.fn(),
     createSpeakerEmbeddingManager: jest.fn(),
     destroySpeakerEmbeddingManager: jest.fn(),
     speakerEmbeddingManagerAdd: jest.fn(),
@@ -57,6 +58,7 @@ describe('createSpeakerIdentification', () => {
     initializeSpeakerEmbeddingExtractor: jest.Mock;
     unloadSpeakerEmbeddingExtractor: jest.Mock;
     computeSpeakerEmbeddingOffline: jest.Mock;
+    identifySpeakerOffline: jest.Mock;
     createSpeakerEmbeddingManager: jest.Mock;
     destroySpeakerEmbeddingManager: jest.Mock;
     speakerEmbeddingManagerAdd: jest.Mock;
@@ -93,6 +95,7 @@ describe('createSpeakerIdentification', () => {
     });
     native.unloadSpeakerEmbeddingExtractor.mockResolvedValue(null);
     native.computeSpeakerEmbeddingOffline.mockResolvedValue({ embedding: emb });
+    native.identifySpeakerOffline.mockResolvedValue({ name: 'alice' });
     native.createSpeakerEmbeddingManager.mockResolvedValue({ success: true });
     native.destroySpeakerEmbeddingManager.mockResolvedValue(null);
     native.speakerEmbeddingManagerAdd.mockResolvedValue({ ok: true });
@@ -149,11 +152,14 @@ describe('createSpeakerIdentification', () => {
 
     const identified = await sid.identify('off_query', { threshold: 0.6 });
     expect(identified).toEqual({ name: 'alice' });
-    expect(native.speakerEmbeddingManagerSearch).toHaveBeenCalledWith(
+    expect(native.identifySpeakerOffline).toHaveBeenCalledWith(
+      sid.instanceId,
       sid.managerId,
-      emb,
+      'off_query',
       0.6
     );
+    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenCalledTimes(2);
+    expect(native.speakerEmbeddingManagerSearch).not.toHaveBeenCalled();
 
     await expect(sid.verify('alice', 'off_query')).resolves.toBe(true);
     expect(native.speakerEmbeddingManagerVerify).toHaveBeenCalledWith(
@@ -186,11 +192,18 @@ describe('createSpeakerIdentification', () => {
   });
 
   it('returns null name when search misses', async () => {
-    native.speakerEmbeddingManagerSearch.mockResolvedValue({ name: '' });
+    native.identifySpeakerOffline.mockResolvedValue({ name: '' });
     const sid = await createSpeakerIdentification({
       modelSource: { kind: 'fs', path: '/models/speaker-embedding' },
     });
     await expect(sid.identify('off_query')).resolves.toEqual({ name: null });
+    expect(native.identifySpeakerOffline).toHaveBeenCalledWith(
+      sid.instanceId,
+      sid.managerId,
+      'off_query',
+      0.5
+    );
+    expect(native.speakerEmbeddingManagerSearch).not.toHaveBeenCalled();
   });
 
   it('enroll rejects duplicate name before extracting embeddings', async () => {
@@ -567,7 +580,7 @@ describe('createSpeakerIdentification', () => {
         durationMs: 100,
       },
     ]);
-    native.speakerEmbeddingManagerSearch
+    native.identifySpeakerOffline
       .mockResolvedValueOnce({ name: 'alice' })
       .mockResolvedValueOnce({ name: '' });
 
@@ -580,20 +593,26 @@ describe('createSpeakerIdentification', () => {
     });
 
     expect(result).toEqual({ labeledCount: 1, unknownCount: 1 });
-    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenNthCalledWith(
+    expect(native.identifySpeakerOffline).toHaveBeenNthCalledWith(
       1,
       sid.instanceId,
+      sid.managerId,
       AUDIO_ID,
+      0.55,
       0,
       1600
     );
-    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenNthCalledWith(
+    expect(native.identifySpeakerOffline).toHaveBeenNthCalledWith(
       2,
       sid.instanceId,
+      sid.managerId,
       AUDIO_ID,
+      0.55,
       2000,
       3600
     );
+    expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
+    expect(native.speakerEmbeddingManagerSearch).not.toHaveBeenCalled();
     expect(
       audiobuffer.getOfflineAudioBufferSamplesSlice
     ).not.toHaveBeenCalled();
@@ -618,11 +637,6 @@ describe('createSpeakerIdentification', () => {
       expect.objectContaining({
         payload: { source: 'sid', speakerName: null },
       })
-    );
-    expect(native.speakerEmbeddingManagerSearch).toHaveBeenCalledWith(
-      sid.managerId,
-      emb,
-      0.55
     );
     expect(segs.finalizeLiveSegmentBuffer).toHaveBeenCalledWith(STAGING_LIVE);
     expect(segs.populateOfflineSegmentBufferIfEmpty).toHaveBeenCalledWith(
@@ -715,9 +729,9 @@ describe('createSpeakerIdentification', () => {
     expect(secondElapsed).toBeGreaterThanOrEqual(firstElapsed);
 
     const firstProgressOrder = onProgress.mock.invocationCallOrder[0]!;
-    const firstComputeOrder =
-      native.computeSpeakerEmbeddingOffline.mock.invocationCallOrder[0]!;
-    expect(firstProgressOrder).toBeLessThan(firstComputeOrder);
+    const firstIdentifyOrder =
+      native.identifySpeakerOffline.mock.invocationCallOrder[0]!;
+    expect(firstProgressOrder).toBeLessThan(firstIdentifyOrder);
     expect(
       audiobuffer.getOfflineAudioBufferSamplesSlice
     ).not.toHaveBeenCalled();
@@ -757,6 +771,7 @@ describe('createSpeakerIdentification', () => {
     await expect(
       sid.labelOfflineSegments(AUDIO_ID, SEGS_IN, SEGS_OUT, { onProgress })
     ).rejects.toThrow(/progress failed/);
+    expect(native.identifySpeakerOffline).not.toHaveBeenCalled();
     expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
     expect(segs.releasePipelineSegmentBuffer).toHaveBeenCalledWith(
       STAGING_LIVE
@@ -1060,7 +1075,7 @@ describe('createSpeakerIdentification', () => {
         durationMs: 200,
       },
     ]);
-    native.speakerEmbeddingManagerSearch
+    native.identifySpeakerOffline
       .mockResolvedValueOnce({ name: 'alice' })
       .mockResolvedValueOnce({ name: '' });
 

--- a/src/speaker-identification/__tests__/createSpeakerIdentification.test.ts
+++ b/src/speaker-identification/__tests__/createSpeakerIdentification.test.ts
@@ -279,9 +279,27 @@ describe('createSpeakerIdentification', () => {
     await sid.enrollOfflineSegments('alice', AUDIO_ID, SEGS_IN);
 
     expect(segs.getOfflineSegmentBufferSegments).toHaveBeenCalledWith(SEGS_IN);
-    expect(audiobuffer.getOfflineAudioBufferSamplesSlice).toHaveBeenCalledTimes(
-      2
+    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenCalledTimes(2);
+    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenNthCalledWith(
+      1,
+      sid.instanceId,
+      AUDIO_ID,
+      0,
+      1600
     );
+    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenNthCalledWith(
+      2,
+      sid.instanceId,
+      AUDIO_ID,
+      3200,
+      4800
+    );
+    expect(
+      audiobuffer.getOfflineAudioBufferSamplesSlice
+    ).not.toHaveBeenCalled();
+    expect(
+      audiobuffer.createOfflineAudioBufferFromSamples
+    ).not.toHaveBeenCalled();
     expect(native.speakerEmbeddingManagerAdd).toHaveBeenCalledWith(
       sid.managerId,
       'alice',
@@ -346,6 +364,20 @@ describe('createSpeakerIdentification', () => {
     await sid.enrollOfflineSegments(['alice', 'bob'], AUDIO_ID, SEGS_IN);
 
     expect(native.computeSpeakerEmbeddingOffline).toHaveBeenCalledTimes(2);
+    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenNthCalledWith(
+      1,
+      sid.instanceId,
+      AUDIO_ID,
+      0,
+      1600
+    );
+    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenNthCalledWith(
+      2,
+      sid.instanceId,
+      AUDIO_ID,
+      3200,
+      4800
+    );
     expect(native.speakerEmbeddingManagerAdd).toHaveBeenCalledTimes(2);
     expect(native.speakerEmbeddingManagerAdd).toHaveBeenNthCalledWith(
       1,
@@ -548,6 +580,23 @@ describe('createSpeakerIdentification', () => {
     });
 
     expect(result).toEqual({ labeledCount: 1, unknownCount: 1 });
+    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenNthCalledWith(
+      1,
+      sid.instanceId,
+      AUDIO_ID,
+      0,
+      1600
+    );
+    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenNthCalledWith(
+      2,
+      sid.instanceId,
+      AUDIO_ID,
+      2000,
+      3600
+    );
+    expect(
+      audiobuffer.getOfflineAudioBufferSamplesSlice
+    ).not.toHaveBeenCalled();
     expect(segs.createLiveSegmentBuffer).toHaveBeenCalledWith({
       sourceAudioBufferId: AUDIO_ID,
       spooling: { mode: 'on' },
@@ -666,10 +715,12 @@ describe('createSpeakerIdentification', () => {
     expect(secondElapsed).toBeGreaterThanOrEqual(firstElapsed);
 
     const firstProgressOrder = onProgress.mock.invocationCallOrder[0]!;
-    const firstSliceOrder = (
-      audiobuffer.getOfflineAudioBufferSamplesSlice as unknown as jest.Mock
-    ).mock.invocationCallOrder[0]!;
-    expect(firstProgressOrder).toBeLessThan(firstSliceOrder);
+    const firstComputeOrder =
+      native.computeSpeakerEmbeddingOffline.mock.invocationCallOrder[0]!;
+    expect(firstProgressOrder).toBeLessThan(firstComputeOrder);
+    expect(
+      audiobuffer.getOfflineAudioBufferSamplesSlice
+    ).not.toHaveBeenCalled();
   });
 
   it('labelOfflineSegments rejects non-function onProgress', async () => {
@@ -706,9 +757,7 @@ describe('createSpeakerIdentification', () => {
     await expect(
       sid.labelOfflineSegments(AUDIO_ID, SEGS_IN, SEGS_OUT, { onProgress })
     ).rejects.toThrow(/progress failed/);
-    expect(
-      audiobuffer.getOfflineAudioBufferSamplesSlice
-    ).not.toHaveBeenCalled();
+    expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
     expect(segs.releasePipelineSegmentBuffer).toHaveBeenCalledWith(
       STAGING_LIVE
     );

--- a/src/speaker-identification/__tests__/createSpeakerIdentification.test.ts
+++ b/src/speaker-identification/__tests__/createSpeakerIdentification.test.ts
@@ -5,6 +5,7 @@ jest.mock('../../NativeSherpaOnnx', () => ({
     unloadSpeakerEmbeddingExtractor: jest.fn(),
     computeSpeakerEmbeddingOffline: jest.fn(),
     identifySpeakerOffline: jest.fn(),
+    verifySpeakerOffline: jest.fn(),
     createSpeakerEmbeddingManager: jest.fn(),
     destroySpeakerEmbeddingManager: jest.fn(),
     speakerEmbeddingManagerAdd: jest.fn(),
@@ -59,6 +60,7 @@ describe('createSpeakerIdentification', () => {
     unloadSpeakerEmbeddingExtractor: jest.Mock;
     computeSpeakerEmbeddingOffline: jest.Mock;
     identifySpeakerOffline: jest.Mock;
+    verifySpeakerOffline: jest.Mock;
     createSpeakerEmbeddingManager: jest.Mock;
     destroySpeakerEmbeddingManager: jest.Mock;
     speakerEmbeddingManagerAdd: jest.Mock;
@@ -96,6 +98,7 @@ describe('createSpeakerIdentification', () => {
     native.unloadSpeakerEmbeddingExtractor.mockResolvedValue(null);
     native.computeSpeakerEmbeddingOffline.mockResolvedValue({ embedding: emb });
     native.identifySpeakerOffline.mockResolvedValue({ name: 'alice' });
+    native.verifySpeakerOffline.mockResolvedValue({ ok: true });
     native.createSpeakerEmbeddingManager.mockResolvedValue({ success: true });
     native.destroySpeakerEmbeddingManager.mockResolvedValue(null);
     native.speakerEmbeddingManagerAdd.mockResolvedValue({ ok: true });
@@ -162,12 +165,15 @@ describe('createSpeakerIdentification', () => {
     expect(native.speakerEmbeddingManagerSearch).not.toHaveBeenCalled();
 
     await expect(sid.verify('alice', 'off_query')).resolves.toBe(true);
-    expect(native.speakerEmbeddingManagerVerify).toHaveBeenCalledWith(
+    expect(native.verifySpeakerOffline).toHaveBeenCalledWith(
+      sid.instanceId,
       sid.managerId,
+      'off_query',
       'alice',
-      emb,
       0.5
     );
+    expect(native.speakerEmbeddingManagerVerify).not.toHaveBeenCalled();
+    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenCalledTimes(2);
 
     await expect(sid.listSpeakers()).resolves.toEqual(['alice']);
     native.speakerEmbeddingManagerContains.mockResolvedValue({ ok: true });
@@ -875,7 +881,7 @@ describe('createSpeakerIdentification', () => {
         durationMs: 200,
       },
     ]);
-    native.speakerEmbeddingManagerVerify
+    native.verifySpeakerOffline
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({ ok: false });
 
@@ -897,14 +903,28 @@ describe('createSpeakerIdentification', () => {
       matches: [true, false],
     });
 
-    expect(native.computeSpeakerEmbeddingOffline).toHaveBeenCalledTimes(2);
-    expect(native.speakerEmbeddingManagerVerify).toHaveBeenNthCalledWith(
+    expect(native.verifySpeakerOffline).toHaveBeenNthCalledWith(
       1,
+      sid.instanceId,
       sid.managerId,
+      AUDIO_ID,
       'alice',
-      emb,
-      0.55
+      0.55,
+      0,
+      1600
     );
+    expect(native.verifySpeakerOffline).toHaveBeenNthCalledWith(
+      2,
+      sid.instanceId,
+      sid.managerId,
+      AUDIO_ID,
+      'alice',
+      0.55,
+      2000,
+      3600
+    );
+    expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
+    expect(native.speakerEmbeddingManagerVerify).not.toHaveBeenCalled();
     expect(onProgress).toHaveBeenCalledTimes(2);
     expect(onVerified).toHaveBeenNthCalledWith(
       1,
@@ -948,7 +968,7 @@ describe('createSpeakerIdentification', () => {
         durationMs: 200,
       },
     ]);
-    native.speakerEmbeddingManagerVerify
+    native.verifySpeakerOffline
       .mockResolvedValueOnce({ ok: true })
       .mockResolvedValueOnce({ ok: false });
 
@@ -967,20 +987,27 @@ describe('createSpeakerIdentification', () => {
       matches: [true, false],
     });
 
-    expect(native.speakerEmbeddingManagerVerify).toHaveBeenNthCalledWith(
+    expect(native.verifySpeakerOffline).toHaveBeenNthCalledWith(
       1,
+      sid.instanceId,
       sid.managerId,
+      AUDIO_ID,
       'alice',
-      emb,
-      0.5
+      0.5,
+      0,
+      1600
     );
-    expect(native.speakerEmbeddingManagerVerify).toHaveBeenNthCalledWith(
+    expect(native.verifySpeakerOffline).toHaveBeenNthCalledWith(
       2,
+      sid.instanceId,
       sid.managerId,
+      AUDIO_ID,
       'bob',
-      emb,
-      0.5
+      0.5,
+      2000,
+      3600
     );
+    expect(native.speakerEmbeddingManagerVerify).not.toHaveBeenCalled();
     expect(onVerified).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ expectedName: 'alice', matched: true })
@@ -1021,6 +1048,7 @@ describe('createSpeakerIdentification', () => {
       /name list length \(1\) must match speech span count \(2\)/
     );
     expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
+    expect(native.verifySpeakerOffline).not.toHaveBeenCalled();
   });
 
   it('verifyOfflineSegments rejects when no speech spans', async () => {
@@ -1041,6 +1069,7 @@ describe('createSpeakerIdentification', () => {
       sid.verifyOfflineSegments('alice', AUDIO_ID, SEGS_IN)
     ).rejects.toThrow(/at least one non-empty speech span/);
     expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
+    expect(native.verifySpeakerOffline).not.toHaveBeenCalled();
   });
 
   it('verifyOfflineSegments rejects non-function onVerified', async () => {

--- a/src/speaker-identification/__tests__/labelLiveSegments.test.ts
+++ b/src/speaker-identification/__tests__/labelLiveSegments.test.ts
@@ -13,6 +13,11 @@ jest.mock('../../NativeSherpaOnnx', () => ({
     speakerEmbeddingManagerContains: jest.fn(),
     speakerEmbeddingManagerNumSpeakers: jest.fn(),
     speakerEmbeddingManagerAllSpeakerNames: jest.fn(),
+    startSpeakerIdentificationOfflineLivePipeline: jest.fn(),
+    stopStreamingPipeline: jest.fn(),
+    flushStreamingPipeline: jest.fn(),
+    resetStreamingPipeline: jest.fn(),
+    getStreamingPipelineStatus: jest.fn(),
   },
 }));
 
@@ -23,28 +28,6 @@ jest.mock('../../detect/resolveModelInput', () => ({
 }));
 
 jest.mock('../../audiobuffer', () => ({
-  createOfflineAudioBufferFromSamples: jest.fn((samples: Float32Array) => ({
-    bufferId: `off_temp_${samples.length}`,
-  })),
-  getOfflineAudioBufferSamplesSlice: jest.fn(
-    () => new Float32Array([0.1, 0.2, 0.3, 0.4])
-  ),
-  getLiveAudioBufferSamplesSlice: jest.fn(
-    () => new Float32Array([0.1, 0.2, 0.3, 0.4])
-  ),
-  getPipelineAudioBufferInfo: jest.fn(async () => ({
-    bufferId: 'live_audio',
-    kind: 'livePcmBuffer',
-    state: 'recording',
-    sampleRate: 16000,
-    channelCount: 1,
-    numSamples: 0,
-    durationMs: 0,
-    totalSamplesWritten: 0,
-    ringEvictedSamples: 0,
-    hasActiveSpool: false,
-  })),
-  releasePipelineAudioBuffer: jest.fn(async () => undefined),
   resolvePipelineAudioBufferId: jest.fn((value: unknown) => {
     if (typeof value === 'string') return value;
     if (
@@ -58,14 +41,9 @@ jest.mock('../../audiobuffer', () => ({
   }),
 }));
 
+const mockSubscribeLiveSegmentBufferEvents = jest.fn();
 jest.mock('../../segmentbuffer', () => ({
-  getOfflineSegmentBufferSegments: jest.fn(),
-  createLiveSegmentBuffer: jest.fn(),
-  appendLiveSegment: jest.fn(),
-  finalizeLiveSegmentBuffer: jest.fn(),
-  populateOfflineSegmentBufferIfEmpty: jest.fn(),
-  releasePipelineSegmentBuffer: jest.fn(),
-  resolveOfflineSegmentBufferId: jest.fn((value: unknown) => String(value)),
+  finalizeLiveSegmentBuffer: jest.fn(async () => undefined),
   resolveLiveSegmentBufferId: jest.fn((value: unknown) => {
     if (typeof value === 'string') return value;
     if (
@@ -77,8 +55,8 @@ jest.mock('../../segmentbuffer', () => ({
     }
     return String(value);
   }),
-  getLiveSegmentBufferSegmentCount: jest.fn(),
-  getLiveSegmentBufferSegments: jest.fn(),
+  subscribeLiveSegmentBufferEvents: (...args: unknown[]) =>
+    mockSubscribeLiveSegmentBufferEvents(...args),
 }));
 
 jest.mock('../../segment', () => ({
@@ -87,8 +65,13 @@ jest.mock('../../segment', () => ({
   getSegmentationEngineInfo: jest.fn(),
 }));
 
+const mockCreateStreamingPipelineCompletionPromise = jest.fn();
+jest.mock('../../audiobuffer/streamingPipelineCompletion', () => ({
+  createStreamingPipelineCompletionPromise: (pipelineId: string) =>
+    mockCreateStreamingPipelineCompletionPromise(pipelineId),
+}));
+
 import SherpaOnnx from '../../NativeSherpaOnnx';
-import * as audiobuffer from '../../audiobuffer';
 import * as segment from '../../segment';
 import * as segmentbuffer from '../../segmentbuffer';
 import { createSpeakerIdentification } from '../index';
@@ -102,14 +85,11 @@ describe('labelLiveSegments', () => {
     createSpeakerEmbeddingManager: jest.Mock;
     destroySpeakerEmbeddingManager: jest.Mock;
     speakerEmbeddingManagerSearch: jest.Mock;
-  };
-
-  const segs = segmentbuffer as unknown as {
-    appendLiveSegment: jest.Mock;
-    finalizeLiveSegmentBuffer: jest.Mock;
-    resolveLiveSegmentBufferId: jest.Mock;
-    getLiveSegmentBufferSegmentCount: jest.Mock;
-    getLiveSegmentBufferSegments: jest.Mock;
+    startSpeakerIdentificationOfflineLivePipeline: jest.Mock;
+    stopStreamingPipeline: jest.Mock;
+    flushStreamingPipeline: jest.Mock;
+    resetStreamingPipeline: jest.Mock;
+    getStreamingPipelineStatus: jest.Mock;
   };
 
   const seg = segment as unknown as {
@@ -118,35 +98,35 @@ describe('labelLiveSegments', () => {
     getSegmentationEngineInfo: jest.Mock;
   };
 
-  const AUDIO_LIVE = 'live_123e4567-e89b-12d3-a456-426614174000';
-  const SEGS_OUT = 'seg_live_223e4567-e89b-12d3-a456-426614174000';
-  const INTERNAL_SEGS = 'seg_live_323e4567-e89b-12d3-a456-426614174000';
-  const ENGINE_ID = 'seg_engine_1';
-  const emb = [1, 2, 3, 4];
-
-  const defaultPolicy = {
-    evaluator: 'speech_energy_silence' as const,
-    silenceThresholdMs: 500,
-    energyThresholdDb: -40,
-    minSegmentMs: 1000,
-    maxSegmentMs: 120000,
-    hangoverMs: 300,
+  const segs = segmentbuffer as unknown as {
+    finalizeLiveSegmentBuffer: jest.Mock;
   };
 
-  const speechSpan = (start: number, end: number, durationMs = 100) => ({
-    id: `s_${start}`,
-    kind: 'speech' as const,
-    sourceAudioBufferId: AUDIO_LIVE,
-    startSample: start,
-    endSample: end,
-    sampleRate: 16000,
-    durationMs,
-    confidence: 0.9,
-  });
+  const AUDIO_LIVE = 'live_audio';
+  const SEGS_OUT = 'seg_live_out';
+  const ENGINE_ID = 'seg_engine_1';
+  const SEG_LIVE_INTERNAL = 'seg_live_internal';
+  const PIPELINE_ID = 'sid_live_pipe_1';
+
+  const defaultPolicy = { evaluator: 'speech_energy_silence' as const };
+
+  const emb = [0.1, 0.2, 0.3, 0.4];
+
+  let completionResolve: ((value: unknown) => void) | undefined;
+  let completionReject: ((reason?: unknown) => void) | undefined;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.useRealTimers();
+    completionResolve = undefined;
+    completionReject = undefined;
+
+    mockCreateStreamingPipelineCompletionPromise.mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          completionResolve = resolve;
+          completionReject = reject;
+        })
+    );
 
     native.initializeSpeakerEmbeddingExtractor.mockResolvedValue({
       success: true,
@@ -154,10 +134,24 @@ describe('labelLiveSegments', () => {
       modelType: 'wespeaker',
     });
     native.unloadSpeakerEmbeddingExtractor.mockResolvedValue(null);
-    native.computeSpeakerEmbeddingOffline.mockResolvedValue({ embedding: emb });
     native.createSpeakerEmbeddingManager.mockResolvedValue({ success: true });
     native.destroySpeakerEmbeddingManager.mockResolvedValue(null);
-    native.speakerEmbeddingManagerSearch.mockResolvedValue({ name: 'alice' });
+    native.computeSpeakerEmbeddingOffline.mockResolvedValue({ embedding: emb });
+    native.speakerEmbeddingManagerSearch.mockResolvedValue({ name: '' });
+    native.startSpeakerIdentificationOfflineLivePipeline.mockResolvedValue({
+      pipelineId: PIPELINE_ID,
+    });
+    native.stopStreamingPipeline.mockResolvedValue(undefined);
+    native.flushStreamingPipeline.mockResolvedValue(undefined);
+    native.resetStreamingPipeline.mockResolvedValue(undefined);
+    native.getStreamingPipelineStatus.mockResolvedValue({
+      pipelineId: PIPELINE_ID,
+      isRunning: true,
+      chunksProcessed: 0,
+      unitsRead: 0,
+      unitsWritten: 0,
+      error: null,
+    });
 
     seg.attachSegmentationEngine.mockResolvedValue({ engineId: ENGINE_ID });
     seg.getSegmentationEngineInfo.mockResolvedValue({
@@ -167,34 +161,11 @@ describe('labelLiveSegments', () => {
       policy: defaultPolicy,
       state: 'active',
       totalSegmentsCommitted: 0,
-      segmentBufferId: INTERNAL_SEGS,
+      segmentBufferId: SEG_LIVE_INTERNAL,
     });
     seg.detachSegmentationEngine.mockResolvedValue(undefined);
 
-    segs.appendLiveSegment.mockResolvedValue({
-      segmentId: 'labeled_1',
-      segmentIndex: 0,
-    });
-    segs.finalizeLiveSegmentBuffer.mockResolvedValue(undefined);
-    segs.getLiveSegmentBufferSegmentCount.mockResolvedValue(0);
-    segs.getLiveSegmentBufferSegments.mockResolvedValue([]);
-
-    (audiobuffer.getPipelineAudioBufferInfo as jest.Mock).mockResolvedValue({
-      bufferId: AUDIO_LIVE,
-      kind: 'livePcmBuffer',
-      state: 'recording',
-      sampleRate: 16000,
-      channelCount: 1,
-      numSamples: 0,
-      durationMs: 0,
-      totalSamplesWritten: 0,
-      ringEvictedSamples: 0,
-      hasActiveSpool: false,
-    });
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
+    mockSubscribeLiveSegmentBufferEvents.mockImplementation(() => jest.fn());
   });
 
   it('rejects missing segmentation with LIVE_OFFLINE_SEGMENTATION_REQUIRED', async () => {
@@ -251,22 +222,28 @@ describe('labelLiveSegments', () => {
     ).rejects.toThrow(/onLabeled must be a function/);
   });
 
-  it('labels committed spans: extract → search → append → onLabeled', async () => {
-    const spans = [speechSpan(0, 1600), speechSpan(2000, 3600, 200)];
-    let committed = 0;
-    segs.getLiveSegmentBufferSegmentCount.mockImplementation(async () => {
-      return committed;
-    });
-    segs.getLiveSegmentBufferSegments.mockImplementation(
-      async (_id: string, start: number, max: number) => {
-        return spans.slice(start, start + max);
+  it('starts native live pipeline with extractor, manager, and segmentation context', async () => {
+    const onLabeled = jest.fn();
+    let onAppended:
+      | ((event: {
+          kind: string;
+          segmentIndex: number;
+          startSample: number;
+          endSample: number;
+          sampleRate: number;
+          durationMs: number;
+          confidence?: number;
+          payload?: { source: string; speakerName: string | null };
+        }) => void)
+      | undefined;
+
+    mockSubscribeLiveSegmentBufferEvents.mockImplementation(
+      (_id: unknown, callbacks: { onSegmentAppended?: typeof onAppended }) => {
+        onAppended = callbacks.onSegmentAppended;
+        return jest.fn();
       }
     );
-    native.speakerEmbeddingManagerSearch
-      .mockResolvedValueOnce({ name: 'alice' })
-      .mockResolvedValueOnce({ name: '' });
 
-    const onLabeled = jest.fn();
     const sid = await createSpeakerIdentification({
       modelSource: { kind: 'fs', path: '/models/speaker-embedding' },
     });
@@ -281,50 +258,48 @@ describe('labelLiveSegments', () => {
       AUDIO_LIVE,
       expect.objectContaining({ policy: defaultPolicy })
     );
-    expect(handle.pipelineId).toMatch(/^sid_live_/);
+    expect(
+      native.startSpeakerIdentificationOfflineLivePipeline
+    ).toHaveBeenCalledWith(
+      sid.instanceId,
+      sid.managerId,
+      AUDIO_LIVE,
+      SEGS_OUT,
+      {
+        attachedSegmentationEngineId: ENGINE_ID,
+        segmentLiveBufferId: SEG_LIVE_INTERNAL,
+        threshold: 0.55,
+      }
+    );
+    expect(native.computeSpeakerEmbeddingOffline).not.toHaveBeenCalled();
+    expect(native.speakerEmbeddingManagerSearch).not.toHaveBeenCalled();
+    expect(handle.pipelineId).toBe(PIPELINE_ID);
     expect(handle.instanceId).toBe(sid.instanceId);
+    expect(mockSubscribeLiveSegmentBufferEvents).toHaveBeenCalledWith(
+      SEGS_OUT,
+      expect.objectContaining({ onSegmentAppended: expect.any(Function) })
+    );
 
-    // Simulate segmentation committing two spans, then finalize input.
-    committed = 2;
-    (audiobuffer.getPipelineAudioBufferInfo as jest.Mock).mockResolvedValue({
-      bufferId: AUDIO_LIVE,
-      kind: 'livePcmBuffer',
-      state: 'finished',
+    onAppended?.({
+      kind: 'speech',
+      segmentIndex: 0,
+      startSample: 0,
+      endSample: 1600,
       sampleRate: 16000,
-      channelCount: 1,
-      numSamples: 3600,
-      durationMs: 225,
-      totalSamplesWritten: 3600,
-      ringEvictedSamples: 0,
-      hasActiveSpool: false,
+      durationMs: 100,
+      confidence: 0.9,
+      payload: { source: 'sid', speakerName: 'alice' },
+    });
+    onAppended?.({
+      kind: 'speech',
+      segmentIndex: 1,
+      startSample: 2000,
+      endSample: 3600,
+      sampleRate: 16000,
+      durationMs: 100,
+      payload: { source: 'sid', speakerName: null },
     });
 
-    await handle.completed;
-
-    expect(audiobuffer.getLiveAudioBufferSamplesSlice).toHaveBeenCalledTimes(2);
-    expect(native.speakerEmbeddingManagerSearch).toHaveBeenCalledWith(
-      sid.managerId,
-      emb,
-      0.55
-    );
-    expect(segs.appendLiveSegment).toHaveBeenCalledTimes(2);
-    expect(segs.appendLiveSegment).toHaveBeenNthCalledWith(
-      1,
-      SEGS_OUT,
-      expect.objectContaining({
-        kind: 'speech',
-        startSample: 0,
-        endSample: 1600,
-        payload: { source: 'sid', speakerName: 'alice' },
-      })
-    );
-    expect(segs.appendLiveSegment).toHaveBeenNthCalledWith(
-      2,
-      SEGS_OUT,
-      expect.objectContaining({
-        payload: { source: 'sid', speakerName: null },
-      })
-    );
     expect(onLabeled).toHaveBeenCalledTimes(2);
     expect(onLabeled).toHaveBeenNthCalledWith(
       1,
@@ -343,25 +318,24 @@ describe('labelLiveSegments', () => {
         speakerName: null,
       })
     );
+
+    completionResolve?.({
+      pipelineId: PIPELINE_ID,
+      reason: 'completed',
+      chunksProcessed: 2,
+      unitsRead: 3200,
+      unitsWritten: 2,
+      error: null,
+    });
+    await handle.completed;
+
     expect(seg.detachSegmentationEngine).toHaveBeenCalledWith(ENGINE_ID, {
       flushFinal: true,
     });
     expect(segs.finalizeLiveSegmentBuffer).toHaveBeenCalledWith(SEGS_OUT);
-    expect(audiobuffer.releasePipelineAudioBuffer).toHaveBeenCalled();
   });
 
-  it('stop() drains tail, finalizes, resolves completed with reason stopped', async () => {
-    const spans = [speechSpan(0, 1600)];
-    let committed = 0;
-    segs.getLiveSegmentBufferSegmentCount.mockImplementation(async () => {
-      return committed;
-    });
-    segs.getLiveSegmentBufferSegments.mockImplementation(
-      async (_id: string, start: number, max: number) => {
-        return spans.slice(start, start + max);
-      }
-    );
-
+  it('stop() resolves completed with reason stopped and finalizes', async () => {
     const sid = await createSpeakerIdentification({
       modelSource: { kind: 'fs', path: '/models/speaker-embedding' },
     });
@@ -369,14 +343,29 @@ describe('labelLiveSegments', () => {
       segmentation: { policy: defaultPolicy },
     });
 
-    committed = 1;
-    await handle.flush();
-    expect(segs.appendLiveSegment).toHaveBeenCalledTimes(1);
+    native.stopStreamingPipeline.mockImplementation(async () => {
+      completionResolve?.({
+        pipelineId: PIPELINE_ID,
+        reason: 'stopped',
+        chunksProcessed: 1,
+        unitsRead: 1600,
+        unitsWritten: 1,
+        error: null,
+      });
+    });
+    native.getStreamingPipelineStatus.mockResolvedValue({
+      pipelineId: PIPELINE_ID,
+      isRunning: false,
+      chunksProcessed: 1,
+      unitsRead: 1600,
+      unitsWritten: 1,
+      error: null,
+    });
 
     await handle.stop();
     const completion = await handle.completed;
     expect(completion.reason).toBe('stopped');
-    expect(completion.chunksProcessed).toBe(1);
+    expect(native.stopStreamingPipeline).toHaveBeenCalledWith(PIPELINE_ID);
     expect(segs.finalizeLiveSegmentBuffer).toHaveBeenCalledWith(SEGS_OUT);
     expect(seg.detachSegmentationEngine).toHaveBeenCalledWith(ENGINE_ID, {
       flushFinal: true,
@@ -389,7 +378,6 @@ describe('labelLiveSegments', () => {
   });
 
   it('getStatus reports counters while running', async () => {
-    segs.getLiveSegmentBufferSegmentCount.mockResolvedValue(0);
     const sid = await createSpeakerIdentification({
       modelSource: { kind: 'fs', path: '/models/speaker-embedding' },
     });
@@ -409,22 +397,20 @@ describe('labelLiveSegments', () => {
       })
     );
 
+    native.stopStreamingPipeline.mockImplementation(async () => {
+      completionResolve?.({
+        pipelineId: PIPELINE_ID,
+        reason: 'stopped',
+        chunksProcessed: 0,
+        unitsRead: 0,
+        unitsWritten: 0,
+        error: null,
+      });
+    });
     await handle.stop();
   });
 
-  it('completed rejects when labeling throws', async () => {
-    const spans = [speechSpan(0, 1600)];
-    let committed = 0;
-    segs.getLiveSegmentBufferSegmentCount.mockImplementation(async () => {
-      return committed;
-    });
-    segs.getLiveSegmentBufferSegments.mockImplementation(
-      async (_id: string, start: number, max: number) => {
-        return spans.slice(start, start + max);
-      }
-    );
-    segs.appendLiveSegment.mockRejectedValue(new Error('append failed'));
-
+  it('completed rejects when pipeline errors and still finalizes', async () => {
     const sid = await createSpeakerIdentification({
       modelSource: { kind: 'fs', path: '/models/speaker-embedding' },
     });
@@ -432,12 +418,18 @@ describe('labelLiveSegments', () => {
       segmentation: { policy: defaultPolicy },
     });
 
-    committed = 1;
+    const err = Object.assign(new Error('append failed'), {
+      code: 'STREAMING_PIPELINE_ERROR',
+    });
+    completionReject?.(err);
+
     await expect(handle.completed).rejects.toMatchObject({
       code: 'STREAMING_PIPELINE_ERROR',
       message: expect.stringContaining('append failed'),
     });
-    expect(seg.detachSegmentationEngine).toHaveBeenCalled();
+    expect(seg.detachSegmentationEngine).toHaveBeenCalledWith(ENGINE_ID, {
+      flushFinal: false,
+    });
     expect(segs.finalizeLiveSegmentBuffer).toHaveBeenCalledWith(SEGS_OUT);
   });
 
@@ -463,5 +455,8 @@ describe('labelLiveSegments', () => {
     expect(seg.detachSegmentationEngine).toHaveBeenCalledWith(ENGINE_ID, {
       flushFinal: false,
     });
+    expect(
+      native.startSpeakerIdentificationOfflineLivePipeline
+    ).not.toHaveBeenCalled();
   });
 });

--- a/src/speaker-identification/index.ts
+++ b/src/speaker-identification/index.ts
@@ -524,12 +524,14 @@ export async function createSpeakerIdentification(
       thresholdOptions?: SpeakerIdentificationThresholdOptions
     ): Promise<boolean> {
       guard();
-      const embedding = await engine.extractFromOfflineAudio(audio);
-      return manager.verify(
+      const result = await SherpaOnnx.verifySpeakerOffline(
+        engine.instanceId,
+        manager.managerId,
+        resolvePipelineAudioBufferId(audio),
         name,
-        embedding,
         resolveThreshold(thresholdOptions)
       );
+      return result.ok;
     },
     async verifyOfflineSegments(
       nameOrNames: string | string[],
@@ -539,7 +541,7 @@ export async function createSpeakerIdentification(
     ): Promise<VerifyOfflineSegmentsResult> {
       guard();
       assertVerifyOptions(verifyOptions);
-      resolvePipelineAudioBufferId(audioIn);
+      const audioBufferId = resolvePipelineAudioBufferId(audioIn);
       resolveOfflineSegmentBufferId(segmentsIn);
       const threshold = resolveThreshold(verifyOptions);
       const spans = collectSpeechSpans(
@@ -569,15 +571,16 @@ export async function createSpeakerIdentification(
         const expectedName = expectedPerSpan[i]!;
         const durationMs = spanDurationMs(span);
         progressSession.emitStep(i, spans.length, durationMs);
-        const embedding = await engine.extractFromOfflineAudio(audioIn, {
-          startSample: span.startSample,
-          endSample: span.endSample,
-        });
-        const matched = await manager.verify(
+        const result = await SherpaOnnx.verifySpeakerOffline(
+          engine.instanceId,
+          manager.managerId,
+          audioBufferId,
           expectedName,
-          embedding,
-          threshold
+          threshold,
+          span.startSample,
+          span.endSample
         );
+        const matched = result.ok;
         matches.push(matched);
         if (matched) {
           matchCount += 1;

--- a/src/speaker-identification/index.ts
+++ b/src/speaker-identification/index.ts
@@ -1,3 +1,4 @@
+import SherpaOnnx from '../NativeSherpaOnnx';
 import type {
   LiveAudioBufferIdSource,
   OfflineAudioBufferIdSource,
@@ -397,12 +398,13 @@ export async function createSpeakerIdentification(
       thresholdOptions?: SpeakerIdentificationThresholdOptions
     ): Promise<IdentifyResult> {
       guard();
-      const embedding = await engine.extractFromOfflineAudio(audio);
-      const name = await manager.search(
-        embedding,
+      const result = await SherpaOnnx.identifySpeakerOffline(
+        engine.instanceId,
+        manager.managerId,
+        resolvePipelineAudioBufferId(audio),
         resolveThreshold(thresholdOptions)
       );
-      const trimmed = name.trim();
+      const trimmed = result.name.trim();
       return { name: trimmed.length > 0 ? trimmed : null };
     },
     async labelOfflineSegments(
@@ -445,12 +447,15 @@ export async function createSpeakerIdentification(
           const durationMs = spanDurationMs(span);
           progressSession.emitStep(i, spans.length, durationMs);
 
-          const embedding = await engine.extractFromOfflineAudio(audioIn, {
-            startSample: span.startSample,
-            endSample: span.endSample,
-          });
-          const rawName = await manager.search(embedding, threshold);
-          const trimmed = rawName.trim();
+          const result = await SherpaOnnx.identifySpeakerOffline(
+            engine.instanceId,
+            manager.managerId,
+            audioBufferId,
+            threshold,
+            span.startSample,
+            span.endSample
+          );
+          const trimmed = result.name.trim();
           const speakerName = trimmed.length > 0 ? trimmed : null;
           if (speakerName == null) {
             unknownCount += 1;

--- a/src/speaker-identification/index.ts
+++ b/src/speaker-identification/index.ts
@@ -95,6 +95,38 @@ function cloneEmbeddings(embeddings: Float32Array[]): Float32Array[] {
   return embeddings.map((embedding) => new Float32Array(embedding));
 }
 
+function unflattenEmbeddings(flat: number[], dim: number): Float32Array[] {
+  if (!(dim > 0)) {
+    throw new Error('unflattenEmbeddings requires dim > 0');
+  }
+  if (!Array.isArray(flat) || flat.length === 0 || flat.length % dim !== 0) {
+    throw new Error(
+      `SID_ENROLL_INVALID_RESULT: embeddings length ${
+        Array.isArray(flat) ? flat.length : -1
+      } must be a positive multiple of dim ${dim}`
+    );
+  }
+  const count = flat.length / dim;
+  const out: Float32Array[] = [];
+  for (let i = 0; i < count; i++) {
+    const embedding = new Float32Array(dim);
+    const offset = i * dim;
+    for (let j = 0; j < dim; j++) {
+      const value = flat[offset + j]!;
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new Error(
+          `SID_ENROLL_INVALID_RESULT: embeddings[${
+            offset + j
+          }] must be a finite number`
+        );
+      }
+      embedding[j] = value;
+    }
+    out.push(embedding);
+  }
+  return out;
+}
+
 function embeddingsToNumberArrays(embeddings: Float32Array[]): number[][] {
   return embeddings.map((embedding) => Array.from(embedding));
 }
@@ -317,17 +349,26 @@ export async function createSpeakerIdentification(
       if (buffers.length === 0) {
         throw new Error('enroll() requires at least one audio buffer');
       }
-      const embeddings: Float32Array[] = [];
-      for (const buffer of buffers) {
-        embeddings.push(await engine.extractFromOfflineAudio(buffer));
-      }
-      const ok = await manager.add(trimmed, embeddings);
-      if (!ok) {
+      const audioBufferIds = buffers.map((buffer) =>
+        resolvePipelineAudioBufferId(buffer)
+      );
+      const result = await SherpaOnnx.enrollSpeakerOffline(
+        engine.instanceId,
+        manager.managerId,
+        trimmed,
+        audioBufferIds,
+        null,
+        null
+      );
+      if (!result.ok) {
         throw new Error(
           `Failed to enroll speaker '${trimmed}' (name may already exist)`
         );
       }
-      rememberEnrollment(trimmed, embeddings);
+      rememberEnrollment(
+        trimmed,
+        unflattenEmbeddings(result.embeddings ?? [], engine.dim)
+      );
     },
     async enrollOfflineSegments(
       nameOrNames: string | string[],
@@ -337,7 +378,7 @@ export async function createSpeakerIdentification(
     ): Promise<void> {
       guard();
       assertSegmentOptions(segmentOptions);
-      resolvePipelineAudioBufferId(audioIn);
+      const audioBufferId = resolvePipelineAudioBufferId(audioIn);
       resolveOfflineSegmentBufferId(segmentsIn);
       const spans = collectSpeechSpans(
         await getOfflineSegmentBufferSegments(segmentsIn)
@@ -366,31 +407,45 @@ export async function createSpeakerIdentification(
       const progressSession = createSpeakerIdentificationProgressSession(
         segmentOptions?.onProgress
       );
-      const byName = new Map<string, Float32Array[]>();
+      const byName = new Map<
+        string,
+        { startSamples: number[]; endSamples: number[] }
+      >();
       for (let i = 0; i < spans.length; i++) {
         const span = spans[i]!;
         const speakerName = trimmedPerSpan[i]!;
         progressSession.emitStep(i, spans.length, spanDurationMs(span));
-        const embedding = await engine.extractFromOfflineAudio(audioIn, {
-          startSample: span.startSample,
-          endSample: span.endSample,
-        });
         const bucket = byName.get(speakerName);
         if (bucket) {
-          bucket.push(embedding);
+          bucket.startSamples.push(span.startSample);
+          bucket.endSamples.push(span.endSample);
         } else {
-          byName.set(speakerName, [embedding]);
+          byName.set(speakerName, {
+            startSamples: [span.startSample],
+            endSamples: [span.endSample],
+          });
         }
       }
 
-      for (const [speakerName, embeddings] of byName) {
-        const ok = await manager.add(speakerName, embeddings);
-        if (!ok) {
+      for (const [speakerName, ranges] of byName) {
+        const audioBufferIds = ranges.startSamples.map(() => audioBufferId);
+        const result = await SherpaOnnx.enrollSpeakerOffline(
+          engine.instanceId,
+          manager.managerId,
+          speakerName,
+          audioBufferIds,
+          ranges.startSamples,
+          ranges.endSamples
+        );
+        if (!result.ok) {
           throw new Error(
             `Failed to enroll speaker '${speakerName}' (name may already exist)`
           );
         }
-        rememberEnrollment(speakerName, embeddings);
+        rememberEnrollment(
+          speakerName,
+          unflattenEmbeddings(result.embeddings ?? [], engine.dim)
+        );
       }
     },
     async identify(

--- a/src/speaker-identification/live.ts
+++ b/src/speaker-identification/live.ts
@@ -1,10 +1,5 @@
-import {
-  createOfflineAudioBufferFromSamples,
-  getLiveAudioBufferSamplesSlice,
-  getPipelineAudioBufferInfo,
-  releasePipelineAudioBuffer,
-  resolvePipelineAudioBufferId,
-} from '../audiobuffer';
+import { resolvePipelineAudioBufferId } from '../audiobuffer';
+import { createStreamingPipelineCompletionPromise } from '../audiobuffer/streamingPipelineCompletion';
 import type {
   LiveAudioBufferIdSource,
   LiveAudioBufferRef,
@@ -15,34 +10,34 @@ import type {
   StreamingPipelineStatus,
 } from '../audiobuffer/streamingPipelineTypes';
 import { validateLiveOfflinePipelineOptions } from '../livePipeline';
+import SherpaOnnx from '../NativeSherpaOnnx';
 import {
   attachSegmentationEngine,
   detachSegmentationEngine,
   getSegmentationEngineInfo,
 } from '../segment';
 import {
-  appendLiveSegment,
   finalizeLiveSegmentBuffer,
-  getLiveSegmentBufferSegmentCount,
-  getLiveSegmentBufferSegments,
   resolveLiveSegmentBufferId,
+  subscribeLiveSegmentBufferEvents,
 } from '../segmentbuffer';
 import type {
   LiveSegmentBufferIdSource,
   LiveSegmentBufferRef,
-  SegmentMeta,
+  LiveSegmentBufferSegmentAppendedEvent,
+  SidSpeechSegmentPayload,
 } from '../segmentbuffer/types';
 import type {
   SpeakerEmbeddingEngine,
   SpeakerEmbeddingManager,
 } from '../speaker-embedding/types';
 import type { SpeakerIdentificationPipelineHandle } from './streamingTypes';
-import type { SpeakerIdentificationLiveLabelOptions } from './types';
+import type {
+  SidLiveLabeledSegmentEvent,
+  SpeakerIdentificationLiveLabelOptions,
+} from './types';
 
 const DEFAULT_THRESHOLD = 0.5;
-const POLL_INTERVAL_MS = 50;
-
-let sidLivePipelineCounter = 0;
 
 function resolveThreshold(
   options?: SpeakerIdentificationLiveLabelOptions
@@ -93,55 +88,96 @@ export function isLiveSegmentSource(
   return false;
 }
 
-function spanDurationMs(span: SegmentMeta): number {
+function mapAppendedEventToLabeled(
+  event: LiveSegmentBufferSegmentAppendedEvent
+): SidLiveLabeledSegmentEvent | null {
+  if (event.kind !== 'speech') return null;
+  const payload = event.payload as SidSpeechSegmentPayload | undefined;
+  if (payload?.source !== 'sid') return null;
+
+  const labeled: SidLiveLabeledSegmentEvent = {
+    segmentIndex: event.segmentIndex,
+    startSample: event.startSample,
+    endSample: event.endSample,
+    sampleRate: event.sampleRate,
+    durationMs: event.durationMs,
+    speakerName: payload.speakerName,
+  };
   if (
-    typeof span.durationMs === 'number' &&
-    Number.isFinite(span.durationMs) &&
-    span.durationMs > 0
+    typeof event.confidence === 'number' &&
+    Number.isFinite(event.confidence)
   ) {
-    return span.durationMs;
+    labeled.confidence = event.confidence;
   }
-  const sampleRate = span.sampleRate;
-  if (sampleRate > 0) {
-    return Math.round(
-      ((span.endSample - span.startSample) * 1000) / sampleRate
+  return labeled;
+}
+
+function createSidPipelineHandle(
+  instanceId: string,
+  pipelineId: string,
+  attachedEngineId: string,
+  segmentsOutId: string,
+  onLabeled?: (event: SidLiveLabeledSegmentEvent) => void
+): SpeakerIdentificationPipelineHandle {
+  let unsubEvents: (() => void) | null = null;
+  if (onLabeled) {
+    unsubEvents = subscribeLiveSegmentBufferEvents(segmentsOutId, {
+      onSegmentAppended: (event) => {
+        const labeled = mapAppendedEventToLabeled(event);
+        if (labeled) onLabeled(labeled);
+      },
+    });
+  }
+
+  let cleanedUp = false;
+  const cleanup = async (flushFinal: boolean): Promise<void> => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    unsubEvents?.();
+    unsubEvents = null;
+    await detachSegmentationEngine(attachedEngineId, { flushFinal }).catch(
+      () => undefined
     );
-  }
-  return 0;
-}
+    await finalizeLiveSegmentBuffer(segmentsOutId).catch(() => undefined);
+  };
 
-function isNonEmptySpeechSpan(seg: SegmentMeta): boolean {
-  return (
-    seg.kind === 'speech' &&
-    Number.isFinite(seg.startSample) &&
-    Number.isFinite(seg.endSample) &&
-    seg.endSample > seg.startSample
+  const rawCompleted = createStreamingPipelineCompletionPromise(pipelineId);
+  const completed: Promise<StreamingPipelineCompletion> = rawCompleted.then(
+    async (completion) => {
+      await cleanup(completion.reason !== 'error');
+      return completion;
+    },
+    async (err) => {
+      await cleanup(false);
+      throw err;
+    }
   );
-}
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return {
+    instanceId,
+    pipelineId,
+    completed,
+    async stop(): Promise<void> {
+      await SherpaOnnx.stopStreamingPipeline(pipelineId);
+      await completed.catch(() => undefined);
+    },
+    async flush(): Promise<void> {
+      await SherpaOnnx.flushStreamingPipeline(pipelineId);
+    },
+    async reset(): Promise<void> {
+      await SherpaOnnx.resetStreamingPipeline(pipelineId);
+    },
+    async getStatus(): Promise<StreamingPipelineStatus> {
+      return SherpaOnnx.getStreamingPipelineStatus(pipelineId);
+    },
+  };
 }
-
-type PipelineState = {
-  isRunning: boolean;
-  chunksProcessed: number;
-  unitsRead: number;
-  unitsWritten: number;
-  error: string | null;
-  cursor: number;
-  segmentIndex: number;
-  stopRequested: boolean;
-  inputFinishedSeen: boolean;
-  finalizedOut: boolean;
-  detached: boolean;
-};
 
 /**
  * Live overload for SID: attach speech segmentation to `audioIn`, label each
- * committed utterance into `segmentsOut`, return a pipeline handle.
+ * committed utterance into `segmentsOut` via a native OfflineLivePipelineWorker.
  *
- * Maintainer note: JS orchestration — see docs/internal/live-overload.md §11.
+ * Maintainer note: native drain — see docs/internal/live-overload.md §11.
  */
 export async function labelLiveSegments(
   embeddingEngine: SpeakerEmbeddingEngine,
@@ -171,7 +207,6 @@ export async function labelLiveSegments(
   );
   const segmentsOutId = resolveLiveSegmentBufferId(segmentsOut);
   const threshold = resolveThreshold(options);
-  const pipelineId = `sid_live_${++sidLivePipelineCounter}`;
 
   const attached = await attachSegmentationEngine(
     audioIn as PipelineAudioBufferIdSource,
@@ -188,8 +223,8 @@ export async function labelLiveSegments(
     throw err;
   }
 
-  const internalSegBufId = engineInfo.segmentBufferId;
-  if (!internalSegBufId) {
+  const segmentLiveBufferId = engineInfo.segmentBufferId;
+  if (!segmentLiveBufferId) {
     await detachSegmentationEngine(attached.engineId, {
       flushFinal: false,
     }).catch(() => undefined);
@@ -198,258 +233,33 @@ export async function labelLiveSegments(
     );
   }
 
-  const state: PipelineState = {
-    isRunning: true,
-    chunksProcessed: 0,
-    unitsRead: 0,
-    unitsWritten: 0,
-    error: null,
-    cursor: 0,
-    segmentIndex: 0,
-    stopRequested: false,
-    inputFinishedSeen: false,
-    finalizedOut: false,
-    detached: false,
-  };
-
-  let settleCompletion: ((value: StreamingPipelineCompletion) => void) | null =
-    null;
-  let rejectCompletion: ((reason?: unknown) => void) | null = null;
-  let settled = false;
-
-  const completed = new Promise<StreamingPipelineCompletion>(
-    (resolve, reject) => {
-      settleCompletion = resolve;
-      rejectCompletion = reject;
-    }
-  );
-
-  const toCompletion = (
-    reason: StreamingPipelineCompletion['reason']
-  ): StreamingPipelineCompletion => ({
-    pipelineId,
-    reason,
-    chunksProcessed: state.chunksProcessed,
-    unitsRead: state.unitsRead,
-    unitsWritten: state.unitsWritten,
-    error: state.error,
-  });
-
-  const settle = (reason: StreamingPipelineCompletion['reason']): void => {
-    if (settled) return;
-    settled = true;
-    state.isRunning = false;
-    const completion = toCompletion(reason);
-    if (reason === 'error') {
-      const error = Object.assign(
-        new Error(
-          state.error ??
-            `Speaker identification live pipeline ${pipelineId} failed`
-        ),
+  let pipelineId: string;
+  try {
+    const result =
+      await SherpaOnnx.startSpeakerIdentificationOfflineLivePipeline(
+        embeddingEngine.instanceId,
+        manager.managerId,
+        audioInId,
+        segmentsOutId,
         {
-          code: 'STREAMING_PIPELINE_ERROR',
-          completion,
+          attachedSegmentationEngineId: attached.engineId,
+          segmentLiveBufferId,
+          threshold,
         }
       );
-      rejectCompletion?.(error);
-    } else {
-      settleCompletion?.(completion);
-    }
-  };
+    pipelineId = result.pipelineId;
+  } catch (err) {
+    await detachSegmentationEngine(attached.engineId, {
+      flushFinal: false,
+    }).catch(() => undefined);
+    throw err;
+  }
 
-  const detachIfNeeded = async (flushFinal: boolean): Promise<void> => {
-    if (state.detached) return;
-    state.detached = true;
-    await detachSegmentationEngine(attached.engineId, { flushFinal }).catch(
-      () => undefined
-    );
-  };
-
-  const finalizeOutIfNeeded = async (): Promise<void> => {
-    if (state.finalizedOut) return;
-    state.finalizedOut = true;
-    await finalizeLiveSegmentBuffer(segmentsOutId).catch(() => undefined);
-  };
-
-  const labelSpan = async (span: SegmentMeta): Promise<void> => {
-    const startSample = Math.max(0, Math.floor(span.startSample));
-    const endSample = Math.max(startSample, Math.floor(span.endSample));
-    const frameCount = endSample - startSample;
-    const sampleRate = span.sampleRate;
-    const durationMs = spanDurationMs(span);
-
-    const audioInfo = await getPipelineAudioBufferInfo(audioInId);
-    const channelCount =
-      'channelCount' in audioInfo && typeof audioInfo.channelCount === 'number'
-        ? audioInfo.channelCount
-        : 1;
-
-    const samples =
-      frameCount > 0
-        ? getLiveAudioBufferSamplesSlice(audioInId, startSample, frameCount)
-        : new Float32Array(0);
-
-    state.unitsRead += frameCount;
-
-    const temp = createOfflineAudioBufferFromSamples(
-      samples,
-      sampleRate > 0
-        ? sampleRate
-        : 'sampleRate' in audioInfo
-        ? audioInfo.sampleRate
-        : 16000,
-      channelCount,
-      { targetSampleRateHz: 0 }
-    );
-
-    let speakerName: string | null = null;
-    try {
-      const embedding = await embeddingEngine.extractFromOfflineAudio(temp);
-      const rawName = await manager.search(embedding, threshold);
-      const trimmed = rawName.trim();
-      speakerName = trimmed.length > 0 ? trimmed : null;
-    } finally {
-      await releasePipelineAudioBuffer(temp.bufferId).catch(() => undefined);
-    }
-
-    await appendLiveSegment(segmentsOutId, {
-      kind: 'speech',
-      sourceAudioBufferId: audioInId,
-      startSample,
-      endSample,
-      sampleRate,
-      durationMs,
-      ...(span.confidence != null ? { confidence: span.confidence } : {}),
-      payload: { source: 'sid', speakerName },
-    });
-
-    state.unitsWritten += 1;
-    state.chunksProcessed += 1;
-
-    const event = {
-      segmentIndex: state.segmentIndex,
-      startSample,
-      endSample,
-      sampleRate,
-      durationMs,
-      speakerName,
-      ...(span.confidence != null ? { confidence: span.confidence } : {}),
-    };
-    state.segmentIndex += 1;
-    options.onLabeled?.(event);
-  };
-
-  let drainChain: Promise<void> = Promise.resolve();
-
-  const drainNewSpans = (): Promise<void> => {
-    const run = async (): Promise<void> => {
-      const total = await getLiveSegmentBufferSegmentCount(internalSegBufId);
-      if (total <= state.cursor) {
-        return;
-      }
-      const batch = await getLiveSegmentBufferSegments(
-        internalSegBufId,
-        state.cursor,
-        total - state.cursor
-      );
-      state.cursor += batch.length;
-
-      for (const span of batch) {
-        if (!isNonEmptySpeechSpan(span)) {
-          continue;
-        }
-        await labelSpan(span);
-      }
-    };
-
-    drainChain = drainChain.then(run, run);
-    return drainChain;
-  };
-
-  let loopActive = true;
-
-  const runLoop = async (): Promise<void> => {
-    try {
-      while (loopActive && !state.stopRequested) {
-        await drainNewSpans();
-
-        const info = await getPipelineAudioBufferInfo(audioInId);
-        if (
-          info.kind === 'livePcmBuffer' &&
-          info.state === 'finished' &&
-          !state.inputFinishedSeen
-        ) {
-          state.inputFinishedSeen = true;
-          // Input finalized: flush final segmentation, drain tail, complete.
-          await detachIfNeeded(true);
-          await drainNewSpans();
-          await finalizeOutIfNeeded();
-          settle('completed');
-          return;
-        }
-
-        if (state.stopRequested) {
-          break;
-        }
-        await sleep(POLL_INTERVAL_MS);
-      }
-
-      if (state.stopRequested) {
-        await detachIfNeeded(true);
-        await drainNewSpans();
-        await finalizeOutIfNeeded();
-        settle('stopped');
-      }
-    } catch (err) {
-      state.error = err instanceof Error ? err.message : String(err);
-      await detachIfNeeded(false).catch(() => undefined);
-      await finalizeOutIfNeeded().catch(() => undefined);
-      settle('error');
-    } finally {
-      loopActive = false;
-    }
-  };
-
-  // Kick off the poll loop without awaiting (handle returns immediately).
-  Promise.resolve()
-    .then(() => runLoop())
-    .catch(() => undefined);
-
-  const handle: SpeakerIdentificationPipelineHandle = {
-    instanceId: embeddingEngine.instanceId,
+  return createSidPipelineHandle(
+    embeddingEngine.instanceId,
     pipelineId,
-    completed,
-    async stop(): Promise<void> {
-      if (settled) return;
-      state.stopRequested = true;
-      // Wait until the loop settles completed.
-      await completed.catch(() => undefined);
-    },
-    async flush(): Promise<void> {
-      if (settled || !state.isRunning) return;
-      // Drain already-committed spans; tail utterance emits on stop/finalize.
-      await drainNewSpans();
-    },
-    async reset(): Promise<void> {
-      // Soft no-op for JS counters only; native segmentation reset is not exposed.
-      // Matches OfflineLivePipelineWorker.reset() intentional no-op.
-      if (settled || !state.isRunning) return;
-      state.chunksProcessed = 0;
-      state.unitsRead = 0;
-      state.unitsWritten = 0;
-      state.error = null;
-    },
-    async getStatus(): Promise<StreamingPipelineStatus> {
-      return {
-        pipelineId,
-        isRunning: state.isRunning,
-        chunksProcessed: state.chunksProcessed,
-        unitsRead: state.unitsRead,
-        unitsWritten: state.unitsWritten,
-        error: state.error,
-      };
-    },
-  };
-
-  return handle;
+    attached.engineId,
+    segmentsOutId,
+    options.onLabeled
+  );
 }


### PR DESCRIPTION
This pull request refactors the JNI C++ code for both diarization and speaker embedding modules to improve thread safety, resource management, and simplify the code. The main theme is replacing raw and unique pointers with `std::shared_ptr`, introducing helper lookup functions, and ensuring that resources are properly managed even when operations are in flight. This also streamlines the JNI interface and reduces the risk of use-after-free or race conditions.

The most important changes are:

**Resource Management & Thread Safety:**
* Changed the global instance maps in both `diarization` and `speaker-embedding` modules from using `std::unique_ptr` to `std::shared_ptr`, allowing safe replacement and destruction of objects while other threads may still be using them. [[1]](diffhunk://#diff-21d0b91ad4e14cbbdc089e2b6ef214b68e51700f486fe05ee557e4d1c8bcd4b6L23-R33) [[2]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21L23-R27)
* On initialization and unload, the code now replaces or moves out the shared pointer in the map, ensuring that the object is only destroyed when no references remain, and preventing premature deletion during in-flight operations. [[1]](diffhunk://#diff-21d0b91ad4e14cbbdc089e2b6ef214b68e51700f486fe05ee557e4d1c8bcd4b6L243-R252) [[2]](diffhunk://#diff-21d0b91ad4e14cbbdc089e2b6ef214b68e51700f486fe05ee557e4d1c8bcd4b6R274) [[3]](diffhunk://#diff-21d0b91ad4e14cbbdc089e2b6ef214b68e51700f486fe05ee557e4d1c8bcd4b6R472-R485) [[4]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21L130-R148) [[5]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21R157) [[6]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21L166-R188) [[7]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21L237-R275) [[8]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21L292-R293)

**Helper Lookup Functions:**
* Introduced `LookupDiarization`, `LookupExtractor`, and `LookupManager` helper functions to safely retrieve shared pointers from the global maps under mutex protection, simplifying repeated lookup patterns throughout the code. [[1]](diffhunk://#diff-21d0b91ad4e14cbbdc089e2b6ef214b68e51700f486fe05ee557e4d1c8bcd4b6L23-R33) [[2]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21R114-R129)

**Simplification of JNI Methods:**
* Refactored JNI methods to use the new helper functions and shared pointers, removing redundant lock and pointer management code. This affects all major operations including processing, reclustering, cluster embedding retrieval, cancellation, and manager operations. [[1]](diffhunk://#diff-21d0b91ad4e14cbbdc089e2b6ef214b68e51700f486fe05ee557e4d1c8bcd4b6L318-L331) [[2]](diffhunk://#diff-21d0b91ad4e14cbbdc089e2b6ef214b68e51700f486fe05ee557e4d1c8bcd4b6L369-R376) [[3]](diffhunk://#diff-21d0b91ad4e14cbbdc089e2b6ef214b68e51700f486fe05ee557e4d1c8bcd4b6L392-R394) [[4]](diffhunk://#diff-21d0b91ad4e14cbbdc089e2b6ef214b68e51700f486fe05ee557e4d1c8bcd4b6L464-R460) [[5]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21R217-L228) [[6]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21L325-R320) [[7]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21L341-R333) [[8]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21L362-R351) [[9]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21L388-R374) [[10]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21L404-R387) [[11]](diffhunk://#diff-8d1a92ea373642adb2e0c1e1adce9f4ae772c945b73d069ec735001fe386ff21L418-R408)

**JNI Data Marshalling Improvements:**
* Changed the speaker embedding JNI output from returning a Java `ArrayList<Float>` to a more efficient `jfloatArray`, reducing JNI overhead and simplifying the code.

These changes collectively make the JNI layer safer, more maintainable, and more robust in multithreaded scenarios.