### PR TITLE
Chore/update sherpa onnx to 1 13 18

### DIFF
--- a/.github/workflows/framework-sherpa-onnx-ios-framework.yml
+++ b/.github/workflows/framework-sherpa-onnx-ios-framework.yml
@@ -12,7 +12,7 @@ on:
       onnxruntime_version:
         description: 'ONNX Runtime version for csukuangfj/onnxruntime-libs static iOS xcframework. Passed as SHERPA_ONNX_ONNXRUNTIME_VERSION to build-ios.sh.'
         required: false
-        default: '1.28.1'
+        default: '1.28.2'
 
 jobs:
   build-framework:
@@ -74,7 +74,7 @@ jobs:
           SHERPA_ONNX_ONNXRUNTIME_VERSION: ${{ github.event.inputs.onnxruntime_version }}
         run: |
           if [ -z "${SHERPA_ONNX_ONNXRUNTIME_VERSION:-}" ]; then
-            export SHERPA_ONNX_ONNXRUNTIME_VERSION="1.28.1"
+            export SHERPA_ONNX_ONNXRUNTIME_VERSION="1.28.2"
           fi
           echo "SHERPA_ONNX_ONNXRUNTIME_VERSION=${SHERPA_ONNX_ONNXRUNTIME_VERSION}"
           cd third_party/sherpa-onnx-prebuilt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Features
 
+* **diarization:** Opt-in per-segment silhouette `confidence` (`clustering.computeConfidence`, default **false**, upstream parity). Ported into the shared offline C++ core — not via Kotlin `OfflineSpeakerDiarization`.
 * **pcm:** Standalone PCM player: `createPcmPlayer({ sampleRate, feed, ttsInstanceId? })` — play any mono float PCM, not just TTS output. Import from `react-native-sherpa-onnx/pcm`.
 * **pcm:** Player controls: `pause()`, `resume()`, `destroy()` on `PcmPlayer`.
 * **tts:** Native streaming playback: `generateSpeechStream(text, opts, handlers, { playback: true })` — zero-bridge-PCM playback.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Full doc index: [docs/README.md](./docs/README.md). New to models? See [How to s
 - ✅ Spoken language identification (SLID): [Offline](./docs/language-identification-offline.md) · [Live overload](./docs/language-identification-live.md)
 - ✅ Keyword spotting (KWS): [Streaming](./docs/kws-streaming.md)
 - ✅ Audio tagging / sound event detection: [Offline](./docs/audio-tagging-offline.md) · [Live overload](./docs/audio-tagging-live.md)
-- ❌ Diacritization: *(Not yet implemented in SDK)*
+- ❌ Diacritization: *(Planned for a future release)*
 
 ### Pipeline & orchestration
 
@@ -455,8 +455,8 @@ Full guide: [Audio visualization](./docs/audio-visualization.md).
 
 | Platform | Version |
 |----------|---------|
-| Android | 1.13.7 |
-| iOS | 1.13.7 |
+| Android | 1.13.8 |
+| iOS | 1.13.8 |
 
 ## Known issues
 

--- a/android/src/main/cpp/diarization/agglomerative-clustering.cpp
+++ b/android/src/main/cpp/diarization/agglomerative-clustering.cpp
@@ -227,6 +227,99 @@ std::vector<int32_t> CutreeCdist(const std::vector<Merge>& merges, int32_t n,
   return AssignLabelsFromParents(parent, n);
 }
 
+// Per-point silhouette coefficients using the condensed cosine-dissimilarity
+// matrix. Mirrors upstream sherpa-onnx FastClustering::ComputeSilhouettes.
+void ComputeSilhouettes(const std::vector<double>& distance,
+                        const std::vector<int32_t>& labels, int32_t num_rows,
+                        std::vector<float>* silhouettes) {
+  if (silhouettes == nullptr || labels.empty() || num_rows <= 0) {
+    return;
+  }
+  const int32_t num_clusters =
+      *std::max_element(labels.begin(), labels.end()) + 1;
+  if (num_clusters <= 0) {
+    silhouettes->assign(static_cast<size_t>(num_rows),
+                        kUnavailableConfidence);
+    return;
+  }
+
+  const size_t total_elements =
+      static_cast<size_t>(num_rows) * static_cast<size_t>(num_clusters);
+  std::vector<double> sum(total_elements, 0.0);
+  std::vector<int32_t> count(total_elements, 0);
+
+  int32_t distance_matrix_index = 0;
+  for (int32_t row_index = 0; row_index != num_rows; ++row_index) {
+    const size_t row_offset =
+        static_cast<size_t>(row_index) * static_cast<size_t>(num_clusters);
+    for (int32_t col_index = row_index + 1; col_index != num_rows;
+         ++col_index, ++distance_matrix_index) {
+      const double pair_distance =
+          distance[static_cast<size_t>(distance_matrix_index)];
+      const int32_t row_point_cluster =
+          labels[static_cast<size_t>(row_index)];
+      const int32_t col_point_cluster =
+          labels[static_cast<size_t>(col_index)];
+      const size_t col_offset =
+          static_cast<size_t>(col_index) * static_cast<size_t>(num_clusters);
+
+      sum[row_offset + static_cast<size_t>(col_point_cluster)] +=
+          pair_distance;
+      count[row_offset + static_cast<size_t>(col_point_cluster)] += 1;
+
+      sum[col_offset + static_cast<size_t>(row_point_cluster)] +=
+          pair_distance;
+      count[col_offset + static_cast<size_t>(row_point_cluster)] += 1;
+    }
+  }
+
+  silhouettes->assign(static_cast<size_t>(num_rows), 0.0f);
+  for (int32_t row_index = 0; row_index != num_rows; ++row_index) {
+    const int32_t row_point_cluster =
+        labels[static_cast<size_t>(row_index)];
+    const size_t base =
+        static_cast<size_t>(row_index) * static_cast<size_t>(num_clusters);
+
+    const int32_t own_count =
+        count[base + static_cast<size_t>(row_point_cluster)];
+    if (own_count == 0) {
+      // Singleton cluster → silhouette 0.
+      continue;
+    }
+
+    const double a =
+        sum[base + static_cast<size_t>(row_point_cluster)] / own_count;
+    double b = std::numeric_limits<double>::infinity();
+
+    for (int32_t cluster_index = 0; cluster_index != num_clusters;
+         ++cluster_index) {
+      if (cluster_index == row_point_cluster) {
+        continue;
+      }
+      const int32_t neighbor_count =
+          count[base + static_cast<size_t>(cluster_index)];
+      if (neighbor_count == 0) {
+        continue;
+      }
+      const double mean =
+          sum[base + static_cast<size_t>(cluster_index)] / neighbor_count;
+      if (mean < b) {
+        b = mean;
+      }
+    }
+
+    if (!std::isfinite(b)) {
+      (*silhouettes)[static_cast<size_t>(row_index)] =
+          kUnavailableConfidence;
+      continue;
+    }
+
+    const double denom = std::max(a, b);
+    (*silhouettes)[static_cast<size_t>(row_index)] =
+        denom > 0 ? static_cast<float>((b - a) / denom) : 0.0f;
+  }
+}
+
 }  // namespace
 
 AgglomerativeClusterer::AgglomerativeClusterer(ClusteringConfig config)
@@ -236,13 +329,20 @@ void AgglomerativeClusterer::setConfig(ClusteringConfig config) {
   config_ = config;
 }
 
-std::vector<int32_t> AgglomerativeClusterer::Cluster(float* features,
-                                                     int32_t num_rows,
-                                                     int32_t num_cols) const {
+std::vector<int32_t> AgglomerativeClusterer::Cluster(
+    float* features, int32_t num_rows, int32_t num_cols,
+    std::vector<float>* silhouettes) const {
+  if (silhouettes != nullptr) {
+    silhouettes->clear();
+  }
+
   if (features == nullptr || num_rows <= 0 || num_cols <= 0) {
     return {};
   }
   if (num_rows == 1) {
+    if (silhouettes != nullptr && config_.compute_confidence) {
+      silhouettes->assign(1, 0.0f);
+    }
     return {0};
   }
 
@@ -263,10 +363,19 @@ std::vector<int32_t> AgglomerativeClusterer::Cluster(float* features,
   }
 
   auto merges = LinkageComplete(dist, num_rows);
+  std::vector<int32_t> labels;
   if (config_.num_clusters > 0) {
-    return CutreeK(merges, num_rows, config_.num_clusters);
+    labels = CutreeK(merges, num_rows, config_.num_clusters);
+  } else {
+    labels =
+        CutreeCdist(merges, num_rows, static_cast<double>(config_.threshold));
   }
-  return CutreeCdist(merges, num_rows, static_cast<double>(config_.threshold));
+
+  if (silhouettes != nullptr && config_.compute_confidence &&
+      !labels.empty()) {
+    ComputeSilhouettes(dist, labels, num_rows, silhouettes);
+  }
+  return labels;
 }
 
 }  // namespace sherpaonnx::diarization

--- a/android/src/main/cpp/diarization/agglomerative-clustering.h
+++ b/android/src/main/cpp/diarization/agglomerative-clustering.h
@@ -13,6 +13,11 @@ struct ClusteringConfig {
   int32_t num_clusters = -1;
   /** Cosine-dissimilarity threshold used when num_clusters <= 0. */
   float threshold = 0.5f;
+  /**
+   * When true, Cluster() optionally fills per-embedding silhouette scores.
+   * Default false — matches upstream FastClusteringConfig.compute_confidence.
+   */
+  bool compute_confidence = false;
 };
 
 /**
@@ -24,13 +29,17 @@ class AgglomerativeClusterer {
   explicit AgglomerativeClusterer(ClusteringConfig config);
 
   void setConfig(ClusteringConfig config);
+  ClusteringConfig config() const { return config_; }
 
   /**
    * \p features row-major (num_rows × num_cols). Modified in place (row normalize).
    * Returns cluster label per row in [0, num_clusters).
+   * \p silhouettes optional output; when non-null and config.compute_confidence,
+   * filled with one silhouette per row ([-1,1] or kUnavailableConfidence).
    */
   std::vector<int32_t> Cluster(float* features, int32_t num_rows,
-                               int32_t num_cols) const;
+                               int32_t num_cols,
+                               std::vector<float>* silhouettes = nullptr) const;
 
  private:
   ClusteringConfig config_;

