### PR TITLE
Refactor/livetext events as fabric safe json tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### BREAKING CHANGES
 
+* **textbuffer:** LiveText segment `meta` is now a Fabric-safe **JSON tree** (`Record<string, JsonValue>`). Nested objects/arrays round-trip through Android emit, iOS passthrough, JS `sanitizeJsonMeta`, and `getLiveTextBufferSegments({ includeMeta })`. Soft limits: depth ≤ 4, array length ≤ 64, keys/level ≤ 64 (excess dropped). Apps that relied on silent dropping of nested keys will now see those keys. **KWS** and other scalar-only producers need no change.
+* **audio-tagging:** Live overload `meta.events` is a nested array of `{ name, index, prob }`. The previous JSON-string workaround is removed (no string parse).
 * **tts:** `startPcmPlayer`, `writePcmChunk`, `stopPcmPlayer` removed from `StreamingTtsEngine`. Use standalone `createPcmPlayer` from `react-native-sherpa-onnx/pcm` or `playback: true` on streaming options.
 * **turbo-module:** `startTtsPcmPlayer`, `writeTtsPcmChunk`, `stopTtsPcmPlayer` replaced by `createPcmPlayer`, `writePcmChunk`, `pausePcmPlayer`, `resumePcmPlayer`, `destroyPcmPlayer` with `playerId`.
 * **tts:** `GeneratedAudio.samples` (number[]) has been removed. PCM data is now held in a native sink and not transferred over the bridge by default.

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -371,20 +371,9 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
           }
 
           snapshotMeta?.let { rawMeta ->
-            val metaMap = Arguments.createMap()
-            for ((key, value) in rawMeta) {
-              when (value) {
-                null -> metaMap.putNull(key)
-                is Boolean -> metaMap.putBoolean(key, value)
-                is Int -> metaMap.putInt(key, value)
-                is Number -> metaMap.putDouble(key, value.toDouble())
-                is String -> metaMap.putString(key, value)
-                else -> {
-                  // Skip unsupported meta value types (typed puts only).
-                }
-              }
+            com.sherpaonnx.text.pipeline.LiveTextJsonMeta.packMetaMap(rawMeta)?.let { metaMap ->
+              putMap("meta", metaMap)
             }
-            putMap("meta", metaMap)
           }
         }
         eventEmitter.emit("pipelineLiveTextSegmentAppended", payload)
@@ -3813,20 +3802,9 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
             putArray("timestamps", tsArr)
           }
           if (includeMeta && segment.meta != null) {
-            val metaMap = Arguments.createMap()
-            for ((key, value) in segment.meta) {
-              when (value) {
-                is String -> metaMap.putString(key, value)
-                is Int -> metaMap.putInt(key, value)
-                is Double -> metaMap.putDouble(key, value)
-                is Float -> metaMap.putDouble(key, value.toDouble())
-                is Boolean -> metaMap.putBoolean(key, value)
-                is Number -> metaMap.putDouble(key, value.toDouble())
-                null -> metaMap.putNull(key)
-                else -> metaMap.putString(key, value.toString())
-              }
+            com.sherpaonnx.text.pipeline.LiveTextJsonMeta.packMetaMap(segment.meta)?.let { metaMap ->
+              putMap("meta", metaMap)
             }
-            putMap("meta", metaMap)
           }
         }
         outSegments.pushMap(map)