--- a/android/src/main/cpp/diarization/diarization-session.cpp
+++ b/android/src/main/cpp/diarization/diarization-session.cpp
@@ -21,6 +21,7 @@ void DiarizationSession::Release() {
   chunk_labels_.clear();
   speakers_per_frame_.clear();
   chunk_speaker_keys_.clear();
+  embedding_sample_ranges_.clear();
   embedding_matrix_ = {};
   last_cluster_labels_.clear();
   last_segments_.clear();
@@ -37,10 +38,12 @@ int32_t DiarizationSession::sampleRate() const {
   return segmentation_.isLoaded() ? segmentation_.meta().sample_rate : 0;
 }
 
-void DiarizationSession::setClustering(int32_t num_clusters, float threshold) {
+void DiarizationSession::setClustering(int32_t num_clusters, float threshold,
+                                       bool compute_confidence) {
   ClusteringConfig cfg;
   cfg.num_clusters = num_clusters;
   cfg.threshold = threshold;
+  cfg.compute_confidence = compute_confidence;
   clusterer_.setConfig(cfg);
 }
 
@@ -74,7 +77,8 @@ Status DiarizationSession::Initialize(const DiarizationInitConfig& config) {
     return st;
   }
 
-  setClustering(config.num_clusters, config.threshold);
+  setClustering(config.num_clusters, config.threshold,
+                config.compute_confidence);
   timeline_config_.meta = segmentation_.meta();
   timeline_config_.min_duration_on = config.min_duration_on;
   timeline_config_.min_duration_off = config.min_duration_off;
@@ -268,6 +272,8 @@ ProcessResult DiarizationSession::Process(const std::vector<float>& mono_samples
   emb_mat.resize(static_cast<int32_t>(sample_indexes.size()), dim, 0.f);
   chunk_speaker_keys_.clear();
   chunk_speaker_keys_.reserve(sample_indexes.size());
+  embedding_sample_ranges_.clear();
+  embedding_sample_ranges_.reserve(sample_indexes.size());
 
   int32_t valid_rows = 0;
   const int32_t total_emb = static_cast<int32_t>(sample_indexes.size());
@@ -287,6 +293,8 @@ ProcessResult DiarizationSession::Process(const std::vector<float>& mono_samples
     }
     std::copy(emb.begin(), emb.end(), emb_mat.rowPtr(valid_rows));
     chunk_speaker_keys_.push_back(sample_indexes[static_cast<size_t>(i)].key);
+    embedding_sample_ranges_.push_back(
+        sample_indexes[static_cast<size_t>(i)].ranges);
     ++valid_rows;
   }
 
@@ -316,8 +324,11 @@ ProcessResult DiarizationSession::FinishFromCache(
 
   // Copy features — Cluster normalizes in place.
   FloatMatrix features = embedding_matrix_;
+  std::vector<float> silhouettes;
+  const bool want_confidence = clusterer_.config().compute_confidence;
   last_cluster_labels_ = clusterer_.Cluster(
-      features.data.data(), features.rows, features.cols);
+      features.data.data(), features.rows, features.cols,
+      want_confidence ? &silhouettes : nullptr);
   if (last_cluster_labels_.empty()) {
     result.status = Status::Ok();
     return result;
@@ -336,6 +347,12 @@ ProcessResult DiarizationSession::FinishFromCache(
   Int8Matrix final_labels =
       FinalizeLabels(speaker_count, speakers_per_frame_);
   last_segments_ = ComputeResult(final_labels, timeline_config_);
+
+  if (want_confidence && !silhouettes.empty()) {
+    ApplySegmentConfidence(&last_segments_, embedding_sample_ranges_,
+                           last_cluster_labels_, silhouettes,
+                           working_sample_rate_);
+  }
 
   last_speaker_map_.clear();
   int32_t next_id = 0;
@@ -366,7 +383,8 @@ ProcessResult DiarizationSession::FinishFromCache(
 }
 
 ProcessResult DiarizationSession::Recluster(int32_t num_clusters,
-                                            float threshold) {
+                                            float threshold,
+                                            bool compute_confidence) {
   ProcessResult result;
   if (!initialized_) {
     result.status =
@@ -378,7 +396,7 @@ ProcessResult DiarizationSession::Recluster(int32_t num_clusters,
         Status::Fail(kErrInvalidArgument, "no cached embeddings to recluster");
     return result;
   }
-  setClustering(num_clusters, threshold);
+  setClustering(num_clusters, threshold, compute_confidence);
   ProcessOptions opts;
   opts.include_overlap = false;
   return FinishFromCache(opts);

--- a/android/src/main/cpp/diarization/diarization-session.h
+++ b/android/src/main/cpp/diarization/diarization-session.h
@@ -22,6 +22,8 @@ struct DiarizationInitConfig {
   float window_shift_ratio = 0.1f;
   int32_t num_clusters = -1;
   float threshold = 0.5f;
+  /** Default false — upstream FastClusteringConfig.compute_confidence parity. */
+  bool compute_confidence = false;
   float min_duration_on = 0.3f;
   float min_duration_off = 0.5f;
   int32_t num_threads = 1;
@@ -73,7 +75,8 @@ class DiarizationSession {
 
   int32_t sampleRate() const;
 
-  void setClustering(int32_t num_clusters, float threshold);
+  void setClustering(int32_t num_clusters, float threshold,
+                     bool compute_confidence);
   void requestCancel();
   void clearCancel();
 
@@ -81,7 +84,8 @@ class DiarizationSession {
                         int32_t sample_rate, const ProcessOptions& options);
 
   /** Re-run clustering on cached embeddings (no re-inference). */
-  ProcessResult Recluster(int32_t num_clusters, float threshold);
+  ProcessResult Recluster(int32_t num_clusters, float threshold,
+                          bool compute_confidence);
 
   std::vector<ClusterEmbedding> getClusterEmbeddings() const;
 
@@ -102,6 +106,8 @@ class DiarizationSession {
   std::vector<Int8Matrix> chunk_labels_;
   std::vector<int32_t> speakers_per_frame_;
   std::vector<ChunkSpeakerKey> chunk_speaker_keys_;
+  /** Sample ranges per cached embedding row (aligned with embedding_matrix_). */
+  std::vector<std::vector<SampleRange>> embedding_sample_ranges_;
   FloatMatrix embedding_matrix_;
   std::vector<int32_t> last_cluster_labels_;
   std::vector<DiarizationSegment> last_segments_;

--- a/android/src/main/cpp/diarization/diarization-types.h
+++ b/android/src/main/cpp/diarization/diarization-types.h
@@ -19,6 +19,9 @@ inline constexpr const char* kErrCancelled = "DIARIZATION_CANCELLED";
 inline constexpr const char* kErrNoSpeakers = "DIARIZATION_NO_SPEAKERS";
 inline constexpr const char* kErrInternal = "DIARIZATION_INTERNAL_ERROR";
 
+/** Sentinel when confidence was not computed or could not be determined. Outside [-1, 1]. */
+inline constexpr float kUnavailableConfidence = -2.0f;
+
 using SampleRange = ::sherpaonnx::speaker_embedding::SampleRange;
 using Status = ::sherpaonnx::speaker_embedding::Status;
 
@@ -26,6 +29,8 @@ struct DiarizationSegment {
   float start = 0.f;
   float end = 0.f;
   int32_t speaker = 0;
+  /** Silhouette-based confidence in [-1, 1], or kUnavailableConfidence. */
+  float confidence = kUnavailableConfidence;
 };
 
 struct PyannoteMeta {

--- a/android/src/main/cpp/diarization/sherpa-onnx-diarization-wrapper.cpp
+++ b/android/src/main/cpp/diarization/sherpa-onnx-diarization-wrapper.cpp
@@ -28,6 +28,7 @@ DiarizationProcessResult ToProcessResult(
     dto.start = s.start;
     dto.end = s.end;
     dto.speaker = s.speaker;
+    dto.confidence = s.confidence;
     out.segments.push_back(dto);
   }
   return out;
@@ -61,8 +62,9 @@ void DiarizationWrapper::cancel() {
 DiarizationInitializeResult DiarizationWrapper::initialize(
     const std::string& segmentationModel, const std::string& embeddingModel,
     float windowShiftRatio, int32_t numClusters, float threshold,
-    float minDurationOn, float minDurationOff, int32_t numThreads,
-    const std::optional<std::string>& provider, bool debug) {
+    bool computeConfidence, float minDurationOn, float minDurationOff,
+    int32_t numThreads, const std::optional<std::string>& provider,
+    bool debug) {
   DiarizationInitializeResult result;
   if (!pImpl) {
     result.errorCode = diarization::kErrInternal;
@@ -76,6 +78,7 @@ DiarizationInitializeResult DiarizationWrapper::initialize(
   cfg.window_shift_ratio = windowShiftRatio;
   cfg.num_clusters = numClusters;
   cfg.threshold = threshold;
+  cfg.compute_confidence = computeConfidence;
   cfg.min_duration_on = minDurationOn;
   cfg.min_duration_off = minDurationOff;
   cfg.num_threads = numThreads;
@@ -120,14 +123,16 @@ DiarizationProcessResult DiarizationWrapper::processMonoSamples(
 }
 
 DiarizationProcessResult DiarizationWrapper::recluster(int32_t numClusters,
-                                                       float threshold) {
+                                                       float threshold,
+                                                       bool computeConfidence) {
   if (!pImpl || !pImpl->session.isInitialized()) {
     DiarizationProcessResult out;
     out.errorCode = diarization::kErrNotInitialized;
     out.error = "diarization not initialized";
     return out;
   }
-  return ToProcessResult(pImpl->session.Recluster(numClusters, threshold));
+  return ToProcessResult(
+      pImpl->session.Recluster(numClusters, threshold, computeConfidence));
 }
 
 std::vector<DiarizationClusterEmbeddingDto>

--- a/android/src/main/cpp/diarization/sherpa-onnx-diarization-wrapper.h
+++ b/android/src/main/cpp/diarization/sherpa-onnx-diarization-wrapper.h
@@ -22,6 +22,8 @@ struct DiarizationSegmentDto {
   float start = 0.f;
   float end = 0.f;
   int32_t speaker = 0;
+  /** [-1, 1] when computed; kUnavailableConfidence (-2) when not. */
+  float confidence = -2.f;
 };
 
 struct DiarizationProcessResult {
@@ -61,14 +63,16 @@ class DiarizationWrapper {
   DiarizationInitializeResult initialize(
       const std::string& segmentationModel, const std::string& embeddingModel,
       float windowShiftRatio, int32_t numClusters, float threshold,
-      float minDurationOn, float minDurationOff, int32_t numThreads,
-      const std::optional<std::string>& provider, bool debug);
+      bool computeConfidence, float minDurationOn, float minDurationOff,
+      int32_t numThreads, const std::optional<std::string>& provider,
+      bool debug);
 
   DiarizationProcessResult processMonoSamples(
       const std::vector<float>& monoSamples, int32_t sampleRate,
       bool includeOverlap, const DiarizationProgressFn& onProgress);
 
-  DiarizationProcessResult recluster(int32_t numClusters, float threshold);
+  DiarizationProcessResult recluster(int32_t numClusters, float threshold,
+                                     bool computeConfidence);
 
   std::vector<DiarizationClusterEmbeddingDto> getClusterEmbeddings() const;
 

--- a/android/src/main/cpp/diarization/speaker-timeline.cpp
+++ b/android/src/main/cpp/diarization/speaker-timeline.cpp
@@ -354,6 +354,60 @@ std::vector<DiarizationSegment> ComputeResult(const Int8Matrix& final_labels,
   return result;
 }
 
+void ApplySegmentConfidence(
+    std::vector<DiarizationSegment>* segments,
+    const std::vector<std::vector<SampleRange>>& embedding_ranges,
+    const std::vector<int32_t>& cluster_labels,
+    const std::vector<float>& silhouettes, int32_t sample_rate) {
+  if (segments == nullptr || segments->empty() || sample_rate <= 0) {
+    return;
+  }
+  const size_t n = std::min(
+      {embedding_ranges.size(), cluster_labels.size(), silhouettes.size()});
+  if (n == 0) {
+    return;
+  }
+
+  struct SilhouetteInterval {
+    int32_t start_sample = 0;
+    int32_t end_sample = 0;
+    float silhouette = kUnavailableConfidence;
+  };
+  std::unordered_map<int32_t, std::vector<SilhouetteInterval>> by_cluster;
+  for (size_t i = 0; i < n; ++i) {
+    const int32_t cluster = cluster_labels[i];
+    const float silhouette = silhouettes[i];
+    auto& bucket = by_cluster[cluster];
+    for (const auto& range : embedding_ranges[i]) {
+      bucket.push_back({range.start, range.end, silhouette});
+    }
+  }
+
+  for (auto& seg : *segments) {
+    auto it = by_cluster.find(seg.speaker);
+    if (it == by_cluster.end()) {
+      seg.confidence = kUnavailableConfidence;
+      continue;
+    }
+    const int32_t seg_start =
+        static_cast<int32_t>(seg.start * static_cast<float>(sample_rate));
+    const int32_t seg_end =
+        static_cast<int32_t>(seg.end * static_cast<float>(sample_rate));
+    double sum = 0.0;
+    int32_t count = 0;
+    for (const auto& interval : it->second) {
+      if (interval.end_sample > seg_start &&
+          interval.start_sample < seg_end) {
+        sum += static_cast<double>(interval.silhouette);
+        count += 1;
+      }
+    }
+    seg.confidence =
+        count == 0 ? kUnavailableConfidence
+                   : static_cast<float>(sum / static_cast<double>(count));
+  }
+}
+
 Int8Matrix SpeechUnionLabels(const std::vector<int32_t>& speakers_per_frame) {
   Int8Matrix out;
   const int32_t rows = static_cast<int32_t>(speakers_per_frame.size());

--- a/android/src/main/cpp/diarization/speaker-timeline.h
+++ b/android/src/main/cpp/diarization/speaker-timeline.h
@@ -53,6 +53,18 @@ std::vector<DiarizationSegment> ComputeResult(const Int8Matrix& final_labels,
                                               const TimelineConfig& config);
 
 /**
+ * Assign per-segment confidence as the mean silhouette of embedding sample
+ * intervals that overlap the segment (upstream pyannote parity).
+ * No-op when silhouettes empty or sizes mismatch. Leaves
+ * kUnavailableConfidence when no overlapping interval exists.
+ */
+void ApplySegmentConfidence(
+    std::vector<DiarizationSegment>* segments,
+    const std::vector<std::vector<SampleRange>>& embedding_ranges,
+    const std::vector<int32_t>& cluster_labels,
+    const std::vector<float>& silhouettes, int32_t sample_rate);
+
+/**
  * Collapse speakers-per-frame into a single speech/silence column
  * (`1` when count >= 1). Used by `speech_pyannote_segmentation` (union-only).
  */

--- a/android/src/main/cpp/jni/diarization/sherpa-onnx-diarization-jni.cpp
+++ b/android/src/main/cpp/jni/diarization/sherpa-onnx-diarization-jni.cpp
@@ -190,6 +190,10 @@ jobject DiarizationProcessResultToJava(
       PutFloat(env, segMap, segPut, "start", seg.start);
       PutFloat(env, segMap, segPut, "end", seg.end);
       PutInt(env, segMap, segPut, "speaker", seg.speaker);
+      // Omit unavailable sentinel (-2) so JS can treat missing as undefined.
+      if (seg.confidence > -1.5f) {
+        PutFloat(env, segMap, segPut, "confidence", seg.confidence);
+      }
       env->CallBooleanMethod(segments, listAdd, segMap);
       env->DeleteLocalRef(segMap);
     }
@@ -242,6 +246,7 @@ Java_com_sherpaonnx_diarization_facade_SherpaOnnxDiarizationHelper_nativeInitial
     jfloat windowShiftRatio,
     jint numClusters,
     jfloat threshold,
+    jboolean computeConfidence,
     jfloat minDurationOn,
     jfloat minDurationOff,
     jint numThreads,
@@ -254,10 +259,11 @@ Java_com_sherpaonnx_diarization_facade_SherpaOnnxDiarizationHelper_nativeInitial
   const auto providerOpt = CopyOptionalJstring(env, provider);
 
   LOGI(
-      "nativeInitializeDiarization: instanceId=%s threads=%d numClusters=%d",
+      "nativeInitializeDiarization: instanceId=%s threads=%d numClusters=%d computeConfidence=%d",
       instanceIdStr.c_str(),
       numThreads,
-      numClusters
+      numClusters,
+      computeConfidence == JNI_TRUE ? 1 : 0
   );
 
   sherpaonnx::DiarizationInitializeResult result;
@@ -271,6 +277,7 @@ Java_com_sherpaonnx_diarization_facade_SherpaOnnxDiarizationHelper_nativeInitial
         windowShiftRatio,
         numClusters,
         threshold,
+        computeConfidence == JNI_TRUE,
         minDurationOn,
         minDurationOff,
         numThreads > 0 ? numThreads : 1,
@@ -370,14 +377,16 @@ Java_com_sherpaonnx_diarization_facade_SherpaOnnxDiarizationHelper_nativeReclust
     jclass /* clazz */,
     jstring instanceId,
     jint numClusters,
-    jfloat threshold
+    jfloat threshold,
+    jboolean computeConfidence
 ) {
   const std::string instanceIdStr = CopyRequiredJstring(env, instanceId);
   LOGI(
-      "nativeReclusterDiarization: instanceId=%s numClusters=%d threshold=%f",
+      "nativeReclusterDiarization: instanceId=%s numClusters=%d threshold=%f computeConfidence=%d",
       instanceIdStr.c_str(),
       numClusters,
-      threshold
+      threshold,
+      computeConfidence == JNI_TRUE ? 1 : 0
   );
 
   sherpaonnx::DiarizationProcessResult result;
@@ -388,7 +397,8 @@ Java_com_sherpaonnx_diarization_facade_SherpaOnnxDiarizationHelper_nativeReclust
     result.error = "Diarization instance not found: " + instanceIdStr;
     return DiarizationProcessResultToJava(env, result);
   }
-  result = wrapper->recluster(numClusters, threshold);
+  result = wrapper->recluster(numClusters, threshold,
+                              computeConfidence == JNI_TRUE);
   return DiarizationProcessResultToJava(env, result);
 }
 

--- a/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
+++ b/android/src/main/java/com/sherpaonnx/SherpaOnnxModule.kt
@@ -5301,9 +5301,16 @@ class SherpaOnnxModule(reactContext: ReactApplicationContext) :
     instanceId: String,
     numClusters: Double,
     threshold: Double,
+    computeConfidence: Boolean,
     promise: Promise
   ) {
-    diarizationHelper.reclusterDiarization(instanceId, numClusters, threshold, promise)
+    diarizationHelper.reclusterDiarization(
+      instanceId,
+      numClusters,
+      threshold,
+      computeConfidence,
+      promise,
+    )
   }
 
   override fun getDiarizationClusterEmbeddings(instanceId: String, promise: Promise) {

--- a/android/src/main/java/com/sherpaonnx/diarization/facade/SherpaOnnxDiarizationHelper.kt
+++ b/android/src/main/java/com/sherpaonnx/diarization/facade/SherpaOnnxDiarizationHelper.kt
@@ -82,6 +82,10 @@ internal class SherpaOnnxDiarizationHelper(
     val windowShiftRatio = optDouble(options, "windowShiftRatio", 0.1)
     val numClusters = optDouble(options, "numClusters", -1.0).toInt()
     val threshold = optDouble(options, "threshold", 0.5).toFloat()
+    val computeConfidence =
+      options.hasKey("computeConfidence") &&
+        !options.isNull("computeConfidence") &&
+        options.getBoolean("computeConfidence")
     val minDurationOn = optDouble(options, "minDurationOn", 0.3).toFloat()
     val minDurationOff = optDouble(options, "minDurationOff", 0.5).toFloat()
     val numThreads = optDouble(options, "numThreads", 1.0).toInt().coerceAtLeast(1)
@@ -98,6 +102,7 @@ internal class SherpaOnnxDiarizationHelper(
           windowShiftRatio.toFloat(),
           numClusters,
           threshold,
+          computeConfidence,
           minDurationOn,
           minDurationOff,
           numThreads,
@@ -260,6 +265,7 @@ internal class SherpaOnnxDiarizationHelper(
           val startSec = (seg["start"] as? Number)?.toDouble() ?: 0.0
           val endSec = (seg["end"] as? Number)?.toDouble() ?: 0.0
           val speaker = (seg["speaker"] as? Number)?.toInt() ?: 0
+          val confidence = (seg["confidence"] as? Number)?.toDouble()
           val startSample =
             kotlin.math
               .round(startSec * sampleRate)
@@ -285,7 +291,7 @@ internal class SherpaOnnxDiarizationHelper(
               endSample = endSample,
               sampleRate = sampleRate,
               durationMs = durationMs,
-              confidence = null,
+              confidence = confidence,
               payloadJson = """{"source":"diarization","speaker":$speaker}""",
             ),
           )
@@ -317,6 +323,7 @@ internal class SherpaOnnxDiarizationHelper(
     instanceId: String,
     numClusters: Double,
     threshold: Double,
+    computeConfidence: Boolean,
     promise: Promise,
   ) {
     if (instanceId.isBlank()) {
@@ -329,6 +336,7 @@ internal class SherpaOnnxDiarizationHelper(
           instanceId,
           numClusters.toInt(),
           threshold.toFloat(),
+          computeConfidence,
         )
         if (result == null) {
           promise.reject(
@@ -483,6 +491,10 @@ internal class SherpaOnnxDiarizationHelper(
       m.putDouble("start", start)
       m.putDouble("end", end)
       m.putInt("speaker", speaker)
+      val confidence = (seg["confidence"] as? Number)?.toDouble()
+      if (confidence != null) {
+        m.putDouble("confidence", confidence)
+      }
       segmentsArr.pushMap(m)
     }
     map.putArray("segments", segmentsArr)
@@ -961,6 +973,7 @@ internal class SherpaOnnxDiarizationHelper(
       windowShiftRatio: Float,
       numClusters: Int,
       threshold: Float,
+      computeConfidence: Boolean,
       minDurationOn: Float,
       minDurationOff: Float,
       numThreads: Int,
@@ -981,6 +994,7 @@ internal class SherpaOnnxDiarizationHelper(
       instanceId: String,
       numClusters: Int,
       threshold: Float,
+      computeConfidence: Boolean,
     ): HashMap<String, Any>?
 
     @JvmStatic

--- a/docs/diarization-offline.md
+++ b/docs/diarization-offline.md
@@ -80,23 +80,30 @@ Detects `pyannote` / `reverb` packs (prefers `model.onnx` over `model.int8.onnx`
 | `embedding.modelSource` | Required. Separate embedding ONNX |
 | `clustering.numClusters` | If `> 0`, threshold ignored |
 | `clustering.threshold` | Cosine dissimilarity; default `0.5` |
+| `clustering.computeConfidence` | Opt-in silhouette confidence per segment; **default `false`** (upstream parity) |
 | `minDurationOn` / `minDurationOff` | Segment filter / gap merge (seconds) |
 
 ### `engine.diarize(audioIn, segmentOut, options?)`
 
 Runs the full pipeline and writes `{start,end,speaker}` into `segmentOut`
 natively (`kind: 'diarization'`, payload `{ source: 'diarization', speaker }`).
+When `clustering.computeConfidence` is `true`, each segment also gets
+`confidence` in `[-1, 1]` (segment-buffer field + optional timeline entry).
+If confidence was not requested or could not be computed for a segment, the
+field is omitted (native sentinel `-2` is never surfaced to JS).
 
 `segmentOut` must be an **empty** offline segment buffer.
 
 Options: `onProgress`, `signal` (`AbortSignal` → `cancelDiarization`),
 `includeOverlap` (returns `speakersPerFrame` when supported).
 
-### `engine.recluster({ numClusters?, threshold? })`
+### `engine.recluster({ numClusters?, threshold?, computeConfidence? })`
 
 Re-runs clustering on the **cached** embeddings from the last `diarize` — no
-re-inference. Use a fresh empty `segmentOut` + another `diarize` if you need the
-timeline rewritten into a buffer, or read `getClusterEmbeddings()`.
+re-inference. `computeConfidence` overrides the session flag when provided;
+otherwise the previous setting is kept. Use a fresh empty `segmentOut` + another
+`diarize` if you need the timeline rewritten into a buffer, or read
+`getClusterEmbeddings()`.
 
 ### `engine.getClusterEmbeddings()`
 
@@ -126,7 +133,8 @@ Composes `getClusterEmbeddings` + `sid.search` + reading the buffer filled by
 
 The native core is a **shared C++** pipeline (Android + iOS): pyannote ONNX via
 ORT, powerset decode, timeline stitch, sherpa C-API embedding extractor (refcounted
-registry), and own agglomerative clustering. It does **not** wrap the upstream
+registry), and own agglomerative clustering (optional silhouette confidence,
+ported from upstream `compute_confidence`). It does **not** wrap the upstream
 `SherpaOnnxOfflineSpeakerDiarization` monolith (`_Exit` risk). See
 [internal/speaker-embedding-foundation.md](./internal/speaker-embedding-foundation.md) §10.
 

--- a/docs/future-work/offline-diacritization-kotlin-api-parity.md
+++ b/docs/future-work/offline-diacritization-kotlin-api-parity.md
@@ -1,88 +1,210 @@
-# Upstream: OfflineDiacritization Kotlin API parity
+# Offline Diacritization: Kotlin API parity (+ deferred SDK research)
 
-**Status:** Blocked / waiting on upstream (or our prebuilt packaging fix).  
-**Priority:** Prerequisite for SDK Diacritization — **do not** implement `feat/add-diacritization-feature` until this lands in the Maven `classes.jar` we ship.  
+**Status:** Waiting on upstream Kotlin API (or equivalent packaging). SDK feature work is **deferred**.  
+**Priority:** Prerequisite before any `createOfflineDiacritization` / LiveText work in this SDK.  
 **Research date:** 2026-09-11  
-**Related:** [diacritization-plan.md](../internal/diacritization-plan.md) (SDK feature plan — deferred), [k2-fsa/sherpa-onnx#3669](https://github.com/k2-fsa/sherpa-onnx/pull/3669) (Java bindings only).
+**Upstream:** [k2-fsa/sherpa-onnx#3647](https://github.com/k2-fsa/sherpa-onnx/pull/3647) (C/C++/Python), [k2-fsa/sherpa-onnx#3669](https://github.com/k2-fsa/sherpa-onnx/pull/3669) (Java only).  
+**Matrix:** `docs/internal/sdk-feature-support-matrix.md` — Diacritization offline Yes upstream / SDK No.
 
 ---
 
-## 1. Problem
+## Part A — Upstream Kotlin API (do this first)
 
-sherpa-onnx already has **offline CATT diacritization** end-to-end in native code:
+### A.1 Guiding principle (non-negotiable)
 
-| Layer | Status (as of `v1.13.7` / `v1.13.8` / `master`) |
+When implementing or reviewing the Kotlin bindings:
+
+1. **Primary goal = parity with the existing `java-api`**, not with this RN SDK’s buffer/pipeline shape.
+2. Mirror **`OfflinePunctuation.kt` ↔ `OfflinePunctuation.java`** (and AudioTagging): same types, same JNI entry points, same lifecycle (`newFromFile` / `newFromAsset` / `delete` / `addDiacritics`).
+3. Keep the Kotlin surface **idiomatic and clean** (data classes / builders consistent with the rest of `kotlin-api/`), but **do not** invent RN-specific methods, buffer IDs, segmentation hooks, or LiveText concepts in upstream.
+4. This SDK (and any other consumer) adapts **after** a complete upstream Kotlin API exists — never the other way around.
+
+### A.2 Problem
+
+| Layer | Status (`v1.13.7` / `v1.13.8` / `master`) |
 | --- | --- |
-| C / CXX API | ✅ Present |
-| JNI (`offline-diacritization.cc`) | ✅ Present (`Java_com_k2fsa_sherpa_onnx_OfflineDiacritization_*`) |
-| **`java-api/`** | ✅ `OfflineDiacritization.java` + Config / ModelConfig |
-| **`kotlin-api/`** | ❌ **No** `OfflineDiacritization.kt` (and no diacrit mentions) |
+| C / CXX API | ✅ |
+| JNI (`offline-diacritization.cc`) | ✅ `Java_com_k2fsa_sherpa_onnx_OfflineDiacritization_*` |
+| **`java-api/`** | ✅ since **`v1.13.3`** — `OfflineDiacritization` + Config / ModelConfig |
+| **`kotlin-api/`** | ❌ no `OfflineDiacritization.kt` (no diacrit mentions at all) |
 
-Our Android Maven AAR (`com.xdcobra.sherpa:sherpa-onnx`) packages **`kotlin-api` → `classes.jar` by default**. Verified on published **`1.13.7-1`**:
+Our Maven AAR (`com.xdcobra.sherpa:sherpa-onnx:**1.13.7-1**`, verified 2026-09-02 publish — not a stale extract) builds **`kotlin-api` → `classes.jar` by default**:
 
-- JNI `.so` **includes** OfflineDiacritization symbols  
-- AAR `c-api/*.h` **includes** the C API  
-- `classes.jar` has **0** `OfflineDiacritization*.class` (while Punctuation / AudioTagging **are** present)
+| AAR layer | OfflineDiacritization? |
+| --- | --- |
+| `jni/*/libsherpa-onnx-jni.so` | ✅ |
+| `c-api/c-api.h` / `cxx-api.h` | ✅ |
+| `classes.jar` | ❌ **0** classes (Punctuation / AudioTagging **are** present) |
 
-So the gap is **not** “wrong sherpa version” and **not** a stale local extract — it is **API surface asymmetry**: Java got bindings in [#3669](https://github.com/k2-fsa/sherpa-onnx/pull/3669); Kotlin never did. Contrast Punctuation / AudioTagging, which exist in **both** `java-api` and `kotlin-api`.
+Gap = **java vs kotlin API asymmetry**, not “missing sherpa version”. Bumping to `v1.13.8` alone does **not** fix it.
 
----
+Java reference surface (example `java-api-examples/OfflineAddDiacritics.java`):
 
-## 2. Goal
-
-Ship Kotlin wrappers that match the existing Java/JNI contract so our default AAR `classes.jar` exposes:
-
-```text
-OfflineDiacritization
-OfflineDiacritizationConfig
-OfflineDiacritizationModelConfig
-→ addDiacritics(text: String): String
+```java
+OfflineDiacritizationModelConfig modelConfig =
+  OfflineDiacritizationModelConfig.builder()
+    .setCattEncoder("./catt_eo_model_onnx/encoder.onnx")
+    .setCattDecoder("./catt_eo_model_onnx/decoder.onnx")
+    .setNumThreads(1)
+    .setDebug(true)
+    .build();
+OfflineDiacritizationConfig config =
+  OfflineDiacritizationConfig.builder().setModel(modelConfig).build();
+OfflineDiacritization diacrt = new OfflineDiacritization(config);
+String out = diacrt.addDiacritics(text);
 ```
 
-…with the same init fields as Java (`cattEncoder`, `cattDecoder`, `numThreads`, `provider`, `debug`), following the style of `OfflinePunctuation.kt`.
+C-API (iOS / non-Kotlin): Create → `SherpaOfflineDiacritizationAddDiacritics` → FreeText → Destroy (already in our xcframework).
 
-After that, republish the Maven AAR (e.g. `1.13.7-2` or next pin) and only then resume the SDK feature plan.
+### A.3 Goal (upstream only)
 
----
+Add under `sherpa-onnx/kotlin-api/`:
 
-## 3. Preferred path (upstream)
+```text
+OfflineDiacritization.kt
+OfflineDiacritizationConfig.kt   // or nested in same file — match kotlin-api conventions
+OfflineDiacritizationModelConfig.kt
+```
 
-1. Open / land a **k2-fsa/sherpa-onnx** PR adding Kotlin API files under `sherpa-onnx/kotlin-api/`, mirroring `java-api` + JNI method names (same pattern as `OfflinePunctuation.kt` ↔ `OfflinePunctuation.java`).
-2. Bump `third_party/sherpa-onnx` and rebuild via `third_party/sherpa-onnx-prebuilt` → publish `com.xdcobra.sherpa:sherpa-onnx`.
-3. Confirm `jar tf …/classes.jar | grep OfflineDiacritization` is non-empty; smoke `addDiacritics` on device.
+Expose the **same contract** as Java/JNI:
 
-**Acceptance:**
+- `cattEncoder` / `cattDecoder` / `numThreads` / `provider` / `debug`
+- `addDiacritics(text: String): String`
+- `release()` / finalizer pattern consistent with siblings
 
-- [ ] `OfflineDiacritization.kt` (+ config types) on upstream `master` (or our fork until merged)
-- [ ] Published Maven AAR `classes.jar` contains the new classes
-- [ ] JNI symbols still resolve (no packaging regression)
-- [ ] Short Android smoke (Java example parity: undiacritized Arabic → diacritized string)
+Then rebuild + publish Maven so `classes.jar` contains the new classes.
 
----
+### A.4 Preferred path
 
-## 4. Fallback paths (only if upstream is slow)
+1. **Upstream PR** to k2-fsa (or temporary fork): Kotlin files = faithful port of Java + JNI names; style peer-reviewed against `OfflinePunctuation.kt`.
+2. Bump `third_party/sherpa-onnx`, rebuild via `third_party/sherpa-onnx-prebuilt`, publish `com.xdcobra.sherpa:sherpa-onnx`.
+3. Verify `jar tf …/classes.jar | grep OfflineDiacritization`; device smoke with Arabic sample strings (parity with Java example).
+
+**Acceptance (Part A):**
+
+- [ ] Kotlin types on upstream `master` (or fork) with **java-api behavioral parity**
+- [ ] No RN/SDK concepts in upstream Kotlin API
+- [ ] Published Maven `classes.jar` includes the classes; JNI still resolves
+- [ ] Android smoke: undiacritized Arabic → diacritized string
+
+### A.5 Fallbacks (packaging only — still not SDK-shaped)
 
 | Option | Notes |
 | --- | --- |
-| **A. Patch kotlin-api in our build tree** | Add the `.kt` files under `third_party/sherpa-onnx` (or prebuilt overlay) before `kotlin-api-build` jar; publish Maven. Prefer contributing upstream afterward. |
-| **B. Ship `java-api` classes into AAR** | `build_sherpa_onnx.sh --java` / `--both` + package Java OfflineDiacritization into the jar we consume. Works, but diverges from “Kotlin API is the AAR default” for one feature. |
-| **C. Hand-written thin Kotlin JNI wrappers in the RN module** | Last resort — duplicates upstream surface; avoid unless packaging is blocked. |
+| **A. Patch kotlin-api in our build tree** | Add `.kt` files before `kotlin-api-build`; still write them as **java-parity** wrappers; contribute upstream after |
+| **B. Ship `java-api` classes into AAR** | `--java` / `--both`; usable but diverges from “Kotlin is default `classes.jar`” |
+| **C. Thin JNI wrappers inside the RN module** | Last resort; duplicates upstream; avoid |
 
-Do **not** reimplement CATT via raw ORT in the RN SDK.
+Do **not** reimplement CATT via raw ORT.
 
----
+### A.6 Non-goals for Part A
 
-## 5. Explicit non-goals (this note)
-
-- Implementing SDK `createOfflineDiacritization` / LiveText overload (see deferred [diacritization-plan.md](../internal/diacritization-plan.md))
-- Collect / license / detect / example screen
-- CATT ED (encoder–decoder) packs
-- Inventing `OnlineDiacritization`
+- RN `createOfflineDiacritization`, detect/collect, LiveText overload, example screen  
+- Changing JNI / C-API contracts for SDK convenience  
+- CATT ED packs / inventing `OnlineDiacritization`
 
 ---
 
-## 6. Unblock checklist for Diacritization feature work
+## Part B — Deferred SDK feature research (archive)
 
-1. Kotlin (or packaged Java) OfflineDiacritization visible in Maven `classes.jar` we pin  
-2. iOS C-API already OK on current xcframework — no change required for this note  
-3. Resume [diacritization-plan.md](../internal/diacritization-plan.md) Phase 1+
+> **Do not start Part B until Part A acceptance is green.**  
+> Research below was drafted 2026-09-11 as an internal plan; kept here so we do not re-discover upstream behaviour, models, and pipeline shape.
+
+### B.1 What diacritization is
+
+Arabic *tashkeel*: restore short-vowel / diacritic marks on undiacritized text via CATT EO (`addDiacritics(plain) → diacritized`). Typical chain: **STT (ar) → diacritization → TTS (ar)** (upstream PR motivation: better TTS with diacritics).
+
+| Question | Answer |
+| --- | --- |
+| Offline upstream? | **Yes** — `OfflineDiacritization*` |
+| Online / streaming? | **No** — no `OnlineDiacritization` |
+| Core op | Batch string in → string out |
+| SDK template | **Offline punctuation** (text→text + optional live overload) — **not** KWS |
+
+### B.2 Models / licenses / collect
+
+- Weights today: [abjadai/catt `v2` `eo_model_onnx.zip`](https://github.com/abjadai/catt/releases/download/v2/eo_model_onnx.zip) → `encoder.onnx` + `decoder.onnx`  
+- Config paths: `catt_encoder` / `catt_decoder`  
+- License: **Apache-2.0** (was CC-BY-NC; verify NOTICE in CSV)  
+- **No** `diacritization-models` tag on k2-fsa as of research → prefer later k2-fsa/Maven mirror tag; interim collect from `abjadai/catt`  
+- ED zip exists but **not** wired in sherpa EO API — out of MVP  
+- Do **not** piggyback punctuation/ASR license CSVs
+
+### B.3 Runtime semantics
+
+1. Load EO ONNX pair → construct engine → `addDiacritics` → release  
+2. Arabic-only; no tokens/timestamps from core API  
+3. Long text → segment (like offline punctuation), not one unbounded string  
+
+### B.4 Intended SDK shape (after Part A)
+
+| Mode | I/O |
+| --- | --- |
+| Offline oneshot | OfflineText → OfflineText (+ optional `diacritizeString`) |
+| Offline segmented | Long OfflineText + segmentation (punctuation parity) |
+| Live overload | LiveText → LiveText (offline weights per commit — punctuation live overload pattern) |
+
+- Factory: `createOfflineDiacritization` — **no** `createStreamingDiacritization` in MVP  
+- Module sketch: `src/diacritization/` (`offline.ts`, `detect.ts`, `live.ts`, …)  
+- Import: `react-native-sherpa-onnx/diacritization`  
+- Docs later: `diacritization-offline.md` + `diacritization-live.md`  
+- Analog: API/orchestration → offline punctuation; collect → dedicated stream like AT/punctuation  
+- iOS: C-API already in xcframework; Android: Kotlin class from Part A  
+
+```mermaid
+flowchart TB
+  subgraph TS ["TS src/diacritization/"]
+    CLI["createOfflineDiacritization"]
+    API["OfflineDiacritizationEngine"]
+  end
+  subgraph MODES ["Modes"]
+    M1["OfflineText → OfflineText"]
+    M2["Segmented offline"]
+    M3["LiveText overload"]
+  end
+  subgraph CORE ["sherpa-onnx"]
+    OD["OfflineDiacritization.addDiacritics"]
+    PACK["CATT EO ONNX pair"]
+  end
+  CLI --> API --> M1 & M2 & M3 --> OD --> PACK
+```
+
+### B.5 Phased SDK delivery (reminder)
+
+| Phase | Focus |
+| --- | --- |
+| **0** | Part A complete + Maven pin with Kotlin classes |
+| **1** | Category, detect, collect, licenses |
+| **2** | Native bridges + offline oneshot |
+| **3** | Offline segmentation |
+| **4** | Live overload |
+| **5** | Example showcase |
+| **6** | Public docs + download catalog |
+
+**SDK non-goals:** fake streaming factory; custom ORT; non-Arabic; KWS-style audio pipeline.
+
+### B.6 Open questions (when resuming SDK work)
+
+1. Collect host: k2-fsa `diacritization-models` vs interim `abjadai/catt`  
+2. Offline text segmentation: reuse punctuation helpers vs minimal split  
+3. Example fixtures (Arabic strings / optional STT wav)  
+4. Public method name `diacritize` vs native `addDiacritics` (map 1:1 under the hood)
+
+### B.7 Anchors
+
+| Area | Follow |
+| --- | --- |
+| Kotlin sibling | `third_party/sherpa-onnx/.../kotlin-api/OfflinePunctuation.kt` |
+| Java source of truth | `.../java-api/.../OfflineDiacritization*.java` |
+| Offline text SDK | `src/punctuation/offline.ts`, `docs/punctuation-offline.md` |
+| Live overload | `docs/migration/liveOverload/sub-04-punctuation-live-overload.md` |
+| Model zip | `https://github.com/abjadai/catt/releases/download/v2/eo_model_onnx.zip` |
+
+---
+
+## Unblock checklist
+
+1. Part A acceptance (Kotlin = **java-api parity**, clean upstream API)  
+2. Maven pin with classes in `classes.jar`  
+3. iOS C-API already OK  
+4. Only then start Part B phases 1+

--- a/docs/future-work/offline-diacritization-kotlin-api-parity.md
+++ b/docs/future-work/offline-diacritization-kotlin-api-parity.md
@@ -1,0 +1,88 @@
+# Upstream: OfflineDiacritization Kotlin API parity
+
+**Status:** Blocked / waiting on upstream (or our prebuilt packaging fix).  
+**Priority:** Prerequisite for SDK Diacritization — **do not** implement `feat/add-diacritization-feature` until this lands in the Maven `classes.jar` we ship.  
+**Research date:** 2026-09-11  
+**Related:** [diacritization-plan.md](../internal/diacritization-plan.md) (SDK feature plan — deferred), [k2-fsa/sherpa-onnx#3669](https://github.com/k2-fsa/sherpa-onnx/pull/3669) (Java bindings only).
+
+---
+
+## 1. Problem
+
+sherpa-onnx already has **offline CATT diacritization** end-to-end in native code:
+
+| Layer | Status (as of `v1.13.7` / `v1.13.8` / `master`) |
+| --- | --- |
+| C / CXX API | ✅ Present |
+| JNI (`offline-diacritization.cc`) | ✅ Present (`Java_com_k2fsa_sherpa_onnx_OfflineDiacritization_*`) |
+| **`java-api/`** | ✅ `OfflineDiacritization.java` + Config / ModelConfig |
+| **`kotlin-api/`** | ❌ **No** `OfflineDiacritization.kt` (and no diacrit mentions) |
+
+Our Android Maven AAR (`com.xdcobra.sherpa:sherpa-onnx`) packages **`kotlin-api` → `classes.jar` by default**. Verified on published **`1.13.7-1`**:
+
+- JNI `.so` **includes** OfflineDiacritization symbols  
+- AAR `c-api/*.h` **includes** the C API  
+- `classes.jar` has **0** `OfflineDiacritization*.class` (while Punctuation / AudioTagging **are** present)
+
+So the gap is **not** “wrong sherpa version” and **not** a stale local extract — it is **API surface asymmetry**: Java got bindings in [#3669](https://github.com/k2-fsa/sherpa-onnx/pull/3669); Kotlin never did. Contrast Punctuation / AudioTagging, which exist in **both** `java-api` and `kotlin-api`.
+
+---
+
+## 2. Goal
+
+Ship Kotlin wrappers that match the existing Java/JNI contract so our default AAR `classes.jar` exposes:
+
+```text
+OfflineDiacritization
+OfflineDiacritizationConfig
+OfflineDiacritizationModelConfig
+→ addDiacritics(text: String): String
+```
+
+…with the same init fields as Java (`cattEncoder`, `cattDecoder`, `numThreads`, `provider`, `debug`), following the style of `OfflinePunctuation.kt`.
+
+After that, republish the Maven AAR (e.g. `1.13.7-2` or next pin) and only then resume the SDK feature plan.
+
+---
+
+## 3. Preferred path (upstream)
+
+1. Open / land a **k2-fsa/sherpa-onnx** PR adding Kotlin API files under `sherpa-onnx/kotlin-api/`, mirroring `java-api` + JNI method names (same pattern as `OfflinePunctuation.kt` ↔ `OfflinePunctuation.java`).
+2. Bump `third_party/sherpa-onnx` and rebuild via `third_party/sherpa-onnx-prebuilt` → publish `com.xdcobra.sherpa:sherpa-onnx`.
+3. Confirm `jar tf …/classes.jar | grep OfflineDiacritization` is non-empty; smoke `addDiacritics` on device.
+
+**Acceptance:**
+
+- [ ] `OfflineDiacritization.kt` (+ config types) on upstream `master` (or our fork until merged)
+- [ ] Published Maven AAR `classes.jar` contains the new classes
+- [ ] JNI symbols still resolve (no packaging regression)
+- [ ] Short Android smoke (Java example parity: undiacritized Arabic → diacritized string)
+
+---
+
+## 4. Fallback paths (only if upstream is slow)
+
+| Option | Notes |
+| --- | --- |
+| **A. Patch kotlin-api in our build tree** | Add the `.kt` files under `third_party/sherpa-onnx` (or prebuilt overlay) before `kotlin-api-build` jar; publish Maven. Prefer contributing upstream afterward. |
+| **B. Ship `java-api` classes into AAR** | `build_sherpa_onnx.sh --java` / `--both` + package Java OfflineDiacritization into the jar we consume. Works, but diverges from “Kotlin API is the AAR default” for one feature. |
+| **C. Hand-written thin Kotlin JNI wrappers in the RN module** | Last resort — duplicates upstream surface; avoid unless packaging is blocked. |
+
+Do **not** reimplement CATT via raw ORT in the RN SDK.
+
+---
+
+## 5. Explicit non-goals (this note)
+
+- Implementing SDK `createOfflineDiacritization` / LiveText overload (see deferred [diacritization-plan.md](../internal/diacritization-plan.md))
+- Collect / license / detect / example screen
+- CATT ED (encoder–decoder) packs
+- Inventing `OnlineDiacritization`
+
+---
+
+## 6. Unblock checklist for Diacritization feature work
+
+1. Kotlin (or packaged Java) OfflineDiacritization visible in Maven `classes.jar` we pin  
+2. iOS C-API already OK on current xcframework — no change required for this note  
+3. Resume [diacritization-plan.md](../internal/diacritization-plan.md) Phase 1+

--- a/docs/internal/speaker-embedding-foundation.md
+++ b/docs/internal/speaker-embedding-foundation.md
@@ -375,9 +375,11 @@ own types:
 
 - Segmentation: `model` path, `window_shift_ratio` (default `0.1`), threads/provider
 - Embedding: separate `model` path (tarballs contain **no** embedding ONNX)
-- Clustering: `num_clusters` (`>0` → threshold ignored) / `threshold`
+- Clustering: `num_clusters` (`>0` → threshold ignored) / `threshold` /
+  `compute_confidence` (default **false**; when true, per-segment silhouette
+  confidence in `[-1, 1]`, or unavailable sentinel when not computable)
 - `min_duration_on` / `min_duration_off`
-- Segment: `{ start, end, speaker }` in seconds (speaker = cluster id)
+- Segment: `{ start, end, speaker[, confidence] }` in seconds (speaker = cluster id)
 
 ONNX metadata keys (must all be present): `sample_rate`, `window_size`,
 `receptive_field_size`, `receptive_field_shift`, `num_speakers`,

--- a/example/src/screens/diarization/DiarizationScreen.styles.ts
+++ b/example/src/screens/diarization/DiarizationScreen.styles.ts
@@ -446,6 +446,19 @@ export const styles = StyleSheet.create({
     color: '#374151',
     fontFamily: 'monospace',
   },
+  timelineConfidenceBadge: {
+    backgroundColor: '#DBEAFE',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    marginLeft: 4,
+  },
+  timelineConfidenceText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#1D4ED8',
+    fontFamily: 'monospace',
+  },
   // Diagnostics
   statusBox: {
     backgroundColor: '#1E293B',

--- a/example/src/screens/diarization/DiarizationScreen.tsx
+++ b/example/src/screens/diarization/DiarizationScreen.tsx
@@ -4,6 +4,7 @@ import {
   Alert,
   Animated,
   ScrollView,
+  Switch,
   Text,
   TextInput,
   TouchableOpacity,
@@ -66,6 +67,8 @@ export type SpeakerTurn = {
   durationSec: number;
   startSample: number;
   endSample: number;
+  /** Silhouette confidence in [-1, 1] when computeConfidence is on. */
+  confidence?: number;
 };
 
 type EventLogItem = {
@@ -80,6 +83,7 @@ type EngineInfo = {
   embId: string;
   numClusters: number;
   threshold: number;
+  computeConfidence: boolean;
   numThreads: number;
   windowShiftRatio: number;
   minDurationOn: number;
@@ -142,6 +146,8 @@ export default function DiarizationScreen() {
   const [tuningExpanded, setTuningExpanded] = useState(false);
   const [clusteringThreshold, setClusteringThreshold] = useState(0.5);
   const [numClusters, setNumClusters] = useState(4); // default 4 for initial 4-speaker sample audio
+  /** Opt-in silhouette confidence; default false matches SDK / upstream. */
+  const [computeConfidence, setComputeConfidence] = useState(false);
   const [minDurationOn, setMinDurationOn] = useState(0.3); // 0.3s filters spurious frame-glitches for clean turns
   const [minDurationOff, setMinDurationOff] = useState(0.5); // 0.5s merges conversational pauses
   const [windowShiftRatio, setWindowShiftRatio] = useState(0.25); // 0.25 (75% overlap) provides fast execution on mobile CPU
@@ -333,6 +339,7 @@ export default function DiarizationScreen() {
         clustering: {
           numClusters: numClusters > 0 ? numClusters : undefined,
           threshold: clusteringThreshold,
+          computeConfidence,
         },
         minDurationOn,
         minDurationOff,
@@ -346,12 +353,15 @@ export default function DiarizationScreen() {
         embId: embLabel,
         numClusters,
         threshold: clusteringThreshold,
+        computeConfidence,
         numThreads,
         windowShiftRatio,
         minDurationOn,
         minDurationOff,
       });
-      appendEvent('Diarization engine initialized successfully');
+      appendEvent(
+        `Diarization engine initialized successfully (computeConfidence=${computeConfidence})`
+      );
       return engine;
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -364,6 +374,7 @@ export default function DiarizationScreen() {
   }, [
     appendEvent,
     clusteringThreshold,
+    computeConfidence,
     customEmbSource,
     customSegSource,
     embCatalog,
@@ -416,6 +427,7 @@ export default function DiarizationScreen() {
         engineInfo.numClusters !== numClusters ||
         engineInfo.numThreads !== numThreads ||
         engineInfo.threshold !== clusteringThreshold ||
+        engineInfo.computeConfidence !== computeConfidence ||
         engineInfo.windowShiftRatio !== windowShiftRatio ||
         engineInfo.minDurationOn !== minDurationOn ||
         engineInfo.minDurationOff !== minDurationOff;
@@ -478,13 +490,22 @@ export default function DiarizationScreen() {
           durationSec: endSec - startSec,
           startSample: seg.startSample,
           endSample: seg.endSample,
+          ...(typeof seg.confidence === 'number'
+            ? { confidence: seg.confidence }
+            : {}),
         };
       });
 
       setTurns(newTurns);
       setHasDiarizedOnce(true);
+      const withConf = newTurns.filter(
+        (t) => typeof t.confidence === 'number'
+      ).length;
       appendEvent(
-        `Diarization complete in ${durMs}ms: ${res.numSpeakers} speakers, ${res.segmentCount} segments`
+        `Diarization complete in ${durMs}ms: ${res.numSpeakers} speakers, ${res.segmentCount} segments` +
+          (computeConfidence
+            ? ` (confidence on ${withConf}/${newTurns.length})`
+            : '')
       );
     } catch (e) {
       if (abortCtrl.signal.aborted) {
@@ -507,6 +528,7 @@ export default function DiarizationScreen() {
   }, [
     appendEvent,
     clusteringThreshold,
+    computeConfidence,
     diarizeBusy,
     engineInfo,
     initEngine,
@@ -537,11 +559,12 @@ export default function DiarizationScreen() {
       appendEvent(
         `Reclustering (threshold=${clusteringThreshold.toFixed(
           2
-        )}, numClusters=${numClusters})...`
+        )}, numClusters=${numClusters}, computeConfidence=${computeConfidence})...`
       );
       const res = await engineRef.current.recluster({
         numClusters: numClusters > 0 ? numClusters : undefined,
         threshold: clusteringThreshold,
+        computeConfidence,
       });
       const durMs = Date.now() - startedAt;
       setProcessingTimeMs(durMs);
@@ -556,6 +579,9 @@ export default function DiarizationScreen() {
           durationSec: s.end - s.start,
           startSample: Math.round(s.start * sampleRate),
           endSample: Math.round(s.end * sampleRate),
+          ...(typeof s.confidence === 'number'
+            ? { confidence: s.confidence }
+            : {}),
         }));
         setTurns(updatedTurns);
         setEngineInfo((prev) =>
@@ -564,11 +590,18 @@ export default function DiarizationScreen() {
                 ...prev,
                 numClusters,
                 threshold: clusteringThreshold,
+                computeConfidence,
               }
             : prev
         );
+        const withConf = updatedTurns.filter(
+          (t) => typeof t.confidence === 'number'
+        ).length;
         appendEvent(
-          `Recluster complete in ${durMs}ms: ${res.numSpeakers} speakers, ${res.segmentCount} segments`
+          `Recluster complete in ${durMs}ms: ${res.numSpeakers} speakers, ${res.segmentCount} segments` +
+            (computeConfidence
+              ? ` (confidence on ${withConf}/${updatedTurns.length})`
+              : '')
         );
       } else {
         appendEvent(
@@ -585,6 +618,7 @@ export default function DiarizationScreen() {
   }, [
     appendEvent,
     clusteringThreshold,
+    computeConfidence,
     diarizeBusy,
     numClusters,
     reclusterBusy,
@@ -652,9 +686,13 @@ export default function DiarizationScreen() {
     const text = turns
       .map((t) => {
         const alias = speakerAliases[t.speaker] ?? `Speaker ${t.speaker}`;
+        const conf =
+          typeof t.confidence === 'number'
+            ? ` conf=${t.confidence.toFixed(3)}`
+            : '';
         return `[${formatTime(t.startSec)} → ${formatTime(
           t.endSec
-        )}] ${alias} (+${formatDuration(t.durationSec)})`;
+        )}] ${alias} (+${formatDuration(t.durationSec)})${conf}`;
       })
       .join('\n');
     Clipboard.setString(text);
@@ -871,6 +909,25 @@ export default function DiarizationScreen() {
                 </View>
               </View>
 
+              {/* Per-segment silhouette confidence (opt-in) */}
+              <View style={styles.paramRow}>
+                <View style={styles.flex1}>
+                  <Text style={styles.paramLabel}>
+                    Compute segment confidence
+                  </Text>
+                  <Text style={styles.cardSubtitle}>
+                    Silhouette score per turn [-1, 1]. Default off (SDK parity).
+                    Re-run diarize after toggling.
+                  </Text>
+                </View>
+                <Switch
+                  value={computeConfidence}
+                  onValueChange={setComputeConfidence}
+                  disabled={diarizeBusy || reclusterBusy}
+                  accessibilityLabel="Compute segment confidence"
+                />
+              </View>
+
               {/* Min Duration On */}
               <View style={styles.paramRow}>
                 <Text style={styles.paramLabel}>Min Speech Turn Duration</Text>
@@ -1064,6 +1121,12 @@ export default function DiarizationScreen() {
                   {engineInfo.numClusters > 0
                     ? `${engineInfo.numClusters} clusters (fixed)`
                     : `Threshold ${engineInfo.threshold.toFixed(2)}`}
+                </Text>
+              </View>
+              <View style={styles.metaBadge}>
+                <Text style={styles.metaBadgeLabel}>Confidence</Text>
+                <Text style={styles.metaBadgeValue}>
+                  {engineInfo.computeConfidence ? 'On' : 'Off'}
                 </Text>
               </View>
             </View>
@@ -1445,6 +1508,13 @@ export default function DiarizationScreen() {
                         +{formatDuration(turn.durationSec)}
                       </Text>
                     </View>
+                    {typeof turn.confidence === 'number' ? (
+                      <View style={styles.timelineConfidenceBadge}>
+                        <Text style={styles.timelineConfidenceText}>
+                          {turn.confidence.toFixed(2)}
+                        </Text>
+                      </View>
+                    ) : null}
                   </View>
                 );
               })}
@@ -1455,7 +1525,7 @@ export default function DiarizationScreen() {
                 {turns.length === 0
                   ? 'No speaker turns available. Run diarization to analyze the audio.'
                   : 'No turns match the selected speaker filter.'}
-        </Text>
+              </Text>
             </View>
           )}
         </View>
@@ -1562,7 +1632,7 @@ export default function DiarizationScreen() {
               </ScrollView>
             </View>
           )}
-      </View>
+        </View>
       </ScrollView>
     </SafeAreaView>
   );

--- a/ios/diarization/bridge/SherpaOnnx+DiarizationOffline.mm
+++ b/ios/diarization/bridge/SherpaOnnx+DiarizationOffline.mm
@@ -44,11 +44,15 @@ int32_t OptInt32(std::optional<double> value, int32_t fallback) {
 NSDictionary *ProcessResultToDict(const sherpaonnx::DiarizationProcessResult &result) {
   NSMutableArray *segments = [NSMutableArray arrayWithCapacity:result.segments.size()];
   for (const auto &seg : result.segments) {
-    [segments addObject:@{
+    NSMutableDictionary *segDict = [@{
       @"start": @(seg.start),
       @"end": @(seg.end),
       @"speaker": @(seg.speaker),
-    }];
+    } mutableCopy];
+    if (seg.confidence > -1.5f) {
+      segDict[@"confidence"] = @(seg.confidence);
+    }
+    [segments addObject:segDict];
   }
 
   NSMutableDictionary *out = [@{
@@ -138,6 +142,11 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
   const float windowShiftRatio = OptFloat(options.windowShiftRatio(), 0.1f);
   const int32_t numClusters = OptInt32(options.numClusters(), -1);
   const float threshold = OptFloat(options.threshold(), 0.5f);
+  bool computeConfidence = false;
+  auto computeConfidenceOpt = options.computeConfidence();
+  if (computeConfidenceOpt.has_value()) {
+    computeConfidence = computeConfidenceOpt.value();
+  }
   const float minDurationOn = OptFloat(options.minDurationOn(), 0.3f);
   const float minDurationOff = OptFloat(options.minDurationOff(), 0.5f);
   const int32_t numThreads = std::max(1, OptInt32(options.numThreads(), 1));
@@ -160,6 +169,7 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
           windowShiftRatio,
           numClusters,
           threshold,
+          computeConfidence,
           minDurationOn,
           minDurationOff,
           numThreads,
@@ -322,7 +332,12 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
         r.endSample = endSample;
         r.sampleRate = sampleRate;
         r.durationMs = durationMs;
-        r.hasConfidence = false;
+        if (seg.confidence > -1.5f) {
+          r.hasConfidence = true;
+          r.confidence = seg.confidence;
+        } else {
+          r.hasConfidence = false;
+        }
         r.payloadJson =
             std::string("{\"source\":\"diarization\",\"speaker\":") +
             std::to_string(seg.speaker) + "}";
@@ -360,6 +375,7 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
 - (void)reclusterDiarization:(NSString *)instanceId
                  numClusters:(double)numClusters
                    threshold:(double)threshold
+           computeConfidence:(BOOL)computeConfidence
                      resolve:(RCTPromiseResolveBlock)resolve
                       reject:(RCTPromiseRejectBlock)reject
 {
@@ -381,7 +397,8 @@ NSString *RejectCodeForProcess(const sherpaonnx::DiarizationProcessResult &resul
       }
       sherpaonnx::DiarizationProcessResult result =
           wrapper->recluster(static_cast<int32_t>(numClusters),
-                             static_cast<float>(threshold));
+                             static_cast<float>(threshold),
+                             computeConfidence ? true : false);
       if (!result.success) {
         reject(RejectCodeForProcess(result),
                result.error.empty()

--- a/src/NativeSherpaOnnx.ts
+++ b/src/NativeSherpaOnnx.ts
@@ -150,6 +150,8 @@ export type DiarizationInitBridgeOptions = {
   windowShiftRatio?: number;
   numClusters?: number;
   threshold?: number;
+  /** Default false — upstream FastClusteringConfig.compute_confidence parity. */
+  computeConfidence?: boolean;
   minDurationOn?: number;
   minDurationOff?: number;
   numThreads?: number;
@@ -254,7 +256,13 @@ export type DiarizationProcessNativeResult = {
    * Product `diarizeOffline` writes `segmentsOut` natively and may omit this
    * (prefer `segmentCount`).
    */
-  segments?: Array<{ start: number; end: number; speaker: number }>;
+  segments?: Array<{
+    start: number;
+    end: number;
+    speaker: number;
+    /** Present when clustering.computeConfidence was enabled. Range [-1, 1]. */
+    confidence?: number;
+  }>;
   /** Number of segments written to `segmentsOut` (product `diarizeOffline`). */
   segmentCount?: number;
   numSpeakers: number;
@@ -1908,7 +1916,8 @@ export interface Spec extends TurboModule {
   reclusterDiarization(
     instanceId: string,
     numClusters: number,
-    threshold: number
+    threshold: number,
+    computeConfidence: boolean
   ): Promise<DiarizationProcessNativeResult>;
 
   getDiarizationClusterEmbeddings(

--- a/src/diarization/diarizationNativeBridge.ts
+++ b/src/diarization/diarizationNativeBridge.ts
@@ -62,6 +62,9 @@ export async function buildDiarizationInitBridgeOptions(
     ...(options.clustering?.threshold !== undefined
       ? { threshold: options.clustering.threshold }
       : {}),
+    ...(options.clustering?.computeConfidence !== undefined
+      ? { computeConfidence: options.clustering.computeConfidence }
+      : {}),
     ...(options.minDurationOn !== undefined
       ? { minDurationOn: options.minDurationOn }
       : {}),

--- a/src/diarization/index.ts
+++ b/src/diarization/index.ts
@@ -218,6 +218,8 @@ export async function createDiarization(
       : 0;
 
   let destroyed = false;
+  /** Effective clustering confidence flag (init default false; recluster may override). */
+  let computeConfidence = options.clustering?.computeConfidence === true;
   const guard = () => {
     if (destroyed) {
       throw new Error(
@@ -307,10 +309,14 @@ export async function createDiarization(
         typeof reclusterOptions?.threshold === 'number'
           ? reclusterOptions.threshold
           : 0.5;
+      if (typeof reclusterOptions?.computeConfidence === 'boolean') {
+        computeConfidence = reclusterOptions.computeConfidence;
+      }
       const nativeResult = await SherpaOnnx.reclusterDiarization(
         instanceId,
         numClusters,
-        threshold
+        threshold,
+        computeConfidence
       );
       if (!nativeResult.success) {
         throw new Error(

--- a/src/diarization/types.ts
+++ b/src/diarization/types.ts
@@ -55,6 +55,11 @@ export interface DiarizationClusteringOptions {
   numClusters?: number;
   /** Cosine-dissimilarity threshold when numClusters is unset/≤0. Default 0.5 */
   threshold?: number;
+  /**
+   * When true, each segment includes silhouette-based `confidence` in [-1, 1].
+   * Default **false** (upstream `compute_confidence` parity).
+   */
+  computeConfidence?: boolean;
 }
 
 export interface DiarizationInitializeOptions {
@@ -81,12 +86,20 @@ export interface DiarizeResult {
   sampleRate: number;
   processingTimeMs: number;
   speakersPerFrame?: number[];
-  segments?: Array<{ start: number; end: number; speaker: number }>;
+  segments?: Array<{
+    start: number;
+    end: number;
+    speaker: number;
+    /** Present when `clustering.computeConfidence` was enabled. Range [-1, 1]. */
+    confidence?: number;
+  }>;
 }
 
 export interface DiarizationReclusterOptions {
   numClusters?: number;
   threshold?: number;
+  /** Override session confidence flag for this recluster. Default: keep prior. */
+  computeConfidence?: boolean;
 }
 
 export interface DiarizationClusterEmbedding {

--- a/test/cpp/diarization/diarization_core_test.cpp
+++ b/test/cpp/diarization/diarization_core_test.cpp
@@ -96,6 +96,38 @@ TEST(DiarizationClustering, CutreeKForcesClusterCount) {
   EXPECT_EQ(max_label, 1);
 }
 
+TEST(DiarizationClustering, SilhouetteWhenComputeConfidence) {
+  ClusteringConfig cfg;
+  cfg.num_clusters = 2;
+  cfg.threshold = 0.5f;
+  cfg.compute_confidence = true;
+  AgglomerativeClusterer clusterer(cfg);
+  // Two tight pairs in orthogonal directions.
+  float features[] = {
+      1.f, 0.f, 0.95f, 0.05f, 0.f, 1.f, 0.05f, 0.95f,
+  };
+  std::vector<float> silhouettes;
+  auto labels = clusterer.Cluster(features, 4, 2, &silhouettes);
+  ASSERT_EQ(labels.size(), 4u);
+  ASSERT_EQ(silhouettes.size(), 4u);
+  for (float s : silhouettes) {
+    EXPECT_GE(s, -1.0f);
+    EXPECT_LE(s, 1.0f);
+  }
+}
+
+TEST(DiarizationClustering, NoSilhouetteWhenComputeConfidenceOff) {
+  ClusteringConfig cfg;
+  cfg.num_clusters = 2;
+  cfg.compute_confidence = false;
+  AgglomerativeClusterer clusterer(cfg);
+  float features[] = {1.f, 0.f, -1.f, 0.f};
+  std::vector<float> silhouettes;
+  auto labels = clusterer.Cluster(features, 2, 2, &silhouettes);
+  ASSERT_EQ(labels.size(), 2u);
+  EXPECT_TRUE(silhouettes.empty());
+}
+
 TEST(DiarizationTimeline, ExcludeOverlapZerosMultiSpeakerFrames) {
   Int8Matrix m;
   m.resize(2, 2, 0);

--- a/third_party/sherpa-onnx-prebuilt/ANDROID_RELEASE_TAG
+++ b/third_party/sherpa-onnx-prebuilt/ANDROID_RELEASE_TAG
@@ -1,1 +1,1 @@
-sherpa-onnx-android-v1.13.7-1
+sherpa-onnx-android-v1.13.8-1

--- a/third_party/sherpa-onnx-prebuilt/IOS_RELEASE_TAG
+++ b/third_party/sherpa-onnx-prebuilt/IOS_RELEASE_TAG
@@ -1,1 +1,1 @@
-sherpa-onnx-ios-v1.13.7-1
+sherpa-onnx-ios-v1.13.8-1

--- a/third_party/sherpa-onnx-prebuilt/build_sherpa_onnx_ios.sh
+++ b/third_party/sherpa-onnx-prebuilt/build_sherpa_onnx_ios.sh
@@ -6,10 +6,10 @@
 # and outputs sherpa_onnx.xcframework.
 #
 # Usage: build_sherpa_onnx_ios.sh <GIT_REF>
-#   GIT_REF: branch or tag to use (e.g. v1.13.7, main). Required.
+#   GIT_REF: branch or tag to use (e.g. v1.13.8, main). Required.
 #
 # Environment:
-#   SHERPA_ONNX_ONNXRUNTIME_VERSION or ONNXRUNTIME_VERSION — ORT version (default 1.28.1)
+#   SHERPA_ONNX_ONNXRUNTIME_VERSION or ONNXRUNTIME_VERSION — ORT version (default 1.28.2)
 #
 # Output: third_party/sherpa-onnx-prebuilt/sherpa_onnx.xcframework
 # Requires: macOS, Xcode, CMake. Run from repo root or from third_party/sherpa-onnx-prebuilt.
@@ -18,7 +18,7 @@ set -e
 
 if [ -z "$1" ]; then
   echo "Usage: $0 <GIT_REF>" >&2
-  echo "  GIT_REF: branch or tag for k2-fsa/sherpa-onnx (e.g. v1.13.7, main)" >&2
+  echo "  GIT_REF: branch or tag for k2-fsa/sherpa-onnx (e.g. v1.13.8, main)" >&2
   exit 1
 fi
 GIT_REF="$1"
@@ -29,7 +29,7 @@ BUILD_TOP="$SCRIPT_DIR/build_ios_work"
 SHERPA_SRC="$BUILD_TOP/sherpa-onnx-source"
 OUTPUT_XCFRAMEWORK="$SCRIPT_DIR/sherpa_onnx.xcframework"
 
-ORT_VERSION="${SHERPA_ONNX_ONNXRUNTIME_VERSION:-${ONNXRUNTIME_VERSION:-1.28.1}}"
+ORT_VERSION="${SHERPA_ONNX_ONNXRUNTIME_VERSION:-${ONNXRUNTIME_VERSION:-1.28.2}}"
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "iOS builds require macOS" >&2


### PR DESCRIPTION
This pull request adds opt-in per-segment silhouette confidence scoring to the offline speaker diarization pipeline, improving parity with upstream implementations. It introduces a new `compute_confidence` option that, when enabled, computes and attaches silhouette-based confidence values for each diarization segment. The implementation is integrated into the C++ core and exposes the new functionality in the API. Additionally, the pull request updates ONNX Runtime to version 1.28.2 and bumps the Android/iOS SDK version to 1.13.8.

**Diarization: Per-segment silhouette confidence (main feature)**
* Added `compute_confidence` option to `ClusteringConfig`, `DiarizationInitConfig`, and related APIs, defaulting to false for upstream parity. When enabled, the clustering process computes per-embedding silhouette scores (`[-1, 1]` or `kUnavailableConfidence`) and attaches them to diarization segments. [[1]](diffhunk://#diff-103a20587f4c280b50b8345bfd072f83e20ac879285307514a2b30bb94f17d17R16-R20) [[2]](diffhunk://#diff-b9cb4e5535b54eb6b339d0cfb4bf39aadbfb7d69fee34f0d56c2b24072484398R25-R26) [[3]](diffhunk://#diff-e8b80158b083f38ffaf8a3a52b0bee8f21494d7d0d867262dea9d39103acf0bcR230-R322) [[4]](diffhunk://#diff-e8b80158b083f38ffaf8a3a52b0bee8f21494d7d0d867262dea9d39103acf0bcL239-R345) [[5]](diffhunk://#diff-e8b80158b083f38ffaf8a3a52b0bee8f21494d7d0d867262dea9d39103acf0bcR366-R378) [[6]](diffhunk://#diff-8f401a674b751736fbcb2307a2e0f35a594cb3e25f738d0bdf19ddbd4002b3c6R327-R331) [[7]](diffhunk://#diff-8f401a674b751736fbcb2307a2e0f35a594cb3e25f738d0bdf19ddbd4002b3c6R351-R356) [[8]](diffhunk://#diff-61e60e6b87aa3b13283ff8b770b561fada43ebe5d92fad591368751a9bd9c499L64-R67) [[9]](diffhunk://#diff-61e60e6b87aa3b13283ff8b770b561fada43ebe5d92fad591368751a9bd9c499R81)
* Extended the diarization C++ API (`DiarizationSession`, `AgglomerativeClusterer`, and wrappers) to support the new confidence option and propagate silhouette confidence values through the result objects. [[1]](diffhunk://#diff-8f401a674b751736fbcb2307a2e0f35a594cb3e25f738d0bdf19ddbd4002b3c6L40-R46) [[2]](diffhunk://#diff-8f401a674b751736fbcb2307a2e0f35a594cb3e25f738d0bdf19ddbd4002b3c6L77-R81) [[3]](diffhunk://#diff-8f401a674b751736fbcb2307a2e0f35a594cb3e25f738d0bdf19ddbd4002b3c6L369-R387) [[4]](diffhunk://#diff-b9cb4e5535b54eb6b339d0cfb4bf39aadbfb7d69fee34f0d56c2b24072484398L76-R88) [[5]](diffhunk://#diff-b9cb4e5535b54eb6b339d0cfb4bf39aadbfb7d69fee34f0d56c2b24072484398R109-R110) [[6]](diffhunk://#diff-61e60e6b87aa3b13283ff8b770b561fada43ebe5d92fad591368751a9bd9c499R31)
* Updated the `DiarizationSegment` struct to include a `confidence` field and defined a sentinel value `kUnavailableConfidence`.

**SDK and dependency updates**
* Updated ONNX Runtime version from 1.28.1 to 1.28.2 in the iOS framework build workflow. [[1]](diffhunk://#diff-4d99c98c0c302023bc2c9b0e176bbd80fbaca0fcf9cf8e653f30762a8d4cd060L15-R15) [[2]](diffhunk://#diff-4d99c98c0c302023bc2c9b0e176bbd80fbaca0fcf9cf8e653f30762a8d4cd060L77-R77)
* Bumped Android and iOS SDK versions to 1.13.8 in documentation.

**Documentation**
* Documented the new `diarization` confidence feature in `CHANGELOG.md`.
* Clarified that diacritization is planned for a future release in `README.md`.