--- a/android/src/main/java/com/sherpaonnx/audiotagging/pipeline/AudioTaggingOfflineLivePipelineWorker.kt
+++ b/android/src/main/java/com/sherpaonnx/audiotagging/pipeline/AudioTaggingOfflineLivePipelineWorker.kt
@@ -133,8 +133,16 @@ internal class AudioTaggingOfflineLivePipelineWorker(
     val endTime =
       if (speech.sampleRate > 0) speech.endSample.toFloat() / speech.sampleRate.toFloat() else 0f
 
+    val eventMaps = ArrayList<Map<String, Any>>(events.size)
     val eventsJson = JSONArray()
     for (ev in events) {
+      eventMaps.add(
+        mapOf(
+          "name" to ev.name,
+          "index" to ev.index,
+          "prob" to ev.prob.toDouble(),
+        ),
+      )
       eventsJson.put(
         JSONObject()
           .put("name", ev.name)
@@ -143,8 +151,7 @@ internal class AudioTaggingOfflineLivePipelineWorker(
       )
     }
 
-    // LiveText meta is scalar-only across the RN bridge / JS projector.
-    // Nested lists are dropped; commit top-K as a JSON string instead.
+    // LiveText meta is a Fabric-safe JSON tree (nested events array).
     textOutputEntry.commitSegment(
       text = primaryName,
       tokens = emptyArray(),
@@ -152,7 +159,7 @@ internal class AudioTaggingOfflineLivePipelineWorker(
       source = "audio_tagging",
       meta = mapOf(
         "durationMs" to durationMs,
-        "events" to eventsJson.toString(),
+        "events" to eventMaps,
       ),
     )
     addUnitsWritten(primaryName.length.toLong())

--- a/android/src/main/java/com/sherpaonnx/text/pipeline/LiveTextJsonMeta.kt
+++ b/android/src/main/java/com/sherpaonnx/text/pipeline/LiveTextJsonMeta.kt
@@ -1,0 +1,161 @@
+package com.sherpaonnx.text.pipeline
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableArray
+import com.facebook.react.bridge.WritableMap
+
+/**
+ * Fabric-safe recursive packing of LiveText segment meta into WritableMap/Array.
+ *
+ * Soft limits (drop on exceed, never throw):
+ * - max depth 4
+ * - max array length 64
+ * - max object keys per level 64
+ */
+object LiveTextJsonMeta {
+  const val MAX_DEPTH = 4
+  const val MAX_ARRAY_LENGTH = 64
+  const val MAX_OBJECT_KEYS = 64
+
+  fun packMetaMap(raw: Map<String, Any?>?, depth: Int = 1): WritableMap? {
+    if (raw == null || raw.isEmpty()) return null
+    val out = Arguments.createMap()
+    var count = 0
+    var wrote = false
+    for ((key, value) in raw) {
+      if (count >= MAX_OBJECT_KEYS) break
+      if (putJsonValue(out, key, value, depth)) {
+        wrote = true
+      }
+      count++
+    }
+    return if (wrote) out else null
+  }
+
+  fun putJsonValue(map: WritableMap, key: String, value: Any?, depth: Int = 1): Boolean {
+    return when (val packed = packValue(value, depth)) {
+      PackResult.Drop -> false
+      PackResult.Null -> {
+        map.putNull(key)
+        true
+      }
+      is PackResult.Bool -> {
+        map.putBoolean(key, packed.value)
+        true
+      }
+      is PackResult.IntNum -> {
+        map.putInt(key, packed.value)
+        true
+      }
+      is PackResult.DoubleNum -> {
+        map.putDouble(key, packed.value)
+        true
+      }
+      is PackResult.Str -> {
+        map.putString(key, packed.value)
+        true
+      }
+      is PackResult.MapVal -> {
+        map.putMap(key, packed.value)
+        true
+      }
+      is PackResult.ArrVal -> {
+        map.putArray(key, packed.value)
+        true
+      }
+    }
+  }
+
+  fun putJsonValue(array: WritableArray, value: Any?, depth: Int = 1): Boolean {
+    return when (val packed = packValue(value, depth)) {
+      PackResult.Drop -> false
+      PackResult.Null -> {
+        array.pushNull()
+        true
+      }
+      is PackResult.Bool -> {
+        array.pushBoolean(packed.value)
+        true
+      }
+      is PackResult.IntNum -> {
+        array.pushInt(packed.value)
+        true
+      }
+      is PackResult.DoubleNum -> {
+        array.pushDouble(packed.value)
+        true
+      }
+      is PackResult.Str -> {
+        array.pushString(packed.value)
+        true
+      }
+      is PackResult.MapVal -> {
+        array.pushMap(packed.value)
+        true
+      }
+      is PackResult.ArrVal -> {
+        array.pushArray(packed.value)
+        true
+      }
+    }
+  }
+
+  private sealed class PackResult {
+    data object Drop : PackResult()
+    data object Null : PackResult()
+    data class Bool(val value: Boolean) : PackResult()
+    data class IntNum(val value: Int) : PackResult()
+    data class DoubleNum(val value: Double) : PackResult()
+    data class Str(val value: String) : PackResult()
+    data class MapVal(val value: WritableMap) : PackResult()
+    data class ArrVal(val value: WritableArray) : PackResult()
+  }
+
+  private fun packValue(value: Any?, depth: Int): PackResult {
+    if (depth > MAX_DEPTH) return PackResult.Drop
+    return when (value) {
+      null -> PackResult.Null
+      is Boolean -> PackResult.Bool(value)
+      is Int -> PackResult.IntNum(value)
+      is Long -> PackResult.DoubleNum(value.toDouble())
+      is Float -> PackResult.DoubleNum(value.toDouble())
+      is Double -> if (value.isFinite()) PackResult.DoubleNum(value) else PackResult.Drop
+      is Number -> {
+        val d = value.toDouble()
+        if (d.isFinite()) PackResult.DoubleNum(d) else PackResult.Drop
+      }
+      is String -> PackResult.Str(value)
+      is Map<*, *> -> {
+        if (depth >= MAX_DEPTH) return PackResult.Drop
+        val out = Arguments.createMap()
+        var count = 0
+        var wrote = false
+        for ((k, v) in value) {
+          if (count >= MAX_OBJECT_KEYS) break
+          val key = k as? String ?: continue
+          if (putJsonValue(out, key, v, depth + 1)) {
+            wrote = true
+          }
+          count++
+        }
+        if (wrote) PackResult.MapVal(out) else PackResult.Drop
+      }
+      is List<*> -> packList(value, depth)
+      is Array<*> -> packList(value.asList(), depth)
+      else -> PackResult.Drop
+    }
+  }
+
+  private fun packList(list: List<*>, depth: Int): PackResult {
+    if (depth >= MAX_DEPTH) return PackResult.Drop
+    val out = Arguments.createArray()
+    val limit = minOf(list.size, MAX_ARRAY_LENGTH)
+    var wrote = false
+    for (i in 0 until limit) {
+      if (putJsonValue(out, list[i], depth + 1)) {
+        wrote = true
+      }
+    }
+    return if (wrote || list.isEmpty()) PackResult.ArrVal(out) else PackResult.Drop
+  }
+}

--- a/docs/audio-tagging-live.md
+++ b/docs/audio-tagging-live.md
@@ -154,11 +154,11 @@ Each committed span writes one LiveText segment:
 | `source` | `'audio_tagging'` |
 | `timestamps` | `[startTime, endTime]` (seconds) |
 | `meta.durationMs` | Span duration in ms |
-| `meta.events` | **JSON string** of top-K `[{ name, index, prob }]` |
+| `meta.events` | Nested top-K array `[{ name, index, prob }]` |
 
-LiveText meta is **scalar-only** across the React Native bridge today, so nested event lists are stringified. Apps that read the buffer directly should `JSON.parse(meta.events)`. The JS `onSegment` callback parses this for you into `AudioTaggingLiveSegmentEvent.result`.
+LiveText `meta` is a Fabric-safe JSON tree. Apps that read the buffer directly see `meta.events` as an array. The JS `onSegment` callback maps it into `AudioTaggingLiveSegmentEvent.result`.
 
-Planned root fix (breaking later): [live-text-meta-json-tree-contract.md](future-work/live-text-meta-json-tree-contract.md).
+See [live-text-meta-json-tree-contract.md](future-work/live-text-meta-json-tree-contract.md).
 
 ## API reference
 

--- a/docs/future-work/live-text-meta-json-tree-contract.md
+++ b/docs/future-work/live-text-meta-json-tree-contract.md
@@ -1,47 +1,45 @@
-# LiveText meta: JSON-tree contract (future work)
+# LiveText meta: JSON-tree contract
 
-**Status:** Design note — schedule **after Audio Tagging** lands (Phases 5–6).  
-**Priority:** Cross-cutting contract upgrade; **breaking changes are acceptable and preferred** when they yield a clearer, more robust long-term API.  
-**Trigger:** Audio Tagging live overload needs top-K `events[]` on LiveText commits; today’s scalar-only meta forces a JSON-string workaround.  
+**Status:** Done (landed).  
+**Priority:** Cross-cutting contract upgrade; **breaking changes accepted**.  
+**Trigger:** Audio Tagging live overload needs top-K `events[]` on LiveText commits; the former scalar-only meta forced a JSON-string workaround.  
 **Related (adjacent):** [live-text-pipeline-append-partial-channel.md](./live-text-pipeline-append-partial-channel.md), [segmentation-ec-03-live-text-segment-index-dedup-invariant.md](./segmentation-ec-03-live-text-segment-index-dedup-invariant.md).
 
 ---
 
-## 1. Problem
+## 1. Problem (historical)
 
-LiveText segment `meta` is documented and enforced as:
+LiveText segment `meta` was documented and enforced as:
 
 - **JSON scalars** (`string | number | boolean | null`)
 - plus optional **`extra: Record<string, string>`** (TTS)
 
-Two layers silently drop nested values:
+Two layers silently dropped nested values:
 
-| Layer | Behaviour today |
+| Layer | Former behaviour |
 |---|---|
 | Android `pipelineLiveTextSegmentAppended` emit | `WritableMap` typed puts only; nested `List` / `Map` → **skipped** |
 | JS `projectNativeSegmentMeta` / `toPublicTextMeta` | Scalars + string-only `extra`; arrays / nested objects → **stripped** |
 
-iOS can pass nested `NSDictionary` / `NSArray` more readily, but JS still strips them — so **Android and iOS disagree** and apps cannot rely on nested meta.
+iOS could pass nested `NSDictionary` / `NSArray` more readily, but JS still stripped them — so **Android and iOS disagreed**.
 
-### What features do today (workarounds)
+### What features did (workarounds)
 
-| Feature | LiveText `meta` today | Structured data elsewhere |
+| Feature | LiveText `meta` (pre-landing) | Structured data elsewhere |
 |---|---|---|
 | **Audio Tagging (live)** | `durationMs` + `events` as **JSON string** | Optional live segment `payloadJson` (also JSON string, full events) |
 | **SLID (live)** | `durationMs` only (primary lang in `text`) | Segment `payloadJson` `{ source, lang }`; offline result has nested `distribution` / `switches` via **promise result**, not LiveText |
 | **SID (live)** | No LiveText | Segment `payloadJson` only |
-| **KWS** | Scalars (`keyword`, `source`, …) | Tokens / timestamps as **first-class** segment fields |
+| **KWS** | Scalars (`keyword`, `source`, …) | Tokens / timestamps as **first-class** segment fields — **no change needed** after JSON-tree |
 | **Punctuation / STT** | Scalars / reserved `__segment*` | — |
 | **TTS** | `sid`, `speed`, `extra: Record<string, string>` | Nested needs → flatten into `extra` strings |
 | **VAD / Diarization** | N/A (segment channel) | `payloadJson` strings |
 
-Audio Tagging’s string encode/decode is **house-consistent** with `payloadJson` / TTS `extra`, but it is **not** the end-state we want for LiveText: feature code must serialize/parse, typos fail at runtime, and the public “opaque meta” story promises more than the bridge delivers.
-
 ---
 
-## 2. Goal (new contract)
+## 2. Goal (landed contract)
 
-Make LiveText `meta` a **Fabric-safe JSON tree**:
+LiveText `meta` is a **Fabric-safe JSON tree**:
 
 ```ts
 type JsonScalar = string | number | boolean | null;
@@ -50,114 +48,88 @@ type JsonValue = JsonScalar | JsonValue[] | { [key: string]: JsonValue };
 meta?: Record<string, JsonValue>;
 ```
 
-**Invariants (non-negotiable):**
+**Invariants:**
 
 1. **Plain data only** — no native handles, HybridData, typed arrays, or host objects in meta that survive across the bridge.
-2. **Finite depth / size** — document soft limits (e.g. depth ≤ 4, payload ≤ few KB per segment) so spool / event storms stay bounded.
-3. **Deterministic projection** — Android emit, iOS emit, JS projector, and `getLiveTextBufferSegments(..., { includeMeta })` all round-trip the **same** JSON tree.
+2. **Finite depth / size** — soft limits: depth ≤ **4**, array length ≤ **64**, object keys per level ≤ **64** (excess dropped, no throw on emit).
+3. **Deterministic projection** — Android emit, iOS emit, JS `sanitizeJsonMeta`, and `getLiveTextBufferSegments(..., { includeMeta })` round-trip the **same** JSON tree.
 4. **Reserved keys** stay reserved (`__segmentReason`, …); public meta remains filterable via `toPublicTextMeta`.
+5. **Spool:** Meta is **not** persisted or reconstituted from spool (status quo).
 
-**Breaking changes are in scope and desirable**, including:
-
-- Removing silent drop of nested values (apps that accidentally relied on “nested = gone” will observe new keys).
-- Tightening TypeScript types away from unbounded `Record<string, unknown>` toward `JsonValue`.
-- Deprecating / deleting feature-level JSON-string conventions once nested trees work.
-- Optionally narrowing TTS `extra` from “strings only” into the general tree (or folding `extra` into plain nested keys).
-
-Do **not** preserve the scalar-only contract for compatibility theatre. Prefer one honest contract over dual “scalar vs stringified JSON” paths.
+TTS `extra` remains `Record<string, string>` under `meta.extra` (valid subtree; no TTS API change in this epic).
 
 ---
 
-## 3. Implementation sketch
+## 3. Implementation (landed)
 
 ### 3.1 Native emit / read
 
-- **Android:** Recursive `Any?` → `WritableMap` / `WritableArray` (and reverse for slice APIs). Replace `else -> skip` / `value.toString()` footguns in:
-  - live segment event emit (`SherpaOnnxModule` / text pipeline)
-  - `getLiveTextBufferSegments` meta packing
-- **iOS:** Keep `NSDictionary` / `NSArray` trees; ensure every path that copies meta into events or TurboModule maps preserves arrays/dicts (no accidental stringification).
-- **Storage:** In-memory segment `meta` may stay as platform maps; spool/checkpoint must either omit meta or store **canonical JSON** (decide explicitly — prefer canonical JSON in spool if meta is ever reconstituted).
+- **Android:** `LiveTextJsonMeta` recursive `Any?` → `WritableMap` / `WritableArray` in `emitLiveTextSegment` and `getLiveTextBufferSegments`.
+- **iOS:** `NSDictionary` / `NSArray` passthrough in textbuffer bridge; SLID live commits `durationMs` in meta (parity with Android).
+- **Storage:** In-memory segment `meta` stays platform maps; spool omits meta.
 
 ### 3.2 JS boundary
 
-- Replace `projectNativeSegmentMeta` / `toPublicTextMeta` scalar filters with a **recursive JSON sanitizer** (drop non-JSON values; keep reserved-key stripping for public views).
-- Export a shared helper (e.g. `sanitizeJsonMeta`) used by live events and offline/live segment reads.
-- Update `src/textbuffer/types.ts` + public docs (`textbuffer-streaming.md`, internal `livetextbuffer-internal.md`).
+- `src/textbuffer/jsonMeta.ts` — `sanitizeJsonMeta` (+ `JsonValue` types).
+- `projectNativeSegmentMeta` / `toPublicTextMeta` / `getLiveTextBufferSegments` all use the sanitizer.
+- Types: `LiveTextSegment.meta` → `Record<string, JsonValue>`.
 
-### 3.3 Tests (required)
+### 3.3 Audio Tagging migration
 
-- Round-trip: nested object + array of objects through **emit → onSegment** and **getSegments includeMeta** on Android **and** iOS.
-- Reject / strip HybridData-like / function / `undefined` values.
-- Depth / size guard behaviour (document + test).
-- Regression: existing scalar-only features (KWS, punctuation, SLID `durationMs`) unchanged in shape.
-
----
-
-## 4. Cross-feature simplifications (after contract lands)
-
-Once nested meta works, migrate features **away** from string encode/decode where LiveText is the primary live callback channel:
-
-| Feature | Simplify to | Notes |
-|---|---|---|
-| **Audio Tagging** | `meta.events: AudioTaggingEvent[]` (real array) + `durationMs` | Delete native `JSONArray.toString()` / JS `JSON.parse` path; keep segment `payloadJson` only if segment buffer remains optional dual output. |
-| **SLID live** | Optional `meta.score` / `meta.candidates` / per-span diagnostics | Today live `onSegment` is lang-only; nested meta unlocks parity with richer offline insights **without** forcing `targetSegmentBuffer`. Distribution across the whole session can stay on finalize/result APIs. |
-| **SID** | If/when a LiveText label path exists: `meta.speakerName`, `meta.score`, … | Today SID is segment-payload-only; nested LiveText meta is optional enrichment, not required to keep SID on segments. |
-| **KWS** | Optional `meta.score` / keyword metadata objects | Scalars already work; nested is optional enrichment. |
-| **TTS** | Nested generation options in meta instead of string-only `extra` | Breaking OK: prefer typed nested keys over `Record<string, string>` bag. |
-| **Punctuation / STT** | Unchanged unless new structured side-channels appear | First-class `tokens` / `timestamps` stay first-class (do **not** shove them into meta). |
-| **VAD / Diarization** | Keep segment `payload` as structured when emitted to JS | Related cleanup (see §5); not blocked on LiveText, but same JSON-tree discipline. |
-
-**Do not** use nested LiveText meta as a dumping ground for large embeddings or PCM — those stay on audio/segment buffers.
+- Native workers commit nested `meta.events` arrays (no `JSONArray.toString()` / `NSJSONSerialization` for LiveText meta).
+- JS reads nested arrays only (JSON-string workaround removed — clean cut).
+- Segment `payloadJson` unchanged (optional dual output).
 
 ---
 
-## 5. Related cleanup (optional same epic or follow-up)
+## 4. Cross-feature notes
 
-**Segment `payloadJson: string`** is the twin workaround on the speech-segment channel (SLID, SID, AT, VAD, diarization). A parallel “segment payload = JSON tree” contract would:
+| Feature | Status after landing |
+|---|---|
+| **Audio Tagging** | `meta.events: AudioTaggingEvent[]` + `durationMs` |
+| **KWS** | **No change needed** — scalars remain valid JSON trees |
+| **SLID live** | `durationMs` in meta on both platforms; richer nested meta still optional |
+| **TTS** | `extra` string map unchanged |
+| **Segment `payloadJson`** | Out of scope — follow-up (§5) |
 
-- Align LiveText meta and segment payload mental models
-- Remove duplicate stringify/parse in native workers + JS mappers
-- Allow typed `SpeechSegmentPayload` to flow without `JSON.parse` at the boundary
+**Do not** use nested LiveText meta as a dumping ground for large embeddings or PCM.
 
-Treat as **same design family**, possibly same PR series, but **not** a blocker for LiveText meta trees. Prefer one shared native/JS JSON bridge helper for both.
+---
+
+## 5. Related cleanup (follow-up)
+
+**Segment `payloadJson: string`** remains the twin workaround on the speech-segment channel. A parallel “segment payload = JSON tree” contract is **out of scope** for this epic.
 
 ---
 
 ## 6. Explicit non-goals
 
 - Changing LiveText **text** / **tokens** / **timestamps** first-class fields
-- Making meta a substitute for Offline/Live **result** promises (e.g. full SLID `distribution` for a whole file)
-- Preserving binary compatibility with apps that stringify nested meta manually (they keep working if they still pass strings; we simply stop *requiring* that)
+- Making meta a substitute for Offline/Live **result** promises (e.g. full SLID `distribution`)
+- TTS `extra` → free nested keys
+- Spool-meta persistence
+- Large embeddings/PCM in meta
 
 ---
 
-## 7. Suggested rollout
+## 7. Acceptance criteria
 
-1. Land Audio Tagging with current JSON-string workaround (done / in progress).
-2. Implement JSON-tree LiveText meta (this doc) as a dedicated change set — **break** projector + Android emit first, then migrate AT.
-3. Migrate AT → nested `meta.events`; remove string parse helpers.
-4. Opportunistically enrich SLID/TTS/KWS where nested meta removes dual channels or string bags.
-5. Optionally tackle segment `payloadJson` tree alignment.
-
----
-
-## 8. Acceptance criteria
-
-- [ ] Documented public contract: LiveText `meta` is a JSON tree; scalars-only language removed from types/docs.
-- [ ] Android + iOS emit and slice APIs round-trip nested arrays/objects.
-- [ ] JS projector no longer strips arrays/objects; still strips non-JSON / reserved internals on public views.
-- [ ] Audio Tagging live uses nested `meta.events` (no required JSON string).
-- [ ] At least one other consumer simplified or explicitly documented as “no change needed” (e.g. KWS).
-- [ ] Breaking-change note in changelog / migration blurb: nested meta now visible; stringified payloads deprecated for AT.
+- [x] Documented public contract: LiveText `meta` is a JSON tree; scalars-only language removed from types/docs.
+- [x] Android + iOS emit and slice APIs round-trip nested arrays/objects.
+- [x] JS projector no longer strips arrays/objects; still strips non-JSON / reserved internals on public views.
+- [x] Audio Tagging live uses nested `meta.events` (no required JSON string).
+- [x] At least one other consumer simplified or explicitly documented as “no change needed” (KWS).
+- [x] Breaking-change note in changelog / migration blurb: nested meta now visible; AT JSON-string `meta.events` removed.
 
 ---
 
-## 9. Code / doc anchors
+## 8. Code / doc anchors
 
-- JS projector: `src/textbuffer/index.ts` — `projectNativeSegmentMeta`, `toPublicTextMeta`
-- Types: `src/textbuffer/types.ts` — segment `meta` comment
-- Android emit: `SherpaOnnxModule` live text segment event meta packing (`else -> skip`)
-- AT workaround: `AudioTaggingOfflineLivePipelineWorker` (Android/iOS) + `src/audio-tagging/live.ts` `parseEventsFromMeta`
-- SLID live (scalar-only meta): `SlidOfflineLivePipelineWorker` + `src/language-identification/live.ts`
-- Internal architecture: [livetextbuffer-internal.md](../internal/livetextbuffer-internal.md)
-- AT plan LiveText row: [audio-tagging-plan.md](../internal/audio-tagging-plan.md)
+- JS sanitizer: `src/textbuffer/jsonMeta.ts`
+- JS projector: `src/textbuffer/index.ts` — `projectNativeSegmentMeta`, `toPublicTextMeta`, `getLiveTextBufferSegments`
+- Types: `src/textbuffer/types.ts` — `LiveTextSegment.meta`
+- Android pack: `android/.../text/pipeline/LiveTextJsonMeta.kt`
+- iOS textbuffer: `ios/textbuffer/bridge/SherpaOnnx+TextBuffer.mm`
+- AT live: `AudioTaggingOfflineLivePipelineWorker` (Android/iOS), `src/audio-tagging/live.ts`
+- Public docs: `docs/textbuffer-streaming.md`, `docs/audio-tagging-live.md`
+- Internal: `docs/internal/livetextbuffer-internal.md`

--- a/docs/internal/audio-tagging-plan.md
+++ b/docs/internal/audio-tagging-plan.md
@@ -218,9 +218,9 @@ interface AudioTaggingResult {
 
 | Sink | What to write |
 | --- | --- |
-| **LiveText (required)** | `text` = primary event `name`; `source` = `'audio_tagging'`; `meta.events` = **JSON string** of top-K `[{name,index,prob}]` (LiveText meta is scalar-only across the bridge — interim); `meta.durationMs`; timestamps = span start/end |
+| **LiveText (required)** | `text` = primary event `name`; `source` = `'audio_tagging'`; `meta.events` = nested top-K `[{name,index,prob}]` (JSON-tree LiveText contract); `meta.durationMs`; timestamps = span start/end |
 
-> **Follow-up (post AT):** Lift LiveText meta to a real JSON-tree contract and drop the string encode/decode workaround — see [live-text-meta-json-tree-contract.md](../future-work/live-text-meta-json-tree-contract.md). Breaking changes welcome.
+> **Done:** LiveText meta JSON-tree contract landed — see [live-text-meta-json-tree-contract.md](../future-work/live-text-meta-json-tree-contract.md). String encode/decode workaround removed (clean cut).
 | **LiveSegment (optional `targetSegmentBuffer`)** | Same payload as offline: `{ source: 'audioTagging', primaryName?, events? }` |
 | **JS callbacks** | `onSegment` / `onEvent` from LiveText commits (map primary name + meta) — **no** SLID-style `onLanguageChanged` |
 
@@ -437,7 +437,7 @@ Do **not** piggyback ASR licenses — these tarballs never appear in `asr-models
 ### 8.3 Lifecycle / Fabric notes
 
 - Snapshot event arrays to plain JSON before emitting to JS (avoid retaining native HybridData — lesson from KWS LiveText meta).
-- **Interim LiveText meta:** top-K `events` committed as a **JSON string** under `meta.events` (scalar-only LiveText contract). Planned root fix: [live-text-meta-json-tree-contract.md](../future-work/live-text-meta-json-tree-contract.md).
+- **LiveText meta:** top-K `events` committed as a nested array under `meta.events` (JSON-tree LiveText contract). See [live-text-meta-json-tree-contract.md](../future-work/live-text-meta-json-tree-contract.md).
 - Always await worker stop before `release()` (pipeline join lesson).
 
 ---

--- a/docs/internal/livetextbuffer-internal.md
+++ b/docs/internal/livetextbuffer-internal.md
@@ -77,7 +77,7 @@ The segment log is an **ordered list** of committed text segments.
   - `source`: discriminator (`'stt_stream'`, `'append'`, `'replace'`, `'mixed'`, `'unknown'`).
   - `tokens`: optional token-level breakdown.
   - `timestamps`: optional per-token timestamps.
-  - `meta`: opaque metadata dictionary (pipeline workers interpret feature-specific keys, e.g., TTS `sid`, `speed`). **Today’s bridge contract is scalar-only** (+ optional `extra: Record<string, string>`); nested arrays/objects are dropped on Android emit / JS projection — see planned upgrade [live-text-meta-json-tree-contract.md](../future-work/live-text-meta-json-tree-contract.md).
+  - `meta`: Fabric-safe JSON tree (`Record<string, JsonValue>`). Nested arrays/objects round-trip through Android recursive Writable packing, iOS `NSDictionary`/`NSArray` passthrough, and JS `sanitizeJsonMeta`. Soft guards: depth ≤ 4, array length ≤ 64, keys/level ≤ 64 (excess dropped). TTS `extra` stays `Record<string, string>`. **Spool does not persist or reconstitute segment meta** (status quo — commits store text/tokens/timestamps only).
 - **Segment index:** Monotonically increasing, never reset. Even after eviction from the in-memory window, the index continues.
 
 ### 2.3 Spool (On-Disk Persistence)

--- a/docs/textbuffer-streaming.md
+++ b/docs/textbuffer-streaming.md
@@ -116,6 +116,8 @@ Each time the native worker (or `appendLiveTextSegment`) **commits** a new trans
 - `segment` — committed segment (`domain: 'text'`, `text`, `segmentIndex`, optional `tokens` / `timestamps` / `meta`)  
 - `totalSegments` — retained segment count **after** this commit (upper bound for pull APIs)
 
+`meta` is a **Fabric-safe JSON tree** (`Record<string, JsonValue>`): scalars, nested objects, and arrays are preserved across Android emit, iOS passthrough, JS projection, and `getLiveTextBufferSegments(..., { includeMeta: true })`. Soft limits (values beyond these are dropped, not thrown): depth ≤ **4**, array length ≤ **64**, object keys per level ≤ **64**. Non-JSON values (`undefined`, functions, non-finite numbers, host objects) are stripped. Public views also remove reserved `__segment*` keys. TTS `meta.extra` remains string-valued only. **KWS** and other scalar-only producers need no change — scalars remain valid trees.
+
 This is the right hook when you want **“new subtitle line”** semantics instead of high-frequency **`onPartial`** updates. It complements (does not replace) **`onPartial`** for streaming STT.
 
 ```ts
@@ -281,9 +283,11 @@ function appendLiveTextSegment(
   text: string,
   tokens?: string[],
   timestamps?: number[],
-  meta?: Record<string, unknown>
+  meta?: Record<string, JsonValue>
 ): Promise<{ segmentIndex: number }>;
 ```
+
+`meta` accepts nested JSON (same contract as live `onSegment`); see [Committed text segments](#committed-text-segments-onsegment-no-polling).
 
 ```ts
 await appendLiveTextSegment(live, 'hello world', ['h', 'e', 'l', 'l', 'o']);

--- a/ios/audio-tagging/pipeline/AudioTaggingOfflineLivePipelineWorker.mm
+++ b/ios/audio-tagging/pipeline/AudioTaggingOfflineLivePipelineWorker.mm
@@ -155,22 +155,10 @@ void AudioTaggingOfflineLivePipelineWorker::onSegmentCommitted(
           ? static_cast<float>(speech.endSample) / static_cast<float>(speech.sampleRate)
           : 0.f;
 
-  NSError *jsonError = nil;
-  NSData *eventsData = [NSJSONSerialization dataWithJSONObject:events
-                                                       options:0
-                                                         error:&jsonError];
-  NSString *eventsJson =
-      eventsData != nil
-          ? [[NSString alloc] initWithData:eventsData encoding:NSUTF8StringEncoding]
-          : @"[]";
-  if (jsonError != nil || eventsJson == nil) {
-    eventsJson = @"[]";
-  }
-
-  // LiveText meta is scalar-only across the RN bridge / JS projector.
+  // LiveText meta is a Fabric-safe JSON tree (nested events array).
   NSDictionary *meta = @{
     @"durationMs": @(durationMs),
-    @"events": eventsJson,
+    @"events": events,
   };
 
   std::vector<std::string> tokens;

--- a/ios/slid/pipeline/SlidOfflineLivePipelineWorker.mm
+++ b/ios/slid/pipeline/SlidOfflineLivePipelineWorker.mm
@@ -114,13 +114,14 @@ void SlidOfflineLivePipelineWorker::onSegmentCommitted(
   std::vector<std::string> tokens;
   std::vector<float> timestamps = { startTime, endTime };
   std::string err;
+  NSDictionary *meta = @{ @"durationMs": @(durationMs) };
   if (!txt_live_commit_segment(
         textOutput_,
         lang,
         tokens,
         timestamps,
         "language_id",
-        nil,
+        meta,
         &err
       )) {
     throw std::runtime_error(

--- a/src/audio-tagging/__tests__/tagAudioTagging.live.test.ts
+++ b/src/audio-tagging/__tests__/tagAudioTagging.live.test.ts
@@ -219,57 +219,6 @@ describe('audio tagging live overload', () => {
     });
   });
 
-  it('maps meta.events JSON string (LiveText scalar contract) to top-K', async () => {
-    let textOnSegment: ((event: any) => void) | undefined;
-    mockSubscribeLiveTextBufferEvents.mockImplementation(
-      (_id: unknown, callbacks: { onSegment?: (event: any) => void }) => {
-        textOnSegment = callbacks.onSegment;
-        return jest.fn();
-      }
-    );
-
-    const engine = await createEngine();
-    const onSegment = jest.fn();
-
-    await engine.tag(LIVE_AUDIO, LIVE_TEXT, {
-      segmentation: {
-        mode: 'auto',
-        policy: { evaluator: 'continuous_frames', checkpointIntervalMs: 2000 },
-      },
-      onSegment,
-    });
-
-    textOnSegment?.({
-      segment: {
-        domain: 'text',
-        segmentIndex: 1,
-        text: 'Whistling',
-        timestamps: [2, 4],
-        meta: {
-          durationMs: 2000,
-          events: JSON.stringify([
-            { name: 'Whistling', index: 10, prob: 0.8 },
-            { name: 'Music', index: 1, prob: 0.15 },
-          ]),
-        },
-      },
-    });
-
-    expect(onSegment).toHaveBeenCalledWith(
-      expect.objectContaining({
-        segmentIndex: 1,
-        result: expect.objectContaining({
-          primary: { name: 'Whistling', index: 10, prob: 0.8 },
-          events: [
-            { name: 'Whistling', index: 10, prob: 0.8 },
-            { name: 'Music', index: 1, prob: 0.15 },
-          ],
-          topK: 2,
-        }),
-      })
-    );
-  });
-
   it('detaches segmentation on stop', async () => {
     const engine = await createEngine();
     const handle = (await engine.tag(LIVE_AUDIO, LIVE_TEXT, {

--- a/src/audio-tagging/live.ts
+++ b/src/audio-tagging/live.ts
@@ -101,21 +101,10 @@ function assertLiveOptions(options: AudioTaggingLivePipelineOptions): void {
   }
 }
 
-/**
- * LiveText meta is Fabric-safe scalars only (see projectNativeSegmentMeta).
- * Native commits top-K as a JSON string under `meta.events`; keep array parse
- * for tests / any path that still delivers a plain list.
- */
+/** Read nested `meta.events` arrays (JSON-tree LiveText contract). */
 function parseEventsFromMeta(meta: unknown): AudioTaggingEvent[] {
   if (meta == null || typeof meta !== 'object') return [];
-  let raw: unknown = (meta as Record<string, unknown>).events;
-  if (typeof raw === 'string') {
-    try {
-      raw = JSON.parse(raw);
-    } catch {
-      return [];
-    }
-  }
+  const raw: unknown = (meta as Record<string, unknown>).events;
   if (!Array.isArray(raw)) return [];
   const out: AudioTaggingEvent[] = [];
   for (const item of raw) {

--- a/src/textbuffer/__tests__/jsonMeta.test.ts
+++ b/src/textbuffer/__tests__/jsonMeta.test.ts
@@ -1,0 +1,108 @@
+import {
+  JSON_META_MAX_ARRAY_LENGTH,
+  JSON_META_MAX_DEPTH,
+  JSON_META_MAX_OBJECT_KEYS,
+  sanitizeJsonMeta,
+} from '../jsonMeta';
+
+describe('sanitizeJsonMeta', () => {
+  it('keeps scalars and nested object + array trees', () => {
+    const out = sanitizeJsonMeta({
+      durationMs: 1500,
+      flag: true,
+      missing: null,
+      events: [
+        { name: 'Speech', index: 0, prob: 0.9 },
+        { name: 'Music', index: 1, prob: 0.4 },
+      ],
+      nested: { a: { b: 'ok' } },
+    });
+    expect(out).toEqual({
+      durationMs: 1500,
+      flag: true,
+      missing: null,
+      events: [
+        { name: 'Speech', index: 0, prob: 0.9 },
+        { name: 'Music', index: 1, prob: 0.4 },
+      ],
+      nested: { a: { b: 'ok' } },
+    });
+  });
+
+  it('strips non-JSON values', () => {
+    const out = sanitizeJsonMeta({
+      ok: 'x',
+      undef: undefined,
+      fn: () => 1,
+      nan: Number.NaN,
+      inf: Number.POSITIVE_INFINITY,
+      host: new Date(),
+    });
+    expect(out).toEqual({ ok: 'x' });
+  });
+
+  it('drops reserved keys in publicView', () => {
+    const out = sanitizeJsonMeta(
+      {
+        __segmentReason: 'manual',
+        __segmentSource: 'append',
+        durationMs: 10,
+      },
+      { publicView: true }
+    );
+    expect(out).toEqual({ durationMs: 10 });
+  });
+
+  it('keeps reserved keys without publicView', () => {
+    const out = sanitizeJsonMeta({
+      __segmentReason: 'manual',
+      durationMs: 10,
+    });
+    expect(out).toEqual({
+      __segmentReason: 'manual',
+      durationMs: 10,
+    });
+  });
+
+  it('keeps only string values under extra', () => {
+    const out = sanitizeJsonMeta({
+      extra: {
+        voice: 'en',
+        sid: 1,
+        nested: { a: 1 },
+      },
+    });
+    expect(out).toEqual({ extra: { voice: 'en' } });
+  });
+
+  it('drops values beyond max depth', () => {
+    const deep = { a: { b: { c: { d: { e: 'too-deep' } } } } };
+    const out = sanitizeJsonMeta(deep);
+    // depth1=a obj, d2=b, d3=c, d4=d is object at max → dropped (no e)
+    expect(out).toEqual({ a: { b: { c: {} } } });
+    expect(JSON_META_MAX_DEPTH).toBe(4);
+  });
+
+  it('truncates arrays and object keys at soft limits', () => {
+    const arr = Array.from(
+      { length: JSON_META_MAX_ARRAY_LENGTH + 5 },
+      (_, i) => i
+    );
+    const keys: Record<string, number> = {};
+    for (let i = 0; i < JSON_META_MAX_OBJECT_KEYS + 5; i++) {
+      keys[`k${i}`] = i;
+    }
+    const out = sanitizeJsonMeta({ arr, keys });
+    expect(Array.isArray(out?.arr)).toBe(true);
+    expect((out?.arr as number[]).length).toBe(JSON_META_MAX_ARRAY_LENGTH);
+    expect(Object.keys(out?.keys as object).length).toBe(
+      JSON_META_MAX_OBJECT_KEYS
+    );
+  });
+
+  it('returns undefined for non-objects', () => {
+    expect(sanitizeJsonMeta(null)).toBeUndefined();
+    expect(sanitizeJsonMeta('x')).toBeUndefined();
+    expect(sanitizeJsonMeta([1, 2])).toBeUndefined();
+  });
+});

--- a/src/textbuffer/index.ts
+++ b/src/textbuffer/index.ts
@@ -24,6 +24,7 @@ import {
 } from '../segment/runtime-state';
 import type { TextSegment } from '../segment/segment';
 import { PipelineTextErrorCode, TEXT_MAX_SLICE_COUNT } from './types';
+import { sanitizeJsonMeta, type JsonValue } from './jsonMeta';
 import {
   toSegmentReason,
   toSegmentSource,
@@ -176,92 +177,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value != null && !Array.isArray(value);
 }
 
-/** Internal LiveText meta keys consumed by emitLocalTextSegmentEvent — not public. */
-const RESERVED_SEGMENT_META_KEYS = new Set([
-  '__segmentReason',
-  '__segmentSource',
-  '__segmentCreatedAtMs',
-  '__segmentId',
-  '__segmentLang',
-]);
-
-function asJsonScalar(
-  value: unknown
-): string | number | boolean | null | undefined {
-  if (
-    value === null ||
-    typeof value === 'string' ||
-    typeof value === 'number' ||
-    typeof value === 'boolean'
-  ) {
-    return value;
-  }
-  return undefined;
-}
-
 /**
- * Bridge boundary: project native event `meta` into a plain object.
- *
- * Contract: JSON scalars, optional `extra: Record<string, string>` (TTS).
- * Do not spread or retain host maps past this function.
+ * Bridge boundary: project native event `meta` into a Fabric-safe JSON tree.
  */
 function projectNativeSegmentMeta(
   meta: unknown
-): Record<string, unknown> | undefined {
-  if (!isRecord(meta)) {
-    return undefined;
-  }
-  const out: Record<string, unknown> = {};
-  for (const key of Object.keys(meta)) {
-    const value = meta[key];
-    const scalar = asJsonScalar(value);
-    if (scalar !== undefined) {
-      out[key] = scalar;
-      continue;
-    }
-    if (key === 'extra' && isRecord(value)) {
-      const extra: Record<string, string> = {};
-      for (const extraKey of Object.keys(value)) {
-        if (typeof value[extraKey] === 'string') {
-          extra[extraKey] = value[extraKey];
-        }
-      }
-      if (Object.keys(extra).length > 0) {
-        out.extra = extra;
-      }
-    }
-  }
-  return Object.keys(out).length > 0 ? out : undefined;
+): Record<string, JsonValue> | undefined {
+  return sanitizeJsonMeta(meta);
 }
 
 function toPublicTextMeta(
-  meta: Record<string, unknown> | undefined
-): Record<string, unknown> | undefined {
-  if (!meta) return undefined;
-  const out: Record<string, unknown> = {};
-  for (const key of Object.keys(meta)) {
-    if (RESERVED_SEGMENT_META_KEYS.has(key)) continue;
-    const scalar = asJsonScalar(meta[key]);
-    if (scalar !== undefined) {
-      out[key] = scalar;
-      continue;
-    }
-    if (key === 'extra' && isRecord(meta[key])) {
-      const extra: Record<string, string> = {};
-      for (const extraKey of Object.keys(
-        meta[key] as Record<string, unknown>
-      )) {
-        const v = (meta[key] as Record<string, unknown>)[extraKey];
-        if (typeof v === 'string') {
-          extra[extraKey] = v;
-        }
-      }
-      if (Object.keys(extra).length > 0) {
-        out.extra = extra;
-      }
-    }
-  }
-  return Object.keys(out).length > 0 ? out : undefined;
+  meta: Record<string, JsonValue> | undefined
+): Record<string, JsonValue> | undefined {
+  return sanitizeJsonMeta(meta, { publicView: true });
 }
 
 function dispatchLiveTextSegmentEvent(
@@ -307,11 +235,15 @@ function emitLocalTextSegmentEvent(
   const previousEnd = textLastSegmentEndOffsetByBuffer.get(liveBufferId) ?? 0;
   const utf16Length = segment.text.length;
   const source = toSegmentSource(
-    rawMeta?.__segmentSource,
+    typeof rawMeta?.__segmentSource === 'string'
+      ? rawMeta.__segmentSource
+      : undefined,
     segment.source === 'append' ? 'manual' : 'segmentation_engine'
   );
   const reason = toSegmentReason(
-    rawMeta?.__segmentReason,
+    typeof rawMeta?.__segmentReason === 'string'
+      ? rawMeta.__segmentReason
+      : undefined,
     inferSegmentReasonFromSource(segment.source)
   );
   const createdAtMsRaw = rawMeta?.__segmentCreatedAtMs;
@@ -1088,12 +1020,13 @@ export async function appendLiveTextSegment(
   meta?: Record<string, unknown>
 ): Promise<{ segmentIndex: number }> {
   const id = resolveLiveTextBufferId(liveBufferId);
+  const sanitizedMeta = sanitizeJsonMeta(meta);
   const out = await getNative().appendLiveTextSegment(
     id,
     text,
     tokens,
     timestamps,
-    meta
+    sanitizedMeta
   );
 
   const callbacks = textSegmentCallbacks.get(id);
@@ -1109,7 +1042,7 @@ export async function appendLiveTextSegment(
       segmentIndex: out.segmentIndex,
       ...(tokens && tokens.length > 0 ? { tokens } : {}),
       ...(timestamps && timestamps.length > 0 ? { timestamps } : {}),
-      ...(meta ? { meta } : {}),
+      ...(sanitizedMeta ? { meta: sanitizedMeta } : {}),
     };
     emitLocalTextSegmentEvent(id, segment, out.segmentIndex + 1);
   }
@@ -1154,9 +1087,7 @@ export async function getLiveTextBufferSegments(
     ...(Array.isArray(segment.timestamps)
       ? { timestamps: segment.timestamps }
       : {}),
-    ...(segment.meta != null
-      ? { meta: segment.meta as Record<string, unknown> }
-      : {}),
+    ...(segment.meta != null ? { meta: sanitizeJsonMeta(segment.meta) } : {}),
   }));
 }
 
@@ -1211,6 +1142,20 @@ export {
   TEXT_DEFAULT_SLICE_COUNT,
   TEXT_MAX_SLICE_COUNT,
 } from './types';
+
+export type {
+  JsonScalar,
+  JsonValue,
+  SanitizeJsonMetaOptions,
+} from './jsonMeta';
+
+export {
+  sanitizeJsonMeta,
+  JSON_META_MAX_DEPTH,
+  JSON_META_MAX_ARRAY_LENGTH,
+  JSON_META_MAX_OBJECT_KEYS,
+  RESERVED_SEGMENT_META_KEYS,
+} from './jsonMeta';
 
 /**
  * Resolve a text buffer source to a native buffer ID string.

--- a/src/textbuffer/jsonMeta.ts
+++ b/src/textbuffer/jsonMeta.ts
@@ -1,0 +1,163 @@
+/**
+ * Fabric-safe JSON-tree sanitizer for LiveText segment meta.
+ *
+ * Soft limits (drop on exceed, never throw on emit/read paths):
+ * - max depth 4
+ * - max array length 64
+ * - max object keys per level 64
+ */
+
+export type JsonScalar = string | number | boolean | null;
+export type JsonValue = JsonScalar | JsonValue[] | { [key: string]: JsonValue };
+
+export const JSON_META_MAX_DEPTH = 4;
+export const JSON_META_MAX_ARRAY_LENGTH = 64;
+export const JSON_META_MAX_OBJECT_KEYS = 64;
+
+export const RESERVED_SEGMENT_META_KEYS = new Set([
+  '__segmentReason',
+  '__segmentSource',
+  '__segmentCreatedAtMs',
+  '__segmentId',
+  '__segmentLang',
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function sanitizeJsonValue(
+  value: unknown,
+  depth: number
+): JsonValue | undefined {
+  if (depth > JSON_META_MAX_DEPTH) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  const t = typeof value;
+  if (t === 'string' || t === 'boolean') {
+    return value as string | boolean;
+  }
+  if (t === 'number') {
+    return Number.isFinite(value as number) ? (value as number) : undefined;
+  }
+  if (
+    t === 'undefined' ||
+    t === 'function' ||
+    t === 'symbol' ||
+    t === 'bigint'
+  ) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    if (depth >= JSON_META_MAX_DEPTH) {
+      return undefined;
+    }
+    const out: JsonValue[] = [];
+    const limit = Math.min(value.length, JSON_META_MAX_ARRAY_LENGTH);
+    for (let i = 0; i < limit; i++) {
+      const child = sanitizeJsonValue(value[i], depth + 1);
+      if (child !== undefined) {
+        out.push(child);
+      }
+    }
+    return out;
+  }
+
+  if (!isPlainObject(value)) {
+    // Host objects / class instances / Maps — drop.
+    return undefined;
+  }
+
+  if (depth >= JSON_META_MAX_DEPTH) {
+    return undefined;
+  }
+
+  const out: { [key: string]: JsonValue } = {};
+  const keys = Object.keys(value);
+  const limit = Math.min(keys.length, JSON_META_MAX_OBJECT_KEYS);
+  for (let i = 0; i < limit; i++) {
+    const key = keys[i]!;
+    const child = sanitizeJsonValue(value[key], depth + 1);
+    if (child !== undefined) {
+      out[key] = child;
+    }
+  }
+  return out;
+}
+
+function sanitizeExtra(value: unknown): Record<string, string> | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+  const extra: Record<string, string> = {};
+  const keys = Object.keys(value);
+  const limit = Math.min(keys.length, JSON_META_MAX_OBJECT_KEYS);
+  for (let i = 0; i < limit; i++) {
+    const key = keys[i]!;
+    const v = value[key];
+    if (typeof v === 'string') {
+      extra[key] = v;
+    }
+  }
+  return Object.keys(extra).length > 0 ? extra : undefined;
+}
+
+export type SanitizeJsonMetaOptions = {
+  /** Drop reserved `__segment*` keys for public event views. */
+  publicView?: boolean;
+};
+
+/**
+ * Project arbitrary meta into a plain JSON tree suitable for LiveText.
+ */
+export function sanitizeJsonMeta(
+  input: unknown,
+  options?: SanitizeJsonMetaOptions
+): Record<string, JsonValue> | undefined {
+  if (!isPlainObject(input)) {
+    return undefined;
+  }
+
+  const publicView = options?.publicView === true;
+  const out: Record<string, JsonValue> = {};
+  const keys = Object.keys(input);
+  const limit = Math.min(keys.length, JSON_META_MAX_OBJECT_KEYS);
+
+  for (let i = 0; i < limit; i++) {
+    const key = keys[i]!;
+    if (publicView && RESERVED_SEGMENT_META_KEYS.has(key)) {
+      continue;
+    }
+
+    const value = input[key];
+
+    // TTS compatibility: extra stays a string-only map.
+    if (key === 'extra') {
+      const extra = sanitizeExtra(value);
+      if (extra) {
+        out.extra = extra;
+      }
+      continue;
+    }
+
+    const child = sanitizeJsonValue(value, 1);
+    if (child !== undefined) {
+      out[key] = child;
+    }
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
+}

--- a/src/textbuffer/types.ts
+++ b/src/textbuffer/types.ts
@@ -12,6 +12,7 @@
 import type { StreamEventSpec } from '../pipeline/streamEvents';
 import type { Segment } from '../segment/segment';
 import type { SegmentationPolicy } from '../segment/engine-types';
+import type { JsonValue } from './jsonMeta';
 
 // ========== Buffer Kinds ==========
 
@@ -113,12 +114,11 @@ export interface LiveTextSegment {
    * Opaque metadata dictionary attached to this segment.
    * Pipeline workers interpret feature-specific keys and fall back to pipeline defaults.
    *
-   * Native → JS projects meta to JSON scalars (+ optional `extra` string map).
-   * Nested host maps are not retained across the event boundary.
-   *
-   * TTS worker keys: { sid?: number; speed?: number; extra?: Record<string, string> }
+   * Contract: Fabric-safe JSON tree (`JsonValue`) after bridge projection.
+   * Soft limits: depth ≤ 4, array length ≤ 64, object keys/level ≤ 64.
+   * TTS: `{ sid?: number; speed?: number; extra?: Record<string, string> }`
    */
-  meta?: Record<string, unknown>;
+  meta?: Record<string, JsonValue>;
 }
 
 /** Discriminated union of all pipeline text buffer info types. */


### PR DESCRIPTION
This pull request introduces a breaking change to the LiveText segment `meta` format, upgrading it from a scalar-only structure to a Fabric-safe JSON tree that supports nested objects and arrays. This enables features like Audio Tagging to emit structured data (such as nested event arrays) directly, eliminating the need for JSON string workarounds. The implementation includes a new recursive packing utility on Android, documentation updates, and migration of all relevant code paths to the new contract.

**LiveText meta: JSON tree support**

- The LiveText segment `meta` field now supports nested objects and arrays, up to a soft limit (depth ≤ 4, array length ≤ 64, keys/level ≤ 64). This is enforced and packed recursively for safe cross-platform (Fabric) transport. Apps that previously saw nested keys dropped will now receive them. (`CHANGELOG.md`, `LiveTextJsonMeta.kt`, `SherpaOnnxModule.kt`, `live-text-meta-json-tree-contract.md`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R8) [[2]](diffhunk://#diff-0c880361592edde845cb0ca39668c86e4731414bc32bb0b117c40027647a7469R1-R161) [[3]](diffhunk://#diff-879656a663809608669376c509d884bda0e032ec094f58ce4e41a60afbbcf80dL374-R378) [[4]](diffhunk://#diff-879656a663809608669376c509d884bda0e032ec094f58ce4e41a60afbbcf80dL3816-R3809) [[5]](diffhunk://#diff-729b5a0fec6305c7e6fa575c7cc18d284d663ed20692c80816ee9b30e88574ceL1-R42)

- A new utility class `LiveTextJsonMeta` has been added to Android, providing recursive packing of `meta` into `WritableMap`/`WritableArray` with soft limits and type safety. (`LiveTextJsonMeta.kt`)

**Audio Tagging meta events**

- The Audio Tagging live pipeline now emits `meta.events` as a nested array of event objects (`{ name, index, prob }`), instead of a JSON string. Downstream consumers receive this as an array, and the previous JSON string workaround is removed. (`AudioTaggingOfflineLivePipelineWorker.kt`, `audio-tagging-live.md`) [[1]](diffhunk://#diff-e39776016755c0d080377b29c3029d342408dc80216be2d9a60402edfe3b70c2R136-R145) [[2]](diffhunk://#diff-e39776016755c0d080377b29c3029d342408dc80216be2d9a60402edfe3b70c2L146-R162) [[3]](diffhunk://#diff-af4524fd71c0a0a7c57d3469bc2c985fb8872c0cc40144d3d090330510e43db4L157-R161)

**Documentation updates**

- The documentation for Audio Tagging live output and the LiveText meta JSON tree contract has been updated to reflect the new structure and clarify the removal of previous workarounds. (`audio-tagging-live.md`, `live-text-meta-json-tree-contract.md`) [[1]](diffhunk://#diff-af4524fd71c0a0a7c57d3469bc2c985fb8872c0cc40144d3d090330510e43db4L157-R161) [[2]](diffhunk://#diff-729b5a0fec6305c7e6fa575c7cc18d284d663ed20692c80816ee9b30e88574ceL1-R42)

**Breaking changes**

- This change is breaking for any app that relied on the silent dropping of nested keys in LiveText `meta`. Apps expecting only scalars must now handle possible nested structures. (`CHANGELOG.md`)